### PR TITLE
feat(opencode): force branded model name to win via modelsInfoOverwrite

### DIFF
--- a/charts/librechat-opencode-wellknown/values.yaml
+++ b/charts/librechat-opencode-wellknown/values.yaml
@@ -45,20 +45,20 @@ wellKnown:
       # plugin code we validated, and a publish upstream can't change
       # behaviour under us mid-rollout. Bump these deliberately (and
       # re-validate) rather than letting them drift. The three @vymalo/*
-      # plugins share one version line (released together, currently 0.6.2).
+      # plugins share one version line (released together, currently 0.6.3).
       # The lone exception is opencode-skills-collection (kept @latest — see
       # its note below).
-      - "@vymalo/opencode-oauth2@0.6.2"
+      - "@vymalo/opencode-oauth2@0.6.3"
       # Enriches the model catalog with context length, pricing,
       # modalities, capability flags. See ADR-0015.
-      - "@vymalo/opencode-models-info@0.6.2"
+      - "@vymalo/opencode-models-info@0.6.3"
       # Reads the IETF draft-03 `x-ratelimit-*` response headers our
       # Envoy AI Gateway emits (the per-model BackendTrafficPolicy,
       # ADR-0021) and makes opencode rate-limit-aware: on a short burst
       # reset it waits the quota out, and on a days-away monthly-budget
       # reset it fails fast — see the per-model-scoped `rateLimit.tiers`
       # under the provider options below.
-      - "@vymalo/opencode-ratelimit@0.6.2"
+      - "@vymalo/opencode-ratelimit@0.6.3"
       # Dynamic Context Pruning — auto-compresses/dedups stale tool
       # outputs and prunes failed-tool inputs from the running context.
       # Zero-config (sensible defaults); provider-agnostic. Pushed
@@ -108,7 +108,7 @@ wellKnown:
             # Route inference through the OpenAI **Responses API**
             # (`/v1/responses`) instead of Chat Completions
             # (`/v1/chat/completions`). Requires the plugin ≥ 0.6.2
-            # (vymalo/opencode-oauth2#37 — we pin 0.6.2 in the plugin list
+            # (vymalo/opencode-oauth2#37 — we pin 0.6.3 in the plugin list
             # above). Mechanically this swaps the registered AI-SDK
             # package from `@ai-sdk/openai-compatible` (chat-only) to the
             # native `@ai-sdk/openai`, whose default languageModel() has
@@ -136,8 +136,23 @@ wellKnown:
             # TTL (24h default upstream); override if you want fresher
             # catalogs:
             # modelsInfoTtlSeconds: 3600
+            # Force our endpoint's `name` to win over the normalized label
+            # the oauth2 plugin pre-stamps (vymalo/opencode-models-info#38,
+            # needs plugin ≥ 0.6.3 — pinned 0.6.3 above). models-info merges
+            # upstream-wins, and oauth2's model discovery auto-stamps a
+            # normalized `name` (e.g. id `adorsys-coder` → "Adorsys Coder")
+            # BEFORE the models-info hook runs; upstream-wins then can't tell
+            # that from handwritten config, so our `/v1/models/info` `name`
+            # (= each model's branded `info.displayName`, e.g. "Adorsys Coder
+            # (MiniMax M2.7)", ADR-0044) never landed — the UI showed the
+            # plain normalized label. Listing `name` here exempts ONLY that
+            # field from upstream-wins so the endpoint value replaces it. (A
+            # field only changes when the endpoint actually provides it; a
+            # missing value never blanks an existing one.)
+            modelsInfoOverwrite:
+              - name
             # @vymalo/opencode-ratelimit config. Needs the `scope` + `tiers`
-            # schema (plugin ≥ 0.6.1; we pin 0.6.2 in the plugin list
+            # schema (plugin ≥ 0.6.1; we pin 0.6.3 in the plugin list
             # above). headerPrefix "x-ratelimit" matches
             # Envoy's draft-03 header names — plugin default.
             #

