### PR TITLE
feat(coder): add node toleration, resources, and ClusterIP service

### DIFF
--- a/charts/apps/values.yaml
+++ b/charts/apps/values.yaml
@@ -1292,10 +1292,19 @@ applications:
                   value: "sslmode=disable"
                 - name: CODER_OAUTH2_GITHUB_DEFAULT_PROVIDER_ENABLE
                   value: "false"
-            tolerations:
-              - key: ai.camer.digital/offline-work
-                operator: Exists
-                value: dev-container
+              tolerations:
+                - key: ai.camer.digital/offline-work
+                  operator: Equal
+                  value: dev-container
+              resources:
+                requests:
+                  cpu: 1000m
+                  memory: 1024Mi
+                limits:
+                  cpu: 2000m
+                  memory: 4096Mi
+              service:
+                type: ClusterIP
     destination:
       namespace: coder
     syncPolicy:


### PR DESCRIPTION
Add toleration to schedule Coder deployment on nodes with ai.camer.digital/offline-work=dev-container taint. Add 2vCPU/4GB memory resources. Set service type to ClusterIP.