### PR TITLE
feat(coder): add node toleration for offline-work

### DIFF
--- a/charts/apps/values.yaml
+++ b/charts/apps/values.yaml
@@ -1292,6 +1292,10 @@ applications:
                   value: "sslmode=disable"
                 - name: CODER_OAUTH2_GITHUB_DEFAULT_PROVIDER_ENABLE
                   value: "false"
+            tolerations:
+              - key: ai.camer.digital/offline-work
+                operator: Exists
+                value: dev-container
     destination:
       namespace: coder
     syncPolicy:


### PR DESCRIPTION
Add toleration to schedule Coder deployment on nodes with ai.camer.digital/offline-work=dev-container taint.