--- a/docs/opencode-well-known.md
+++ b/docs/opencode-well-known.md
@@ -154,7 +154,7 @@ Expected:
   },
   "config": {
     "$schema": "https://opencode.ai/config.json",
-    "plugin": ["@vymalo/opencode-oauth2@0.6.2"],
+    "plugin": ["@vymalo/opencode-oauth2@0.6.3"],
     "provider": {
       "camer-digital": {
         "name": "Camer Digital",
@@ -189,6 +189,17 @@ them OpenCode aborts with `text part <id> not found`). It is provider-wide
 — every `camer-digital` request goes through `/v1/responses` — and does not
 touch the token lifecycle. See the inline comment in
 `charts/librechat-opencode-wellknown/values.yaml`.
+
+`meta.modelsInfoOverwrite: ["name"]` (models-info plugin ≥ 0.6.3,
+[vymalo/opencode-models-info#38](https://github.com/vymalo/opencode-oauth2/pull/38))
+exempts `name` from the plugin's upstream-wins merge. The oauth2 plugin's
+model discovery auto-stamps a *normalized* `name` (id `adorsys-coder` →
+"Adorsys Coder") before the models-info hook runs, which upstream-wins treats
+as handwritten config — so our `/v1/models/info` `name` (each model's branded
+`info.displayName`, e.g. "Adorsys Coder (MiniMax M2.7)", ADR-0044) never
+landed and the UI showed the plain normalized label. Listing `name` lets the
+endpoint value replace it; a field only changes when the endpoint actually
+provides one.
 
 ## Prerequisites the cluster must satisfy
 


### PR DESCRIPTION
## 1. Summary

This PR changes:

- Adds `meta.modelsInfoOverwrite: ["name"]` to the org-wide opencode well-known config (`charts/librechat-opencode-wellknown/values.yaml`).
- Bumps the pinned `@vymalo/*` plugin trio `0.6.2` → `0.6.3` (the version that ships the feature).
- Syncs the doc example + comments.

It solves / source of truth:

- Applies **https://github.com/vymalo/opencode-oauth2/pull/38** (released `@vymalo/opencode-models-info` 0.6.3). Our branded `Adorsys *` model names from `/v1/models/info` were being overridden by oauth2's normalized label; this is the upstream escape hatch.

---

## 2. Intent

The intent of this PR is:

> Make our branded model display names actually show in opencode. `@vymalo/opencode-models-info` merges our `/v1/models/info` metadata **upstream-wins**, but `@vymalo/opencode-oauth2`'s model discovery auto-stamps a *normalized* `name` (id `adorsys-coder` → "Adorsys Coder") **before** the models-info hook runs — and upstream-wins can't distinguish that pre-stamp from handwritten config, so our endpoint's real `name` (each model's branded `info.displayName`, e.g. "Adorsys Coder (MiniMax M2.7)", ADR-0044; `ai-models-info` maps `displayName` → `name`) never landed. `meta.modelsInfoOverwrite: ["name"]` exempts just that field from upstream-wins so the endpoint value wins.

---

## 3. Scope

### In Scope

- The `modelsInfoOverwrite: ["name"]` knob + the `@vymalo` 0.6.3 bump + comment/doc sync.

### Out of Scope

- `@tarquinen/opencode-dcp` / `opencode-skills-collection` pins (unchanged).
- The "vision model won't accept images" symptom — per the upstream PR that's a cache/fetch issue, NOT a merge problem (oauth2 doesn't pre-stamp `modalities`/`attachment`), so it needs no override.

---

## 4. Verification

I verified this change by:

- [x] Running automated tests (helm lint --strict + render)
- [x] Running manual tests (rendered JSON inspection; confirmed our endpoint serves branded `name` via ai-models-info displayName→name mapping)
- [ ] Checking logs
- [ ] Checking metrics
- [ ] Testing error cases
- [ ] Testing permissions/security behavior
- [ ] Testing rollback or failure behavior, if relevant

Commands run:

```bash
npm view @vymalo/opencode-models-info version     # -> 0.6.3 (and oauth2, ratelimit)
helm lint charts/librechat-opencode-wellknown/ --strict
helm template wk charts/librechat-opencode-wellknown/ | grep -o '"meta":{[^}]*}'
helm template wk charts/librechat-opencode-wellknown/ | grep -o '"plugin":\[[^]]*\]'
```

Results:

```text
1 chart(s) linted, 0 chart(s) failed
"meta":{"modelsInfoOverwrite":["name"],"modelsInfoUrl":"models/info","rateLimit":{...}}
"plugin":["@vymalo/opencode-oauth2@0.6.3","@vymalo/opencode-models-info@0.6.3","@vymalo/opencode-ratelimit@0.6.3","@tarquinen/opencode-dcp@3.1.12","opencode-skills-collection@3.0.45"]
```

---

## 5. Screenshots / Evidence

* Upstream PR (mechanics + tests): https://github.com/vymalo/opencode-oauth2/pull/38
* Our displayName→name mapping: `charts/ai-models-info/templates/_helpers.tpl`

---

## 6. Risk Assessment

Risk level:

* [x] Low
* [ ] Medium
* [ ] High

Potential risks:

* A minor plugin bump (0.6.2 → 0.6.3) across the trio; the only behavioural delta beyond `name` precedence is re-including #37's already-live responseApi work.

Mitigation:

* `modelsInfoOverwrite` is backward-compatible (absent = current behaviour) and scoped to `name` only; a missing endpoint value never blanks an existing one.
* Rollback is a one-line revert (drop the key + restore 0.6.2 pins).

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [ ] Refactoring
* [ ] Generating tests
* [x] Drafting documentation
* [x] Reviewing the diff
* [ ] Not used

Human verification:

* [x] I understand every meaningful change in this PR
* [x] I checked generated code manually
* [ ] I checked generated tests manually
* [x] I removed unsupported AI assumptions
* [x] I accept responsibility for this PR

---

## 8. Reviewer Focus

Please focus your review on:

* [x] Correctness
* [ ] Architecture
* [ ] Security
* [ ] Performance
* [ ] Tests
* [x] Maintainability
* [x] Product intent
* [ ] Edge cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)
