### PR TITLE
chore(opencode): pin org-wide plugin versions in the well-known config

### DIFF
--- a/charts/librechat-opencode-wellknown/values.yaml
+++ b/charts/librechat-opencode-wellknown/values.yaml
@@ -34,33 +34,45 @@ wellKnown:
   config:
     $schema: https://opencode.ai/config.json
     plugin:
-      # opencode auto-installs both via `bun install` at startup; cached
+      # opencode auto-installs each via `bun install` at startup; cached
       # under ~/.cache/opencode/node_modules/. No user action needed.
-      - "@vymalo/opencode-oauth2"
+      #
+      # VERSION-PINNED on purpose. opencode treats a `name@x.y.z` spec as an
+      # exact pin — it installs that version and runs NO stale/latest checks,
+      # whereas a bare `name` floats to @latest and silently refreshes when
+      # the cache goes stale (per opencode's plugin install spec). Pinning
+      # makes this org-wide push deterministic: every user runs the same
+      # plugin code we validated, and a publish upstream can't change
+      # behaviour under us mid-rollout. Bump these deliberately (and
+      # re-validate) rather than letting them drift. The three @vymalo/*
+      # plugins share one version line (released together, currently 0.6.2).
+      # The lone exception is opencode-skills-collection (kept @latest — see
+      # its note below).
+      - "@vymalo/opencode-oauth2@0.6.2"
       # Enriches the model catalog with context length, pricing,
       # modalities, capability flags. See ADR-0015.
-      - "@vymalo/opencode-models-info"
+      - "@vymalo/opencode-models-info@0.6.2"
       # Reads the IETF draft-03 `x-ratelimit-*` response headers our
       # Envoy AI Gateway emits (the per-model BackendTrafficPolicy,
       # ADR-0021) and makes opencode rate-limit-aware: on a short burst
       # reset it waits the quota out, and on a days-away monthly-budget
       # reset it fails fast — see the per-model-scoped `rateLimit.tiers`
       # under the provider options below.
-      - "@vymalo/opencode-ratelimit"
+      - "@vymalo/opencode-ratelimit@0.6.2"
       # Dynamic Context Pruning — auto-compresses/dedups stale tool
       # outputs and prunes failed-tool inputs from the running context.
       # Zero-config (sensible defaults); provider-agnostic. Pushed
       # org-wide it lowers per-request token spend against the ADR-0021
       # per-user budgets — a cost win for every session. Users can tune
       # via an optional ~/.config/opencode/dcp.jsonc.
-      - "@tarquinen/opencode-dcp"
+      - "@tarquinen/opencode-dcp@3.1.12"
       # Curated skills bundle (1000+) behind a token-efficient
       # "SkillPointer" loader (~80k → ~255 startup tokens vs. inlining
-      # them). Zero-config. MUST stay pinned to @latest — the package
-      # IS the skill catalog, so a fixed version freezes the skills and
-      # defeats its auto-sync. Users can opt into risk-filtering via an
-      # optional ~/.config/opencode/skill-filter.jsonc (all skills load
-      # by default).
+      # them). Zero-config. MUST stay on @latest — the package IS the skill
+      # catalog, so an exact pin would freeze the skills and defeat its
+      # auto-sync. This is the deliberate exception to the version-pinning
+      # above. Users can opt into risk-filtering via an optional
+      # ~/.config/opencode/skill-filter.jsonc (all skills load by default).
       - "opencode-skills-collection@latest"
     provider:
       camer-digital:
@@ -93,8 +105,8 @@ wellKnown:
             # Route inference through the OpenAI **Responses API**
             # (`/v1/responses`) instead of Chat Completions
             # (`/v1/chat/completions`). Requires the plugin ≥ 0.6.2
-            # (vymalo/opencode-oauth2#37; opencode auto-pulls latest at
-            # startup). Mechanically this swaps the registered AI-SDK
+            # (vymalo/opencode-oauth2#37 — we pin 0.6.2 in the plugin list
+            # above). Mechanically this swaps the registered AI-SDK
             # package from `@ai-sdk/openai-compatible` (chat-only) to the
             # native `@ai-sdk/openai`, whose default languageModel() has
             # targeted Responses since AI SDK v5; with our `/v1` baseURL it
@@ -121,9 +133,9 @@ wellKnown:
             # TTL (24h default upstream); override if you want fresher
             # catalogs:
             # modelsInfoTtlSeconds: 3600
-            # @vymalo/opencode-ratelimit config. Requires the plugin
-            # ≥ 0.6.1 (the `scope` + `tiers` schema; opencode auto-pulls
-            # latest at startup). headerPrefix "x-ratelimit" matches
+            # @vymalo/opencode-ratelimit config. Needs the `scope` + `tiers`
+            # schema (plugin ≥ 0.6.1; we pin 0.6.2 in the plugin list
+            # above). headerPrefix "x-ratelimit" matches
             # Envoy's draft-03 header names — plugin default.
             #
             # `scope: model` keys rate-limit state per model, matching

