### PR TITLE
fix(security): harden mcpo + mongod securityContext, scope-ignore KSV-0109 false positives

### DIFF
--- a/.github/workflows/release-helm-charts.yml
+++ b/.github/workflows/release-helm-charts.yml
@@ -86,6 +86,11 @@ jobs:
           format: 'table'
           exit-code: '1'
           severity: 'HIGH,CRITICAL'
+          # Trivy auto-detects a plain `.trivyignore` but NOT `.trivyignore.yaml`,
+          # so the structured (path-scoped) ignore file must be named explicitly.
+          # It scopes the KSV-0109 false positives to two specific ConfigMap
+          # templates — see .trivyignore.yaml for the justification.
+          trivyignores: '.trivyignore.yaml'
 
       - name: Configure Git
         if: github.event_name == 'workflow_dispatch'

--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -1,0 +1,28 @@
+# Trivy misconfiguration ignores for the chart `config` scan.
+#
+# Read by BOTH Trivy gates over charts/ — the dedicated Security Audit workflow
+# (.github/workflows/security.yml → ADORSYS-GIS/ai-ops security-gates) and the
+# release-helm-charts workflow — since each checks out this repo and Trivy reads
+# this file from the working directory.
+#
+# Policy: keep every entry SCOPED (id + explicit paths) and justified. Never a
+# blanket whole-ID ignore — a real finding in another chart must still fail.
+# Path-scoping is deliberately brittle: if a template is renamed/moved the
+# ignore stops applying and the finding re-surfaces for re-review.
+misconfigurations:
+  - id: KSV-0109
+    # KSV-0109 "ConfigMap with secrets" — FALSE POSITIVE here: these two
+    # ConfigMap keys are merely NAMED *secret* but carry no secret VALUE.
+    #  - keycloak-baseline realm-configmap `clientSecret:` renders EMPTY (no
+    #    value set in values.yaml; the IdP brokering secret is supplied
+    #    out-of-band, not from this ConfigMap).
+    #  - librechat-config `client_secret:` is a `${GITHUB_MCP_SECRET_ID}` /
+    #    `${CD_MCP_SECRET_ID}` env placeholder that LibreChat substitutes at
+    #    runtime from an ESO-provided Secret (see CLAUDE.md "Secrets + ESO").
+    # No real secret is ever stored in either ConfigMap.
+    statement: >-
+      ConfigMap keys named *secret* whose values are empty or ${ENV} placeholders;
+      real secrets are injected at runtime via ESO, never stored in the ConfigMap.
+    paths:
+      - "keycloak-baseline/templates/realm-configmap.yaml"
+      - "librechat-app/templates/configmap.yaml"

--- a/charts/librechat-app/values.yaml
+++ b/charts/librechat-app/values.yaml
@@ -792,3 +792,36 @@ db:
   replicaSet:
     name: rs0
     members: 1
+  # Pod + container hardening so the mongod StatefulSet clears Trivy
+  # KSV-0118 (non-default securityContext) + KSV-0014 (readOnlyRootFilesystem).
+  # The official `mongo` image runs fine as UID 999 (its own `mongodb` user);
+  # the chart already sets fsGroup 999 so the data PVC stays writable. With a
+  # read-only root fs mongod still needs a writable /tmp — it puts its unix
+  # socket at /tmp/mongodb-27017.sock — so a `tmp` emptyDir is mounted there via
+  # the subchart's extraVolumes/extraVolumeMounts.
+  # ⚠️ This reconciles onto the LIVE LibreChat database (a mongod pod restart) —
+  # roll out deliberately and watch the StatefulSet come Ready.
+  podSecurityContext:
+    fsGroup: 999
+    runAsNonRoot: true
+    runAsUser: 999
+    runAsGroup: 999
+    seccompProfile:
+      type: RuntimeDefault
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 999
+    runAsGroup: 999
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
+    capabilities:
+      drop:
+        - ALL
+    seccompProfile:
+      type: RuntimeDefault
+  extraVolumes:
+    - name: tmp
+      emptyDir: {}
+  extraVolumeMounts:
+    - name: tmp
+      mountPath: /tmp

--- a/charts/mcpo/values.yaml
+++ b/charts/mcpo/values.yaml
@@ -39,6 +39,25 @@ mcpo:
                   type: Utilization
                   averageUtilization: 80
 
