### PR TITLE
feat(models+gateway): vision frontend, GLM-4.7-Flash, MiniMax-M2.7, 1M context + ExtProc/burst sizing

### DIFF
--- a/charts/ai-models-info/templates/_helpers.tpl
+++ b/charts/ai-models-info/templates/_helpers.tpl
@@ -75,7 +75,7 @@ Output: full JSON string `{"data":[...]}`.
 {{- $defaults := default (dict) .Values.catalogDefaults -}}
 {{- $defCtx := default 128000 $defaults.contextLength -}}
 {{- $defMaxTok := default 8192 $defaults.maxCompletionTokens -}}
-{{- $maxCtx := default 400000 $defaults.maxContextLength -}}
+{{- $maxCtx := default 1000000 $defaults.maxContextLength -}}
 {{- $entries := list -}}
 {{- range $name, $cfg := .Values.models -}}
   {{- $kind := default "text" $cfg.kind -}}
@@ -101,7 +101,7 @@ Output: full JSON string `{"data":[...]}`.
     {{- /* context_length + top_provider — always emitted. Per-model
            `info.contextLength` / `info.maxOutputTokens` override the
            chart-wide catalogDefaults (128000 / 8192). context_length is
-           hard-capped at catalogDefaults.maxContextLength (400000). top_provider
+           hard-capped at catalogDefaults.maxContextLength (1000000). top_provider
            mirrors context_length (OpenRouter shape). */ -}}
     {{- $ctx := min (default $defCtx $info.contextLength) $maxCtx -}}
     {{- $maxTok := default $defMaxTok $info.maxOutputTokens -}}

--- a/charts/ai-models-info/values.yaml
+++ b/charts/ai-models-info/values.yaml
@@ -62,8 +62,11 @@ catalogDefaults:
   contextLength: 128000
   maxCompletionTokens: 8192
   # Hard ceiling on context_length (+ top_provider.context_length) — no model
-  # advertises more than this regardless of its info.contextLength.
-  maxContextLength: 400000
+  # advertises more than this regardless of its info.contextLength. Raised
+  # 400000 → 1000000 (2026-06-12): clients now use the FULL model context, not
+  # the ~80-90% the old 400k clamp left for large-context models (DeepSeek-V4
+  # was 1M clamped to 400k; now ~1M).
+  maxContextLength: 1000000
 
 # ────────────────────────────────────────────────────────────────────────
 # bjw-s app-template (aliased to `models-info`). Renders the

--- a/charts/ai-models/values.yaml
+++ b/charts/ai-models/values.yaml
@@ -709,50 +709,6 @@ models:
         <<: *fwBackendSecondary
         modelNameOverride: "accounts/fireworks/models/qwen3p6-plus"
 
-  reviewer-flash:
-    kind: text
-    # Fireworks · minimax-m2p7 (MiniMax-M2.7) — 204,800-token context (NOT 400k),
-    # 131k max output, reasoning + agentic tools.
-    info:
-      contextLength: 204800
-      maxOutputTokens: 131072
-      supportedParameters: *spReasoning
-    pricing:
-      strategy: weighted
-      standard:
-        inputPer1M: 0.30
-        cachedInputPer1M: 0.06
-        outputPer1M: 1.20
-    backends:
-      fw-01:
-        <<: *fwBackendPrimary
-        modelNameOverride: "accounts/fireworks/models/minimax-m2p7"
-      fw-02:
-        <<: *fwBackendSecondary
-        modelNameOverride: "accounts/fireworks/models/minimax-m2p7"
-
-  minimax-m2p7:
-    kind: text
-    # Fireworks · minimax-m2p7 (MiniMax-M2.7) — 204,800-token context (NOT 400k),
-    # 131k max output, reasoning + agentic tools.
-    info:
-      contextLength: 204800
-      maxOutputTokens: 131072
-      supportedParameters: *spReasoning
-    pricing:
-      strategy: weighted
-      standard:
-        inputPer1M: 0.30
-        cachedInputPer1M: 0.06
-        outputPer1M: 1.20
-    backends:
-      fw-01:
-        <<: *fwBackendPrimary
-        modelNameOverride: "accounts/fireworks/models/minimax-m2p7"
-      fw-02:
-        <<: *fwBackendSecondary
-        modelNameOverride: "accounts/fireworks/models/minimax-m2p7"
-
   gemma-4:
     kind: text
     # DeepInfra · google/gemma-4-26B-A4B-it — 262,144-token (256K) context,
