### PR TITLE
ci(mcp): render-test all three charts/mcp modes via ci/ fixtures

### DIFF
--- a/.github/workflows/helm-lint.yaml
+++ b/.github/workflows/helm-lint.yaml
@@ -50,6 +50,19 @@ jobs:
 
             helm lint "$chart_dir" --strict
             helm template "$chart_name" "$chart_dir" --dry-run > /dev/null
+
+            # Render any ci/*-values.yaml fixtures (Helm convention) so chart
+            # branches that the default values.yaml never reaches get covered.
+            # E.g. charts/mcp defaults to mode=external, so the selfHosted and
+            # proxiedExternal branches are ONLY render-tested via these fixtures.
+            if [[ -d "$chart_dir/ci" ]]; then
+              for vf in "$chart_dir"/ci/*-values.yaml; do
+                [[ -e "$vf" ]] || continue
+                echo "  🧪 fixture $(basename "$vf")"
+                helm template "$chart_name" "$chart_dir" -f "$vf" --dry-run > /dev/null
+              done
+            fi
+
             echo "✅ $chart_name OK"
           done
 

--- a/charts/mcp/ci/external-values.yaml
+++ b/charts/mcp/ci/external-values.yaml
@@ -1,0 +1,19 @@
+# CI render fixture — mode: external (MCPRoute points straight at the upstream
+# FQDN over TLS; legacy, ADR-0039/0040). This is also the chart default, but
+# pinning it as an explicit ci/ fixture keeps all three modes covered by the
+# charts/*/ci/*-values.yaml loop and exercises the external-mode BackendTLSPolicy
+# branch with oauth enabled (the deployed shape).
+mcp:
+  name: example-external
+  mode: external
+  path: /mcp/example
+  backendPath: /mcp
+  externalHost: example.example.com
+  externalPort: 443
+  tls: true
+
+oauth:
+  enabled: true
+  issuer: https://auth.verif.fyi/realms/camer-digital
+  publicOrigin: https://api.ai.camer.digital
+  resourceName: Example External MCP Server

--- a/charts/mcp/ci/proxiedexternal-values.yaml
+++ b/charts/mcp/ci/proxiedexternal-values.yaml
@@ -1,0 +1,29 @@
+# CI render fixture — mode: proxiedExternal (Caddy normalizing proxy fronting an
+# external hosted MCP, ADR-0040). Mirrors the real `refero` entry in the mcps
+# orchestrator (charts/mcps values.yaml): externalSecret enabled (so the
+# MCP_TOKEN env block + Caddyfile Authorization header both render — the exact
+# branch a stray `-}}` comment-chomp broke on 2026-06-11) AND the response
+# Content-Type rewrite. helm-lint.yaml renders every charts/*/ci/*-values.yaml;
+# before this the proxiedExternal branch was render-tested by no CI gate.
+mcp:
+  name: refero
+  mode: proxiedExternal
+  path: /mcp/refero
+  backendPath: /mcp
+  externalHost: api.refero.design
+  proxy:
+    rewriteResponseContentType: application/json
+
+oauth:
+  enabled: true
+  issuer: https://auth.verif.fyi/realms/camer-digital
+  publicOrigin: https://api.ai.camer.digital
+  resourceName: Refero Design MCP Server
+
+externalSecret:
+  enabled: true
+  secretName: refero-token
+  data:
+    - secretKey: apiKey
+      key: ai/camer/digital/prod/env
+      property: refero_api_key

--- a/charts/mcp/ci/selfhosted-values.yaml
+++ b/charts/mcp/ci/selfhosted-values.yaml
@@ -1,0 +1,37 @@
+# CI render fixture — mode: selfHosted (an in-cluster MCP image + Service).
+# Mirrors the real `brave` entry in the mcps orchestrator (charts/mcps
+# values.yaml) so CI render-tests the shape we actually deploy, not a synthetic
+# one. helm-lint.yaml renders every charts/*/ci/*-values.yaml; without this the
+# selfHosted branch of templates/deployment.yaml is never exercised.
+mcp:
+  name: brave-search
+  mode: selfHosted
+  path: /mcp/brave
+  backendPath: /mcp
+  image: docker.io/mcp/brave-search:latest
+  port: 8080
+  args:
+    - --transport
+    - http
+  env:
+    - name: BRAVE_API_KEY
+      valueFrom:
+        secretKeyRef:
+          name: brave-token
+          key: apiKey
+    - name: BRAVE_MCP_TRANSPORT
+      value: "http"
+
+oauth:
+  enabled: true
+  issuer: https://auth.verif.fyi/realms/camer-digital
+  publicOrigin: https://api.ai.camer.digital
+  resourceName: Brave Search MCP Server
+
+externalSecret:
+  enabled: true
+  secretName: brave-token
+  data:
+    - secretKey: apiKey
+      key: ai/camer/digital/prod/env
+      property: brave_api_key


### PR DESCRIPTION
## 1. Summary

This PR changes:

- Adds three Helm `ci/*-values.yaml` render fixtures to `charts/mcp` — one per mode (`external`, `selfHosted`, `proxiedExternal`) — grounded in the real deployed shapes from the `mcps` orchestrator.
- Extends `.github/workflows/helm-lint.yaml` to render every `charts/*/ci/*-values.yaml` after the per-chart default render, consistent with how the workflow already iterates charts.

It solves:

- **Source of truth:** the chomp-vulnerable `MCP_TOKEN` env block shipped in commit [`eb12640`](https://github.com/ADORSYS-GIS/ai-helm/commit/eb12640c7909953f07e4d8087d376531516a9de2), and the broader 2026-06-11 MCP incident is documented in [`docs/2026-06-10-mcp-external-server-proxy-debug.md`](https://github.com/ADORSYS-GIS/ai-helm/blob/main/docs/2026-06-10-mcp-external-server-proxy-debug.md).
- `charts/mcp` defaults to `mcp.mode: external`, so every CI gate render-tested only that one branch. helm-lint ran `helm template charts/mcp` with default values; `tools/release.sh` render-checks the orchestrator `charts/mcps`, not the leaf. The `selfHosted` and `proxiedExternal` branches of `templates/deployment.yaml` (the Caddy normalizing-proxy Deployment + ConfigMap, ADR-0040) were therefore **never** render-tested by any gate.

## 2. Intent

The intent of this PR is:

> To close a real CI blind spot. On 2026-06-11 a Go-template comment's trailing `*/ -}}` chomped the newline before `env:` in the `proxiedExternal` branch and corrupted the rendered YAML, yet every gate reported "clean" because none set `mode=proxiedExternal`. This adds render coverage for all three modes so a mode-gated template error fails CI. See commit [`eb12640`](https://github.com/ADORSYS-GIS/ai-helm/commit/eb12640c7909953f07e4d8087d376531516a9de2) and [`docs/2026-06-10-mcp-external-server-proxy-debug.md`](https://github.com/ADORSYS-GIS/ai-helm/blob/main/docs/2026-06-10-mcp-external-server-proxy-debug.md).

## 3. Scope

### In Scope

- `charts/mcp/ci/{external,selfhosted,proxiedexternal}-values.yaml` fixtures (values mirror the `brave` / `refero` / external orchestrator entries — not synthetic `--set` flags).
- Generic `ci/*-values.yaml` render loop in the helm-lint workflow (opt-in for any chart that adds a `ci/` dir).

### Out of Scope

- `tools/release.sh` — left rendering the orchestrator only. Extending the always-on helm-lint gate (runs on every push/PR) is the broader, earlier check; adding leaf-fixture rendering to `release.sh` as belt-and-suspenders can be a follow-up if wanted.
- No chart template or runtime behaviour changes — fixtures + CI only.

## 4. Verification

I verified this change by:

- [x] Running automated tests
- [x] Testing error cases
- [x] Testing rollback or failure behavior, if relevant

Commands run:

```bash
# All four render clean (default + 3 fixtures)
helm template mcp charts/mcp --dry-run
for vf in charts/mcp/ci/*-values.yaml; do helm template mcp charts/mcp -f "$vf" --dry-run; done

# Proof the new gate catches the 2026-06-11 class of bug:
# reintroduce the `*/ -}}` chomp in templates/deployment.yaml, then:
helm template mcp charts/mcp --dry-run                                    # default (external)
helm template mcp charts/mcp -f charts/mcp/ci/proxiedexternal-values.yaml --dry-run
```

