### PR TITLE
feat(opencode-wellknown): bump @vymalo plugin line 0.7.1 → 0.7.3

### DIFF
--- a/charts/librechat-opencode-wellknown/values.yaml
+++ b/charts/librechat-opencode-wellknown/values.yaml
@@ -53,20 +53,20 @@ wellKnown:
       # plugin code we validated, and a publish upstream can't change
       # behaviour under us mid-rollout. Bump these deliberately (and
       # re-validate) rather than letting them drift. The four @vymalo/*
-      # plugins share one version line (released together, currently 0.7.1).
+      # plugins share one version line (released together, currently 0.7.3).
       # The lone exception is opencode-skills-collection (kept @latest — see
       # its note below).
-      - "@vymalo/opencode-oauth2@0.7.1"
+      - "@vymalo/opencode-oauth2@0.7.3"
       # Enriches the model catalog with context length, pricing,
       # modalities, capability flags. See ADR-0015.
-      - "@vymalo/opencode-models-info@0.7.1"
+      - "@vymalo/opencode-models-info@0.7.3"
       # Reads the IETF draft-03 `x-ratelimit-*` response headers our
       # Envoy AI Gateway emits (the per-model BackendTrafficPolicy,
       # ADR-0021) and makes opencode rate-limit-aware: on a short burst
       # reset it waits the quota out, and on a days-away monthly-budget
       # reset it fails fast — see the per-model-scoped `rateLimit.tiers`
       # under the provider options below.
-      - "@vymalo/opencode-ratelimit@0.7.1"
+      - "@vymalo/opencode-ratelimit@0.7.3"
       # Gives an agent a real browser: registers `browser_*` tools (open
       # tabs, click, type, scroll, screenshot — in named tab groups) backed
       # by a localhost WebSocket bridge a companion browser EXTENSION dials
@@ -81,7 +81,7 @@ wellKnown:
       # in the plugin TUPLE's second arg — this plugin reads its options from
       # there (NOT from provider.options.meta like the others), i.e.
       # opencode's `[name, {opts}]` install form, which toJson renders as a
-      # JSON 2-tuple. Part of the 0.7.1 vymalo line — pin matches the three
+      # JSON 2-tuple. Part of the 0.7.3 vymalo line — pin matches the three
       # above.
       #
       # TWO independent token levers, at different scopes:
@@ -116,7 +116,7 @@ wellKnown:
       # right form here: it's local-only (bridge + extension on the user's box,
       # so it can't ride the remote gateway /mcp/* routes anyway) and its opencode
       # adapter saves screenshots to disk for the model to read. One source only.
-      - - "@vymalo/opencode-browser@0.7.1"
+      - - "@vymalo/opencode-browser@0.7.3"
         - port: 4517
           groups:
             - page


### PR DESCRIPTION
## 1. Summary

This PR changes:

- Bumps the four shared-version `@vymalo/*` opencode plugins (`oauth2`, `models-info`, `ratelimit`, `browser`) from `0.7.1` to `0.7.3` in the org-wide opencode well-known config (`charts/librechat-opencode-wellknown/values.yaml`).
- Updates the inline comments that name the version line ("currently 0.7.1", "Part of the 0.7.1 vymalo line") so the pins and the prose stay in lockstep.

It solves:

- Keeps the org-wide pushed plugin pins current with the latest released `@vymalo/*` line. Source of truth (npm, all four published as `latest`): https://www.npmjs.com/package/@vymalo/opencode-oauth2/v/0.7.3 · https://www.npmjs.com/package/@vymalo/opencode-models-info/v/0.7.3 · https://www.npmjs.com/package/@vymalo/opencode-ratelimit/v/0.7.3 · https://www.npmjs.com/package/@vymalo/opencode-browser/v/0.7.3

---

## 2. Intent

The intent of this PR is:

> The four `@vymalo/*` plugins ship as one release line and are version-pinned (exact `name@x.y.z`) so the org-wide push stays deterministic — every user installs the same validated plugin code rather than floating to `@latest`. This bumps that line deliberately from `0.7.1` to the current `0.7.3`.

---

## 3. Scope

### In Scope

- The four `@vymalo/*` plugin pins → `0.7.3`.
- The two prose comments naming the version line.

### Out of Scope

- `@vymalo/opencode-skills-collection` — intentionally kept `@latest` (see its in-file note), not part of this pinned line.
- No change to plugin config (browser `groups`/`port`, provider options, agents).
- README references are bare/unversioned — nothing to change there.

---

## 4. Verification

I verified this change by:

- [x] Running automated tests
- [ ] Running manual tests
- [ ] Checking logs
- [ ] Checking metrics
- [ ] Testing error cases
- [ ] Testing permissions/security behavior
- [ ] Testing rollback or failure behavior, if relevant

Commands run:

```bash
helm dep build charts/librechat-opencode-wellknown
helm template x charts/librechat-opencode-wellknown   # render OK
helm template x charts/librechat-opencode-wellknown | grep -o '@vymalo/[^"@]*@0\.7\.[0-9]*' | sort -u
grep -rn '0.7.1' charts/librechat-opencode-wellknown   # none left
for p in oauth2 models-info ratelimit browser; do npm view @vymalo/opencode-$p version; done
```

Results:

```text
RENDER OK
rendered ConfigMap carries @0.7.3 for all four plugins; no 0.7.1 refs remain
npm latest for all four = 0.7.3 (the pinned target exists/published)
```

---

## 5. Screenshots / Evidence

* npm (target exists, published as latest): https://www.npmjs.com/package/@vymalo/opencode-oauth2/v/0.7.3
* Render output verified locally (see §4).

---

## 6. Risk Assessment

Risk level:

* [x] Low
* [ ] Medium
* [ ] High

Potential risks:

* Org-wide push: every opencode user installs `0.7.3` on next session start (bun-install, cached). A regression in the new plugin line would reach all users.

Mitigation:

* Exact pins keep the rollout deterministic; rollback = revert this bump (or repoint the root to the prior immutable tag). The `0.7.x` jump is a patch line.

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [x] Reviewing the diff

Human verification:

* [x] I understand every meaningful change in this PR
* [x] I checked generated code manually
* [x] I removed unsupported AI assumptions
* [x] I accept responsibility for this PR

---

## 8. Reviewer Focus

Please focus your review on:

* [x] Correctness
* [x] Product intent

🤖 Generated with [Claude Code](https://claude.com/claude-code)