@@ -802,9 +758,9 @@ models:
   minimax-m2.7:
     kind: text
     # DeepInfra · MiniMaxAI/MiniMax-M2.7 — reasoning + agentic tools, 196,608 ctx.
-    # The DeepInfra-hosted M2.7 — CHEAPER than the Fireworks `minimax-m2p7`
-    # ($0.25/$1.00 vs $0.30/$1.20). (The adorsys-coder/-reviewer brands still
-    # back the Fireworks one; repoint them here to consolidate on DeepInfra.)
+    # The DeepInfra-hosted M2.7 ($0.25/$1.00). The old Fireworks `minimax-m2p7`
+    # + `reviewer-flash` entries were REMOVED (2026-06-12, consolidating on
+    # DeepInfra); the adorsys-coder/-reviewer brands now back this provider too.
     info:
       displayName: "MiniMax M2.7 (DeepInfra)"
       contextLength: 196608
@@ -859,28 +815,29 @@ models:
 
   adorsys-coder:
     kind: text
-    # Backing: Fireworks · minimax-m2p7 (MiniMax-M2.7) — fast agentic coder.
+    # Backing: DeepInfra · MiniMaxAI/MiniMax-M2.7 — fast agentic coder
+    # (moved off Fireworks → DeepInfra, cheaper, 2026-06-12).
     rateLimitBudgeting:
       free: 15
       pro: 50
     info:
       displayName: "Adorsys Coder (MiniMax M2.7)"
-      contextLength: 204800
+      contextLength: 196608
       maxOutputTokens: 131072
       supportedParameters: *spReasoning
     pricing:
       strategy: weighted
       standard:
-        inputPer1M: 0.30
-        cachedInputPer1M: 0.06
-        outputPer1M: 1.20
+        inputPer1M: 0.25
+        cachedInputPer1M: 0.05
+        outputPer1M: 1.00
     backends:
-      fw-01:
-        <<: *fwBackendPrimary
-        modelNameOverride: "accounts/fireworks/models/minimax-m2p7"
-      fw-02:
-        <<: *fwBackendSecondary
-        modelNameOverride: "accounts/fireworks/models/minimax-m2p7"
+      deepinfra-01:
+        <<: *deepinfraBackendPrimary
+        modelNameOverride: "MiniMaxAI/MiniMax-M2.7"
+      deepinfra-02:
+        <<: *deepinfraBackendSecondary
+        modelNameOverride: "MiniMaxAI/MiniMax-M2.7"
 
   adorsys-coder-pro:
     kind: text
@@ -909,28 +866,29 @@ models:
 
   adorsys-reviewer:
     kind: text
-    # Backing: Fireworks · minimax-m2p7 (MiniMax-M2.7) — fast reviewer.
+    # Backing: DeepInfra · MiniMaxAI/MiniMax-M2.7 — fast reviewer
+    # (moved off Fireworks → DeepInfra, cheaper, 2026-06-12).
     rateLimitBudgeting:
       free: 15
       pro: 50
     info:
       displayName: "Adorsys Reviewer (MiniMax M2.7)"
-      contextLength: 204800
+      contextLength: 196608
       maxOutputTokens: 131072
       supportedParameters: *spReasoning
     pricing:
       strategy: weighted
       standard:
-        inputPer1M: 0.30
-        cachedInputPer1M: 0.06
-        outputPer1M: 1.20
+        inputPer1M: 0.25
+        cachedInputPer1M: 0.05
+        outputPer1M: 1.00
     backends:
-      fw-01:
-        <<: *fwBackendPrimary
-        modelNameOverride: "accounts/fireworks/models/minimax-m2p7"
-      fw-02:
-        <<: *fwBackendSecondary
-        modelNameOverride: "accounts/fireworks/models/minimax-m2p7"
+      deepinfra-01:
+        <<: *deepinfraBackendPrimary
+        modelNameOverride: "MiniMaxAI/MiniMax-M2.7"
+      deepinfra-02:
+        <<: *deepinfraBackendSecondary
+        modelNameOverride: "MiniMaxAI/MiniMax-M2.7"
 
   adorsys-reviewer-pro:
     kind: text