+  # Pod-level hardening (bjw-template applies this to every pod). Pairs with the
+  # per-container securityContext below so the Deployment clears Trivy KSV-0118
+  # (non-default securityContext) + KSV-0014 (readOnlyRootFilesystem). The
+  # upstream open-webui/mcpo image ships as root with HOME=/root; running as a
+  # non-root UID + a read-only root fs therefore needs writable emptyDirs for
+  # /tmp and HOME (the MCP servers are spawned via npx/uvx, which write package
+  # caches under $HOME) — mounted via `persistence` below, with HOME + cache
+  # dirs redirected via env. ⚠️ mcpo is NOT a deployed app today (no entry in
+  # charts/apps), so this hardening is render-/scan-verified but untested at
+  # runtime; validate the pod when/if mcpo is enabled.
+  defaultPodOptions:
+    securityContext:
+      runAsNonRoot: true
+      runAsUser: 1000
+      runAsGroup: 1000
+      fsGroup: 1000
+      seccompProfile:
+        type: RuntimeDefault
+
   controllers:
     main:
       type: deployment
@@ -60,13 +79,31 @@ mcpo:
             pullPolicy: IfNotPresent
           
           command: /bin/sh
-          
+
           args:
             - -c
             - |
               set -e
               mcpo --api-key $API_KEY --config=/tmp/config.json
-          
+
+          # Container-level hardening (KSV-0014 + KSV-0118). Root fs is read-only;
+          # writable paths (/tmp, HOME) come from the emptyDirs in `persistence`.
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+
+          # Redirect HOME + the npm/uv caches to the writable `home` emptyDir so
+          # the npx/uvx-spawned MCP servers can write their package caches under
+          # a read-only root fs.
+          env:
+            HOME: /home/app
+            XDG_CACHE_HOME: /home/app/.cache
+            npm_config_cache: /home/app/.npm
+            UV_CACHE_DIR: /home/app/.cache/uv
+
           resources:
             requests:
               cpu: 1000m
@@ -182,4 +219,21 @@ mcpo:
             - path: /tmp/config.json
               readOnly: true
               subPath: config.json
+    # Writable scratch for a read-only root fs (securityContext above). /tmp is
+    # for runtime temp (the config.json subPath mount sits on top of it); home
+    # backs HOME=/home/app for the npx/uvx package caches.
+    tmp:
+      enabled: true
+      type: emptyDir
+      advancedMounts:
+        main:
+          mcpo:
+            - path: /tmp
+    home:
+      enabled: true
+      type: emptyDir
+      advancedMounts:
+        main:
+          mcpo:
+            - path: /home/app
   


### PR DESCRIPTION
## 1. Summary

This PR changes:

- **mcpo** (`charts/mcpo`): adds a pod + container `securityContext` (runAsNonRoot, drop ALL caps, `allowPrivilegeEscalation: false`, `readOnlyRootFilesystem: true`, seccomp `RuntimeDefault`) + writable `tmp`/`home` emptyDirs and redirected HOME/npm/uv caches.
- **librechat-app mongod** (`charts/librechat-app` `db:`): sets the mongodb subchart's pod + container `securityContext` (UID 999, read-only rootfs, drop ALL, seccomp) + a writable `/tmp` emptyDir for mongod's unix socket.
- Adds a **path-scoped** `.trivyignore.yaml` for the two **KSV-0109 false positives**, and points the release workflow's Trivy step at it via `trivyignores`.

It solves:

- The **Release Helm Charts** workflow being red on its inline Trivy `config` gate (7 HIGH findings) on every recent `main` commit. Source of truth: the failing runs of https://github.com/ADORSYS-GIS/ai-helm/actions/workflows/release-helm-charts.yml. Supersedes the closed remove-the-gate PR #377 (which would have dropped the only newer-Trivy gate — see #377's Codex review).

---

## 2. Intent

The intent is to make the release Trivy gate green by **fixing the real misconfigs and scope-ignoring only the false positives** — keeping the gate blocking for any *new* HIGH/CRITICAL finding.

The 7 HIGH findings:

| Finding | Resource | Disposition |
|---|---|---|
| KSV-0014 + KSV-0118 ×3 | `mcpo` Deployment | **Fixed** (securityContext + writable emptyDirs) |
| KSV-0014 + KSV-0118 ×2 | `librechat-app` mongod StatefulSet | **Fixed** (securityContext + `/tmp` emptyDir) |
| KSV-0109 ×2 | `keycloak-baseline-realm`, `librechat-config` ConfigMaps | **False positive** → path-scoped `.trivyignore.yaml` |

KSV-0109 is a false positive: both ConfigMap keys are merely *named* `*secret*` — keycloak `clientSecret` renders **empty** (IdP secret supplied out-of-band) and librechat `client_secret` is a `${GITHUB_MCP_SECRET_ID}`/`${CD_MCP_SECRET_ID}` env placeholder LibreChat substitutes at runtime from an ESO Secret. The ignore is scoped to the two template files, not a blanket KSV-0109 suppression.

