### PR TITLE
feat(opencode): add DCP + skills-collection plugins to the well-known

### DIFF
--- a/charts/librechat-opencode-wellknown/values.yaml
+++ b/charts/librechat-opencode-wellknown/values.yaml
@@ -47,6 +47,21 @@ wellKnown:
       # reset it fails fast — see the per-model-scoped `rateLimit.tiers`
       # under the provider options below.
       - "@vymalo/opencode-ratelimit"
+      # Dynamic Context Pruning — auto-compresses/dedups stale tool
+      # outputs and prunes failed-tool inputs from the running context.
+      # Zero-config (sensible defaults); provider-agnostic. Pushed
+      # org-wide it lowers per-request token spend against the ADR-0021
+      # per-user budgets — a cost win for every session. Users can tune
+      # via an optional ~/.config/opencode/dcp.jsonc.
+      - "@tarquinen/opencode-dcp"
+      # Curated skills bundle (1000+) behind a token-efficient
+      # "SkillPointer" loader (~80k → ~255 startup tokens vs. inlining
+      # them). Zero-config. MUST stay pinned to @latest — the package
+      # IS the skill catalog, so a fixed version freezes the skills and
+      # defeats its auto-sync. Users can opt into risk-filtering via an
+      # optional ~/.config/opencode/skill-filter.jsonc (all skills load
+      # by default).
+      - "opencode-skills-collection@latest"
     provider:
       camer-digital:
         name: "Camer Digital"


### PR DESCRIPTION
## 1. Summary

This PR changes:

- Adds **`@tarquinen/opencode-dcp`** (Dynamic Context Pruning) to the org-wide opencode `.well-known` plugin array.
- Adds **`opencode-skills-collection@latest`** (curated 1000+ skill bundle, token-efficient SkillPointer loader) to the same array.

It solves:

- Request to expand the opencode plugin set offered to all users via `opencode auth login https://ai.camer.digital/opencode`.

---

## 2. Intent

The intent of this PR is:

> Improve every opencode session at two levels — **cost** (DCP prunes stale/duplicate/failed-tool context, lowering per-request token spend against the ADR-0021 per-user budgets) and **capability** (a large curated skill catalog loaded for ~255 tokens instead of ~80k). Both are zero-config and provider-agnostic, so they're safe as an org-wide default.

---

## 3. Scope

### In Scope

- Two plugin entries + explanatory comments in `charts/librechat-opencode-wellknown/values.yaml`.

### Out of Scope (researched, deliberately rejected)

- **Secret/PII redaction** — `opencode-vibeguard` is a no-op without a per-project config file (useless when pushed); `envsitter-guard` only blocks `.env` reads and is v0.0.4. No clean zero-config org-pushable option exists yet.
- **Token/cost meter** — `tokenscope`/`quota` price against their own hardcoded catalogs, not our custom gateway models; our real pricing already flows via `models-info` (ADR-0015) into opencode's **native** cost display, so a meter is redundant/wrong here.
- **Other-provider auth & third-party telemetry plugins** — conflict with our Keycloak OAuth2 / our own observability stack.

---

## 4. Verification

I verified this change by:

- [x] Running manual tests (render + lint)
- [x] Checking logs

Commands run:

```bash
helm template x charts/librechat-opencode-wellknown/   # inspect rendered plugin array
helm lint charts/librechat-opencode-wellknown/
```

Results:

```text
plugins: ["@vymalo/opencode-oauth2", "@vymalo/opencode-models-info",
          "@vymalo/opencode-ratelimit", "@tarquinen/opencode-dcp",
          "opencode-skills-collection@latest"]
1 chart(s) linted, 0 chart(s) failed
```

Each plugin's install/config shape was verified against its npm registry + GitHub README: both are zero-config and provider-agnostic; `skills-collection` must stay `@latest` (the package *is* the skill catalog).

---

## 5. Screenshots / Evidence

- Rendered plugin array (see §4 results).
- Plugin sources: https://github.com/Tarquinen/opencode-dynamic-context-pruning · https://github.com/FrancoStino/opencode-skills-collection

---

## 6. Risk Assessment

Risk level:

* [x] Low

Potential risks:

* Both plugins auto-install via Bun at user startup; a transient install failure degrades to today's behaviour (plugin simply absent).
* `skills-collection@latest` auto-updates daily — less reproducible than a pin, but pinning would freeze the skill catalog.
* DCP prunes context from the running session.

Mitigation:

* Plugin absence is non-fatal — the gateway and auth path are unaffected.
* Risk-filtering for skills is available user-side (`skill-filter.jsonc`); DCP defaults are conservative and disableable via `dcp.jsonc`.

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [x] Drafting documentation
* [x] Reviewing the diff

Human verification:

* [x] I understand every meaningful change in this PR
* [x] I checked generated code manually
* [x] I removed unsupported AI assumptions
* [x] I accept responsibility for this PR

---

## 8. Reviewer Focus

Please focus your review on:

* [x] Product intent
* [x] Maintainability

Specifically: whether `skills-collection@latest` (auto-updating, org-wide) is an acceptable reproducibility trade-off, or if we'd rather vet+pin a version despite freezing the catalog.