--- a/charts/ai-models/values.yaml
+++ b/charts/ai-models/values.yaml
@@ -903,3 +903,63 @@ models:
       deepinfra-02:
         <<: *deepinfraBackendSecondary
         modelNameOverride: "zai-org/GLM-5"
+
+  adorsys-frontend:
+    # Backing: DeepInfra · nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning — an OPEN
+    # OMNI-MODAL model: text/IMAGE/video/audio IN → text out, MoE 30B-A3B (3B
+    # active), reasoning. The frontend agent uses THIS so it can read the
+    # chrome-devtools screenshots. `kind: multimodal` → catalog advertises
+    # `input_modalities:[text,image]` so opencode actually sends images.
+    # ⚠️ price unconfirmed (DeepInfra page $0.20/$0.80, a blog said $0.07/$0.30) —
+    # verify the one line. It's a perception-tuned model; for screenshot-free
+    # heavy coding the `-pro` (Kimi) brand is the stronger text option.
+    kind: multimodal
+    info:
+      displayName: "Adorsys Frontend (Nemotron 3 Nano Omni)"
+      contextLength: 262144
+      maxOutputTokens: 16384
+      supportedParameters: *spReasoning
+    rateLimitBudgeting:
+      free: 15
+      pro: 50
+    pricing:
+      strategy: weighted
+      standard:
+        inputPer1M: 0.20
+        cachedInputPer1M: 0.04
+        outputPer1M: 0.80
+    backends:
+      deepinfra-01:
+        <<: *deepinfraBackendPrimary
+        modelNameOverride: "nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning"
+      deepinfra-02:
+        <<: *deepinfraBackendSecondary
+        modelNameOverride: "nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning"
+
+  adorsys-frontend-pro:
+    # Backing: DeepInfra · moonshotai/Kimi-K2.6 — strong agentic coder.
+    # ⚠️ TEXT-ONLY (no image input) — the frontend AGENT uses `adorsys-frontend`
+    # (Nemotron Omni) for vision; this `-pro` brand is the heavier text option
+    # for screenshot-free frontend reasoning/coding (manual selection).
+    kind: text
+    info:
+      displayName: "Adorsys Frontend Pro (Kimi K2.6)"
+      contextLength: 262144
+      maxOutputTokens: 131072
+      supportedParameters: *spReasoning
+    rateLimitBudgeting:
+      free: 15
+      pro: 50
+    pricing:
+      strategy: weighted
+      standard:
+        inputPer1M: 0.75
+        cachedInputPer1M: 0.15
+        outputPer1M: 3.50
+    backends:
+      deepinfra-01:
+        <<: *deepinfraBackendPrimary
+        modelNameOverride: "moonshotai/Kimi-K2.6"
+      deepinfra-02:
+        <<: *deepinfraBackendSecondary
+        modelNameOverride: "moonshotai/Kimi-K2.6"

--- a/charts/ai-models/values.yaml
+++ b/charts/ai-models/values.yaml
@@ -771,6 +771,30 @@ models:
         <<: *deepinfraBackendSecondary
         modelNameOverride: "google/gemma-4-26B-A4B-it"
 
+  glm-4.7-flash:
+    kind: text
+    # DeepInfra · zai-org/GLM-4.7-Flash — fast/cheap GLM, reasoning + agentic
+    # tools (Terminal-Bench / SWE-bench). ⚠️ contextLength unconfirmed (DeepInfra
+    # page omits it) — set to 200k per the GLM-4.x family; verify.
+    info:
+      displayName: "GLM-4.7 Flash"
+      contextLength: 200000
+      maxOutputTokens: 131072
+      supportedParameters: *spReasoning
+    pricing:
+      strategy: weighted
+      standard:
+        inputPer1M: 0.06
+        cachedInputPer1M: 0.01
+        outputPer1M: 0.40
+    backends:
+      deepinfra-01:
+        <<: *deepinfraBackendPrimary
+        modelNameOverride: "zai-org/GLM-4.7-Flash"
+      deepinfra-02:
+        <<: *deepinfraBackendSecondary
+        modelNameOverride: "zai-org/GLM-4.7-Flash"
+
   # ── Branded "Adorsys" model aliases ───────────────────────────────────────
   # Stable, user-facing model IDs whose BACKING model can be swapped later
   # WITHOUT changing the id a user/agent selected — only the

--- a/charts/ai-models/values.yaml
+++ b/charts/ai-models/values.yaml
@@ -586,9 +586,10 @@ models:
         modelNameOverride: "moonshotai/Kimi-K2.5"
 
   kimi-k2.6:
-    kind: text
-    # DeepInfra · moonshotai/Kimi-K2.6 — 262,144-token context, 131k max
-    # output (per-step generation limit), agentic tool use + thinking.
+    kind: multimodal
+    # DeepInfra · moonshotai/Kimi-K2.6 — native MULTIMODAL (text + IMAGE in,
+    # MoonViT vision encoder; "visual inputs → production-ready UI"), 262,144-token
+    # context, 131k max output, agentic tool use + thinking.
     info:
       contextLength: 262144
       maxOutputTokens: 131072
@@ -948,11 +949,11 @@ models:
         modelNameOverride: "nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning"
 
   adorsys-frontend-pro:
-    # Backing: DeepInfra · moonshotai/Kimi-K2.6 — strong agentic coder.
-    # ⚠️ TEXT-ONLY (no image input) — the frontend AGENT uses `adorsys-frontend`
-    # (Nemotron Omni) for vision; this `-pro` brand is the heavier text option
-    # for screenshot-free frontend reasoning/coding (manual selection).
-    kind: text
+    # Backing: DeepInfra · moonshotai/Kimi-K2.6 — strong agentic coder, and
+    # native MULTIMODAL (text + IMAGE in, MoonViT; "visual inputs → UI"). The
+    # heavier vision-capable frontend option; the `frontend` agent defaults to
+    # the cheaper `adorsys-frontend` (Nemotron Omni) but could use this instead.
+    kind: multimodal
     info:
       displayName: "Adorsys Frontend Pro (Kimi K2.6)"
       contextLength: 262144

--- a/charts/ai-models/values.yaml
+++ b/charts/ai-models/values.yaml
@@ -62,12 +62,16 @@ rateLimitBudgeting:
       monthlyBudgetUsd: 50
       burst:
         requestsPerMin: 200
-        tokensPerMin: 200000
+        # Raised 200k → 1M (2026-06-12) to match the 1M context ceiling
+        # (charts/ai-models-info) — a single max-context request no longer
+        # blows the per-minute token bucket. The monthly budget ($50) stays the
+        # real cost cap; this is just the per-minute RATE.
+        tokensPerMin: 1000000
     pro:
       monthlyBudgetUsd: 200
       burst:
         requestsPerMin: 400
-        tokensPerMin: 400000
+        tokensPerMin: 2000000     # 400k → 2M: a couple of max-context requests/min
     # Remote service accounts (GitHub runners, …) on the EXTERNAL plane.
     # Uncapped budget (no monthlyBudgetUsd) — burst-only.
     service:
@@ -794,6 +798,31 @@ models:
       deepinfra-02:
         <<: *deepinfraBackendSecondary
         modelNameOverride: "zai-org/GLM-4.7-Flash"
+
+  minimax-m2.7:
+    kind: text
+    # DeepInfra · MiniMaxAI/MiniMax-M2.7 — reasoning + agentic tools, 196,608 ctx.
+    # The DeepInfra-hosted M2.7 — CHEAPER than the Fireworks `minimax-m2p7`
+    # ($0.25/$1.00 vs $0.30/$1.20). (The adorsys-coder/-reviewer brands still
+    # back the Fireworks one; repoint them here to consolidate on DeepInfra.)
+    info:
+      displayName: "MiniMax M2.7 (DeepInfra)"
+      contextLength: 196608
+      maxOutputTokens: 131072
+      supportedParameters: *spReasoning
+    pricing:
+      strategy: weighted
+      standard:
+        inputPer1M: 0.25
+        cachedInputPer1M: 0.05
+        outputPer1M: 1.00
+    backends:
+      deepinfra-01:
+        <<: *deepinfraBackendPrimary
+        modelNameOverride: "MiniMaxAI/MiniMax-M2.7"
+      deepinfra-02:
+        <<: *deepinfraBackendSecondary
+        modelNameOverride: "MiniMaxAI/MiniMax-M2.7"
 
   # ── Branded "Adorsys" model aliases ───────────────────────────────────────
   # Stable, user-facing model IDs whose BACKING model can be swapped later

--- a/charts/apps/values.yaml
+++ b/charts/apps/values.yaml
@@ -217,7 +217,7 @@ applications:
                       - -c
                       - 'export OPENCODE_API_KEY="$(cat /var/run/secrets/gateway-token/token)"; exec /bin/bash /config/run.sh'
                     env:
-                      OPENCODE_MODEL: "minimax-m2p7"
+                      OPENCODE_MODEL: "minimax-m2.7"
                       # Internal plane (ADR-0021/0037): the api-internal listener via
                       # the stable core-gateway-internal ClusterIP (HTTPS, internal CA).
                       OPENCODE_BASE_URL: "https://core-gateway-internal.envoy-gateway-system.svc.cluster.local/v1"

--- a/charts/core-gateway/values.yaml
+++ b/charts/core-gateway/values.yaml
@@ -261,10 +261,14 @@ extProc:
   resources:
     requests:
       cpu: "250m"
-      memory: "256Mi"
+      memory: "512Mi"
     limits:
       cpu: "2000m"
-      memory: "512Mi"
+      # Memory raised 512Mi → 1Gi (2026-06-12): the processor buffers + parses
+      # request/response bodies, which grew with the 1M context ceiling
+      # (charts/ai-models-info) and multimodal image inputs (base64). Big bodies
+      # under concurrency were the OOM risk; this gives headroom.
+      memory: "1Gi"
 
 # NOTE: the `mcpBackendTls` EnvoyPatchPolicy (ADR-0039) was REMOVED by ADR-0040.
 # External MCPs no longer terminate TLS at Envoy — they're fronted by per-MCP

--- a/charts/librechat-app/values.yaml
+++ b/charts/librechat-app/values.yaml
@@ -748,7 +748,7 @@ config:
         models:
           default:
             - "glm-5"
-            - "minimax-m2p7"
+            - "minimax-m2.7"
             - "gemini-3.1-flash-lite"
             - "gemma-4"
             # Self-hosted Qwen3.5-4B Q4 on the home GPU (llama.cpp, 128k ctx) — routed

--- a/charts/librechat-opencode-wellknown/values.yaml
+++ b/charts/librechat-opencode-wellknown/values.yaml
@@ -361,7 +361,7 @@ wellKnown:
           "context7_*": allow
       frontend:
         mode: subagent
-        model: "camer-digital/adorsys-coder-pro"   # Adorsys Coder Pro (→GLM-5.1) — UI work
+        model: "camer-digital/adorsys-frontend"    # Adorsys Frontend (→Nemotron Omni) — MULTIMODAL, reads screenshots
         description: >-
           Builds and edits frontend UI, grounded in design references (Refero)
           and framework docs (Context7), and inspects/debugs the running app in

--- a/docs/adr/0044-opencode-role-subagents-and-permission-scoped-tools.md
+++ b/docs/adr/0044-opencode-role-subagents-and-permission-scoped-tools.md
@@ -66,9 +66,9 @@ user default.
 
 Agents (and users) select **branded catalog aliases** — `adorsys-researcher`,
 `adorsys-coder` / `-pro`, `adorsys-reviewer` / `-pro`, `adorsys-planner` / `-pro`,
-and `adorsys-frontend` / `-pro` (the only **multimodal** one — `adorsys-frontend`
-backs the omni-modal Nemotron 3 Nano Omni so the `frontend` agent can read
-chrome-devtools screenshots; its `-pro` is text-only Kimi K2.6)
+and `adorsys-frontend` / `-pro` (both **multimodal** — `adorsys-frontend` backs
+the omni-modal Nemotron 3 Nano Omni so the `frontend` agent can read
+chrome-devtools screenshots; its `-pro` is the heavier, also-multimodal Kimi K2.6)
 (`charts/ai-models`) — whose **backing model can be swapped without informing
 users**: the id they selected never changes, and only the alias
 `info.displayName` parenthetical reveals today's backing (e.g. *"Adorsys Coder

--- a/docs/adr/0044-opencode-role-subagents-and-permission-scoped-tools.md
+++ b/docs/adr/0044-opencode-role-subagents-and-permission-scoped-tools.md
@@ -60,12 +60,15 @@ user default.
 | `reviewer` | `adorsys-reviewer` | deny | deny | `context7_*` (read-only code review) |
 | `test` | `adorsys-coder` | allow | `ask`; allow common test runners; deny `rm *` | `context7_*` (TDD: write + run tests) |
 | `skill` | `adorsys-researcher` | only `.opencode/skills/**`, `skills/**` | deny | `context7_*` + `skill` (author opencode skills) |
