### PR TITLE
feat(opencode): disable responseApi — back to Chat Completions

### DIFF
--- a/charts/librechat-opencode-wellknown/values.yaml
+++ b/charts/librechat-opencode-wellknown/values.yaml
@@ -105,27 +105,18 @@ wellKnown:
             # breaks headless / remote-dev use.
             authFlow: device_code
             syncIntervalMinutes: 60
-            # Route inference through the OpenAI **Responses API**
-            # (`/v1/responses`) instead of Chat Completions
-            # (`/v1/chat/completions`). Requires the plugin ≥ 0.6.2
-            # (vymalo/opencode-oauth2#37 — we pin 0.6.3 in the plugin list
-            # above). Mechanically this swaps the registered AI-SDK
-            # package from `@ai-sdk/openai-compatible` (chat-only) to the
-            # native `@ai-sdk/openai`, whose default languageModel() has
-            # targeted Responses since AI SDK v5; with our `/v1` baseURL it
-            # resolves to the gateway's `/v1/responses`. Auth is untouched —
-            # the real OAuth bearer is still injected per request by the
-            # plugin's chat.headers hook (the native provider's mandatory
-            # apiKey is stamped with an inert placeholder that's never sent).
-            #
-            # The flag ALSO enables the plugin's streaming SSE index-repair,
-            # which injects the `output_index`/`content_index` fields our
-            # Envoy AI Gateway omits from its Responses SSE stream — without
-            # them OpenCode's part layer aborts with `text part <id> not
-            # found`. Verified live end-to-end against this gateway in the PR.
-            # Provider-wide (one boolean, no per-model granularity): EVERY
-            # camer-digital request goes through /v1/responses.
-            responseApi: true
+            # DISABLED 2026-06-13 — back to Chat Completions
+            # (`/v1/chat/completions`, the plugin default). When `true` this
+            # routes inference through the OpenAI **Responses API**
+            # (`/v1/responses`) by registering the provider with the native
+            # `@ai-sdk/openai` instead of `@ai-sdk/openai-compatible` (plugin
+            # ≥ 0.6.2, vymalo/opencode-oauth2#37) and turning on the streaming
+            # SSE index-repair for the `output_index`/`content_index` fields
+            # our Envoy AI Gateway omits. It was enabled (release-2026.06.13)
+            # then turned back off — re-enable by flipping to `true` if/when
+            # we want the Responses path again. Provider-wide (one boolean, no
+            # per-model granularity).
+            responseApi: false
           meta:
             # Relative path → resolves to baseURL + "models/info" =
             # https://api.ai.camer.digital/v1/models/info (the

--- a/docs/opencode-well-known.md
+++ b/docs/opencode-well-known.md
@@ -178,16 +178,18 @@ Expected:
 Content-Type must be `application/json` (nginx adds it via
 `default_type` in the chart's nginx config).
 
-`oauth2.responseApi: true` (plugin ≥ 0.6.2,
+`oauth2.responseApi` (plugin ≥ 0.6.2,
 [vymalo/opencode-oauth2#37](https://github.com/vymalo/opencode-oauth2/pull/37))
-routes inference through the OpenAI **Responses API** (`/v1/responses`)
-instead of Chat Completions by registering the provider with
-`@ai-sdk/openai` rather than `@ai-sdk/openai-compatible`. It also enables
-the plugin's streaming SSE index-repair, which supplies the
+is **currently `false`** — inference uses Chat Completions
+(`/v1/chat/completions`), the plugin default. It was enabled in
+`release-2026.06.13` then turned back off. When `true` it routes inference
+through the OpenAI **Responses API** (`/v1/responses`) by registering the
+provider with `@ai-sdk/openai` rather than `@ai-sdk/openai-compatible`, and
+enables the plugin's streaming SSE index-repair, which supplies the
 `output_index`/`content_index` fields our Envoy AI Gateway omits (without
 them OpenCode aborts with `text part <id> not found`). It is provider-wide
-— every `camer-digital` request goes through `/v1/responses` — and does not
-touch the token lifecycle. See the inline comment in
+— every `camer-digital` request would go through `/v1/responses` — and does
+not touch the token lifecycle. See the inline comment in
 `charts/librechat-opencode-wellknown/values.yaml`.
 
 `meta.modelsInfoOverwrite: ["name"]` (models-info plugin ≥ 0.6.3,


### PR DESCRIPTION
## 1. Summary

This PR changes:

- Flips `oauth2.responseApi` `true` → `false` in the org-wide opencode well-known config (`charts/librechat-opencode-wellknown/values.yaml`).
- Updates the doc note to reflect the disabled state.

It solves / source of truth:

- Reverts the change made in **https://github.com/ADORSYS-GIS/ai-helm/pull/385** (enabled in `release-2026.06.13`). Maintainer request to disable the Responses-API routing and return to Chat Completions.

---

## 2. Intent

The intent of this PR is:

> Return org-wide opencode inference to Chat Completions (`/v1/chat/completions`), the plugin default. `responseApi: true` registered the provider with the native `@ai-sdk/openai` (→ `/v1/responses`) plus a streaming SSE index-repair; setting it `false` re-registers `@ai-sdk/openai-compatible` and makes the repair inert. The flag and its full rationale stay in the inline comment so re-enabling is a one-line flip.

---

## 3. Scope

### In Scope

- The single `responseApi` flag flip + doc-note sync.

### Out of Scope

- Plugin versions (unchanged — still the pinned `@vymalo` 0.6.3 trio + dcp/skills).
- `meta.modelsInfoOverwrite` and all other well-known config (unchanged).

---

## 4. Verification

I verified this change by:

- [x] Running automated tests (helm lint --strict + render)
- [x] Running manual tests (rendered JSON inspection)
- [ ] Checking logs
- [ ] Checking metrics
- [ ] Testing error cases
- [ ] Testing permissions/security behavior
- [x] Testing rollback or failure behavior, if relevant

Commands run:

```bash
helm lint charts/librechat-opencode-wellknown/ --strict
helm template wk charts/librechat-opencode-wellknown/ | grep -o '"responseApi":[a-z]*'
```

Results:

```text
1 chart(s) linted, 0 chart(s) failed
"responseApi":false
```

Rollback: flip back to `true` (one line) — re-enables the Responses path.

---

## 5. Screenshots / Evidence

* Original enablement PR: https://github.com/ADORSYS-GIS/ai-helm/pull/385

---

## 6. Risk Assessment

Risk level:

* [x] Low
* [ ] Medium
* [ ] High

Potential risks:

* Behavioural revert to the long-standing default; no new code path.

Mitigation:

* Chat Completions is the plugin default and was the live behaviour before `release-2026.06.13`.
* One-line flip to re-enable; the rationale stays documented in-chart.

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [ ] Refactoring
* [ ] Generating tests
* [x] Drafting documentation
* [x] Reviewing the diff
* [ ] Not used

Human verification:

* [x] I understand every meaningful change in this PR
* [x] I checked generated code manually
* [ ] I checked generated tests manually
* [x] I removed unsupported AI assumptions
* [x] I accept responsibility for this PR

---

## 8. Reviewer Focus

Please focus your review on:

* [x] Correctness
* [ ] Architecture
* [ ] Security
* [ ] Performance
* [ ] Tests
* [ ] Maintainability
* [x] Product intent
* [ ] Edge cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)
