### PR TITLE
fix(ai-models): give every catalog model a friendly displayName

### DIFF
--- a/charts/ai-models/values.yaml
+++ b/charts/ai-models/values.yaml
@@ -449,6 +449,7 @@ models:
     # (clamped to the 400k catalog ceiling), 384k max output (capped to a
     # sane 131k generation ceiling). Dual Think/Non-Think modes → reasoning.
     info:
+      displayName: "DeepSeek V4 Flash"
       contextLength: 1048576
       maxOutputTokens: 131072
       supportedParameters: *spReasoning
@@ -471,6 +472,7 @@ models:
     # DeepInfra · zai-org/GLM-5 — 202,752-token context, 131k max output,
     # agentic thinking mode + function calling + vision.
     info:
+      displayName: "Reviewer (GLM-5)"
       contextLength: 202752
       maxOutputTokens: 131072
       supportedParameters: *spReasoning
@@ -492,6 +494,7 @@ models:
     kind: text
     # DeepInfra · zai-org/GLM-5 — 202,752-token context, 131k max output.
     info:
+      displayName: "GLM-5"
       contextLength: 202752
       maxOutputTokens: 131072
       supportedParameters: *spReasoning
@@ -568,6 +571,7 @@ models:
     # DeepInfra · moonshotai/Kimi-K2.5 — 262,144-token context, 131k max
     # output, agentic tool use + thinking.
     info:
+      displayName: "Kimi K2.5"
       contextLength: 262144
       maxOutputTokens: 131072
       supportedParameters: *spReasoning
@@ -591,6 +595,7 @@ models:
     # MoonViT vision encoder; "visual inputs → production-ready UI"), 262,144-token
     # context, 131k max output, agentic tool use + thinking.
     info:
+      displayName: "Kimi K2.6"
       contextLength: 262144
       maxOutputTokens: 131072
       supportedParameters: *spReasoning
@@ -628,6 +633,7 @@ models:
     # DeepInfra · MiniMaxAI/MiniMax-M2.5 — 204,800-token context (NOT 400k:
     # 196k usable per sequence), 131k max output, reasoning + agentic tools.
     info:
+      displayName: "MiniMax M2.5"
       contextLength: 204800
       maxOutputTokens: 131072
       supportedParameters: *spReasoning
@@ -652,6 +658,7 @@ models:
     # GLM-5.1 rates (matches adorsys-planner-pro, same model + provider).
     kind: text
     info:
+      displayName: "GLM-5.1"
       contextLength: 202752
       maxOutputTokens: 131072
       supportedParameters: *spReasoning
@@ -693,6 +700,7 @@ models:
     # + 8k max output; multimodal (image input) + reasoning + tools.
     kind: multimodal
     info:
+      displayName: "Qwen3.6 Plus"
       contextLength: 128000
       maxOutputTokens: 8192
       supportedParameters: *spReasoning
@@ -715,6 +723,7 @@ models:
     # DeepInfra · google/gemma-4-26B-A4B-it — 262,144-token (256K) context,
     # 8k max output, native function calling (no exposed thinking mode).
     info:
+      displayName: "Gemma 4"
       contextLength: 262144
       maxOutputTokens: 8192
       supportedParameters: *spStandard


### PR DESCRIPTION
## 1. Summary

This PR changes:

- Adds a `info.displayName` to the nine `charts/ai-models` catalog entries that lacked one, so the public `/v1/models/info` catalog no longer advertises raw model `id`s as human-facing names.

It solves:

- The model picker surfaced ugly raw ids as names. Source of truth (observed live): https://api.ai.camer.digital/v1/models/info — entries `deepseek-v4-flash`, `gemma-4`, `glm-5`, `glm-5p1`, `kimi-k2.5`, `kimi-k2.6`, `minimax-m2p5`, `qwen3p6-plus`, `reviewer` all returned `name == id`.

---

## 2. Intent

The intent of this PR is:

> The `/v1/models/info` catalog (`charts/ai-models-info`) derives each card's `name` from `info.displayName`, falling back to the model `id` when absent. Nine entries had no `displayName`, so the catalog showed raw slugs (`glm-5p1`, `qwen3p6-plus`, …) in opencode/LibreChat pickers. Give every catalog model a friendly name.

---

## 3. Scope

### In Scope

- `displayName` for: `deepseek-v4-flash` → "DeepSeek V4 Flash", `reviewer` → "Reviewer (GLM-5)", `glm-5` → "GLM-5", `kimi-k2.5` → "Kimi K2.5", `kimi-k2.6` → "Kimi K2.6", `minimax-m2p5` → "MiniMax M2.5", `glm-5p1` → "GLM-5.1", `qwen3p6-plus` → "Qwen3.6 Plus", `gemma-4` → "Gemma 4".

### Out of Scope

- Pricing, context, modality, or backend changes — none touched.
- Retiring the legacy bare `reviewer` alias (left as-is, only named).

---

## 4. Verification

I verified this change by:

- [x] Running automated tests
- [ ] Running manual tests
- [ ] Checking logs
- [ ] Checking metrics
- [ ] Testing error cases
- [ ] Testing permissions/security behavior
- [ ] Testing rollback or failure behavior, if relevant

Commands run:

```bash
helm dep build charts/ai-models
helm lint charts/ai-models --strict
helm template x charts/ai-models | grep -i displayName | sort -u
```

Results:

```text
1 chart(s) linted, 0 chart(s) failed
22 distinct displayNames render; zero entries fall back to id-as-name.
```

---

## 5. Screenshots / Evidence

* Live (pre-fix) catalog: https://api.ai.camer.digital/v1/models/info
* Render output verified locally (see §4 command).

---

## 6. Risk Assessment

Risk level:

* [x] Low
* [ ] Medium
* [ ] High

Potential risks:

* Cosmetic only — `name` is a display field; ids, routing, and pricing are unchanged.

Mitigation:

* Tag-based deploy; rollback = repoint the root to the prior tag.

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [x] Reviewing the diff

Human verification:

* [x] I understand every meaningful change in this PR
* [x] I checked generated code manually
* [x] I removed unsupported AI assumptions
* [x] I accept responsibility for this PR

---

## 8. Reviewer Focus

Please focus your review on:

* [x] Correctness
* [x] Product intent

🤖 Generated with [Claude Code](https://claude.com/claude-code)