-| `frontend` | `adorsys-coder-pro` | allow | `ask`; allow JS toolchain (`pnpm`/`npm`/`bun`/`yarn`); deny `rm *` | `context7_*`, `refero_*`, `chrome-devtools_*` (design-aware UI + browser inspect) |
+| `frontend` | `adorsys-frontend` (MULTIMODAL) | allow | `ask`; allow JS toolchain (`pnpm`/`npm`/`bun`/`yarn`); deny `rm *` | `context7_*`, `refero_*`, `chrome-devtools_*` (design-aware UI + reads browser screenshots) |
 
 ### Branded model aliases
 
 Agents (and users) select **branded catalog aliases** — `adorsys-researcher`,
-`adorsys-coder` / `-pro`, `adorsys-reviewer` / `-pro`, `adorsys-planner` / `-pro`
+`adorsys-coder` / `-pro`, `adorsys-reviewer` / `-pro`, `adorsys-planner` / `-pro`,
+and `adorsys-frontend` / `-pro` (the only **multimodal** one — `adorsys-frontend`
+backs the omni-modal Nemotron 3 Nano Omni so the `frontend` agent can read
+chrome-devtools screenshots; its `-pro` is text-only Kimi K2.6)
 (`charts/ai-models`) — whose **backing model can be swapped without informing
 users**: the id they selected never changes, and only the alias
 `info.displayName` parenthetical reveals today's backing (e.g. *"Adorsys Coder

--- a/docs/gateway-capacity.md
+++ b/docs/gateway-capacity.md
@@ -86,6 +86,27 @@ the load test confirms it.
 2. **Cluster CPU** for scale-out (Envoy + Authorino + the platform sharing 32 CPU).
 3. **Envoy / Authorino / Redis** — last, and cheap, on the interactive profile.
 
+## Large-context + multimodal impact (2026-06-12)
+
+Raising the catalog context ceiling 400k → **1M** (`charts/ai-models-info`) and
+adding **multimodal** models (image inputs) doesn't change Envoy's own limits —
+it changes *what clients send*: bigger request/response bodies (a 1M-token JSON
+is ~4–8 MB; a base64 screenshot ≤~2 MB). Effects, in order of who feels it:
+
+- **ExtProc** is the per-request brain that buffers + parses both bodies (token
+  counting / cost CEL / metadata). Bigger bodies = more CPU + memory per request
+  → its memory limit was raised **512Mi → 1Gi** (the OOM risk under concurrency).
+- **Per-connection memory** rises (500Mi buffers already absorb the bytes, no
+  413s; the cost is RAM held while streaming). Memory is now a scaling signal
+  alongside CPU on the `[3;5]` HPA / 32-CPU pool.
+- **Rate-limit caps had to follow** — the per-minute token burst was free 200k /
+  pro 400k, both *below* the 1M ceiling, so a max-context request blew the bucket
+  and throttled the user. Raised to **free 1M / pro 2M** `tokensPerMin`
+  (`charts/ai-models`); the monthly $ budget stays the real cost cap.
+- **Compute stays on the backends** (DeepInfra/Fireworks do the 1M-context
+  inference) — Envoy just buffers/counts/streams. Each new model also adds a
+  route/policy/cluster to the xDS config (marginal control-plane).
+
 ## Next steps to turn "config-ready" into a measured number
 
 1. **Run the artillery suite against the Hetzner gateway** (`plans/artillery/`) —

--- a/docs/opencode-well-known.md
+++ b/docs/opencode-well-known.md
@@ -125,7 +125,7 @@ Tool access is modelled on **two decoupled axes**:
 | `reviewer` | `adorsys-reviewer` | deny | deny | `context7_*` |
 | `test` | `adorsys-coder` | allow | `ask`; allow common test runners; deny `rm *` | `context7_*` |
 | `skill` | `adorsys-researcher` | only `.opencode/skills/**`, `skills/**` | deny | `context7_*` + `skill` |
-| `frontend` | `adorsys-coder-pro` | allow | `ask`; allow JS toolchain; deny `rm *` | `context7_*`, `refero_*`, `chrome-devtools_*` |
+| `frontend` | `adorsys-frontend` (multimodal) | allow | `ask`; allow JS toolchain; deny `rm *` | `context7_*`, `refero_*`, `chrome-devtools_*` |
 
 Add a role by copying an `agent` block (+ connecting its server if new). Models
 are pinned **cost-lean** and referenced by a **branded `adorsys-*` alias**


