### PR TITLE
feat(coder): add CNPG cluster and ArgoCD application for Coder

### DIFF
--- a/charts/apps/values.yaml
+++ b/charts/apps/values.yaml
@@ -1254,59 +1254,43 @@ applications:
         selfHeal: true
 
   # --- Coder ---
-  - name: coder-db
-    finalizers:
-      - resources-finalizer.argocd.argoproj.io
-    additionalAnnotations:
-      argocd.argoproj.io/sync-wave: "1"
-    source:
-      repoURL: https://github.com/ADORSYS-GIS/ai-helm
-      targetRevision: HEAD
-      path: charts/coder-db
-      helm:
-        releaseName: coder-db
-        valuesObject:
-          cluster:
-            name: coder-cnpg
-            instances: 1
-            storage:
-              size: 10Gi
-            bootstrap:
-              initdb:
-                database: coder
-                owner: coder
-    destination:
-      namespace: coder
-    syncPolicy:
-      syncOptions:
-        - CreateNamespace=true
-        - ServerSideApply=true
-      automated:
-        prune: true
-        selfHeal: true
-
   - name: coder
     finalizers:
       - resources-finalizer.argocd.argoproj.io
     additionalAnnotations:
-      argocd.argoproj.io/sync-wave: "2"
-    source:
-      repoURL: oci://ghcr.io/coder/chart/coder
-      targetRevision: 2.29.5
-      helm:
-        releaseName: coder
-        valuesObject:
-          coder:
-            env:
-              - name: CODER_PG_CONNECTION_URL
-                valueFrom:
-                  secretKeyRef:
-                    name: coder-cnpg-app
-                    key: uri
-              - name: CODER_PG_OPTIONS
-                value: "sslmode=disable"
-              - name: CODER_OAUTH2_GITHUB_DEFAULT_PROVIDER_ENABLE
-                value: "false"
+      argocd.argoproj.io/sync-wave: "1"
+    sources:
+      - repoURL: https://github.com/ADORSYS-GIS/ai-helm
+        targetRevision: HEAD
+        path: charts/coder-db
+        helm:
+          releaseName: coder-db
+          valuesObject:
+            cluster:
+              name: coder-cnpg
+              instances: 1
+              storage:
+                size: 10Gi
+              bootstrap:
+                initdb:
+                  database: coder
+                  owner: coder
+      - repoURL: oci://ghcr.io/coder/chart/coder
+        targetRevision: 2.29.5
+        helm:
+          releaseName: coder
+          valuesObject:
+            coder:
+              env:
+                - name: CODER_PG_CONNECTION_URL
+                  valueFrom:
+                    secretKeyRef:
+                      name: coder-cnpg-app
+                      key: uri
+                - name: CODER_PG_OPTIONS
+                  value: "sslmode=disable"
+                - name: CODER_OAUTH2_GITHUB_DEFAULT_PROVIDER_ENABLE
+                  value: "false"
     destination:
       namespace: coder
     syncPolicy:

--- a/charts/apps/values.yaml
+++ b/charts/apps/values.yaml
@@ -1253,6 +1253,70 @@ applications:
         prune: true
         selfHeal: true
 
+  # --- Coder ---
+  - name: coder-db
+    finalizers:
+      - resources-finalizer.argocd.argoproj.io
+    additionalAnnotations:
+      argocd.argoproj.io/sync-wave: "1"
+    source:
+      repoURL: https://github.com/ADORSYS-GIS/ai-helm
+      targetRevision: HEAD
+      path: charts/coder-db
+      helm:
+        releaseName: coder-db
+        valuesObject:
+          cluster:
+            name: coder-cnpg
+            instances: 1
+            storage:
+              size: 10Gi
+            bootstrap:
+              initdb:
+                database: coder
+                owner: coder
+    destination:
+      namespace: coder
+    syncPolicy:
+      syncOptions:
+        - CreateNamespace=true
+        - ServerSideApply=true
+      automated:
+        prune: true
+        selfHeal: true
+
+  - name: coder
+    finalizers:
+      - resources-finalizer.argocd.argoproj.io
+    additionalAnnotations:
+      argocd.argoproj.io/sync-wave: "2"
+    source:
+      repoURL: oci://ghcr.io/coder/chart/coder
+      targetRevision: 2.29.5
+      helm:
+        releaseName: coder
+        valuesObject:
+          coder:
+            env:
+              - name: CODER_PG_CONNECTION_URL
+                valueFrom:
+                  secretKeyRef:
+                    name: coder-cnpg-app
+                    key: uri
+              - name: CODER_PG_OPTIONS
+                value: "sslmode=disable"
+              - name: CODER_OAUTH2_GITHUB_DEFAULT_PROVIDER_ENABLE
+                value: "false"
+    destination:
+      namespace: coder
+    syncPolicy:
+      syncOptions:
+        - CreateNamespace=true
+        - ServerSideApply=true
+      automated:
+        prune: true
+        selfHeal: true
+
   # --- Proxy ---
   - name: models-proxy
     finalizers:

--- a/charts/coder-db/Chart.yaml
+++ b/charts/coder-db/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: coder-db
+description: CNPG Cluster for Coder
+type: application
+version: 0.1.0
+appVersion: "1.0.0"

--- a/charts/coder-db/templates/cluster.yaml
+++ b/charts/coder-db/templates/cluster.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.cluster -}}
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: {{ .Values.cluster.name | default "postgres-cluster" }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  instances: {{ .Values.cluster.instances | default 1 }}
+  storage:
+    size: {{ .Values.cluster.storage.size | default "10Gi" }}
+  {{- with .Values.cluster.storage.storageClass }}
+  storageClassName: {{ . }}
+  {{- end }}
+  {{- if .Values.cluster.bootstrap }}
+  bootstrap:
+    {{- toYaml .Values.cluster.bootstrap | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/coder-db/values.yaml
+++ b/charts/coder-db/values.yaml
@@ -1,0 +1,9 @@
+cluster:
+  name: coder-cnpg
+  instances: 1
+  storage:
+    size: 10Gi
+  bootstrap:
+    initdb:
+      database: coder
+      owner: coder


### PR DESCRIPTION
- Add coder-db chart with CNPG Cluster resource (coder-cnpg)
- Add ArgoCD applications: coder-db (sync-wave 1) and coder (sync-wave 2)
- Configure CODER_PG_CONNECTION_URL from CNPG auto-generated secret
- Add CODER_PG_OPTIONS for configurable sslmode parameter