Results:

```text
default(external) OK
external-values.yaml OK
proxiedexternal-values.yaml OK
selfhosted-values.yaml OK

# With the `*/ -}}` break reintroduced:
default render (mode=external)  -> PASS  (bug slips through, as it did on 2026-06-11)
proxiedexternal fixture         -> FAIL  Error: YAML parse error ... yaml: line 35:
                                          mapping values are not allowed in this context
# Break reverted; git diff on the template is empty.
```

Note: the pre-existing `lint` / `release` CI failures on this PR reproduce identically on `main` HEAD (`eb12640`) and stem from `helm lint --strict` on `charts/ai-model` (`.Values.modelName is required`) — a leaf chart that requires the orchestrator's values. They are unrelated to this diff, which only adds `charts/mcp/ci/*` files and a workflow loop. The `mcp` chart and all three new fixtures render green (`✅ mcp OK`).

## 6. Risk Assessment

Risk level:

* [x] Low

Potential risks:

* CI-only change; no chart template or deployed manifest is modified. Worst case is a fixture that fails to render, which is the intended gate.

Mitigation:

* Fixtures mirror the real orchestrator values, so they render exactly what we deploy.

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [x] Reviewing the diff

Human verification:

* [x] I understand every meaningful change in this PR
* [x] I checked generated code manually
* [x] I accept responsibility for this PR

## 8. Reviewer Focus

Please focus your review on:

* [x] Correctness
* [x] Tests
* [x] Maintainability

🤖 Generated with [Claude Code](https://claude.com/claude-code)