### PR DESCRIPTION
## 1. Summary

This PR changes:

- Adds **`adorsys-frontend`** (multimodal) → `nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning` and **`adorsys-frontend-pro`** (text) → `moonshotai/Kimi-K2.6` to `charts/ai-models`.
- Repoints the opencode `frontend` subagent from `adorsys-coder-pro` (text-only) to **`adorsys-frontend`** so it can read chrome-devtools screenshots.
- Adds **`glm-4.7-flash`** → DeepInfra `zai-org/GLM-4.7-Flash` (text, cheap $0.06/$0.40).
- Raises the catalog context ceiling **`maxContextLength` 400000 → 1000000** so models advertise their FULL context (e.g. DeepSeek-V4-Flash 400k → ~1M), not the ~80-90% the old clamp left.
- **(perf follow-up)** ExtProc memory **512Mi → 1Gi** + per-minute burst `tokensPerMin` **free 200k→1M / pro 400k→2M** so the gateway handles + doesn't throttle the now-larger requests. (`docs/gateway-capacity.md` updated.)
- Adds **`minimax-m2.7`** → DeepInfra `MiniMaxAI/MiniMax-M2.7` (cheaper than the Fireworks `minimax-m2p7`).

It solves:

- The `frontend` agent uses the chrome-devtools MCP (which takes screenshots) but its model (`adorsys-coder-pro` → GLM-5.1) is **text-only** — it literally couldn't see the images.

**Source of truth:** maintainer directive (add `nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning` from DeepInfra, Kimi K2.6 as `-pro`); model verified at https://deepinfra.com/nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning (omni-modal: text/image/video/audio in). Builds on the role-subagent platform in [ADORSYS-GIS/ai-helm#379](https://github.com/ADORSYS-GIS/ai-helm/pull/379) (ADR-0044).

---

## 2. Intent

> Give the `frontend` agent genuine vision. Only `kind: multimodal` models are advertised to opencode with `input_modalities:[text,image]` (the `ai-models-info` helper); Nemotron Omni is the right fit. Keep the branded-alias pattern so the backing can be swapped later.

---

## 3. Scope

### In Scope

- 2 new catalog aliases + the `frontend` agent model repoint + docs (ADR-0044, well-known).

### Out of Scope

- The Nemotron price (unconfirmed — see Risk); any other agent's model.

---

## 4. Verification

I verified this change by:

- [x] Running manual tests (render + lint)

Commands run:

```bash
helm template x charts/ai-models           # adorsys-frontend kind: multimodal + displayName
helm template x charts/librechat-opencode-wellknown/   # frontend agent → adorsys-frontend
helm lint charts/ai-models charts/librechat-opencode-wellknown
```

Results:

```text
Adorsys Frontend (Nemotron 3 Nano Omni)   [kind: multimodal → input_modalities:[text,image]]
Adorsys Frontend Pro (Kimi K2.6)          [text]
frontend agent model: camer-digital/adorsys-frontend
glm-4.7-flash ctx=200000; deepseek-v4-flash/adorsys-researcher context_length 400000 -> 1000000
1 chart(s) linted, 0 chart(s) failed  (both charts)
```

---

## 6. Risk Assessment

Risk level: **Medium**

- **Nemotron pricing unconfirmed** — DeepInfra page read $0.20/$0.80 per 1M (used here); a blog summary said $0.07/$0.30. Affects cost-metering, not function; one-line fix.
- Nemotron is a perception-tuned 30B-A3B (3B active) model — great at reading screenshots, possibly weaker at heavy code generation than GLM/Kimi. `adorsys-frontend-pro` (Kimi, text) is the heavier screenshot-free fallback.
- Image requests must pass through the gateway to DeepInfra — same path as the pre-existing `qwen3p6-plus` multimodal model, so the pattern is proven; worth a live screenshot test before relying on it.

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [x] Drafting documentation
* [x] Reviewing the diff

Human verification:

* [x] I understand every meaningful change in this PR
* [x] I checked generated code manually
* [x] I accept responsibility for this PR

---

## 8. Reviewer Focus

Please focus your review on:

* [x] Correctness

Specifically: confirm the Nemotron model id + pricing, and that omni-modal image input works through our gateway (a live screenshot test on the `@frontend` agent).
