### PR TITLE
chore(opencode): pin opencode-skills-collection (full plugin determinism)

### DIFF
--- a/charts/librechat-opencode-wellknown/values.yaml
+++ b/charts/librechat-opencode-wellknown/values.yaml
@@ -68,12 +68,15 @@ wellKnown:
       - "@tarquinen/opencode-dcp@3.1.12"
       # Curated skills bundle (1000+) behind a token-efficient
       # "SkillPointer" loader (~80k → ~255 startup tokens vs. inlining
-      # them). Zero-config. MUST stay on @latest — the package IS the skill
-      # catalog, so an exact pin would freeze the skills and defeat its
-      # auto-sync. This is the deliberate exception to the version-pinning
-      # above. Users can opt into risk-filtering via an optional
+      # them). Zero-config. PINNED like the rest for a fully deterministic
+      # org-wide rollout — nobody's skill set shifts under them between
+      # releases. ⚠️ Trade-off: the package IS the skill catalog, so this
+      # freezes the available skills at this version — BUMP IT DELIBERATELY
+      # (re-validate) when you want the latest catalog; leaving it on @latest
+      # would auto-sync new skills but reintroduces non-determinism. Users
+      # can opt into risk-filtering via an optional
       # ~/.config/opencode/skill-filter.jsonc (all skills load by default).
-      - "opencode-skills-collection@latest"
+      - "opencode-skills-collection@3.0.45"
     provider:
       camer-digital:
         name: "Camer Digital"


### PR DESCRIPTION
## 1. Summary

This PR changes:

- Pins the last floating opencode plugin: `opencode-skills-collection@latest` → `opencode-skills-collection@3.0.45` in the org-wide well-known config (`charts/librechat-opencode-wellknown/values.yaml`). All five plugins are now pinned end-to-end.

It solves / source of truth:

- Follow-up to **https://github.com/ADORSYS-GIS/ai-helm/pull/386** (which pinned the four code plugins and left this one on `@latest`). Maintainer decision: prefer full determinism over the catalog's auto-sync.

---

## 2. Intent

The intent of this PR is:

> Make the org-wide opencode plugin set 100% deterministic. skills-collection was the one exception left on `@latest` because the package is the skill catalog (so `@latest` auto-syncs new skills). The maintainer chose determinism — pin it so no user's skill set shifts under them between releases. Documented trade-off: the catalog is now frozen at 3.0.45 until a deliberate bump + release.

---

## 3. Scope

### In Scope

- The single `opencode-skills-collection` pin + its updated comment.

### Out of Scope

- The other four plugins (already pinned in #386).
- Any skill-content change.

---

## 4. Verification

I verified this change by:

- [x] Running automated tests (helm lint --strict + render)
- [x] Running manual tests (rendered JSON inspection)
- [ ] Checking logs
- [ ] Checking metrics
- [ ] Testing error cases
- [ ] Testing permissions/security behavior
- [ ] Testing rollback or failure behavior, if relevant

Commands run:

```bash
npm view opencode-skills-collection version          # -> 3.0.45
helm lint charts/librechat-opencode-wellknown/ --strict
helm template wk charts/librechat-opencode-wellknown/ | grep -o '"plugin":\[[^]]*\]'
```

Results:

```text
1 chart(s) linted, 0 chart(s) failed
"plugin":["@vymalo/opencode-oauth2@0.6.2","@vymalo/opencode-models-info@0.6.2","@vymalo/opencode-ratelimit@0.6.2","@tarquinen/opencode-dcp@3.1.12","opencode-skills-collection@3.0.45"]
```

---

## 5. Screenshots / Evidence

* Predecessor PR: https://github.com/ADORSYS-GIS/ai-helm/pull/386
* Rendered plugin array: see §4 Results.

---

## 6. Risk Assessment

Risk level:

* [x] Low
* [ ] Medium
* [ ] High

Potential risks:

* Skill catalog freezes at 3.0.45 — users stop receiving new/updated skills until a manual bump + release.

Mitigation:

* 3.0.45 is the current `@latest`, so no behaviour change vs. what users resolve today.
* Bump is a one-line edit; rollback is a one-line revert to `@latest`.

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [ ] Refactoring
* [ ] Generating tests
* [x] Drafting documentation
* [x] Reviewing the diff
* [ ] Not used

Human verification:

* [x] I understand every meaningful change in this PR
* [x] I checked generated code manually
* [ ] I checked generated tests manually
* [x] I removed unsupported AI assumptions
* [x] I accept responsibility for this PR

---

## 8. Reviewer Focus

Please focus your review on:

* [x] Correctness
* [ ] Architecture
* [ ] Security
* [ ] Performance
* [ ] Tests
* [x] Maintainability
* [x] Product intent
* [ ] Edge cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)