--- a/docs/opencode-well-known.md
+++ b/docs/opencode-well-known.md
@@ -154,7 +154,7 @@ Expected:
   },
   "config": {
     "$schema": "https://opencode.ai/config.json",
-    "plugin": ["@vymalo/opencode-oauth2"],
+    "plugin": ["@vymalo/opencode-oauth2@0.6.2"],
     "provider": {
       "camer-digital": {
         "name": "Camer Digital",


### PR DESCRIPTION
## 1. Summary

This PR changes:

- Pins the opencode plugins we control to exact versions in the org-wide well-known `config.plugin` list (`charts/librechat-opencode-wellknown/values.yaml`): `@vymalo/opencode-oauth2@0.6.2`, `@vymalo/opencode-models-info@0.6.2`, `@vymalo/opencode-ratelimit@0.6.2`, `@tarquinen/opencode-dcp@3.1.12`.
- Keeps `opencode-skills-collection@latest` floating (deliberate exception — the package IS the skill catalog; a pin would freeze it).
- Refreshes the stale "auto-pulls latest at startup" comments + the doc example.

It solves / source of truth:

- Follow-up to **https://github.com/ADORSYS-GIS/ai-helm/pull/385** (which enabled `responseApi`, shipped in `@vymalo/opencode-oauth2` 0.6.2 via **https://github.com/vymalo/opencode-oauth2/pull/37**). Bare plugin names float to `@latest`, so the org-wide rollout was non-deterministic; this makes it reproducible.

---

## 2. Intent

The intent of this PR is:

> Make the org-wide opencode plugin set deterministic. opencode treats a bare `name` as `@latest` (silently refreshes when the cache goes stale) and a `name@x.y.z` as an exact pin that installs that version with no stale/latest checks — confirmed in opencode's plugin install spec. For a config pushed to every user, pinning means everyone runs the same validated plugin code and an upstream publish can't change behaviour mid-rollout. We bump deliberately and re-validate instead of drifting.

---

## 3. Scope

### In Scope

- Exact pins for the four plugins we own/control.
- Comment + doc-example sync.

### Out of Scope

- `opencode-skills-collection` — intentionally stays `@latest` (catalog auto-sync contract).
- The `responseApi` behaviour itself (already merged in #385).

---

## 4. Verification

I verified this change by:

- [x] Running automated tests (helm lint --strict + render)
- [x] Running manual tests (rendered JSON inspection)
- [ ] Checking logs
- [ ] Checking metrics
- [ ] Testing error cases
- [ ] Testing permissions/security behavior
- [ ] Testing rollback or failure behavior, if relevant

Commands run:

```bash
npm view @vymalo/opencode-oauth2 version          # -> 0.6.2 (and models-info, ratelimit)
npm view @tarquinen/opencode-dcp version          # -> 3.1.12
helm lint charts/librechat-opencode-wellknown/ --strict
helm template wk charts/librechat-opencode-wellknown/ | grep -o '"plugin":\[[^]]*\]'
```

Results:

```text
1 chart(s) linted, 0 chart(s) failed
"plugin":["@vymalo/opencode-oauth2@0.6.2","@vymalo/opencode-models-info@0.6.2","@vymalo/opencode-ratelimit@0.6.2","@tarquinen/opencode-dcp@3.1.12","opencode-skills-collection@latest"]
```

opencode pin support (authoritative): opencode's plugin install spec — *"Explicit npm specs with a version suffix (for example pkg@1.2.3) are pinned. Runtime install requests that exact version and does not run stale/latest checks for newer registry versions."*

---

## 5. Screenshots / Evidence

* opencode plugin install spec: https://github.com/anomalyco/opencode/blob/dev/packages/opencode/specs/tui-plugins.md
* Rendered plugin array: see §4 Results.

---

## 6. Risk Assessment

Risk level:

* [x] Low
* [ ] Medium
* [ ] High

Potential risks:

* Pins must be bumped manually for future fixes — a pinned plugin won't auto-receive an upstream patch.

Mitigation:

* All four pins are the current `@latest` at time of writing (no behaviour change vs. what users would resolve today), so this is purely a determinism/reproducibility hardening.
* Rollback is a one-line revert back to bare names.

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [ ] Refactoring
* [ ] Generating tests
* [x] Drafting documentation
* [x] Reviewing the diff
* [ ] Not used

Human verification:

* [x] I understand every meaningful change in this PR
* [x] I checked generated code manually
* [ ] I checked generated tests manually
* [x] I removed unsupported AI assumptions
* [x] I accept responsibility for this PR

---

## 8. Reviewer Focus

Please focus your review on:

* [x] Correctness
* [ ] Architecture
* [ ] Security
* [ ] Performance
* [ ] Tests
* [x] Maintainability
* [x] Product intent
* [ ] Edge cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)
