### PR TITLE
fix(ci): make helm-lint green for leaf + subchart-only charts

### DIFF
--- a/.github/workflows/helm-lint.yaml
+++ b/.github/workflows/helm-lint.yaml
@@ -33,6 +33,7 @@ jobs:
             chart_name=$(yq eval '.name' "$chart_file")
             chart_version=$(yq eval '.version' "$chart_file")
             chart_type=$(yq eval '.type // "application"' "$chart_file")
+            lint_mode=$(yq eval '.annotations."ai-helm.adorsys-gis.github.io/lint-mode" // ""' "$chart_file")
 
             # Skip library charts as they are not installable
             if [[ "$chart_type" == "library" ]]; then
@@ -48,7 +49,40 @@ jobs:
 
             [[ -f "$chart_dir/values.yaml" ]] || echo "⚠️  Missing values.yaml"
 
-            helm lint "$chart_dir" --strict
+            # --strict promotes WARNINGs to errors. A chart whose manifests come
+            # ENTIRELY from a subchart (e.g. bjw-template) has no own templates/
+            # dir, so --strict trips on "[WARNING] templates/: directory not
+            # found" even though it renders fine and passes non-strict lint
+            # (CLAUDE.md tooling-quirks: judge these by render + non-strict
+            # lint). Apply --strict only when the chart has its own templates/.
+            strict_flag="--strict"
+            if [[ ! -d "$chart_dir/templates" ]]; then
+              strict_flag=""
+              echo "  ℹ️  no own templates/ — linting non-strict (subchart-only chart)"
+            fi
+
+            # Render-only LEAF charts (annotation lint-mode=ci-values, e.g.
+            # ai-model) `fail`-guard on per-model values the orchestrator injects
+            # (ADR-0012), so they can't lint/render with the default values.yaml.
+            # Lint AND render them via their ci/*-values.yaml fixtures instead.
+            if [[ "$lint_mode" == "ci-values" ]]; then
+              shopt -s nullglob
+              fixtures=("$chart_dir"/ci/*-values.yaml)
+              shopt -u nullglob
+              if [[ ${#fixtures[@]} -eq 0 ]]; then
+                echo "❌ $chart_name has lint-mode=ci-values but no ci/*-values.yaml fixtures"
+                exit 1
+              fi
+              for vf in "${fixtures[@]}"; do
+                echo "  🧪 fixture $(basename "$vf") (render-only leaf)"
+                helm lint "$chart_dir" $strict_flag -f "$vf"
+                helm template "$chart_name" "$chart_dir" -f "$vf" --dry-run > /dev/null
+              done
+              echo "✅ $chart_name OK"
+              continue
+            fi
+
+            helm lint "$chart_dir" $strict_flag
             helm template "$chart_name" "$chart_dir" --dry-run > /dev/null
 
             # Render any ci/*-values.yaml fixtures (Helm convention) so chart

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,12 +45,22 @@ uv run ruff format . && uv run ruff check .
 # After editing the dashboard .py source, you MUST run `dashboards build`
 # and commit the regenerated JSON — CI fails otherwise.
 
-# Match CI before pushing chart changes — CI lints --strict AND renders every
-# chart (.github/workflows/helm-lint.yaml). To check the whole repo at once:
-for c in charts/*/; do helm lint "$c" --strict && helm template x "$c" --dry-run >/dev/null || echo "FAIL: $c"; done
+# Match CI before pushing chart changes (.github/workflows/helm-lint.yaml). CI
+# lints --strict ONLY for charts with their own templates/ dir, NON-strict for
+# subchart-only charts (no templates/ — --strict false-trips on "templates/:
+# directory not found"), and render-only LEAF charts (Chart.yaml annotation
+# ai-helm.adorsys-gis.github.io/lint-mode: ci-values, e.g. ai-model) are
+# lint+rendered via their ci/*-values.yaml fixtures, not default values. To
+# check the whole repo at once, matching that logic:
+for cf in charts/*/Chart.yaml; do c=$(dirname "$cf"); n=$(yq e .name "$cf")
+  [[ $(yq e '.type // "application"' "$cf") == library ]] && continue
+  sf=--strict; [[ -d "$c/templates" ]] || sf=
+  if [[ $(yq e '.annotations."ai-helm.adorsys-gis.github.io/lint-mode" // ""' "$cf") == ci-values ]]; then
+    for vf in "$c"/ci/*-values.yaml; do helm lint "$c" $sf -f "$vf" >/dev/null && helm template x "$c" -f "$vf" --dry-run >/dev/null || echo "FAIL: $n"; done
+  else helm lint "$c" $sf >/dev/null && helm template x "$c" --dry-run >/dev/null || echo "FAIL: $n"; fi; done
 ```
 
-There is no `npm`, no `pytest`, no `cargo`, no `go build` in this repo. The dashboards Python project at `tools/dashboards/` is the only code that runs; everything else is YAML rendered by Helm. **CI gates** (`.github/workflows/`): `helm-lint` (`helm lint --strict` + `helm template --dry-run` per chart), `dashboards-drift` (`uv run dashboards check`), `security` (scans), `release-helm-charts` (package on tag), `opencode` (the agent/CI rules — see `.github/workflows/opencode.yml`, the canonical agent rules; the stale `.opencode/README.md` is unrelated).
+There is no `npm`, no `pytest`, no `cargo`, no `go build` in this repo. The dashboards Python project at `tools/dashboards/` is the only code that runs; everything else is YAML rendered by Helm. **CI gates** (`.github/workflows/`): `helm-lint` (per-chart `helm lint` + `helm template --dry-run`; `--strict` only for charts with own `templates/`, render-only leaves go through their `ci/*-values.yaml` fixtures — see the tool-quirks note below), `dashboards-drift` (`uv run dashboards check`), `security` (scans), `release-helm-charts` (non-strict lint + Trivy config scan + package on tag), `opencode` (the agent/CI rules — see `.github/workflows/opencode.yml`, the canonical agent rules; the stale `.opencode/README.md` is unrelated).
 
 ## The orchestrator-plus-leaves pattern (used for `ai-models` and `librechart`)
 
@@ -222,7 +232,8 @@ Default shell on the maintainer's laptop is **zsh** (not bash). For shell comman
 - **`gh` CLI** sometimes needs `zsh -i -c '...'` to pick up `GITHUB_TOKEN` from interactive profile. The harness's Bash tool runs zsh but non-interactively.
 - **`helm template` warnings** about `~/.kube/config` group/world readability are noise — ignore.
 - **`helm lint`** WARNING-level output ≠ failure. Look for `1 chart(s) failed`.
-- **bjw-template-only charts fail `helm lint --strict`** with `[WARNING] templates/: directory not found` → `1 chart(s) failed`. This is expected: charts like `mcpo`/`lmcache` carry no own `templates/` dir — every manifest comes from the `bjw-template` subchart. **It's fine for us** — non-strict `helm lint` passes (`0 chart(s) failed`) and the real gate, `helm template … --dry-run`, renders cleanly. Don't add an empty `templates/` dir to silence it; judge these charts by render + non-strict lint.
+- **bjw-template-only charts fail `helm lint --strict`** with `[WARNING] templates/: directory not found` → `1 chart(s) failed`. This is expected: charts like `mcpo`/`lmcache` carry no own `templates/` dir — every manifest comes from the `bjw-template` subchart. **It's fine for us** — non-strict `helm lint` passes (`0 chart(s) failed`) and the real gate, `helm template … --dry-run`, renders cleanly. Don't add an empty `templates/` dir to silence it; judge these charts by render + non-strict lint. **The `helm-lint` CI now does this automatically:** it applies `--strict` only when a chart has its own `templates/` dir, and lints subchart-only charts non-strict (so the workflow is green without weakening the render gate). Before this, `--strict` ran on every chart and CI was red repo-wide on these charts + `ai-model`.
+- **Render-only LEAF charts (e.g. `ai-model`) can't be lint/render-tested standalone** — their templates `fail`-guard on per-model values the orchestrator injects (ADR-0012), so `helm lint`/`helm template` with the default (empty) `values.yaml` aborts by design. **Convention:** mark such a chart with the Chart.yaml annotation `ai-helm.adorsys-gis.github.io/lint-mode: ci-values` and add a representative fixture at `charts/<chart>/ci/lint-values.yaml`. The `helm-lint` CI then skips the default lint+template for that chart and instead **lints AND renders each `ci/*-values.yaml` fixture** (so the leaf is still fully covered). Add a fixture when you add a new render-only leaf — don't exclude the chart from CI, and don't loosen its `fail` guards to make defaults render.
 - **The `.opencode/README.md`** is stale (refers to an unrelated "Azamra monorepo"). Ignore it. The canonical agent/CI rules live in `.github/workflows/opencode.yml`.
 
 ## `.well-known/opencode` is NOT OIDC discovery

--- a/charts/ai-model/Chart.yaml
+++ b/charts/ai-model/Chart.yaml
@@ -12,6 +12,15 @@ description: |
 type: application
 version: 1.0.0
 appVersion: "1.0.0"
+# Render-only LEAF chart: the orchestrating ApplicationSet in charts/ai-models
+# (ADR-0012) injects per-model values that the templates `fail`-guard on
+# (modelName, gatewayRef, backendsInventory, ≥2 enabled backends, pricing,
+# plans). With the default (empty) values.yaml the chart intentionally refuses
+# to render, so it can't be lint/render-tested standalone. CI (.github/
+# workflows/helm-lint.yaml) reads this annotation and lint+renders the chart via
+# its ci/*-values.yaml fixtures instead of the default values.
+annotations:
+  ai-helm.adorsys-gis.github.io/lint-mode: ci-values
 keywords:
   - ai-gateway
   - envoy-ai-gateway

--- a/charts/ai-model/ci/lint-values.yaml
+++ b/charts/ai-model/ci/lint-values.yaml
@@ -1,0 +1,77 @@
+# CI lint/render fixture for the ai-model LEAF chart.
+#
+# ai-model is never installed standalone — the `ai-models` orchestrator
+# (ADR-0012) instantiates it once per model, passing the per-model values its
+# templates `fail`-guard on (modelName, gatewayRef, backendsInventory, ≥2
+# enabled backends, pricing, plans). With the default values.yaml (all empty)
+# the chart intentionally refuses to render, so a standalone
+# `helm lint`/`helm template` can't exercise it.
+#
+# This fixture mirrors ONE representative orchestrator invocation (a 2-backend
+# weighted-pricing SaaS model — the canonical HA shape) so CI can lint AND
+# render the leaf in isolation. Keep it in sync with the leaf value contract in
+# charts/ai-models/templates/applicationset.yaml ($childValues dict); it is a
+# render fixture, not a deployed model.
+modelName: ci-lint-model
+kind: text
+
+gatewayRef:
+  name: core-gateway
+  namespace: converse-gateway
+  sectionName: api-https
+  internalSectionName: api-internal
+
+minBackends: 2
+
+timeout:
+  requestTimeout: 600s
+  connectionIdleTimeout: 1h
+
+# Two enabled backends (priority 0 primary / 1 secondary) — satisfies the
+# default minBackends:2 HA guard. Each `ref` must key into backendsInventory.
+backends:
+  primary:
+    ref: deepinfra-01
+    priority: 0
+    modelNameOverride: "zai-org/GLM-5"
+  secondary:
+    ref: deepinfra-02
+    priority: 1
+    modelNameOverride: "zai-org/GLM-5"
+
+# Mirrors the parent `backends:` map — provides the resourceName lookup the
+# AIGatewayRoute uses to resolve each backend ref to a Service.
+backendsInventory:
+  deepinfra-01:
+    resourceName: deepinfra-backend-01-svc
+  deepinfra-02:
+    resourceName: deepinfra-backend-02-svc
+
+pricing:
+  strategy: weighted
+  standard:
+    inputPer1M: 0.60
+    cachedInputPer1M: 0.12
+    outputPer1M: 2.08
+
+# Full plan set (budgeted + burst-only) so the BackendTrafficPolicy renders
+# every rule family (burst req/min, burst tokens/min, monthly budget).
+plans:
+  free:
+    monthlyBudgetUsd: 50
+    burst:
+      requestsPerMin: 200
+      tokensPerMin: 200000
+  pro:
+    monthlyBudgetUsd: 200
+    burst:
+      requestsPerMin: 400
+      tokensPerMin: 400000
+  service:
+    burst:
+      requestsPerMin: 600
+      tokensPerMin: 2000000
+  internal:
+    burst:
+      requestsPerMin: 1000
+      tokensPerMin: 5000000


### PR DESCRIPTION
## 1. Summary

This PR changes:

- `helm-lint` CI applies `helm lint --strict` only to charts with their own `templates/` dir; subchart-only charts (no `templates/`) are linted **non-strict**.
- Render-only leaf charts carry a new `Chart.yaml` annotation `ai-helm.adorsys-gis.github.io/lint-mode: ci-values`; the workflow lints **and** renders them via their `ci/*-values.yaml` fixtures instead of the default (unrenderable) values. `ai-model` is annotated and gets `charts/ai-model/ci/lint-values.yaml`.
- Updates the now-stale CI notes in `CLAUDE.md` (the "Match CI" snippet and the tool-quirks note).

It solves:

- The **Lint Helm Charts** workflow being red on every recent `main` commit (incl. the deployed release commits), which the team has been merging past.

Source of truth: the failing runs of https://github.com/ADORSYS-GIS/ai-helm/actions/workflows/helm-lint.yaml — companion of the release-gate fix #377.

---

## 2. Intent

The intent of this PR is:

> Get the `helm-lint` check green **without weakening the real gate** (`helm template --dry-run` per chart). The workflow ran `helm lint --strict` on every chart, which two classes of chart cannot satisfy standalone:
> 1. **`ai-model`** is a render-only leaf (ADR-0012): its templates `fail`-guard on per-model values the `ai-models` orchestrator injects (`modelName`, `gatewayRef`, `backendsInventory`, ≥2 enabled backends, pricing, plans). With the default empty `values.yaml` it intentionally refuses to render, so **both** `helm lint --strict` and the default `helm template` abort.
> 2. **Six subchart-only charts** (`keycloak-backup`, `librechat-search`, `lmcache`, `mcpo`, `model-deployment`, `mongodb-backup`) have no own `templates/` dir — every manifest comes from the `bjw-template` subchart — so `--strict` promotes the harmless `[WARNING] templates/: directory not found` to an error. They render fine and pass non-strict lint (the documented gate).

---

## 3. Scope

### In Scope

- `.github/workflows/helm-lint.yaml` — per-chart strictness + render-only-leaf fixture handling.
- `charts/ai-model/Chart.yaml` — `lint-mode: ci-values` annotation.
- `charts/ai-model/ci/lint-values.yaml` — representative 2-backend weighted-pricing fixture (mirrors one orchestrator invocation).
- `CLAUDE.md` — doc accuracy for the new CI behavior + the leaf-fixture convention.

### Out of Scope

- The **Release Helm Charts** workflow red. Its lint step is non-strict and already passes; it fails on a **separate, pre-existing Trivy config-scan finding** (`KSV-0014`/`KSV-0118` missing `readOnlyRootFilesystem`/non-default securityContext on `mcpo` + `librechat-app-db`; `KSV-0109` `clientSecret`/`client_secret` stored in `keycloak-baseline`/`librechat` ConfigMaps). That is security hardening with real workload impact — left untouched here.
- No change to any chart's `fail` guards (the leaf contract is intentionally strict).

---

## 4. Verification

I verified this change by:

- [x] Running automated tests
- [x] Running manual tests
- [x] Checking logs
- [ ] Checking metrics
- [x] Testing error cases
- [ ] Testing permissions/security behavior
- [ ] Testing rollback or failure behavior, if relevant

Commands run:

```bash
# Replicated the exact new workflow logic under bash over the whole repo
# (--kube-version only compensates for local helm 3.12; CI's 3.15.4 needs none):
bash /tmp/lint-replica.sh

# Validated the ai-model fixture passes strict lint AND full render:
helm lint charts/ai-model --strict -f charts/ai-model/ci/lint-values.yaml
helm template ci charts/ai-model -f charts/ai-model/ci/lint-values.yaml --dry-run

# Ran the real CI workflow on the branch:
gh run watch <run-id> --exit-status
```

Results:

```text
Local bash replica:  PASS=27  FAIL=0  (2 library charts skipped)
ai-model fixture:    1 chart(s) linted, 0 chart(s) failed; AIGatewayRoute + BackendTrafficPolicy render

Real CI run 27409958042 (Lint Helm Charts) — exit 0, all steps ✓:
  ✅ ai-model OK            → "🧪 fixture lint-values.yaml (render-only leaf)"
  ✅ model-deployment OK    → "ℹ️ no own templates/ — linting non-strict (subchart-only chart)"
  ✅ mcpo / lmcache / librechat-search / keycloak-backup / mongodb-backup OK (non-strict)
```

---

## 5. Screenshots / Evidence

* Logs: CI run `27409958042` (Lint Helm Charts) on this branch — green.

---

## 6. Risk Assessment

Risk level:

* [x] Low
* [ ] Medium
* [ ] High

Potential risks:

* CI-only change (a GitHub Actions workflow + a lint fixture + docs). No chart templates or deployed manifests change, so ArgoCD reconciliation is unaffected.
* The `--strict` heuristic keys off "has own `templates/` dir". A future subchart-only chart that *should* be strict would be linted non-strict.

Mitigation:

* The render gate (`helm template --dry-run`) is unchanged and still runs for every chart, including the render-only leaf via its fixture.
* The heuristic was verified against the full chart set (all six subchart-only charts lack `templates/`; `ai-model` has one). The convention is documented in `CLAUDE.md`.

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [ ] Refactoring
* [ ] Generating tests
* [x] Drafting documentation
* [x] Reviewing the diff
* [ ] Not used

Human verification:

* [ ] I understand every meaningful change in this PR
* [ ] I checked generated code manually
* [ ] I checked generated tests manually
* [ ] I removed unsupported AI assumptions
* [ ] I accept responsibility for this PR

> AI (Claude Opus 4.8) diagnosed the red CI, wrote the workflow change + fixture, and verified it by replicating the workflow locally and triggering the real CI run. Maintainer to tick the human-verification boxes after review.

---

## 8. Reviewer Focus

Please focus your review on:

* [x] Correctness
* [ ] Architecture
* [ ] Security
* [ ] Performance
* [ ] Tests
* [x] Maintainability
* [ ] Product intent
* [x] Edge cases

> Source of truth: red runs on `main` for the **Lint Helm Charts** workflow (e.g. run `27408901611` and prior). This PR's green run: `27409958042`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