---

## 3. Scope

### In Scope

- `charts/mcpo/values.yaml`, `charts/librechat-app/values.yaml` — securityContext + writable mounts.
- `.trivyignore.yaml` (new) — scoped KSV-0109 ignore with justification.
- `.github/workflows/release-helm-charts.yml` — `trivyignores: '.trivyignore.yaml'` (Trivy auto-detects plain `.trivyignore` but **not** `.trivyignore.yaml`).

### Out of Scope

- The canonical Security Audit gate (`security-gates@v1.0.0`, trivy-action `v0.35.0`) finds **0 HIGH** today regardless. When the org bumps it past v0.35 it'll read the same fixes; the 2 ignores will then need the org workflow to pass `.trivyignore.yaml` (or newer-Trivy auto-detection) — noted as follow-up.

---

## 4. Verification

I verified this change by:

- [x] Running manual tests
- [x] Checking logs
- [x] Reviewing the diff
- [x] Testing error cases

Commands run (Trivy **0.70.0** — the exact binary `trivy-action@v0.36.0` bundles, not my newer local 0.71.1 which flags extra v0.71-only checks):

```bash
# Full CI release-gate simulation:
trivy config charts/ --severity HIGH,CRITICAL --ignorefile .trivyignore.yaml --exit-code 1
# -> exit 0, 0 HIGH/CRITICAL

# Per-finding: mcpo + librechat-app cleared by the securityContext fixes
trivy config charts/mcpo --severity HIGH,CRITICAL          # no HIGH
trivy config charts/librechat-app --severity HIGH,CRITICAL # only KSV-0109 (then ignored)

# Charts still render + lint:
helm lint charts/mcpo ; helm lint charts/librechat-app --strict
helm template x charts/mcpo --dry-run ; helm template x charts/librechat-app --dry-run
```

Results:

```text
trivy 0.70.0 config charts/ --ignorefile .trivyignore.yaml --exit-code 1  ->  EXIT 0  (0 HIGH/CRITICAL)
helm lint/template mcpo + librechat-app  ->  OK
rendered mongod: runAsUser 999 + readOnlyRootFilesystem + /tmp emptyDir
rendered mcpo:   runAsUser 1000 + readOnlyRootFilesystem + /tmp + /home/app emptyDirs + HOME/cache env
```

---

## 5. Screenshots / Evidence

* Logs: red **Release Helm Charts** Trivy step (7 HIGH) → local Trivy 0.70.0 simulation with this branch = exit 0.

---

## 6. Risk Assessment

Risk level:

* [ ] Low
* [x] Medium
* [ ] High

Potential risks:

* ⚠️ **The mongod change reconciles onto the LIVE LibreChat database** (`librechat-db`) — applying the new securityContext restarts the mongod pod. If `readOnlyRootFilesystem` were missing a writable path mongod wouldn't come back.
* mcpo runs as non-root + read-only rootfs for the first time; its MCP servers download via npx/uvx into the new writable caches.

Mitigation:

* mongod's only writable needs are `/data/db` (PVC, kept writable via fsGroup 999) and `/tmp` (socket) — a `/tmp` emptyDir is mounted; the official `mongo` image runs cleanly as UID 999. **Roll out deliberately and watch the StatefulSet come Ready**; revert is a one-commit rollback.
* **mcpo is not a deployed app** (no `charts/apps` entry), so its hardening has zero live blast radius today; validate at runtime if/when enabled (flagged in `charts/mcpo/values.yaml`).
* The Trivy gate stays blocking (`exit-code: 1`); the KSV-0109 ignore is path-scoped, so a real secret-in-ConfigMap elsewhere still fails.

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [x] Reviewing the diff
* [ ] Not used

Human verification:

* [ ] I understand every meaningful change in this PR
* [ ] I checked generated code manually
* [ ] I accept responsibility for this PR

> AI (Claude Opus 4.8) diagnosed the findings, fixed the securityContext, and verified against the exact CI Trivy version (0.70.0) that the gate goes green (0 HIGH) and the charts still render/lint. Maintainer to tick the human-verification boxes — **especially review the live-DB mongod restart** before merge/sync.

---

## 8. Reviewer Focus

Please focus your review on:

* [x] Security
* [x] Correctness
* [x] Edge cases

> Highest-attention item: the **mongod securityContext on the live LibreChat DB** (restart + read-only rootfs). Companion CI fixes: lint #375 (merged), and this supersedes the closed #377.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
