### PR TITLE
feat(obs): upgrade Grafana Helm chart to 9.4.5 (Grafana 12.1.1)

### DIFF
--- a/charts/apps/values.yaml
+++ b/charts/apps/values.yaml
@@ -1055,7 +1055,7 @@ applications:
       argocd.argoproj.io/sync-wave: "0"
     source:
       repoURL: https://grafana.github.io/helm-charts
-      targetRevision: 8.0.0
+      targetRevision: 9.4.5
       chart: grafana
       helm:
         releaseName: grafana


### PR DESCRIPTION
Enables the custom webhook payload feature (added in Grafana 12.0.0) needed to include imageUrl in alerts sent to grafana-apprise-adapter.