### PR TITLE
feat(opencode): route inference via the OpenAI Responses API (responseApi)

### DIFF
--- a/charts/librechat-opencode-wellknown/values.yaml
+++ b/charts/librechat-opencode-wellknown/values.yaml
@@ -90,6 +90,27 @@ wellKnown:
             # breaks headless / remote-dev use.
             authFlow: device_code
             syncIntervalMinutes: 60
+            # Route inference through the OpenAI **Responses API**
+            # (`/v1/responses`) instead of Chat Completions
+            # (`/v1/chat/completions`). Requires the plugin ≥ 0.6.2
+            # (vymalo/opencode-oauth2#37; opencode auto-pulls latest at
+            # startup). Mechanically this swaps the registered AI-SDK
+            # package from `@ai-sdk/openai-compatible` (chat-only) to the
+            # native `@ai-sdk/openai`, whose default languageModel() has
+            # targeted Responses since AI SDK v5; with our `/v1` baseURL it
+            # resolves to the gateway's `/v1/responses`. Auth is untouched —
+            # the real OAuth bearer is still injected per request by the
+            # plugin's chat.headers hook (the native provider's mandatory
+            # apiKey is stamped with an inert placeholder that's never sent).
+            #
+            # The flag ALSO enables the plugin's streaming SSE index-repair,
+            # which injects the `output_index`/`content_index` fields our
+            # Envoy AI Gateway omits from its Responses SSE stream — without
+            # them OpenCode's part layer aborts with `text part <id> not
+            # found`. Verified live end-to-end against this gateway in the PR.
+            # Provider-wide (one boolean, no per-model granularity): EVERY
+            # camer-digital request goes through /v1/responses.
+            responseApi: true
           meta:
             # Relative path → resolves to baseURL + "models/info" =
             # https://api.ai.camer.digital/v1/models/info (the

--- a/docs/opencode-well-known.md
+++ b/docs/opencode-well-known.md
@@ -165,7 +165,8 @@ Expected:
             "clientId": "opencode-cli",
             "scopes": ["openid", "profile", "offline_access"],
             "authFlow": "device_code",
-            "syncIntervalMinutes": 60
+            "syncIntervalMinutes": 60,
+            "responseApi": true
           }
         }
       }
@@ -176,6 +177,18 @@ Expected:
 
 Content-Type must be `application/json` (nginx adds it via
 `default_type` in the chart's nginx config).
+
+`oauth2.responseApi: true` (plugin ≥ 0.6.2,
+[vymalo/opencode-oauth2#37](https://github.com/vymalo/opencode-oauth2/pull/37))
+routes inference through the OpenAI **Responses API** (`/v1/responses`)
+instead of Chat Completions by registering the provider with
+`@ai-sdk/openai` rather than `@ai-sdk/openai-compatible`. It also enables
+the plugin's streaming SSE index-repair, which supplies the
+`output_index`/`content_index` fields our Envoy AI Gateway omits (without
+them OpenCode aborts with `text part <id> not found`). It is provider-wide
+— every `camer-digital` request goes through `/v1/responses` — and does not
+touch the token lifecycle. See the inline comment in
+`charts/librechat-opencode-wellknown/values.yaml`.
 
 ## Prerequisites the cluster must satisfy
 


### PR DESCRIPTION
## 1. Summary

This PR changes:

- Sets `oauth2.responseApi: true` on the `camer-digital` provider in the org-wide opencode well-known config (`charts/librechat-opencode-wellknown/values.yaml`), routing all opencode inference through the OpenAI **Responses API** (`/v1/responses`) instead of Chat Completions.
- Updates `docs/opencode-well-known.md` (config example + an explanatory note on the flag).

It solves / source of truth:

- Activates the opt-in flag shipped upstream in **https://github.com/vymalo/opencode-oauth2/pull/37** (released as `@vymalo/opencode-oauth2` 0.6.2). Our plugin list is unpinned (opencode auto-installs `@latest`), so the 0.6.2 code already floats in — this PR is what actually turns the behavior on.

---

## 2. Intent

The intent of this PR is:

> Move the org-wide opencode client onto the OpenAI Responses API (`/v1/responses`). The 0.6.2 plugin swaps `@ai-sdk/openai-compatible` → native `@ai-sdk/openai` and supplies the streaming SSE index-repair (`output_index`/`content_index`) that our Envoy AI Gateway omits — without which OpenCode aborts with `text part <id> not found`. The upstream PR (https://github.com/vymalo/opencode-oauth2/pull/37) verified this live end-to-end against this exact gateway. Auth/token lifecycle and model discovery (`/v1/models/info`) are untouched.

---

## 3. Scope

### In Scope

- The single `responseApi: true` knob + its inline documentation.
- Doc sync in `docs/opencode-well-known.md`.

### Out of Scope

- Any plugin version pin (intentionally unpinned — floats to `@latest`).
- Per-model granularity (the flag is provider-wide by the plugin's design).
- Gateway changes — `/v1/responses` already works on our Envoy AI Gateway (verified upstream).

---

## 4. Verification

I verified this change by:

- [x] Running automated tests (helm lint --strict + render)
- [x] Running manual tests (rendered JSON inspection)
- [ ] Checking logs
- [ ] Checking metrics
- [ ] Testing error cases
- [ ] Testing permissions/security behavior
- [ ] Testing rollback or failure behavior, if relevant

Commands run:

```bash
helm dep build charts/librechat-opencode-wellknown/
helm lint charts/librechat-opencode-wellknown/ --strict
helm template wk charts/librechat-opencode-wellknown/ | grep -o '"oauth2":{[^}]*}'
```

Results:

```text
1 chart(s) linted, 0 chart(s) failed
"oauth2":{"authFlow":"device_code","clientId":"opencode-cli","issuer":"https://auth.verif.fyi/realms/camer-digital","responseApi":true,"scopes":["openid","profile","offline_access"],"syncIntervalMinutes":60}
```

Upstream live verification (`opencode run` against the gateway with `responseApi: true`): see https://github.com/vymalo/opencode-oauth2/pull/37 (2nd commit — failed with `text part not found` pre-repair, succeeds with it).

---

## 5. Screenshots / Evidence

* Upstream PR (mechanics + live e2e): https://github.com/vymalo/opencode-oauth2/pull/37
* Rendered ConfigMap JSON snippet: see §4 Results.

---

## 6. Risk Assessment

Risk level:

* [ ] Low
* [x] Medium
* [ ] High

Potential risks:

* Provider-wide, one-way org push: every opencode user's inference shifts to `/v1/responses` on their next session. If any backend behind the gateway doesn't faithfully implement the Responses wire contract, those models could break.
* The unpinned `@latest` plugin means 0.6.2 lands regardless; this PR only gates the activation.

Mitigation:

* Rollback is a one-line revert of the flag → providers fall back to Chat Completions (default behavior).
* Upstream verified `/v1/responses` + the SSE repair live against this exact Envoy AI Gateway before merge.

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [ ] Refactoring
* [ ] Generating tests
* [x] Drafting documentation
* [x] Reviewing the diff
* [ ] Not used

Human verification:

* [x] I understand every meaningful change in this PR
* [x] I checked generated code manually
* [ ] I checked generated tests manually
* [x] I removed unsupported AI assumptions
* [x] I accept responsibility for this PR

---

## 8. Reviewer Focus

Please focus your review on:

* [x] Correctness
* [ ] Architecture
* [ ] Security
* [ ] Performance
* [ ] Tests
* [x] Maintainability
* [x] Product intent
* [x] Edge cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)
