### PR TITLE
docs: layered mermaid architecture suite + arc42/architecture refresh + stale-ref sweep

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -53,7 +53,7 @@ How the system is wired and how to integrate against it.
 | [`librechat-oidc-integration.md`](./librechat-oidc-integration.md) | LibreChat ↔ Keycloak OIDC wiring, claim mapping, role propagation |
 | [`librechat-oidc-experiments.md`](./librechat-oidc-experiments.md) | Notes from earlier OIDC iterations — kept as historical record |
 | [`librechat_headers_tracing_doc.md`](./librechat_headers_tracing_doc.md) | How LibreChat templated headers flow into downstream MCP/Converse calls |
-| [`authorino-service-account-bypass.md`](./authorino-service-account-bypass.md) | How service-account tokens skip OPA / external metadata in Authorino |
+| [`authorino-service-account-bypass.md`](./authorino-service-account-bypass.md) | **Historical** (OPA removed 2026-06-04, ADR-0021): how service-account tokens used to skip OPA / external metadata in Authorino |
 | [`per-user-observability.md`](./per-user-observability.md) | Per-user attribution: JWT → Authorino headers → Envoy access log → Loki `user_id`/`azp` labels |
 | [`opencode-well-known.md`](./opencode-well-known.md) | opencode `.well-known/opencode` flow at `ai.camer.digital`; prerequisites, plugin install, troubleshooting |
 | [`opencode-sandboxing.md`](./opencode-sandboxing.md) | Why the opencode permission config is **not** a sandbox (string-matched bash rules over code-execution tools), opencode's lack of a native OS sandbox (worktree = recovery only), the containment options (worktree / OS wrapper / devcontainer / hosted in-cluster), and the recommendation (devcontainer for local; hosted = future ADR reversing ADR-0027) |

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,9 +8,33 @@ know where a topic lives, grep — file names are stable and descriptive.
 > several files (backups, secrets, model gateway) get their own subdirectory
 > with a local `README.md` that indexes the contents.
 
-**Start here:** [`architecture.md`](./architecture.md) for the system map,
-[`adr/README.md`](./adr/README.md) for every architectural decision,
-[`../CONTRIBUTING.md`](../CONTRIBUTING.md) for how to ship a change.
+**Start here:** [`architecture.md`](./architecture.md) for the single-page system
+map, the **[architecture suite](./architecture/README.md)** for the layered
+deep-dive (C4 + per-subsystem, all mermaid), [`arc42.md`](./arc42.md) for the
+formal description, [`adr/README.md`](./adr/README.md) for every architectural
+decision, [`../CONTRIBUTING.md`](../CONTRIBUTING.md) for how to ship a change.
+
+---
+
+## Architecture suite (layered, mermaid)
+
+The primary architecture reference: a navigable set following the **C4 model**
+(context → container → component) plus one page per cross-cutting subsystem.
+Every diagram is mermaid; start at the hub and zoom in.
+
+| File | Layer | Covers |
+|---|---|---|
+| [`architecture/README.md`](./architecture/README.md) | hub | How the layers relate; C4 ↔ arc42 map; diagram conventions |
+| [`architecture/01-context.md`](./architecture/01-context.md) | C4 L1 | Actors + external systems (the one-box view) |
+| [`architecture/02-containers.md`](./architecture/02-containers.md) | C4 L2 | Deployable units by namespace; render patterns |
+| [`architecture/03-gateway-components.md`](./architecture/03-gateway-components.md) | C4 L3 | The gateway request path + 4 runtime sequences |
+| [`architecture/04-gitops-deployment.md`](./architecture/04-gitops-deployment.md) | infra | Two-cluster GitOps, destinations, sync waves, release flow |
+| [`architecture/05-auth-identity.md`](./architecture/05-auth-identity.md) | security | Dual-plane auth, identity surfaces, `x-oidc-*`, GitHub-OIDC binding |
+| [`architecture/06-networking-tls.md`](./architecture/06-networking-tls.md) | infra | Ingress, Hetzner LB, Cilium deny-egress, TLS issuance |
+| [`architecture/07-data-secrets.md`](./architecture/07-data-secrets.md) | infra | Mongo/CNPG/Redis/S3, the ESO secret flow, ownership split |
+| [`architecture/08-observability.md`](./architecture/08-observability.md) | platform | LGTM pipeline, per-user attribution, dashboards-as-code |
+| [`architecture/09-model-serving.md`](./architecture/09-model-serving.md) | platform | Provider fan-out + the self-hosted GPU model; budget tiers |
+| [`architecture/10-mcp.md`](./architecture/10-mcp.md) | platform | MCP routing, the OAuth carve-out, external-proxy modes |
 
 ---
 

--- a/docs/arc42.md
+++ b/docs/arc42.md
@@ -1,41 +1,43 @@
 # arc42 — Camer Digital AI Platform (ai-helm)
 
 > [arc42](https://arc42.org) architecture description for the AI platform
-> deployed by this repository. arc42's twelve sections, applied to the
-> steady state on `claude/magical-bohr-390242`. Cross-references the
-> [architecture map](./architecture.md), the [ADR index](./adr/README.md),
-> the [architectural-shift narrative](./architectural-shift-main-to-magical-bohr.md),
-> and the [OpenAI-alternative plan](../plans/openai-alternative-plan.md).
+> deployed by this repository — the twelve sections applied to the steady state
+> at `release-2026.06.14-v03`. Every diagram is mermaid.
+>
+> **Companion reading:** the single-page [architecture map](./architecture.md),
+> the layered, mermaid-rich [architecture suite](./architecture/README.md)
+> (C4 context → container → component + one page per subsystem), and the
+> [ADR index](./adr/README.md) — the source of truth for every *why*.
 
-**Maintainer:** @stephane-segning · **Date:** 2026-06-04
+**Maintainer:** @stephane-segning · **Updated:** 2026-06-14
 
 ---
 
 ## 1. Introduction and goals
 
 The platform delivers a **multi-tenant, OpenAI-compatible inference service**
-plus the tools around it (a chat UI, a CLI integration, dev environments, MCP
-servers) for Camer Digital. It is delivered entirely as Helm charts reconciled
-by ArgoCD; there is no application build in this repo.
+plus the tools around it (a chat UI, a CLI integration, MCP tool servers, dev
+observability) for Camer Digital. It is delivered entirely as Helm charts
+reconciled by ArgoCD; there is no application build in this repo.
 
 ### Core quality goals
 
 | Priority | Quality | Concrete goal |
 |---|---|---|
 | 1 | **Scalability** | Serve ~2000 concurrent clients sustained, ~5000 at peak, on the OpenAI-compatible endpoint without latency collapse |
-| 2 | **Observability / attribution** | Every request attributable to a user, org, plan, and model; usage and cost queryable in Grafana in near-real-time |
+| 2 | **Observability / attribution** | Every request attributable to a user, plan, and model; usage/cost queryable in Grafana in near-real-time |
 | 3 | **Security / multi-tenancy** | Keycloak JWT is the authorization boundary; per-plan burst + monthly budget enforced at the gateway; tenant isolation by claim |
 | 4 | **Operability (GitOps)** | Every change is a reviewed Git diff; reproducible, declarative, env-overlayable |
-| 5 | **Cost control** | Per-org monthly USD budget enforced; self-hosted object storage; no per-request Python hop |
+| 5 | **Cost control** | Per-person monthly USD budget enforced; self-hosted object storage; no per-request Python hop |
 
 ### Stakeholders
 
 | Role | Concern |
 |---|---|
-| Platform maintainer (@stephane-segning) | Operability, cost, the deploy branch staying green |
+| Platform maintainer (@stephane-segning) | Operability, cost, deploys staying green |
 | End users (humans via LibreChat, devs via opencode/CLI) | Latency, model availability, fair quota |
-| Service accounts (CI runners) | Programmatic access without human auth |
-| Finance / billing | Per-org spend, charge-back data |
+| Service accounts (CI runners) | Programmatic access without human auth or shared keys |
+| Finance / billing | Per-person spend, charge-back data |
 | Security | JWT boundary, tenant isolation, secret hygiene |
 
 ---
@@ -46,7 +48,7 @@ by ArgoCD; there is no application build in this repo.
 |---|---|
 | **GitOps only** — no imperative deploys | Everything is a chart; `kubectl rollout restart` is reverted by ArgoCD selfHeal |
 | **Two clusters** — ArgoCD on Talos `admin@homeos`, workloads on Hetzner k3s `home-remote` | Control objects in-cluster, workloads `home-remote` (ADR-0017) |
-| **Cilium default-deny-egress** baseline | Every API-server / S3 reach needs an additive `CiliumNetworkPolicy`; plain `NetworkPolicy` ipBlock does not match |
+| **Cilium default-deny-egress** baseline | Every API-server / S3 reach needs an additive `CiliumNetworkPolicy`; a plain `NetworkPolicy` ipBlock does not match |
 | **Infra owned externally** (`home-os`, `hetzner-k8s`) | cert-manager, ESO, Redis, Traefik, CNPG, OTel-operator referenced by name only |
 | **k3s `baseline` Pod Security** cluster-wide | Observability collectors' namespace must be `privileged` |
 | **OpenAI API compatibility** | Routes, `/v1/models`, `/v1/models/info` (OpenRouter shape) must match client expectations |
@@ -59,21 +61,28 @@ by ArgoCD; there is no application build in this repo.
 
 ### Business context
 
-```
-   Humans (browser) ─┐
-   Devs (opencode/CLI)┤
-   CI service accounts┘
-            │  OIDC / API key (JWT)
-            ▼
-   ┌────────────────────────────────────────────┐
-   │      Camer Digital AI Platform (ai-helm)    │
-   │   OpenAI-compatible inference + chat + IDE  │
-   └───────┬───────────────────────────┬────────┘
-           │ provider API calls        │ identity
-           ▼                           ▼
-   Model backends                   Keycloak IdP
-   (DeepInfra, Fireworks,           (auth.verif.fyi,
-    Google AI)                       realm camer-digital)
+```mermaid
+flowchart TB
+    H["👤 Humans (browser)"]:::actor
+    D["🧑‍💻 Devs (opencode/CLI)"]:::actor
+    C["🤖 CI service accounts"]:::actor
+
+    P["🟢 Camer Digital AI Platform (ai-helm)<br/>OpenAI-compatible inference + chat + tools"]:::own
+
+    M["🧠 Model backends<br/>DeepInfra · Fireworks · Google AI"]:::ext
+    K["🔑 Keycloak IdP<br/>auth.verif.fyi · realm camer-digital"]:::ext
+    G["🐙 GitHub<br/>Actions OIDC · App webhooks"]:::ext
+
+    H -->|OIDC / JWT| P
+    D -->|API key / JWT| P
+    C -->|GHA OIDC| P
+    P -->|provider calls| M
+    P -->|verify identity| K
+    P -->|CI binding| G
+
+    classDef actor fill:#fff,stroke:#555;
+    classDef own fill:#eaf3ea,stroke:#4a8a4a,stroke-width:2px;
+    classDef ext fill:#eee,stroke:#888,stroke-dasharray:4 3;
 ```
 
 ### Technical context (external systems consumed, not owned)
@@ -85,16 +94,20 @@ by ArgoCD; there is no application build in this repo.
 | External Secrets Operator + `ssegning-aws` store | Secret sync | external |
 | redis-ha (TLS-only) | LibreChat sessions, Envoy ratelimit counters | `home-os` |
 | Traefik | Ingress controller (non-gateway ingresses) | external |
-| CloudNativePG + Barman | Postgres for Coder, backups | external |
-| Hetzner Object Storage (`nbg1.your-objectstorage.com`) | Mimir/Loki/Tempo/CNPG/LibreChat S3 | Hetzner |
+| CloudNativePG + Barman | Postgres for lightbridge-repo-auth, backups | external |
+| Hetzner Object Storage (`nbg1.your-objectstorage.com`) | Mimir/Loki/Tempo/CNPG/Mongo/LibreChat S3 | Hetzner |
 | Hetzner Cloud LB | Public data-plane LB (`46.225.38.138`) | Hetzner |
+| GitHub | Chart source; GHA OIDC issuer; `camer-digital-ai` App webhooks | SaaS |
 | Model providers (DeepInfra/Fireworks/Google AI) | Actual inference | SaaS |
 
 ### System scope (owned by ai-helm)
 
 The Envoy AI Gateway, AuthConfigs/security policies, per-model routing + budget
-policies, LibreChat, opencode well-known + models-info catalog, Coder, MCP
-servers, the observability stack, dashboards, and all the GitOps glue.
+policies, LibreChat, opencode well-known + models-info catalog, the GitHub-OIDC
+CI binding (`lightbridge-repo-auth`), MCP servers, the observability stack,
+dashboards, and all the GitOps glue.
+
+> Detail: [architecture suite · 01 Context](./architecture/01-context.md).
 
 ---
 
@@ -102,13 +115,14 @@ servers, the observability stack, dashboards, and all the GitOps glue.
 
 | Goal | Strategy | Realised by |
 |---|---|---|
-| Scale to 2000/5000 clients | HTTP/2 multiplexing + data-plane HPA + circuit breaking | `core-gateway` ClientTrafficPolicy / EnvoyProxy HPA / BackendTrafficPolicy (ADR-0021, commits `ab39aed`/`d3257b6`) |
-| Attribution | JWT → Authorino `x-oidc-*` headers → Envoy access log → Alloy → Loki labels | ADR-0005/0011, `per-user-observability.md` |
-| Authorization | Keycloak JWT as the boundary; per-host AuthConfig differentiation | ADR-0003/0021 |
-| Quota & billing | Per-plan burst + per-org monthly budget in `BackendTrafficPolicy`; metering via counters | ADR-0021 |
+| Scale to 2000/5000 clients | HTTP/2 multiplexing + data-plane HPA + circuit breaking | `core-gateway` ClientTrafficPolicy / EnvoyProxy HPA / BackendTrafficPolicy (ADR-0021) |
+| Attribution | JWT → Authorino `x-oidc-*` headers → Envoy access log → Alloy → Loki labels | ADR-0005/0011/0046, `per-user-observability.md` |
+| Authorization | Keycloak JWT as the boundary; per-host AuthConfig differentiation | ADR-0021 |
+| CI without shared keys | GitHub Actions OIDC → `lightbridge-repo-auth` org→account binding | ADR-0047/0049 |
+| Quota & billing | Per-plan burst + per-person monthly budget in `BackendTrafficPolicy` | ADR-0021/0035 |
 | Operability | GitOps + umbrella apps + env overlays + App-of-Apps | ADR-0016–0020 |
 | Provider abstraction | Envoy AI Gateway `AIGatewayRoute` per model, fan-out via ApplicationSet | ADR-0012 |
-| Dashboards reproducibility | Python (grafana-foundation-sdk) → `GrafanaDashboard` CRs, drift-checked | ADR-0004/0008 |
+| Dashboards reproducibility | Python (grafana-foundation-sdk) → `GrafanaDashboard` CRs, drift-checked | ADR-0004/0008/0045 |
 
 ---
 
@@ -116,34 +130,28 @@ servers, the observability stack, dashboards, and all the GitOps glue.
 
 ### Level 1 — system decomposition
 
-```
-                         Internet (TLS: Let's Encrypt HTTP-01)
-                                     │
-                          ┌──────────▼───────────┐
-                          │  Envoy AI Gateway     │  charts/core-gateway
-                          │  (core-gateway)       │  + eg/aieg controllers
-                          │  external + internal  │
-                          │  planes; Authorino    │
-                          │  ext_authz            │
-                          └─┬─────────┬────────┬──┘
-            ┌───────────────┘         │        └──────────────┐
-            ▼                         ▼                       ▼
-   ┌─────────────────┐   ┌─────────────────────┐   ┌───────────────────┐
-   │ LibreChat       │   │ AI models (per-model│   │ Coder             │
-   │ (librechart     │   │ AIGatewayRoute +    │   │ (coder + coder-db │
-   │  orchestrator)  │   │ BackendTrafficPolicy│   │  CNPG)            │
-   │ + opencode      │   │ ; ai-models →       │   │                   │
-   │  well-known     │   │ ai-model leaves)    │   │                   │
-   │ + models-info   │   │ + ai-models-backends│   │                   │
-   └─────────────────┘   └─────────────────────┘   └───────────────────┘
-            │                         │                       │
-            └──────────────┬──────────┴───────────┬───────────┘
-                           ▼                       ▼
-                  ┌─────────────────┐     ┌─────────────────────┐
-                  │ MCP servers     │     │ Observability       │
-                  │ (mcpo + mcps)   │     │ (LGTM + Alloy +     │
-                  │                 │     │  grafana-operator)  │
-                  └─────────────────┘     └─────────────────────┘
+```mermaid
+flowchart TB
+    NET["Internet (TLS: Let's Encrypt HTTP-01)"]:::ext
+    GW["Envoy AI Gateway (core-gateway)<br/>+ eg/aieg controllers + Authorino ext_authz<br/>external + internal planes"]:::own
+
+    LC["LibreChat (librechart orchestrator)<br/>+ opencode well-known + models-info"]:::ctrl
+    MODELS["AI models (ai-models → ai-model leaves)<br/>per-model route + budget; provider backends"]:::ctrl
+    REPO["lightbridge-repo-auth<br/>GitHub-OIDC CI binding"]:::own
+    MCP["MCP servers (mcps orchestrator)"]:::ctrl
+    OBS["Observability<br/>(LGTM + Alloy + grafana-operator)"]:::ctrl
+
+    NET --> GW
+    GW --> LC
+    GW --> MODELS
+    GW --> MCP
+    GW -.-> REPO
+    LC --> OBS
+    MODELS --> OBS
+
+    classDef own fill:#eaf3ea,stroke:#4a8a4a;
+    classDef ctrl fill:#e8eef7,stroke:#4a6fa5;
+    classDef ext fill:#eee,stroke:#888,stroke-dasharray:4 3;
 ```
 
 ### Level 2 — key building blocks
@@ -152,38 +160,41 @@ servers, the observability stack, dashboards, and all the GitOps glue.
 |---|---|---|
 | `core-gateway` | Envoy AI Gateway, listeners (external + internal), ClientTrafficPolicy, BackendTrafficPolicy, ACME issuer, OTel collector | Direct |
 | `kuadrant-policies` | Authorino instance + per-host AuthConfigs + SecurityPolicy | Direct |
-| `ai-models` → `ai-model` | Orchestrator ApplicationSet → one Application per model (route + budget policy) | Orchestrator + leaves (ADR-0012) |
+| `ai-models` → `ai-model` | Orchestrator ApplicationSet → one Application per model (route + budget) | Orchestrator + leaves (ADR-0012) |
 | `ai-models-backends` | `AIServiceBackend`/`Backend`/`BackendSecurityPolicy`/`BackendTLSPolicy` + key ExternalSecrets | Direct |
-| `model-serving-qwen3-5` | **🟢 LIVE (active model, 2026-06-08)** — self-hosted Qwen3.5-4B Q4 on the home GPU via **llama.cpp** (`llama-server`): a **bjw-template StatefulSet** with ONE container (no Caddy — native `--api-key`), unsloth UD-Q4_K_XL GGUF from a pre-seeded RWX PVC + seed Job + Ingress. Federated as `qwen3-5-4b-local` (prefix `/v1`). Measured: ~52 tok/s decode, ~1.3k prefill, 4 slots, 128k ctx | Hybrid bjw, `homeCluster: true` (ADR-0022/0028/0030/0032) |
-| `model-serving-qwen3-4b` | Self-hosted Qwen3-4B on the home GPU (the reference build): **bjw-template StatefulSet** with TWO containers — huggingfaceserver (vLLM + in-pod LMCache) + a Caddy auth-proxy sidecar — + seed Job + Ingress. **Now disabled/standby (rollback)**, superseded as active by `model-serving-qwen3-5` 2026-06-08 (renamed from `model-serving`) | Hybrid bjw, `homeCluster: true` (ADR-0022/0028/0029/0030) |
+| `model-serving-qwen3-5` | **🟢 LIVE** self-hosted Qwen3.5-4B Q4 on the home GPU via llama.cpp; bjw-template StatefulSet, native `--api-key` | Hybrid bjw, `homeCluster: true` (ADR-0022/0030/0032) |
+| `model-serving-qwen3-4b` | Self-hosted Qwen3-4B via vLLM + Caddy auth-proxy sidecar; standby/rollback | Hybrid bjw, `homeCluster: true` (ADR-0029/0030) |
 | `ai-models-info` | OpenRouter-shape `/v1/models/info` catalog (nginx static) | Direct (ADR-0015) |
-| `librechart` → `librechat-app` / `librechat-search` / `librechat-opencode-wellknown` | Chat UI + Meili + opencode discovery | Orchestrator + leaves (ADR-0014) |
+| `librechart` → `librechat-app` / `librechat-search` / `librechat-opencode-wellknown` | Chat UI + Mongo + Meili + opencode discovery | Orchestrator + leaves (ADR-0014) |
+| `mcps` → `mcp` | MCP tool servers (self-hosted + proxiedExternal) | Orchestrator + leaves (ADR-0038/0040/0041) |
+| `lightbridge-repo-auth` | GitHub org→account binding for CI OIDC auth | Direct (ADR-0047/0049) |
 | `observability` | LGTM + Alloy + grafana-operator + dashboards | App-of-Apps (ADR-0020) |
-| `coder` → `coder-db` / `coder-app` | Cloud dev environments | App-of-Apps (ADR-0019) |
 | `apps` | Root chart: emits one Application per workload (umbrella multi-source) | Root (ADR-0018) |
 | `bjw-common` / `bjw-template` | Forked bjw-s common library | Library (ADR-0016) |
 
+> Full container map (by namespace): [suite · 02 Containers](./architecture/02-containers.md).
+
 ### Level 3 — the gateway request path (the load-bearing block)
 
+```mermaid
+flowchart TB
+    C["client (HTTP/2)"]:::ext
+    E["EnvoyProxy (HPA 3–20, LeastRequest LB)"]:::own
+    A["Authorino (replicas 2, JWKS ttl 3600)<br/>verify Keycloak JWT<br/>stamp x-oidc-* + x-account-id/x-org-id/x-billing-plan"]:::own
+    R["AIGatewayRoute (per model)"]:::own
+    B["BackendTrafficPolicy<br/>burst (per user) + monthly budget (per person)<br/>circuit breaker + outlier detection"]:::own
+    S["AIServiceBackend → provider<br/>(DeepInfra/Fireworks/Google) or self-hosted GPU"]:::own
+    O["access log (JSON, x-oidc-*) → Alloy → Loki/Mimir"]:::own
+
+    C --> E -->|ext_authz gRPC| A --> E
+    E --> R --> B --> S
+    E --> O
+
+    classDef own fill:#eaf3ea,stroke:#4a8a4a;
+    classDef ext fill:#eee,stroke:#888,stroke-dasharray:4 3;
 ```
-client ──HTTP/2──▶ EnvoyProxy (HPA 3–20, LeastRequest LB)
-                      │ ext_authz gRPC
-                      ▼
-                   Authorino (replicas 2, JWKS ttl 3600)
-                      │ verify Keycloak JWT
-                      │ stamp x-oidc-* + x-account-id/x-org-id/x-billing-plan
-                      ▼
-                   AIGatewayRoute (per model)
-                      │ BackendTrafficPolicy:
-                      │   burst req/min + tokens/min (per user)
-                      │   monthly USD budget (per org)
-                      │   circuit breaker + outlier detection
-                      ▼
-                   AIServiceBackend → provider (DeepInfra/Fireworks/Google)
-                      │ token-cost metadata (llmRequestCosts)
-                      ▼
-                   access log (JSON, x-oidc-*) → OTLP → Alloy → Loki/Mimir
-```
+
+> Sequence diagrams per identity surface: [suite · 03 Gateway components](./architecture/03-gateway-components.md).
 
 ---
 
@@ -191,34 +202,28 @@ client ──HTTP/2──▶ EnvoyProxy (HPA 3–20, LeastRequest LB)
 
 ### Scenario A — human dev via opencode (external plane, full attribution)
 
-1. `opencode auth login` → Keycloak code+PKCE → JWT (carries `sub`, `azp`,
-   `billing_plan`, org).
+1. `opencode auth login` → Keycloak code+PKCE → JWT (carries `sub`, `azp`, `billing_plan`).
 2. Request to `api.ai.camer.digital` with the user's JWT.
-3. Authorino verifies (JWKS cached), stamps `x-oidc-*` + `x-account-id` (=`sub`)
-   + `x-org-id` + `x-billing-plan`.
-4. `BackendTrafficPolicy` checks burst (per user) and monthly budget (per org);
-   denies on any exhausted bucket.
-5. Request proxied to provider; response token cost extracted.
+3. Authorino verifies (JWKS cached), stamps `x-oidc-*` + `x-account-id` (=`sub`) + `x-billing-plan`.
+4. `BackendTrafficPolicy` checks burst (per user) + monthly budget (per person); denies on any exhausted bucket.
+5. Request proxied to provider; response token cost extracted (`llmRequestCosts`).
 6. Access log → Alloy → Loki (labels `user_id`, `azp`) + Mimir counters.
 
-### Scenario B — human via LibreChat (internal plane, service-level attribution)
+### Scenario B — human via LibreChat (internal plane, per-user via forwarded sub)
 
-1. User logs into LibreChat (Keycloak OIDC); LibreChat holds a shared identity.
-2. LibreChat calls `core-gateway-internal.…svc` with a **service-account JWT**.
-3. Internal AuthConfig stamps `x-billing-plan: internal` (uncapped budget,
-   burst-only); metered under LibreChat's `azp`.
-4. Per-user budgeting for LibreChat's humans is LibreChat's own concern (it keeps
-   per-user balances). Gateway-side per-user attribution is structurally
-   impossible here (ADR-0021) — by design.
+1. User logs into LibreChat (Keycloak OIDC).
+2. LibreChat calls `core-gateway-internal.…svc` with an apiKey/SA token **and** `X-LibreChat-User: <end-user sub>`.
+3. Internal AuthConfig prefers that header → per-user `x-account-id`; `x-billing-plan: internal` (uncapped, burst-only).
 
-### Scenario C — CI service account
+### Scenario C — CI service account via GitHub OIDC (ADR-0047)
 
-JWT with `azp` in `serviceAccountClients` → `x-billing-plan: service` (uncapped,
-burst-protected, metered). Historically skipped OPA (ADR-0003); OPA now removed.
+1. Workflow mints its GHA OIDC token (audience = the org's Source URL); keyless.
+2. Authorino verifies (github issuer); `when github-actions` → calls `lightbridge-repo-auth /v1/resolve` with `repository_owner_id`.
+3. Bound + not-blocked → `{account_id, billing_plan}` stamped; unbound/blocked → 403.
 
 ### Scenario D — rollout under load
 
-EnvoyProxy rollout drains for 60s (`minDrainDuration` 15s) so long-lived
+EnvoyProxy rollout drains for 60 s (`minDrainDuration` 15 s) so long-lived
 SSE/token streams aren't cut; HPA keeps ≥3 replicas; PDB `maxUnavailable: 1`.
 
 ---
@@ -227,34 +232,36 @@ SSE/token streams aren't cut; HPA keeps ≥3 replicas; PDB `maxUnavailable: 1`.
 
 ### Two-cluster, two-tier GitOps
 
-```
-admin@homeos (Talos, ArgoCD)                home-remote (Hetzner k3s, workloads)
-  ns argocd:                                  ns apps / data / observability / platform:
-  ┌──────────────────────────┐                ┌────────────────────────────────────┐
-  │ ai-apps-v2 (manual root) │── deploys ───▶ │ Envoy AI Gateway, LibreChat, models,│
-  │ charts/apps              │                │ Coder, MCP, LGTM, dashboards         │
-  │  emits 1 App per workload│                │ (each its own ArgoCD Application,    │
-  │  (control objects here)  │                │  destination home-remote)            │
-  └──────────────────────────┘                └────────────────────────────────────┘
+```mermaid
+flowchart LR
+    subgraph cp["admin@homeos (Talos, ArgoCD) · ns argocd"]
+        ROOT["ai-apps-v2 (manual root)<br/>charts/apps → 1 App per workload<br/>(control objects live here)"]:::ctrl
+    end
+    subgraph wl["home-remote (Hetzner k3s, workloads)"]
+        W["Envoy AI Gateway · LibreChat · models<br/>MCP · LGTM · dashboards · repo-auth<br/>(each its own Application, dest home-remote)"]:::own
+    end
+    HO["home-os charts/cd<br/>pins ai-apps-v2 tag"]:::ext
+
+    HO -.->|GitOps-manages root tag| ROOT
+    ROOT ==>|deploys| W
+
+    classDef own fill:#eaf3ea,stroke:#4a8a4a;
+    classDef ctrl fill:#e8eef7,stroke:#4a6fa5;
+    classDef ext fill:#eee,stroke:#888,stroke-dasharray:4 3;
 ```
 
-- **Workloads** target `home-remote` (`argocd.destination`); a render guard
-  hard-fails an in-cluster workload destination unless `allowInCluster`.
-- **Control objects** (orchestrators emitting ApplicationSets) set
-  `controlPlane: true` → target `https://kubernetes.default.svc` / `argocd` ns.
-- **Per-env knobs** live in `environments/prod/cluster.yaml`; umbrella apps fold
-  in a kustomize dep overlay (`environments/prod/deps/<app>/`) for the ingress
-  `Certificate`, per-app `ExternalSecret`, and any `CiliumNetworkPolicy`.
+- **Workloads** target `home-remote`; a render guard hard-fails an in-cluster workload destination unless `allowInCluster`.
+- **Control objects** (orchestrators emitting ApplicationSets) set `controlPlane: true` → `https://kubernetes.default.svc` / `argocd` ns.
+- **`homeCluster: true`** is the one sanctioned exception — the self-hosted GPU models (ADR-0022).
+- **Per-env knobs** live in `environments/prod/cluster.yaml`; umbrella apps fold in a kustomize dep overlay (`environments/prod/deps/<app>/`).
 
 ### Sync waves (infrastructure → storage → collection → visualisation)
 
-| Wave | What |
-|---|---|
-| −2 | Storage backends (Mimir, Loki, Tempo, kube-state-metrics, node-exporter) |
-| −1 | Operators + grafana-operator + Alloy collector |
-| 0 | Workloads (gateway, LibreChat, per-model apps, Coder) |
-| 1 | Content (dashboards, opencode-wellknown) |
-| 2+ | Post-sync |
+```mermaid
+flowchart LR
+    A["-3 namespace + secrets +<br/>allow-same-namespace"]:::w --> B["-2 storage backends<br/>Mimir/Loki/Tempo/ksm/node-exporter"]:::w --> C["-1 operators + collectors<br/>grafana-operator/Alloy"]:::w --> D["0 workloads<br/>gateway/LibreChat/models"]:::w --> E["1 content<br/>dashboards/opencode-wellknown"]:::w --> F["2+ post-sync"]:::w
+    classDef w fill:#eaf3ea,stroke:#4a8a4a;
+```
 
 Violating this order cost a day once — `MONITORING_FIX.md` is the postmortem.
 
@@ -262,23 +269,24 @@ Violating this order cost a day once — `MONITORING_FIX.md` is the postmortem.
 
 Cilium deny-egress: API-server reach needs `toEntities: [kube-apiserver]`; S3
 needs `toFQDNs: "*.your-objectstorage.com"`. Hetzner LB targets workers only
-(control-plane nodes excluded) and needs `use-private-ip: true`.
+(control-plane nodes excluded) and needs `use-private-ip: true`. Detail:
+[suite · 06 Networking & TLS](./architecture/06-networking-tls.md).
 
 ---
 
 ## 8. Crosscutting concepts
 
-| Concept | How it's realised |
-|---|---|
-| **Identity** | Keycloak JWT (RS256); three surfaces: human/browser (LibreChat), human/API (opencode + self-service keys), service account (CI). `x-oidc-*` contract (ADR-0011). |
-| **Authorization** | JWT validity = entry; per-host AuthConfig differentiates plane/plan; no OPA in path (ADR-0003/0021). |
-| **Multi-tenancy** | `x-account-id` (user), `x-org-id` (org), `x-billing-plan` (Keycloak claim) → rate-limit tiers. |
-| **Quota** | Burst (req/min + tokens/min, per user) + monthly USD budget (per org) in `BackendTrafficPolicy`; Redis-backed counters. |
-| **Observability** | LGTM + Alloy; per-user Loki labels; dashboards-as-code; traces via Tempo. |
-| **Secrets** | ESO + `ssegning-aws`; chart-owned ExternalSecrets; app-scoped vs platform-scoped split. |
-| **TLS** | External: ACME HTTP-01 through the Gateway. Internal: `self-signed-ca` (Home Root CA), same trust model as redis-ha. |
-| **Config portability** | `environments/<env>/` overlays; `global.namespacePodSecurity`; per-cluster LB annotations. |
-| **Cost metadata** | Native Envoy `llmRequestCosts` extraction (Lua filter removed). |
+| Concept | How it's realised | Detail |
+|---|---|---|
+| **Identity** | Keycloak JWT (RS256); 3 surfaces: human/browser, human/API, service account (CI via GHA OIDC). `x-oidc-*` contract (ADR-0011). | [05](./architecture/05-auth-identity.md) |
+| **Authorization** | JWT validity = entry; per-host AuthConfig differentiates plane/plan; no OPA in path. | [05](./architecture/05-auth-identity.md) |
+| **Multi-tenancy** | `x-account-id` (user), `x-org-id`, `x-billing-plan` (Keycloak claim) → rate-limit tiers. | [05](./architecture/05-auth-identity.md) |
+| **Quota** | Burst + monthly USD budget (both per-person, ADR-0035) in `BackendTrafficPolicy`; Redis counters. | [09](./architecture/09-model-serving.md) |
+| **Observability** | LGTM + Alloy; per-user Loki labels; dashboards-as-code; traces via Tempo. | [08](./architecture/08-observability.md) |
+| **Secrets** | ESO + `ssegning-aws`; chart-owned ExternalSecrets; app vs platform split. | [07](./architecture/07-data-secrets.md) |
+| **TLS** | External: ACME HTTP-01 via the Gateway. Internal: `self-signed-ca` (Home Root CA). | [06](./architecture/06-networking-tls.md) |
+| **Config portability** | `environments/<env>/` overlays; `global.namespacePodSecurity`; per-cluster LB annotations. | [04](./architecture/04-gitops-deployment.md) |
+| **Cost metadata** | Native Envoy `llmRequestCosts` extraction (no Lua/Python hop). | [03](./architecture/03-gateway-components.md) |
 
 ---
 
@@ -289,7 +297,6 @@ The complete set lives in [`docs/adr/`](./adr/). The load-bearing ones:
 | ADR | Decision |
 |---|---|
 | 0002 | Phoenix → Tempo for LLM traces |
-| 0003 | `azp`-allowlist for SA-skip-OPA (OPA later removed entirely) |
 | 0004 | grafana-operator external mode + dashboards-as-code |
 | 0005 | Per-user attribution via Authorino headers → Loki labels |
 | 0008 | Python dashboard generation (grafana-foundation-sdk) |
@@ -300,20 +307,22 @@ The complete set lives in [`docs/adr/`](./adr/). The load-bearing ones:
 | 0016 | Fork bjw-s app-template/common locally |
 | 0017 | Two-tier destinations (control in-cluster, workloads home-remote) |
 | 0018 | Umbrella apps + `environments/` overlays |
-| 0019 | Coder App-of-Apps orchestrator |
 | 0020 | Observability App-of-Apps orchestrator |
-| 0021 | Burst/budget/billing via dual-plane AuthConfigs |
-| 0022 | Self-hosted GPU model federated into the gateway (cluster-local + Caddy auth-proxy; `homeCluster: true` exception to 0017) |
-| 0028 | Cost-recovery pricing for owned-hardware models (€/hour TCO → weighted per-token; replaces 0022's flat $0) |
-| 0029 | Self-hosted model as a plain Deployment (drop KServe/Knative) — always-on + Recreate on the dedicated GPU (supersedes 0022 serving mode) |
-| 0030 | Model + Caddy auth-proxy co-located in ONE StatefulSet (proxy → model over localhost), via bjw-template (refines 0029) |
-| 0031 | Tag-based deploys (`release-YYYY.MM.DD`), never `main` — immutable/reproducible/rollback-able; self-ref `targetRevision`s + root pin the tag; external sources pinned to SHAs; `tools/release.sh` |
-| 0032 | llama.cpp (`llama-server`) as a 2nd self-hosted engine alongside vLLM — GGUF/Q4_K_M, native `--api-key` (no Caddy), `/v1`, `/health`; chosen for Qwen3.5-4B Q4 (vLLM Qwen3.5 support turbulent). Chart `model-serving-qwen3-5` — **LIVE 2026-06-08** (swapped in for qwen3-4b) |
-| 0038 | MCP OAuth discovery (RFC 9728) via native AIEG `MCPRoute.securityPolicy.oauth` — gateway-served protected-resource metadata + 401 `resource_metadata` challenge on `/mcp/*`; Envoy-native JWT displaces Authorino there (x-oidc-* re-stamped via claimToHeaders) |
-| 0040 | External hosted MCPs (context7/firecrawl/refero) via per-MCP in-cluster **Caddy normalizing proxies** (`mode: proxiedExternal`) — Go-TLS upstream (handles ECDSA), credential injection, response Content-Type rewrite; reliable in-cluster plain-HTTP backends (supersedes the ADR-0039 EnvoyPatchPolicy) |
-| 0045 | Scrape-first dashboard sourcing — no board without verified metrics; API-verified gnetIds only; dashboards-as-code reserved for bespoke boards (per-user usage, ratelimit, Authorino) |
-| 0046 | Per-user attribution repair — flatten the OTLP access-log `attributes` envelope at Alloy, pin the stream `service_name=envoy-ai-gateway`, promote `user_id`/`azp`/`model` labels (supplements 0005) |
-| 0048 | Global `@vymalo/opencode-browser` plugin (page+control+debug = 33 tools incl. `browser_eval`; `debug` re-enabled 2026-06-14 by maintainer request); **removes the `chrome-devtools` MCP**; promotes `frontend` to a LEAN default primary (`default_agent`) that delegates to subagents (`@browser`, `@design`); pins a multimodal model ONLY on vision agents (`@browser`/`@design`), every other agent (primary + roles) inherits the session model (drops ADR-0044 per-role pins); one source only (don't also connect the MCP form). Corrects ADR-0044's token model — opencode DOES scope the *injected* tool set per agent (`request.ts resolveTools`→`Permission.disabled`: string-form `*`-deny drops a tool from `tools`/`activeTools`, agent `allow` wins), so the lean primary never carries the 33 `browser_*` schemas |
+| 0021 | Burst/budget/billing via dual-plane AuthConfigs (OPA removed) |
+| 0022 | Self-hosted GPU model federated into the gateway (`homeCluster: true`) |
+| 0027 | **Coder removed** (supersedes ADR-0019) |
+| 0028 | Cost-recovery pricing for owned-hardware models |
+| 0029/0030 | Self-hosted model as a plain/StatefulSet deployment (drop KServe) |
+| 0031 | Tag-based deploys (`release-YYYY.MM.DD`), never `main` |
+| 0032 | llama.cpp engine alongside vLLM — Qwen3.5-4B Q4 LIVE |
+| 0035 | Per-person monthly budget (drop the shared org bucket) |
+| 0038 | MCP OAuth discovery (RFC 9728) via native AIEG `MCPRoute.securityPolicy.oauth` |
+| 0040 | External MCPs via per-MCP in-cluster Caddy normalizing proxies |
+| 0041 | openresty request-body protocol-version rewrite for firecrawl |
+| 0045 | Scrape-first dashboard sourcing |
+| 0046 | Per-user attribution repair (flatten OTLP access-log attributes at Alloy) |
+| 0047/0049 | GitHub-OIDC CI binding (`lightbridge-repo-auth`) + operator-only onboarding |
+| 0048 | Global opencode-browser plugin + lean default primary agent |
 
 ADRs are immutable once Accepted; supersede with a new ADR.
 
@@ -321,17 +330,15 @@ ADRs are immutable once Accepted; supersede with a new ADR.
 
 ## 10. Quality requirements
 
-### Quality tree (scenarios)
-
 | Quality | Scenario | Target | Status |
 |---|---|---|---|
-| **Performance** | 2000 sustained clients, 5000 peak, mixed streaming | p95 added gateway latency < 50 ms; no window stalls | Tuned (ADR-0021); needs validated load test (see plan §load) |
+| **Performance** | 2000 sustained, 5000 peak, mixed streaming | p95 added gateway latency < 50 ms; no window stalls | Tuned (ADR-0021); load test pending |
 | **Scalability** | Traffic doubles | HPA scales data plane 3→20; Authorino HA | Configured |
 | **Availability** | A model backend starts erroring | Outlier detection ejects it in ≤30 s; clients reroute | Configured |
 | **Resilience** | Proxy rollout under load | No stream cut (60 s drain) | Configured |
-| **Observability** | "What did org X spend on model Y this month?" | Answerable in Grafana from Mimir counters | Partially shipped (ADR-0021 metering) |
+| **Observability** | "What did user X spend on model Y this month?" | Answerable in Grafana from Mimir counters | Partially shipped |
 | **Security** | Forged/expired JWT | Rejected at Authorino; no backend reached | Enforced |
-| **Cost** | Org exceeds monthly budget | Budget bucket denies; alert at 80% | Designed (ADR-0021) |
+| **Cost** | User exceeds monthly budget | Budget bucket denies; alert at 80% | Designed (ADR-0021) |
 | **Operability** | Add a model | List edit in `ai-models` values → new Application | Mechanical |
 
 ---
@@ -340,17 +347,15 @@ ADRs are immutable once Accepted; supersede with a new ADR.
 
 | Risk / debt | Impact | Mitigation / status |
 |---|---|---|
-| **Load test for 2000/5000 not yet re-run on Hetzner** | Capacity claims unvalidated; gateway is config-ready but not capacity-proven | Assessment + "average user" envelope in `docs/gateway-capacity.md`; Envoy HPA right-sized `[3;20]→[3;5]` to the 32-CPU worker pool; run `plans/artillery/` to get a real number, add workers before raising the ceiling |
-| **Keycloak `billing_plan` / org mappers not landed** | Plan falls back to `free`; org budget can't bucket | ADR-0021 external dependency |
-| **`enforce-valid-key` commented out** | No API-key revocation enforcement at gateway | SA-skip marker preserved for mechanical re-enable |
-| **Cilium deny-egress fragility** | New egress needs a CiliumNetworkPolicy or silent crashloop | Documented in cutover doc; overlay pattern established |
+| **Load test for 2000/5000 not yet re-run on Hetzner** | Capacity claims unvalidated | Envelope in `docs/gateway-capacity.md`; HPA right-sized; run `plans/artillery/` |
+| **Keycloak `billing_plan` / org mappers not landed** | Plan falls back to `free` | ADR-0021 external dependency |
+| **Cilium deny-egress fragility** | New egress needs a CiliumNetworkPolicy or silent crashloop | Overlay pattern established ([06](./architecture/06-networking-tls.md)) |
 | **`ai-gitops` referenced but never created** | Stale ADRs (0010/0013) mislead | CLAUDE.md flags it; env overrides in-repo |
-| **Single env (`prod`) only** | No staging to validate before deploy branch | Second env is a drop-in `environments/<env>/` |
-| **Tag-based deploys** | Manual root Application repoint per release | **Resolved 2026-06-08:** deploys pin the immutable tag `release-2026.06.08` (cut over from the branch); `main` is never a deploy target. Release runbook in CLAUDE.md. |
-| **LibreChat per-user gateway attribution impossible** | Coarse billing for chat users | By design (ADR-0021); handled inside LibreChat |
-| **Mimir 6.0 deferred (breaking)** | Pinned on 5.x | Currency audit tracks it |
-| **Mimir ring wedges if memberlist blocked at startup** | Distributor sees 0 ingesters (`InstancesCount <= 0`) → metrics silently dropped | **Guarded:** durable `allow-same-namespace` (observability-secrets child, wave -3) lands before stores + Mimir `memberlist.rejoin_interval: 1m` self-heals the residual ordering race (audit 2026-06-07) |
-| **External hosted MCPs unreliable as direct Envoy TLS backends** | AIEG empty-SNI `dummy.transport_socket`; BoringSSL rejects context7's ECDSA cert; refero mislabels JSON as `text/event-stream` → empty tools (AIEG #2218) | **Resolved (ADR-0040, `release-2026.06.10-v04`):** each external MCP (context7, firecrawl, refero) fronted by an in-cluster **Caddy normalizing proxy** (`mode: proxiedExternal`) — Go-TLS upstream (handles ECDSA), credential injection, refero Content-Type rewrite. Reliable in-cluster plain-HTTP backends; the ADR-0039 EnvoyPatchPolicy removed. Follow-ups: drop refero's rewrite when #2218 lands; populate `context7_api_key`. Diagnosis: [`docs/2026-06-10-mcp-external-server-proxy-debug.md`](2026-06-10-mcp-external-server-proxy-debug.md) |
+| **Single env (`prod`) only** | No staging to validate before release | Second env is a drop-in `environments/<env>/` |
+| **Tag-based deploys = manual two-repo step** | Forget the home-os repoint → root self-heals to old tag | Release runbook (CLAUDE.md, `docs/releasing.md`) |
+| **Mimir ring wedges if memberlist blocked at startup** | Metrics silently dropped | Guarded: wave -3 `allow-same-namespace` + `rejoin_interval: 1m` |
+| **External MCP proxy engines are interim** | openresty/Content-Type rewrites carried until AIEG #2218/#2219 land | Tracked in ADR-0040/0041 |
+| **MCP `MCP_TOKEN` token-bind race** | Empty-token proxy rejects all requests | Guarded: `optional: false` (waits for ESO) |
 
 ---
 
@@ -359,7 +364,7 @@ ADRs are immutable once Accepted; supersede with a new ADR.
 | Term | Meaning |
 |---|---|
 | **AIGatewayRoute** | Envoy AI Gateway CR: a model route + provider mapping |
-| **BackendTrafficPolicy** | Envoy Gateway CR enforcing rate limits, budget, circuit breaking on a route |
+| **BackendTrafficPolicy** | Envoy Gateway CR enforcing rate limits, budget, circuit breaking |
 | **AuthConfig** | Authorino CR: per-host auth/identity/response rules |
 | **Authorino** | Kuadrant ext_authz service verifying JWT and stamping headers |
 | **App-of-Apps** | Orchestrator chart rendering child `Application` CRs directly |
@@ -371,4 +376,4 @@ ADRs are immutable once Accepted; supersede with a new ADR.
 | **LGTM** | Loki / Grafana / Tempo / Mimir observability stack |
 | **Alloy** | Grafana's OTel-collector/agent (metrics scrape, log tail, OTLP) |
 | **ssegning-aws** | The external `ClusterSecretStore` ESO reads from |
-| **Plane plan / tier** | `free` / `pro` / `service` / `internal` rate-limit + budget tier |
+| **Plan / tier** | `free` / `pro` / `service` / `internal` rate-limit + budget tier |

--- a/docs/arc42.md
+++ b/docs/arc42.md
@@ -179,7 +179,7 @@ flowchart TB
 ```mermaid
 flowchart TB
     C["client (HTTP/2)"]:::ext
-    E["EnvoyProxy (HPA 3–20, LeastRequest LB)"]:::own
+    E["EnvoyProxy (HPA 3–5, LeastRequest LB)"]:::own
     A["Authorino (replicas 2, JWKS ttl 3600)<br/>verify Keycloak JWT<br/>stamp x-oidc-* + x-account-id/x-org-id/x-billing-plan"]:::own
     R["AIGatewayRoute (per model)"]:::own
     B["BackendTrafficPolicy<br/>burst (per user) + monthly budget (per person)<br/>circuit breaker + outlier detection"]:::own
@@ -333,7 +333,7 @@ ADRs are immutable once Accepted; supersede with a new ADR.
 | Quality | Scenario | Target | Status |
 |---|---|---|---|
 | **Performance** | 2000 sustained, 5000 peak, mixed streaming | p95 added gateway latency < 50 ms; no window stalls | Tuned (ADR-0021); load test pending |
-| **Scalability** | Traffic doubles | HPA scales data plane 3→20; Authorino HA | Configured |
+| **Scalability** | Traffic doubles | HPA scales data plane 3→5 (right-sized to the 32-CPU worker pool; raise with workers); Authorino HA | Configured |
 | **Availability** | A model backend starts erroring | Outlier detection ejects it in ≤30 s; clients reroute | Configured |
 | **Resilience** | Proxy rollout under load | No stream cut (60 s drain) | Configured |
 | **Observability** | "What did user X spend on model Y this month?" | Answerable in Grafana from Mimir counters | Partially shipped |

--- a/docs/arc42.md
+++ b/docs/arc42.md
@@ -2,7 +2,7 @@
 
 > [arc42](https://arc42.org) architecture description for the AI platform
 > deployed by this repository — the twelve sections applied to the steady state
-> at `release-2026.06.14-v03`. Every diagram is mermaid.
+> at `release-2026.06.14-v09`. Every diagram is mermaid.
 >
 > **Companion reading:** the single-page [architecture map](./architecture.md),
 > the layered, mermaid-rich [architecture suite](./architecture/README.md)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,324 +1,147 @@
 # Architecture overview
 
-One document mapping how this repo's charts compose into a running
-system. Read after the top-level [README](../README.md), before diving
-into any specific subsystem.
+The single-page map of how this repo's charts compose into a running system.
+Read after the top-level [README](../README.md). For depth, follow the
+**[layered architecture suite](architecture/README.md)** (C4 context → container →
+component, plus one page per subsystem) or the formal
+**[arc42 description](arc42.md)**. Every *why* lives in the
+[ADR index](adr/README.md).
 
-## Cluster topology
+> Reflects `release-2026.06.14-v03`. Coder was removed (ADR-0027) and is not shown.
 
-```
-                          ┌────────────────────────────────────────┐
-                          │             Internet                   │
-                          └────────────────┬───────────────────────┘
-                                           │ TLS (Let's Encrypt + Cloudflare DNS-01)
-                                           ▼
-                          ┌────────────────────────────────────────┐
-                          │ Traefik / Envoy AI Gateway             │
-                          │   (`core-gateway`)                     │
-                          │   ├── ai.camer.digital      → librechat│
-                          │   ├── ai.camer.digital/opencode/...    │
-                          │   │                          → opencode-wellknown
-                          │   ├── api.ai.camer.digital  → AI       │
-                          │   │                            backend │
-                          │   │     (Authorino auth + AIGateway-   │
-                          │   │      Routes per model)             │
-                          │   └── auth.verif.fyi        → Keycloak │
-                          │       (separate cluster, federated)    │
-                          └────────────────┬───────────────────────┘
-                                           │
-                      ┌────────────────────┼────────────────────┐
-                      ▼                    ▼                    ▼
-        ┌──────────────────┐   ┌──────────────────┐   ┌──────────────────┐
-        │  LibreChat       │   │ Lightbridge      │   │ Coder            │
-        │  (charts/        │   │ (lightbridge-    │   │ (coder + coder-db│
-        │   librechart)    │   │  backend)        │   │  CNPG cluster)   │
-        │   ├── librechat- │   │ Validates API    │   │ Dev environments │
-        │   │   app +Mongo │   │ keys; injects    │   │ in cloud         │
-        │   ├── librechat- │   │ x-project-id, ...│   │                  │
-        │   │   search    │   │                  │   │                  │
-        │   │   (Meili)    │   │                  │   │                  │
-        │   └── opencode-  │   │                  │   │                  │
-        │       wellknown  │   │                  │   │                  │
-        └──────────────────┘   └──────────────────┘   └──────────────────┘
-                                           │
-                  ┌────────────────────────┼────────────────────────────┐
-                  ▼                        ▼                            ▼
-        ┌──────────────────┐   ┌──────────────────┐         ┌──────────────────┐
-        │ AI models        │   │ MCP servers      │         │ Observability    │
-        │ (charts/         │   │ (mcpo + mcps:    │         │ (Mimir / Loki /  │
-        │  ai-models, fans │   │  brave, terraform│         │  Tempo / Alloy / │
-        │  out to one App  │   │  firecrawl, ...) │         │  Grafana)        │
-        │  per model)      │   │                  │         │                  │
-        │  ├── DeepInfra   │   │                  │         │  + dashboards    │
-        │  ├── Fireworks   │   │                  │         │    via grafana-  │
-        │  └── Google AI   │   │                  │         │    operator      │
-        └──────────────────┘   └──────────────────┘         └──────────────────┘
+## Where to go for what
+
+```mermaid
+flowchart LR
+    HERE["📍 architecture.md<br/><i>you are here — the map</i>"]:::own
+    SUITE["architecture/ suite<br/><i>11 layered, mermaid pages</i>"]:::own
+    ARC["arc42.md<br/><i>formal 12-section</i>"]:::own
+    ADR["adr/<br/><i>the why</i>"]:::own
+    HERE --> SUITE & ARC & ADR
+    classDef own fill:#eaf3ea,stroke:#4a8a4a;
 ```
 
-## ArgoCD topology
-
-Everything is GitOps:
-
-The **entrypoint** is a single root Application, `ai-apps-v2`, that points at
-`charts/apps` in this repo. There is **no `ai-gitops` repo** — the root is
-**applied manually** (from a maintainer-held manifest) onto the ArgoCD cluster.
-Deploys are **tag-based** (immutable `release-YYYY.MM.DD`, never `main` — ADR-0031):
-
-```yaml
-# applied manually on the ArgoCD cluster (admin@homeos) — no ai-gitops repo
-- name: ai-apps-v2
-  project: ai
-  source:
-    repoURL: https://github.com/ADORSYS-GIS/ai-helm
-    targetRevision: release-2026.06.08-v02   # immutable release tag — never main (ADR-0031)
-    path: charts/apps
-  destination:
-    server: https://kubernetes.default.svc   # in-cluster/argocd: the root is a
-    namespace: argocd                         # control object (ADR-0017); children → home-remote
-  syncPolicy:
-    automated: { prune: true, selfHeal: true }
-```
-
-`charts/apps` is reconciled onto the `home-remote` cluster; the
-Application CRDs it emits land in that cluster's `argocd` namespace and
-are reconciled there. **Every** generated Application references the same
-cluster by the same registered name `home-remote` — never ArgoCD's
-built-in in-cluster handle (a render-time guard enforces this; ADR-0017).
-
-Two-tier destination (ADR-0017): the `Application` / `ApplicationSet`
-CRs themselves live **in-cluster** (the `argocd` namespace where ArgoCD's
-controllers run); the **workloads** they deploy target **`home-remote`**.
-
-```
-ArgoCD (in-cluster)                         ← Application/ApplicationSet CRs live here (argocd ns)
-  ├─ Application: ai-apps-v2               (entry point; points at charts/apps; dest in-cluster)
-  │
-  └─ charts/apps emits 1 Application per workload (workloads → home-remote):
-       │
-       ├─ Application: kube-state-metrics, node-exporter
-       ├─ Application: mimir, loki, tempo, alloy, grafana, grafana-operator
-       ├─ Application: observability-dashboards
-       ├─ Application: eg, aieg, aieg-crd
-       ├─ Application: core-gateway, authorino-operator, security-policies
-       ├─ Application: keycloak-baseline    (keycloak-config-cli realm sync)
-       ├─ Application: librechat  ─┐  controlPlane:true → the ApplicationSet
-       ├─ Application: models     ─┤  lands in-cluster; its child Applications
-       │                           ┘  deploy workloads to home-remote
-       └─ Application: <≈ 25 more apps>     (workloads → home-remote)
-```
-
-**Two render patterns** for complex charts:
-
-1. **Direct** — chart renders its workloads directly. Most charts. One
-   ArgoCD `Application` per chart.
-2. **Orchestrator + leaves** — the chart emits a single `ApplicationSet`
-   (List generator) that fans out to N child Applications, each pointing
-   at a leaf chart in this same repo. Used by `ai-models` (ADR-0012) and
-   `librechart` (ADR-0014). One `Application` becomes one
-   `ApplicationSet` becomes N `Application`s.
-
-Choose pattern (2) when the components inside the chart have
-**different lifecycles** (sync waves, restart cadence, per-component
-rollback) or when adding/removing components should be a list edit
-rather than a values diff.
-
-## Sync waves
-
-Lower waves sync first. Conventions:
-
-| Wave | What |
+| You want… | Go to |
 |---|---|
-| `-5` to `-3` | (reserved for namespace bootstrap, ResourceQuota / LimitRange — see [SYNC_WAVE_PATTERN.md](../SYNC_WAVE_PATTERN.md)) |
-| `-2` | Storage / observability backends (Mimir, Loki, Tempo, kube-state-metrics, node-exporter) |
-| `-1` | Operators + grafana-operator + collectors (Alloy). NOTE: **cert-manager and the External Secrets Operator (ESO) are no longer synced here** — both their controllers/CRDs, the shared ClusterIssuers (`cert-home-cert-http`, `self-signed-ca`, …), and the `ssegning-aws` ClusterSecretStore are provisioned externally (home-os / cluster bootstrap). This repo only references the issuers + Secret names. |
-| `0` | Workloads (LibreChat, AI Gateway, Coder, all per-model apps) |
-| `1` | Content (Grafana dashboards, opencode-wellknown, anything that depends on a running gateway) |
-| `2+` | Per-app post-sync work |
+| Who uses it & what it depends on | [suite · 01 Context](architecture/01-context.md) |
+| What's deployed where | [suite · 02 Containers](architecture/02-containers.md) |
+| How a request flows | [suite · 03 Gateway components](architecture/03-gateway-components.md) |
+| How charts become workloads; releases | [suite · 04 GitOps](architecture/04-gitops-deployment.md) |
+| Auth, identity, the `x-oidc-*` contract | [suite · 05 Auth](architecture/05-auth-identity.md) |
+| Networking, Cilium, TLS | [suite · 06 Networking & TLS](architecture/06-networking-tls.md) |
+| Data, secrets, object storage | [suite · 07 Data & secrets](architecture/07-data-secrets.md) |
+| The observability pipeline | [suite · 08 Observability](architecture/08-observability.md) |
+| Model fan-out + the GPU model | [suite · 09 Model serving](architecture/09-model-serving.md) |
+| MCP routing + proxies | [suite · 10 MCP](architecture/10-mcp.md) |
 
-The rule is **infrastructure before storage before collection before
-visualisation** (and the postmortem in [MONITORING_FIX.md](../MONITORING_FIX.md)
-explains why a violation cost us a day).
+## Cluster topology (the one-glance view)
 
-## Auth & identity
+```mermaid
+flowchart TB
+    NET["🌐 Internet"]:::ext
+    LB["Hetzner LB → Traefik / Envoy data-plane"]:::ext
 
-```
-Browser / CLI ──── OIDC code+PKCE / device-code ─────► Keycloak (auth.verif.fyi)
-                                                       realm: camer-digital
-                                                       ↓
-                                                       JWT (RS256)
-                                                       ↓
-       ┌───────────────────────────────────────────────┴────────┐
-       │                                                        │
-       ▼                                                        ▼
-  api.ai.camer.digital                                    Self-service portal
-  (Envoy AI Gateway)                                      (selfServiceMcpApi
-  ↓                                                       Keycloak client)
-  Authorino ext_authz  (DUAL-PLANE, AuthConfig-per-host — ADR-0021)
-  ↓
-  ├── EXTERNAL host (api.ai-v2…) → verify Keycloak JWT (JWKS)
-  ├── INTERNAL host (core-gateway-internal.svc) → k8s SA TokenReview OR apiKey
-  ├── (OPA REMOVED 2026-06-04 — a valid JWT/SA/apiKey = access; OPA was the old
-  │    lightbridge-validation step, now gone; reserved for future burst control)
-  ├── inject x-oidc-* headers downstream (ADR-0011):
-  │    user_id, user_name, azp, iss, roles, scope, jti, email, name
-  └── inject rate-limit descriptors: x-account-id, x-org-id, x-billing-plan
-       (CEL: Keycloak claims w/ defaults; or a LibreChat-forwarded end-user sub)
-  ↓
-  per-model BackendTrafficPolicy → burst (x-account-id) + budget (x-org-id) by tier
-  ↓
-  Envoy access log (JSON) → Alloy → Loki labels {user_id, azp}
-```
+    subgraph gw["Gateway (converse-gateway + envoy-*-system + authorino-system)"]
+        CG["Envoy AI Gateway (core-gateway)<br/>ai.camer.digital → LibreChat<br/>api.ai.camer.digital → /v1 (Authorino)<br/>api.ai.camer.digital/mcp/* → MCP (native JWT)"]:::own
+    end
 
-> **Exception — `/mcp/*` (ADR-0038):** the five MCPRoutes carry their own
-> `securityPolicy.oauth` (MCP-spec OAuth), which displaces Authorino on those
-> routes: Envoy's native JWT filter verifies the same Keycloak issuer, the
-> gateway itself serves the RFC 9728 discovery surface unauthenticated
-> (`/.well-known/oauth-protected-resource/mcp/<name>` + AS-metadata aliases +
-> the path-appended PRM alias + the 401 `resource_metadata` challenge), and
-> `claimToHeaders` re-stamps the ADR-0011 `x-oidc-*` set. Rate-limit
-> descriptors are NOT stamped on `/mcp/*` (no MCP rate limiting today).
->
-> ⚠️ **External hosted MCPs go through in-cluster Caddy proxies (ADR-0040).**
-> Direct external-TLS MCP backends were unfixable at the Envoy layer (AIEG's
-> empty-SNI `dummy.transport_socket`; BoringSSL rejecting context7's ECDSA cert;
-> refero's mislabeled `text/event-stream` → empty tools, AIEG #2218). Each
-> external MCP (context7, firecrawl, refero) is now fronted by a per-MCP **Caddy
-> normalizing proxy** (`charts/mcp` `mode: proxiedExternal`) that does the
-> upstream TLS (Go TLS handles ECDSA), injects the credential, and (refero only)
-> rewrites the response `Content-Type → application/json`. They become reliable
-> in-cluster plain-HTTP backends like brave/terraform; the ADR-0039
-> EnvoyPatchPolicy is removed. Full diagnosis:
-> [`docs/2026-06-10-mcp-external-server-proxy-debug.md`](2026-06-10-mcp-external-server-proxy-debug.md).
+    subgraph app["Application plane"]
+        LC["LibreChat<br/>(converse-chat)"]:::ctrl
+        MODELS["AI models<br/>(converse)"]:::ctrl
+        MCP["MCP servers<br/>(converse-mcp)"]:::ctrl
+        REPO["lightbridge-repo-auth<br/>(converse)"]:::own
+    end
 
-**Three identity surfaces** to know:
-- **Human users via LibreChat browser** — Keycloak code+PKCE, returns
-  a JWT; LibreChat's session represents it; calls to backends carry
-  LibreChat-templated headers (X-USER-ID, X-USER-EMAIL, etc.) per
-  [`docs/librechat_headers_tracing_doc.md`](librechat_headers_tracing_doc.md).
-- **Humans via the OpenAI-compatible endpoint** — API keys from the
-  Lightbridge self-service portal. Used by `opencode`, third-party
-  CLIs, scripts. Backed by Keycloak OAuth flows via the
-  `@vymalo/opencode-oauth2` plugin (ADR-0014, [`opencode-well-known.md`](opencode-well-known.md)).
-- **Service accounts (CI / remote)** — Keycloak service-account tokens on the
-  external plane. **In-cluster** services use the internal plane instead:
-  a k8s SA token (one-time jobs) or a static apiKey (long-running, e.g.
-  LibreChat) — ADR-0021. (OPA / the `azp`-skip of ADR-0003 are removed.)
+    subgraph infra["Platform plane"]
+        GPU["Self-hosted model 🟢<br/>(converse-poc, home GPU)"]:::gpu
+        OBS["Observability LGTM<br/>(observability)"]:::ctrl
+    end
 
-> ⚠️ The OPA-era detail above (lightbridge-opa validation, the SA-skip-OPA path,
-> the `x-project-id`/`x-api-key-id` headers) is **historical** — OPA was removed
-> 2026-06-04. See **ADR-0021** + `docs/2026-hetzner-cutover.md` for the current
-> dual-plane / Keycloak-JWT model.
+    KC["Keycloak"]:::ext
+    PROV["Model providers"]:::ext
 
-## Observability
+    NET --> LB --> CG
+    CG --> LC & MODELS & MCP
+    CG -.-> REPO
+    MODELS --> PROV & GPU
+    CG -.OIDC.-> KC
+    LC --> OBS
+    MODELS --> OBS
 
-```
-                  ┌──────────────────────────────────────┐
-                  │              Grafana                 │
-                  │  (datasources: mimir, loki, tempo,   │
-                  │   alertmanager)                      │
-                  └──────────────┬───────────────────────┘
-                                 │
-       ┌─────────────────────────┼─────────────────────────┐
-       ▼                         ▼                         ▼
-  ┌──────────┐              ┌──────────┐              ┌──────────┐
-  │  Mimir   │              │   Loki   │              │  Tempo   │
-  │ metrics  │              │   logs   │              │  traces  │
-  └──────────┘              └──────────┘              └──────────┘
-       ▲                         ▲                         ▲
-       │                         │                         │
-       └───────────┬─────────────┴─────────────┬───────────┘
-                   ▼                            ▼
-              ┌──────────┐                ┌──────────┐
-              │   Alloy  │                │   Alloy  │
-              │  (DaemonSet, ServiceMonitor / PodMonitor discovery,
-              │   pod-log tail, OTLP receiver, ai_gateway_user_attribution
-              │   stage promotes user_id/azp to Loki labels)
-              └──────────┘
-                   ▲
-                   │
-    OTLP: traces via the core-gateway -traces OTel collector;
-          Envoy access logs pushed direct to Alloy (the -usage
-          collector was removed — usage/billing is via the AI
-          Gateway + OAuth2 path)
-    /metrics scrape from kube-state-metrics, node-exporter, every
-    workload that ships a Service/PodMonitor
+    classDef own fill:#eaf3ea,stroke:#4a8a4a;
+    classDef ctrl fill:#e8eef7,stroke:#4a6fa5;
+    classDef ext fill:#eee,stroke:#888,stroke-dasharray:4 3;
+    classDef gpu fill:#f7e8f0,stroke:#a54a81;
 ```
 
-**Dashboards** ship as `GrafanaDashboard` CRs via `grafana-operator`
-(external mode — see [ADR-0004](adr/0004-grafana-operator-external-mode.md))
-and are generated from Python in `tools/dashboards/`
-(see [ADR-0008](adr/0008-python-dashboard-generation.md)).
+## GitOps in one diagram
 
-## Where every architectural choice is documented
+Two clusters: ArgoCD runs on `admin@homeos`; workloads run on Hetzner
+`home-remote`. The root `ai-apps-v2` Application is **applied manually** and pins
+an **immutable release tag** (never `main` — ADR-0031). Detail:
+[suite · 04 GitOps](architecture/04-gitops-deployment.md).
 
-In one place: [`docs/adr/`](adr/). Read [ADR-0001](adr/0001-record-architecture-decisions.md)
-first for the format and conventions, then the index in
-[`docs/adr/README.md`](adr/README.md).
+```mermaid
+flowchart LR
+    ROOT["ai-apps-v2 (root, in-cluster/argocd)<br/>→ charts/apps"]:::ctrl
+    APPS["~21 Applications/ApplicationSets<br/>(control objects in argocd ns)"]:::ctrl
+    WL["workloads → home-remote"]:::own
+    ROOT --> APPS ==> WL
+    classDef own fill:#eaf3ea,stroke:#4a8a4a;
+    classDef ctrl fill:#e8eef7,stroke:#4a6fa5;
+```
 
-The high-impact ones:
+## Auth in one diagram
 
-- [ADR-0002](adr/0002-replace-phoenix-with-tempo.md) — Arize Phoenix retired, Tempo is the LLM trace backend
-- [ADR-0003](adr/0003-skip-opa-for-service-accounts.md) — `azp`-allowlist for SA-skip-OPA
-- [ADR-0004](adr/0004-grafana-operator-external-mode.md) — grafana-operator + dashboards-as-code
-- [ADR-0005](adr/0005-per-user-attribution-via-authorino-headers.md) — JWT identity → Loki labels pipeline
-- [ADR-0011](adr/0011-oidc-downstream-headers.md) — canonical `x-oidc-*` header contract
-- [ADR-0012](adr/0012-split-ai-models-applicationset.md) — `ai-models` orchestrator split
-- [ADR-0014](adr/0014-split-librechart-and-opencode-wellknown.md) — `librechart` orchestrator split + opencode well-known
-- [ADR-0021](adr/0021-burst-budget-billing-and-dual-plane-authconfigs.md) — burst/budget/billing via dual-plane AuthConfigs (OPA removed; Keycloak JWT is the boundary)
-- [ADR-0022](adr/0022-self-hosted-gpu-model-federated-into-gateway.md) — self-hosted GPU model federated into the gateway (cluster-local + Caddy auth-proxy; `homeCluster: true`); the *how* is [`self-hosted-model-serving.md`](self-hosted-model-serving.md)
-- [ADR-0028](adr/0028-owned-hardware-model-pricing.md) — cost-recovery pricing for owned-hardware models (€/hour TCO → weighted per-token)
-- [ADR-0029](adr/0029-self-hosted-model-plain-deployment.md) — self-hosted model as a plain Deployment (drop KServe/Knative); always-on + Recreate on the dedicated GPU
-- [ADR-0030](adr/0030-merge-model-and-proxy-into-one-statefulset-bjw.md) — model + Caddy auth-proxy co-located in one StatefulSet (proxy → model over localhost), via bjw-template
-- [ADR-0032](adr/0032-llama-cpp-engine-for-self-hosted-models.md) — llama.cpp (`llama-server`) as a 2nd serving engine; **Qwen3.5-4B Q4 is the LIVE self-hosted model** (2026-06-08, `charts/model-serving-qwen3-5`, GGUF/`/v1`/native-`--api-key`), Qwen3-4B (vLLM) on standby. Per-model papers + measured capacity in [`docs/models/`](models/qwen3.5-4b-q4.md)
+Dual-plane, AuthConfig-per-Host (ADR-0021). A valid Keycloak JWT is the
+authorization boundary; CI uses GitHub OIDC via `lightbridge-repo-auth`. OPA was
+removed (2026-06-04). Detail: [suite · 05 Auth](architecture/05-auth-identity.md).
+
+```mermaid
+flowchart LR
+    H["human / dev"]:::ext -->|JWT / API key| EXT["EXTERNAL plane<br/>api.ai.camer.digital"]:::own
+    CI["CI runner"]:::ext -->|GHA OIDC| EXT
+    SVC["in-cluster svc"]:::ext -->|SA token / apiKey| INT["INTERNAL plane<br/>core-gateway-internal.svc"]:::own
+    EXT --> A["Authorino<br/>x-oidc-* + x-account-id/x-billing-plan"]:::own
+    INT --> A
+    A --> RL["per-model burst + monthly budget"]:::own
+    classDef own fill:#eaf3ea,stroke:#4a8a4a;
+    classDef ext fill:#eee,stroke:#888,stroke-dasharray:4 3;
+```
+
+> ⚠️ `/mcp/*` is the one carve-out from Authorino — Envoy-native JWT verification
+> + RFC 9728 discovery (ADR-0038), with external MCPs fronted by in-cluster
+> normalizing proxies (ADR-0040/0041). See [suite · 10 MCP](architecture/10-mcp.md).
+
+## Observability in one diagram
+
+LGTM + Alloy, per-user attribution from JWT → Loki labels. Detail:
+[suite · 08 Observability](architecture/08-observability.md).
+
+```mermaid
+flowchart BT
+    SRC["workloads · ksm · node-exporter ·<br/>pod logs · Envoy access log · traces"]:::own
+    ALLOY["Alloy (collect)"]:::own
+    STORE["Mimir / Loki / Tempo → S3"]:::own
+    GRAF["Grafana (+ operator dashboards)"]:::own
+    SRC --> ALLOY --> STORE --> GRAF
+    classDef own fill:#eaf3ea,stroke:#4a8a4a;
+```
 
 ## What is *not* in this repo
 
-- **Shared cluster infrastructure (installed externally).** Several
-  platform components are deployed/owned outside this repo — this repo
-  only *consumes* them by name. None of them have an Application here:
-  - **Traefik** — the ingress controller + `traefik` IngressClass (runs
-    in the `traefik` namespace). Charts here set `ingressClassName:
-    traefik`.
-  - **CloudNativePG** — the `cnpg` Postgres operator + the Barman Cloud
-    backup plugin (`cnpg-system`). This repo defines CNPG `Cluster` CRs
-    (e.g. `charts/coder-db`) that the external operator reconciles.
-  - **cert-manager** — controller, CRDs, and the shared ClusterIssuers
-    (home-os). This repo references `cert-manager.io/cluster-issuer:`.
-  - **Redis** — `redis-ha` (home-os, `redis-system`).
-- **Secrets + the External Secrets Operator.** ESO itself (controller +
-  CRDs) is installed externally — *not* by this repo. The
-  `ClusterSecretStore` in use is `ssegning-aws` (cluster-scoped,
-  external). ExternalSecret CRs are now **chart-owned** (in-chart +
-  `environments/<env>/deps/*` overlays), all referencing `ssegning-aws` —
-  the old wholesale `secrets` Application from `ai-ops-secrets.git` was
-  **removed (2026-06-04)**. App secrets pull from key
-  `ai/camer/digital/prod/env`, platform secrets from `prod/meta/test-app`.
-- **Deploy state (no `ai-gitops` repo).** It was planned (ADR-0010/0013) but
-  never built. Instead: per-env config lives **in this repo** under
-  `environments/<env>/` (ADR-0018); the root `ai-apps-v2` `Application` is
-  **applied manually** on the ArgoCD cluster; and the deployed version is an
-  **immutable release tag** `release-YYYY.MM.DD` that every self-reference pins
-  (ADR-0031 — see `docs/releasing.md` + `tools/release.sh`). Image-tag defaults
-  stay in `charts/<x>/values.yaml`, not chart logic (ADR-0013).
-- **Realm config secrets** — Keycloak client secrets are ESO-injected
-  at sync time; the realm structure is in
-  `charts/keycloak-baseline/values.yaml`.
-- **Backups themselves** — only the backup-job definitions
-  (`charts/*-backup/`); the S3 buckets and contents are operated
-  out-of-band.
+Shared cluster infrastructure is owned externally — this repo only *consumes* it
+by name (no Application here): **Traefik**, **CloudNativePG** + Barman,
+**cert-manager** + ClusterIssuers, **redis-ha**, the **External Secrets
+Operator** + the `ssegning-aws` store, and the **OpenTelemetry Operator**. There
+is also **no `ai-gitops` repo** — per-env config lives in `environments/` and the
+root Application is applied manually with its tag pinned in `home-os`
+`charts/cd`. Detail: [suite · 07 Data & secrets](architecture/07-data-secrets.md).
 
 ## Glossary
 
-- **AI Gateway** — Envoy AI Gateway (`aieg`); the OpenAI-compatible
-  reverse proxy fronting upstream LLM providers.
-- **Lightbridge** — first-party authz/authn service that validates
-  API keys + tracks usage per project/account.
-- **LGTM stack** — Grafana Labs' Loki + Grafana + Tempo + Mimir
-  observability set.
-- **MCP** — Model Context Protocol; the protocol LibreChat uses to
-  talk to first-party tool servers (Coder, GitHub, Lightbridge
-  self-service).
-- **ESO** — External Secrets Operator.
-- **CNPG** — CloudNativePG, the Postgres operator.
-- **Authorino** — Kuadrant project's ext_authz implementation;
-  enforces our AuthConfig.
+- **AI Gateway** — Envoy AI Gateway (`aieg`); the OpenAI-compatible reverse proxy fronting upstream LLM providers.
+- **lightbridge-repo-auth** — the GitHub-OIDC → billing-account binding for CI (ADR-0047).
+- **LGTM stack** — Loki + Grafana + Tempo + Mimir.
+- **MCP** — Model Context Protocol; the tool-server protocol exposed at `/mcp/*`.
+- **ESO** — External Secrets Operator. **CNPG** — CloudNativePG. **Authorino** — Kuadrant ext_authz enforcing our AuthConfig.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -7,7 +7,7 @@ component, plus one page per subsystem) or the formal
 **[arc42 description](arc42.md)**. Every *why* lives in the
 [ADR index](adr/README.md).
 
-> Reflects `release-2026.06.14-v03`. Coder was removed (ADR-0027) and is not shown.
+> Reflects `release-2026.06.14-v09`. Coder was removed (ADR-0027) and is not shown.
 
 ## Where to go for what
 

--- a/docs/architecture/01-context.md
+++ b/docs/architecture/01-context.md
@@ -1,0 +1,84 @@
+# 01 · System context (C4 Level 1)
+
+The platform as a single box, with everyone who talks to it and everything it
+depends on. No internals here — that's [02 Containers](02-containers.md).
+
+## The one-box view
+
+```mermaid
+flowchart TB
+    subgraph people["People & automated callers"]
+        HUMAN["👤 End user<br/>browser (chat)"]:::actor
+        DEV["🧑‍💻 Developer<br/>opencode / OpenAI-compatible CLI"]:::actor
+        CI["🤖 CI runner<br/>GitHub Actions"]:::actor
+        OPS["🛠️ Platform maintainer"]:::actor
+        FIN["📊 Finance / billing"]:::actor
+    end
+
+    PLATFORM["🟢 <b>Camer Digital AI Platform</b><br/>(ai-helm)<br/><br/>OpenAI-compatible inference,<br/>chat UI, MCP tools, dev observability"]:::platform
+
+    subgraph ext["External systems (consumed, not owned)"]
+        KC["🔑 Keycloak IdP<br/>auth.verif.fyi<br/>realm camer-digital"]:::ext
+        PROV["🧠 Model providers<br/>DeepInfra · Fireworks · Google AI"]:::ext
+        GH["🐙 GitHub<br/>source · Actions OIDC · App webhooks"]:::ext
+        EXTMCP["🔌 Hosted MCP servers<br/>context7 · firecrawl · refero"]:::ext
+        S3["🪣 Hetzner Object Storage<br/>nbg1.your-objectstorage.com"]:::ext
+        HCLOUD["☁️ Hetzner Cloud LB"]:::ext
+    end
+
+    HUMAN -->|"OIDC login, chat"| PLATFORM
+    DEV -->|"API key / JWT, /v1 calls"| PLATFORM
+    CI -->|"GHA OIDC token → gateway"| PLATFORM
+    OPS -->|"git push (GitOps)"| PLATFORM
+    FIN -->|"reads Grafana"| PLATFORM
+
+    PLATFORM -->|"verify JWT (JWKS)"| KC
+    PLATFORM -->|"proxy inference"| PROV
+    PLATFORM -->|"clone charts; resolve repo→account"| GH
+    PLATFORM -->|"proxy tool calls (via in-cluster proxies)"| EXTMCP
+    PLATFORM -->|"metrics/logs/traces + DB backups"| S3
+    HCLOUD -->|"public ingress"| PLATFORM
+
+    classDef actor fill:#fff,stroke:#555,color:#222;
+    classDef platform fill:#eaf3ea,stroke:#4a8a4a,color:#1a401a,stroke-width:2px;
+    classDef ext fill:#eee,stroke:#888,color:#333,stroke-dasharray:4 3;
+```
+
+## Actors
+
+| Actor | How they reach the platform | Identity |
+|---|---|---|
+| **End user** | LibreChat browser UI at `ai.camer.digital` | Keycloak OIDC (code + PKCE) |
+| **Developer** | `opencode` / any OpenAI-compatible client at `api.ai.camer.digital/v1` | API key from the self-service portal, or a Keycloak JWT |
+| **CI runner** | GitHub Actions calling the gateway | **GitHub Actions OIDC token** → resolved to a billing account by `lightbridge-repo-auth` (no shared key — see [05](05-auth-identity.md)) |
+| **Platform maintainer** | `git push` → ArgoCD reconciles | Git + cluster RBAC |
+| **Finance / billing** | Grafana dashboards | Read-only |
+
+## External systems (the platform's hard dependencies)
+
+These are **referenced by name only** — installed and owned by the companion
+repos (`home-os`, `hetzner-k8s`) or by SaaS vendors. See
+[07 Data & secrets](07-data-secrets.md) and
+[06 Networking & TLS](06-networking-tls.md) for how each is wired in.
+
+| System | Role | Owner |
+|---|---|---|
+| **Keycloak** (`auth.verif.fyi`) | The OIDC identity provider; issues every human/SA JWT; source of the `billing_plan` claim | external |
+| **Model providers** | The actual inference (DeepInfra, Fireworks, Google AI Studio) | SaaS |
+| **GitHub** | Chart source repo; **GHA OIDC** issuer for CI auth; **App webhooks** for `lightbridge-repo-auth` org→account binding | SaaS |
+| **Hosted MCP servers** | Third-party tools (context7, firecrawl, refero) — fronted by in-cluster normalizing proxies | SaaS |
+| **Hetzner Object Storage** | S3 for Mimir/Loki/Tempo blocks, CNPG/Mongo backups, LibreChat files | Hetzner |
+| **Hetzner Cloud LB** | The public data-plane load balancer (`46.225.38.138`) | Hetzner |
+| **cert-manager · ESO · Redis · CNPG · Traefik** | TLS, secret sync, sessions/counters, Postgres, ingress | `home-os` / `hetzner-k8s` |
+
+## Scope boundary
+
+**Inside** the box (this repo owns): the Envoy AI Gateway + auth policies,
+per-model routing + budgets, LibreChat, the opencode discovery + model catalog,
+MCP servers + proxies, the self-hosted GPU model, the observability stack +
+dashboards, and all the GitOps glue.
+
+**Outside** the box: every dashed node above, plus the ArgoCD control plane
+itself (it runs on a *separate* cluster — see [04 GitOps](04-gitops-deployment.md)).
+
+→ Next layer: [02 · Containers](02-containers.md)

--- a/docs/architecture/02-containers.md
+++ b/docs/architecture/02-containers.md
@@ -31,9 +31,9 @@ flowchart TB
         REPOAUTH["lightbridge-repo-auth<br/><i>GitHub org→account binding</i>"]:::own
         UI["converse-ui<br/><i>self-service frontend</i>"]:::own
     end
-    subgraph chat_ns["ns: converse-chat"]
-        LC["librechat<br/><i>app + MongoDB + Meili search<br/>+ opencode well-known</i>"]:::ctrl
-        MB["mongodb-backup"]:::own
+    subgraph chat_ns["ns: converse (LibreChat) · converse-chat (backup)"]
+        LC["librechat → ns converse<br/><i>app + MongoDB + Meili search<br/>+ opencode well-known</i>"]:::ctrl
+        MB["mongodb-backup<br/><i>ns converse-chat</i>"]:::own
     end
     subgraph mcp_ns["ns: converse-mcp"]
         MCPS["mcps<br/><i>brave · terraform (self-hosted)<br/>context7 · firecrawl · refero (proxied)</i>"]:::ctrl
@@ -105,7 +105,7 @@ flowchart TB
 | `lightbridge-backend` | `converse` | `charts/lightbridge` | First-party authz/usage service |
 | `lightbridge-repo-auth` | `converse` | external repo | Binds GitHub orgs → billing accounts so CI authenticates via GHA OIDC ([05](05-auth-identity.md)) |
 | `converse-ui` | `converse` | external repo | Self-service frontend |
-| `librechat` | `converse-chat` | `charts/librechart` (orchestrator) | Chat UI + MongoDB + Meili search + the opencode `.well-known` discovery |
+| `librechat` | `converse` (children, via librechart `destination.namespace`) | `charts/librechart` (orchestrator) | Chat UI + MongoDB + Meili search + the opencode `.well-known` discovery |
 | `mongodb-backup` | `converse-chat` | `charts/mongodb-backup` | CronJob → object storage |
 | `mcps` | `converse-mcp` | `charts/mcps` (orchestrator) | The MCP tool servers — see [10 MCP](10-mcp.md) |
 

--- a/docs/architecture/02-containers.md
+++ b/docs/architecture/02-containers.md
@@ -1,0 +1,149 @@
+# 02 · Containers (C4 Level 2)
+
+The platform broken into deployable units, **grouped by namespace** on the
+Hetzner workload cluster (`home-remote`). Each box is roughly one ArgoCD
+`Application` / one chart. The ArgoCD control plane that *deploys* all of this
+lives on a different cluster — see [04 GitOps](04-gitops-deployment.md).
+
+## Workload map (by namespace)
+
+```mermaid
+flowchart TB
+    LB(["☁️ Hetzner LB → Traefik / Envoy data-plane"]):::ext
+
+    subgraph eg_ns["ns: envoy-gateway-system"]
+        EG["eg<br/><i>Envoy Gateway controller<br/>+ data-plane proxies</i>"]:::own
+    end
+    subgraph aieg_ns["ns: envoy-ai-gateway-system"]
+        AIEG["aieg + aieg-crd<br/><i>AI Gateway controller</i>"]:::own
+    end
+    subgraph gw_ns["ns: converse-gateway"]
+        CG["core-gateway<br/><i>Gateway, listeners, AIGatewayRoutes,<br/>BackendTrafficPolicies, ACME issuer,<br/>OTel traces collector</i>"]:::own
+        SP["security-policies<br/><i>Authorino AuthConfigs + SecurityPolicy</i>"]:::own
+    end
+    subgraph authz_ns["ns: authorino-system"]
+        AUTH["authorino-operator<br/><i>+ Authorino instance (ext_authz)</i>"]:::own
+    end
+
+    subgraph converse_ns["ns: converse"]
+        MODELS["models<br/><i>ai-models orchestrator →<br/>1 route+budget App per model</i>"]:::ctrl
+        LBACK["lightbridge-backend<br/><i>authz/usage service</i>"]:::own
+        REPOAUTH["lightbridge-repo-auth<br/><i>GitHub org→account binding</i>"]:::own
+        UI["converse-ui<br/><i>self-service frontend</i>"]:::own
+    end
+    subgraph chat_ns["ns: converse-chat"]
+        LC["librechat<br/><i>app + MongoDB + Meili search<br/>+ opencode well-known</i>"]:::ctrl
+        MB["mongodb-backup"]:::own
+    end
+    subgraph mcp_ns["ns: converse-mcp"]
+        MCPS["mcps<br/><i>brave · terraform (self-hosted)<br/>context7 · firecrawl · refero (proxied)</i>"]:::ctrl
+    end
+    subgraph poc_ns["ns: converse-poc"]
+        QWEN["model-serving-qwen3-5 🟢<br/><i>Qwen3.5-4B Q4 · llama.cpp · GPU</i>"]:::gpu
+        QWEN4["model-serving-qwen3-4b<br/><i>vLLM · standby</i>"]:::gpu
+    end
+
+    subgraph obs_ns["ns: observability"]
+        OBS["observability orchestrator →<br/>mimir · loki · tempo · alloy ·<br/>grafana · grafana-operator ·<br/>kube-state-metrics · node-exporter ·<br/>dashboards"]:::ctrl
+    end
+    subgraph mon_ns["ns: monitoring"]
+        APPR["apprise-api · opencode-k8s-agent"]:::own
+    end
+    subgraph sys_ns["ns: kube-system"]
+        MS["metrics-server"]:::own
+    end
+
+    subgraph external["External (consumed by name)"]
+        KC["Keycloak"]:::ext
+        REDIS["redis-ha<br/>redis-system"]:::ext
+        CNPG["CNPG operator + lightbridge-db<br/>cnpg-system"]:::ext
+        ESO["ESO + ssegning-aws store<br/>external-secrets"]:::ext
+        S3["Hetzner Object Storage"]:::ext
+        PROV["Model providers"]:::ext
+    end
+
+    LB --> CG
+    CG -.->|ext_authz| AUTH
+    SP -.->|configures| AUTH
+    CG -->|routes| MODELS
+    MODELS -->|provider backends| PROV
+    MODELS -->|self-hosted| QWEN
+    CG -->|"/mcp/*"| MCPS
+    LC -->|/v1 internal plane| CG
+    UI --> LBACK
+    LC --> REDIS
+    LC --> S3
+    REPOAUTH --> CNPG
+    OBS --> S3
+    AUTH -.-> KC
+    converse_ns -.->|secrets| ESO
+    chat_ns -.->|secrets| ESO
+
+    classDef own fill:#eaf3ea,stroke:#4a8a4a,color:#1a401a;
+    classDef ctrl fill:#e8eef7,stroke:#4a6fa5,color:#1a2a40;
+    classDef ext fill:#eee,stroke:#888,color:#333,stroke-dasharray:4 3;
+    classDef gpu fill:#f7e8f0,stroke:#a54a81,color:#401a2e;
+```
+
+## Containers by responsibility
+
+### Edge & gateway
+
+| Container | Namespace | Chart | Role |
+|---|---|---|---|
+| `eg` | `envoy-gateway-system` | upstream gateway-helm | Envoy Gateway controller + the data-plane proxy fleet |
+| `aieg` / `aieg-crd` | `envoy-ai-gateway-system` | upstream ai-gateway-helm | The AI Gateway controller (translates `AIGatewayRoute` → Envoy config) + its CRDs |
+| `core-gateway` | `converse-gateway` | `charts/core-gateway` | The `Gateway`, its listeners (external + internal), traffic/client policies, the in-namespace ACME `Issuer`, the `-traces` OTel collector |
+| `security-policies` | `converse-gateway` | `charts/kuadrant-policies` | The per-host `AuthConfig`s + the `SecurityPolicy` that attaches Authorino |
+| `authorino-operator` | `authorino-system` | upstream kuadrant | Authorino (the ext_authz service that verifies JWTs + stamps headers) |
+
+### Application plane
+
+| Container | Namespace | Chart | Role |
+|---|---|---|---|
+| `models` | `converse` | `charts/ai-models` (orchestrator) | Fans out to one `Application` per model — each an `AIGatewayRoute` + `BackendTrafficPolicy`; plus the provider `AIServiceBackend`s |
+| `lightbridge-backend` | `converse` | `charts/lightbridge` | First-party authz/usage service |
+| `lightbridge-repo-auth` | `converse` | external repo | Binds GitHub orgs → billing accounts so CI authenticates via GHA OIDC ([05](05-auth-identity.md)) |
+| `converse-ui` | `converse` | external repo | Self-service frontend |
+| `librechat` | `converse-chat` | `charts/librechart` (orchestrator) | Chat UI + MongoDB + Meili search + the opencode `.well-known` discovery |
+| `mongodb-backup` | `converse-chat` | `charts/mongodb-backup` | CronJob → object storage |
+| `mcps` | `converse-mcp` | `charts/mcps` (orchestrator) | The MCP tool servers — see [10 MCP](10-mcp.md) |
+
+### Self-hosted inference (home GPU)
+
+| Container | Namespace | Chart | Role |
+|---|---|---|---|
+| `model-serving-qwen3-5` 🟢 | `converse-poc` | `charts/model-serving-qwen3-5` | **LIVE** Qwen3.5-4B Q4 via `llama-server`, `homeCluster: true` |
+| `model-serving-qwen3-4b` | `converse-poc` | `charts/model-serving-qwen3-4b` | vLLM build, standby/rollback |
+
+### Platform services
+
+| Container | Namespace | Chart | Role |
+|---|---|---|---|
+| `observability` | `observability` | `charts/observability` (orchestrator) | The whole LGTM + collection + dashboards stack ([08](08-observability.md)) |
+| `apprise-api` / `opencode-k8s-agent` | `monitoring` | external repo | Notification + the in-cluster opencode agent |
+| `metrics-server` | `kube-system` | upstream | `kubectl top` / HPA metrics (ADR-0015 collision caveat) |
+
+## Render patterns
+
+Three of these containers are **orchestrators** that don't deploy workloads
+directly — they emit child ArgoCD objects. The mechanics are in
+[04 GitOps](04-gitops-deployment.md); the shape:
+
+```mermaid
+flowchart LR
+    subgraph direct["Pattern 1 · Direct"]
+        A1["Application"] --> W1["workloads"]
+    end
+    subgraph orch["Pattern 2 · Orchestrator + leaves<br/>(models, librechat)"]
+        A2["Application"] --> AS["ApplicationSet<br/>(List generator)"] --> L1["leaf App"] & L2["leaf App"]
+    end
+    subgraph aoa["Pattern 3 · App-of-Apps<br/>(observability)"]
+        A3["Application"] --> CH["renders child<br/>Application CRs directly"] --> C1["child"] & C2["child"]
+    end
+
+    classDef d fill:#eaf3ea,stroke:#4a8a4a;
+    class A1,W1,A2,AS,L1,L2,A3,CH,C1,C2 d;
+```
+
+→ Next: [03 · Gateway components](03-gateway-components.md) · or jump to a subsystem [04](04-gitops-deployment.md)–[10](10-mcp.md)

--- a/docs/architecture/03-gateway-components.md
+++ b/docs/architecture/03-gateway-components.md
@@ -10,7 +10,7 @@ metered. This is the layer where latency and correctness live.
 flowchart TB
     CLIENT["client (HTTP/2)"]:::ext
 
-    subgraph dp["Envoy data plane (eg) — HPA 3–20, LeastRequest LB"]
+    subgraph dp["Envoy data plane (eg) — HPA 3–5, LeastRequest LB"]
         LISTEN["Listeners<br/><b>external</b>: api.ai.camer.digital (ACME TLS)<br/><b>internal</b>: core-gateway-internal.svc (self-signed CA)"]:::own
         FILTER["HTTP filter chain<br/>ext_authz → ratelimit → router"]:::own
     end
@@ -117,7 +117,7 @@ sequenceDiagram
     W->>E: /v1 call (Bearer GHA-OIDC)
     E->>A: ext_authz
     A->>A: verify (github issuer), then github-actions →
-    A->>RA: GET /v1/resolve (repository_owner_id)
+    A->>RA: POST /v1/resolve (JSON body: repository_owner_id)
     alt owner bound & not blocked
         RA-->>A: {account_id, billing_plan}
         A-->>E: 200 + x-account-id, x-billing-plan
@@ -154,7 +154,7 @@ sequenceDiagram
 
 | Concern | Mechanism | Where |
 |---|---|---|
-| Throughput | HTTP/2 multiplexing + data-plane HPA `3→20`, LeastRequest LB | `ClientTrafficPolicy` / `EnvoyProxy` |
+| Throughput | HTTP/2 multiplexing + data-plane HPA `3→5` (right-sized to the 32-CPU worker pool), LeastRequest LB | `ClientTrafficPolicy` / `EnvoyProxy` |
 | Fairness | Per-user burst + per-user monthly budget | `BackendTrafficPolicy` + Redis |
 | Resilience | Circuit breaker + outlier detection (eject erroring backend ≤30 s) | `BackendTrafficPolicy` |
 | Zero-cut rollout | 60 s drain (`minDrainDuration` 15 s); PDB `maxUnavailable: 1` | `EnvoyProxy` |

--- a/docs/architecture/03-gateway-components.md
+++ b/docs/architecture/03-gateway-components.md
@@ -1,0 +1,163 @@
+# 03 · Gateway components & the request path (C4 Level 3)
+
+Zoom into the **load-bearing block**: how one inference request crosses the
+Envoy AI Gateway, gets authenticated, rate-limited, routed to a provider, and
+metered. This is the layer where latency and correctness live.
+
+## Components inside the gateway
+
+```mermaid
+flowchart TB
+    CLIENT["client (HTTP/2)"]:::ext
+
+    subgraph dp["Envoy data plane (eg) — HPA 3–20, LeastRequest LB"]
+        LISTEN["Listeners<br/><b>external</b>: api.ai.camer.digital (ACME TLS)<br/><b>internal</b>: core-gateway-internal.svc (self-signed CA)"]:::own
+        FILTER["HTTP filter chain<br/>ext_authz → ratelimit → router"]:::own
+    end
+
+    subgraph authz["Authorino (authorino-system, 2 replicas)"]
+        AC["AuthConfig per Host (ADR-0021)<br/>verify JWT (JWKS, ttl 3600)<br/>stamp x-oidc-* + descriptors"]:::own
+    end
+
+    subgraph route["AI Gateway CRs (per model)"]
+        AIR["AIGatewayRoute<br/><i>model name → backend</i>"]:::own
+        BTP["BackendTrafficPolicy<br/><i>burst + monthly budget + circuit breaker</i>"]:::own
+        ASB["AIServiceBackend<br/><i>provider mapping + key</i>"]:::own
+    end
+
+    PROV["Provider<br/>DeepInfra / Fireworks / Google AI"]:::ext
+    GPU["Self-hosted model<br/>(llama.cpp, home GPU)"]:::gpu
+    REDIS["redis-ha<br/><i>ratelimit counters</i>"]:::ext
+    OBS["Alloy → Loki / Mimir<br/><i>access log + counters</i>"]:::own
+
+    CLIENT --> LISTEN --> FILTER
+    FILTER -->|"gRPC ext_authz"| AC
+    AC -->|allow + headers| FILTER
+    FILTER -->|descriptors| REDIS
+    FILTER --> AIR --> BTP --> ASB
+    ASB --> PROV
+    ASB --> GPU
+    FILTER -->|"JSON access log"| OBS
+
+    classDef own fill:#eaf3ea,stroke:#4a8a4a,color:#1a401a;
+    classDef ext fill:#eee,stroke:#888,color:#333,stroke-dasharray:4 3;
+    classDef gpu fill:#f7e8f0,stroke:#a54a81,color:#401a2e;
+```
+
+| Component | CR / chart | Responsibility |
+|---|---|---|
+| **Listeners** | `Gateway` (`core-gateway`) | Terminate TLS; split external (public, ACME) vs internal (ClusterIP, self-signed CA) planes |
+| **ext_authz** | `SecurityPolicy` → Authorino | Call Authorino over gRPC before routing |
+| **AuthConfig** | `kuadrant-policies` | Per-`Host` JWT verification; stamp `x-oidc-*` + `x-account-id`/`x-org-id`/`x-billing-plan` |
+| **ratelimit** | `BackendTrafficPolicy` + Redis | Burst (req/min, tokens/min, per user) + monthly USD budget (per user, ADR-0035) |
+| **AIGatewayRoute** | `ai-model` leaf | Map an OpenAI model id → an `AIServiceBackend` |
+| **AIServiceBackend** | `ai-models-backends` | Provider endpoint + credential + token-cost metadata (`llmRequestCosts`) |
+| **access log** | `core-gateway` | Emit per-request JSON (carrying `x-oidc-*`) to Alloy |
+
+## Runtime view — the four canonical request paths
+
+### A · Developer via opencode (external plane, full attribution)
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant C as opencode CLI
+    participant E as Envoy (external)
+    participant A as Authorino
+    participant R as Redis
+    participant P as Provider
+    participant O as Alloy→Loki/Mimir
+
+    C->>E: POST /v1/chat/completions (Bearer JWT)
+    E->>A: ext_authz (the JWT)
+    A->>A: verify (JWKS) — read sub, azp, billing_plan
+    A-->>E: 200 + x-oidc-*, x-account-id=sub, x-billing-plan
+    E->>R: check burst + monthly budget buckets
+    alt budget/burst exhausted
+        R-->>E: over limit
+        E-->>C: 429 Too Many Requests
+    else within limits
+        E->>P: proxy request (provider key injected)
+        P-->>E: completion (+ token usage)
+        E-->>C: 200 stream
+        E->>O: JSON access log {user_id, azp, model, cost}
+    end
+```
+
+### B · Human via LibreChat (internal plane, service-level attribution)
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant U as Browser
+    participant L as LibreChat
+    participant E as Envoy (internal)
+    participant A as Authorino
+
+    U->>L: chat (Keycloak session)
+    L->>E: /v1 call to core-gateway-internal.svc
+    Note over L,E: apiKey OR k8s SA token<br/>+ X-LibreChat-User: (end-user sub)
+    E->>A: ext_authz (internal AuthConfig)
+    A->>A: prefer X-LibreChat-User → x-account-id<br/>plan = internal (uncapped, burst-only)
+    A-->>E: 200 + descriptors
+    E->>E: route → provider as path A
+```
+
+### C · CI runner via GitHub OIDC (the repo-auth binding)
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant W as GitHub Actions
+    participant E as Envoy (external)
+    participant A as Authorino
+    participant RA as lightbridge-repo-auth
+
+    W->>W: mint GHA OIDC token (audience = org Source URL)
+    W->>E: /v1 call (Bearer GHA-OIDC)
+    E->>A: ext_authz
+    A->>A: verify (github issuer), then github-actions →
+    A->>RA: GET /v1/resolve (repository_owner_id)
+    alt owner bound & not blocked
+        RA-->>A: {account_id, billing_plan}
+        A-->>E: 200 + x-account-id, x-billing-plan
+        E->>E: route → provider
+    else unbound / blocked
+        RA-->>A: 403
+        A-->>E: deny
+        E-->>W: 403
+    end
+```
+
+### D · MCP tool call (`/mcp/*` — Authorino carve-out)
+
+`/mcp/*` routes **displace** the gateway-attached Authorino policy with
+Envoy-native JWT verification (same Keycloak issuer). Full detail in
+[10 MCP](10-mcp.md).
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant C as MCP client
+    participant E as Envoy (native jwt_authn)
+    participant M as MCP server / proxy
+
+    C->>E: GET /.well-known/oauth-protected-resource/mcp/(name)
+    E-->>C: 200 RFC 9728 metadata (unauthenticated)
+    C->>E: POST /mcp/(name) (Bearer Keycloak JWT)
+    E->>E: native jwt_authn (Keycloak issuer)<br/>claimToHeaders → x-oidc-*
+    E->>M: forward to in-cluster MCP backend
+    M-->>C: tool result
+```
+
+## Why the gateway can scale
+
+| Concern | Mechanism | Where |
+|---|---|---|
+| Throughput | HTTP/2 multiplexing + data-plane HPA `3→20`, LeastRequest LB | `ClientTrafficPolicy` / `EnvoyProxy` |
+| Fairness | Per-user burst + per-user monthly budget | `BackendTrafficPolicy` + Redis |
+| Resilience | Circuit breaker + outlier detection (eject erroring backend ≤30 s) | `BackendTrafficPolicy` |
+| Zero-cut rollout | 60 s drain (`minDrainDuration` 15 s); PDB `maxUnavailable: 1` | `EnvoyProxy` |
+| Cost metering | Native `llmRequestCosts` token extraction (no Lua/Python hop) | `AIGatewayRoute` |
+
+→ Subsystems: [05 Auth](05-auth-identity.md) · [09 Model serving](09-model-serving.md) · [08 Observability](08-observability.md)

--- a/docs/architecture/04-gitops-deployment.md
+++ b/docs/architecture/04-gitops-deployment.md
@@ -1,0 +1,173 @@
+# 04 · GitOps & deployment topology
+
+How charts in this repo become running workloads — the ArgoCD machinery, the
+two-cluster split, the render patterns, the sync-wave ordering, and the
+release flow. Source ADRs: **0017** (destinations), **0018** (umbrellas +
+environments), **0031** (tag-based deploys).
+
+## Two clusters, two roles
+
+ArgoCD does **not** run on the cluster it deploys to.
+
+```mermaid
+flowchart LR
+    subgraph cp["🧠 admin@homeos (Talos) — the CONTROL plane"]
+        ARGOCD["ArgoCD<br/>ns: argocd"]
+        ROOT["Application: ai-apps-v2<br/><i>applied manually; pins a release tag</i>"]
+        APPS["charts/apps renders<br/>~21 Application/ApplicationSet CRs<br/><i>(control objects live here)</i>"]
+        ARGOCD --> ROOT --> APPS
+    end
+
+    subgraph wl["⚙️ home-remote (Hetzner k3s) — the WORKLOAD plane"]
+        NS1["ns: converse* / observability /<br/>envoy-*-system / monitoring / ..."]
+        PODS["actual pods<br/>gateway · librechat · models · LGTM"]
+        NS1 --> PODS
+    end
+
+    HOMEOS["home-os repo<br/>charts/cd/values.yaml<br/><i>pins ai-apps-v2 targetRevision</i>"]:::ext
+    HOMEOS -.->|"GitOps-manages the root tag"| ROOT
+    APPS ==>|"deploys workloads to"| wl
+
+    classDef ext fill:#eee,stroke:#888,color:#333,stroke-dasharray:4 3;
+```
+
+- **Control objects** (`Application`, `ApplicationSet`) must live where ArgoCD's
+  controllers watch → **in-cluster**, the `argocd` namespace on `admin@homeos`.
+- **Workloads** target the registered destination **`home-remote`** (the Hetzner
+  cluster). A render-time guard hard-fails any workload that resolves to the
+  in-cluster handle unless it opts in (`controlPlane` or `homeCluster`).
+
+## Two-tier destinations (ADR-0017)
+
+```mermaid
+flowchart TB
+    subgraph apps["charts/apps — per-app destination logic"]
+        WL["normal workload<br/><i>(default)</i>"]:::own
+        CP["controlPlane: true<br/><i>(orchestrators: models, librechat,<br/>mcps, observability, lightbridge-backend)</i>"]:::ctrl
+        HC["homeCluster: true<br/><i>(model-serving-qwen3-* only — ADR-0022)</i>"]:::gpu
+    end
+
+    DESTW["→ home-remote<br/>(workload namespace)"]:::own
+    DESTC["→ https://kubernetes.default.svc<br/>argocd ns (the AppSet it emits<br/>lands where ArgoCD watches)"]:::ctrl
+    DESTH["→ in-cluster server<br/>but keeps its own workload ns;<br/>guard called with allowInCluster"]:::gpu
+
+    WL --> DESTW
+    CP --> DESTC
+    HC --> DESTH
+
+    GUARD{{"render guard:<br/>workload → in-cluster?<br/>FAIL unless allowInCluster"}}:::warn
+    WL -.checked by.-> GUARD
+
+    classDef own fill:#eaf3ea,stroke:#4a8a4a;
+    classDef ctrl fill:#e8eef7,stroke:#4a6fa5;
+    classDef gpu fill:#f7e8f0,stroke:#a54a81;
+    classDef warn fill:#fbeaea,stroke:#a54a4a;
+```
+
+> **Project invariant:** every Application/ApplicationSet from this repo is in the
+> `ai` AppProject. `charts/apps` hardcodes `project: ai`; orchestrator children
+> set `argocd.project` (= `ai`). There is intentionally **no per-app override**.
+
+## Three render patterns
+
+```mermaid
+flowchart TB
+    subgraph p1["1 · Direct — most charts"]
+        D["Application"] --> DW["chart templates → workloads"]
+    end
+    subgraph p2["2 · Orchestrator + leaves (ADR-0012/0014)"]
+        O["Application"] --> OS["ApplicationSet<br/>(List generator)"]
+        OS --> OL1["leaf: charts/ai-model (route+budget)"]
+        OS --> OL2["leaf: charts/librechat-app ..."]
+    end
+    subgraph p3["3 · App-of-Apps (ADR-0019/0020)"]
+        AA["Application"] --> AAT["templates/applications.yaml<br/>iterates .Values.children"]
+        AAT --> AC1["child: local Helm chart"]
+        AAT --> AC2["child: upstream chart as source"]
+    end
+
+    classDef g fill:#eaf3ea,stroke:#4a8a4a;
+    class D,DW,O,OS,OL1,OL2,AA,AAT,AC1,AC2 g;
+```
+
+| Pattern | Used by | Why |
+|---|---|---|
+| **Direct** | `core-gateway`, `kuadrant-policies`, most | One chart, one lifecycle |
+| **Orchestrator + leaves** | `ai-models` → `ai-model`, `librechart` → `librechat-*` | Per-component sync waves / rollback; adding a component is a list edit |
+| **App-of-Apps** | `observability`, (formerly `coder`) | Fixed, heterogeneous children (local + upstream charts with big inline values) |
+
+## Umbrella apps + `environments/` overlays (ADR-0018)
+
+A flat app and its app-scoped prerequisites sync as **one** multi-source
+Application:
+
+```mermaid
+flowchart LR
+    subgraph umbrella["Umbrella Application (e.g. lightbridge-repo-auth)"]
+        SA["Source A — workload<br/>charts/&lt;x&gt; or upstream chart"]:::own
+        SB["Source B — deps overlay (kustomize)<br/>environments/prod/deps/&lt;app&gt;<br/><i>ingress Certificate, ExternalSecrets,<br/>CiliumNetworkPolicy</i>"]:::own
+        SC["Source C — $values (optional)<br/><i>per-env workload knob</i>"]:::own
+    end
+    CLUSTER["environments/prod/cluster.yaml<br/><i>clusterIssuer, secretStore,<br/>ingressClass, storageClass, domainBase</i>"]:::ext
+    CLUSTER -.->|patched into| SB
+
+    classDef own fill:#eaf3ea,stroke:#4a8a4a;
+    classDef ext fill:#eee,stroke:#888,stroke-dasharray:4 3;
+```
+
+- Attach deps with one field on the app entry: `depsOverlay: environments/prod/deps/<app>`.
+- Kustomize is confined to plain CRs (certs, secrets, network policies) —
+  **never** kustomize-over-Helm.
+- Today only `environments/prod/` exists; a second env is a drop-in sibling.
+
+## Sync waves (the ordering contract)
+
+Lower waves sync first. The rule is **infrastructure → storage → collection →
+visualisation** — violating it once cost a day (`MONITORING_FIX.md`).
+
+```mermaid
+flowchart LR
+    W3["wave -3<br/>namespace bootstrap<br/>observability-secrets<br/>(allow-same-namespace)"]:::w
+    W2["wave -2<br/>storage backends<br/>Mimir · Loki · Tempo<br/>kube-state-metrics · node-exporter"]:::w
+    W1["wave -1<br/>operators + collectors<br/>grafana-operator · Alloy<br/>librechat-search"]:::w
+    W0["wave 0<br/>workloads<br/>gateway · LibreChat · models"]:::w
+    WP1["wave 1<br/>content<br/>dashboards · opencode-wellknown"]:::w
+    WP2["wave 2+<br/>post-sync"]:::w
+    W3 --> W2 --> W1 --> W0 --> WP1 --> WP2
+
+    classDef w fill:#eaf3ea,stroke:#4a8a4a,color:#1a401a;
+```
+
+> cert-manager and ESO are **not** synced here (external). The `allow-same-namespace`
+> CiliumNetworkPolicy ships at wave -3 (before the Mimir stores) so the ring's
+> memberlist gossip isn't blocked at startup — see [06 Networking](06-networking-tls.md).
+
+## Release flow — tag-based, two repos (ADR-0031)
+
+Deploys pin an **immutable release tag** (`release-YYYY.MM.DD-vNN`), never `main`.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant M as Maintainer
+    participant R as tools/release.sh
+    participant GH as ai-helm (git)
+    participant HO as home-os charts/cd
+    participant AC as ArgoCD (cd app)
+
+    M->>R: tools/release.sh (tag) --dry-run, then for real
+    R->>GH: bump every self-referencing targetRevision (1 commit)
+    R->>R: helm template-check
+    R->>GH: tag that commit, push tag → then branch + main
+    Note over GH: tag is self-consistent —<br/>children resolve to a tag containing their own ref
+    M->>HO: bump ai-apps-v2 targetRevision to (new tag) (governance PR)
+    HO->>AC: ArgoCD cd app (selfHeal) reconciles the root pin
+    AC->>AC: root ai-apps-v2 rolls forward to (new tag)
+```
+
+> ⚠️ Skip the **home-os** step and the root self-heals back to the OLD tag — an
+> effective rollback. The durable source of the root's pin is `home-os`
+> `charts/cd`, not a live `kubectl patch`. Rollback = bump the root to any prior
+> tag (immutable → exact prior state). See [`../releasing.md`](../releasing.md).
+
+→ Related: [06 Networking & TLS](06-networking-tls.md) · [07 Data & secrets](07-data-secrets.md)

--- a/docs/architecture/05-auth-identity.md
+++ b/docs/architecture/05-auth-identity.md
@@ -1,0 +1,158 @@
+# 05 · Auth & identity
+
+The authorization boundary, the three identity surfaces, the dual-plane
+AuthConfig model, and the canonical downstream header contract. Source ADRs:
+**0011** (`x-oidc-*`), **0021** (dual-plane + billing), **0035** (per-person
+budgets), **0038** (MCP carve-out), **0047/0049** (GitHub OIDC binding).
+
+> **The boundary in one line:** a valid **Keycloak JWT** = "you are in our
+> system, you may use the gateway." OPA was removed (2026-06-04) — there is no
+> per-request policy hop. Authorization differentiation is done by *which host*
+> the request hits and *what claims* the token carries.
+
+## Dual-plane, AuthConfig-per-Host (ADR-0021)
+
+One `SecurityPolicy` + one Authorino, indexed by `Host`. Same gateway, two
+planes with different trust assumptions.
+
+```mermaid
+flowchart TB
+    subgraph clients["Callers"]
+        H["👤 human (opencode / CLI)"]:::actor
+        CI["🤖 CI runner"]:::actor
+        SVC["⚙️ in-cluster service<br/>(LibreChat, jobs)"]:::actor
+    end
+
+    subgraph ext["EXTERNAL plane · api.ai.camer.digital<br/>(public LB, ACME TLS)"]
+        EA["AuthConfig: external<br/>① Keycloak JWT (humans, remote SAs)<br/>② github-actions JWT → repo-auth /resolve"]:::own
+    end
+    subgraph int["INTERNAL plane · core-gateway-internal.svc<br/>(ClusterIP only, self-signed CA TLS)"]
+        IA["AuthConfig: internal<br/>k8s SA TokenReview (one-time jobs)<br/>OR static apiKey (long-running)<br/>+ prefer X-LibreChat-User"]:::own
+    end
+
+    DESC["Descriptors stamped (CEL, with defaults):<br/>x-account-id · x-org-id · x-billing-plan<br/>+ x-oidc-* identity set (ADR-0011)"]:::ctrl
+
+    H --> EA
+    CI --> EA
+    SVC --> IA
+    EA --> DESC
+    IA --> DESC
+    DESC --> RL["per-model BackendTrafficPolicy<br/>burst + monthly budget by tier"]:::own
+
+    classDef actor fill:#fff,stroke:#555;
+    classDef own fill:#eaf3ea,stroke:#4a8a4a;
+    classDef ctrl fill:#e8eef7,stroke:#4a6fa5;
+```
+
+| Plane | Host | TLS | Accepts | Trust basis |
+|---|---|---|---|---|
+| **External** | `api.ai.camer.digital` | ACME (Let's Encrypt) | Keycloak JWT **or** GitHub Actions OIDC | Full JWT verification; billing/org claims optional (CEL defaults `→ free`/`→ sub`) |
+| **Internal** | `core-gateway-internal.…svc` | `self-signed-ca` | k8s SA token **or** static apiKey | First-party-only; Authorino overwrites descriptors |
+
+## The three identity surfaces
+
+```mermaid
+flowchart LR
+    subgraph s1["1 · Human via browser"]
+        B["LibreChat UI"] -->|Keycloak code+PKCE| BJ["session → internal plane<br/>(service-level attribution)"]
+    end
+    subgraph s2["2 · Human / dev via API"]
+        O["opencode / CLI"] -->|self-service API key OR JWT| OJ["external plane<br/>(full per-user attribution)"]
+    end
+    subgraph s3["3 · Service account / CI"]
+        C["CI runner"] -->|GHA OIDC → repo-auth| CJ["external plane<br/>(per-account attribution)"]
+        K["in-cluster job"] -->|k8s SA / apiKey| KJ["internal plane"]
+    end
+
+    classDef g fill:#eaf3ea,stroke:#4a8a4a;
+    class B,BJ,O,OJ,C,CJ,K,KJ g;
+```
+
+**Per-user attribution for LibreChat:** LibreChat authenticates as *itself*
+(apiKey) but forwards the end-user's Keycloak `sub` as `X-LibreChat-User`. The
+internal AuthConfig's CEL *prefers* that header → the gateway attributes spend to
+the real person. Trust is sound because the internal plane is first-party-only
+and Authorino overwrites the descriptors.
+
+## The GitHub OIDC binding (CI without a shared key — ADR-0047/0049)
+
+CI runners authenticate with their **own** GitHub Actions OIDC token. No shared
+secret, no per-runner registration, no distributed private key.
+
+```mermaid
+flowchart TB
+    subgraph gh["GitHub"]
+        APP["GitHub App: camer-digital-ai<br/><i>control plane (install webhooks)</i>"]:::ext
+        OIDC["GHA OIDC issuer<br/><i>data plane (per-run token)</i>"]:::ext
+    end
+
+    subgraph cluster["in-cluster (converse ns)"]
+        RA["lightbridge-repo-auth"]:::own
+        DB["CNPG repoauth DB<br/>(sources: owner_id → account)"]:::ext
+    end
+
+    A["Authorino (external AuthConfig)"]:::own
+    CTL["repo-auth-ctl<br/><i>operator CLI: claim / block</i>"]:::own
+
+    APP -->|"installation.created webhook<br/>(repository_owner_id)"| RA
+    RA --> DB
+    CTL -->|"claim --owner-id --account-id --plan"| RA
+    OIDC -->|"runner mints token<br/>(audience = org Source URL)"| A
+    A -->|"github-actions JWT →<br/>GET /v1/resolve(owner_id)"| RA
+    RA -->|"account_id + plan, or 403"| A
+
+    classDef own fill:#eaf3ea,stroke:#4a8a4a;
+    classDef ext fill:#eee,stroke:#888,stroke-dasharray:4 3;
+```
+
+- **Binding key** = `repository_owner_id` (GitHub numeric, server-set, immutable —
+  captured from the webhook payload, never user-typed).
+- **Control plane** (the App) only handles install/uninstall webhooks; the
+  **data plane** is the per-run OIDC token, rich with repo/context claims.
+- Onboarding is **operator-driven** (`repo-auth-ctl claim`), not self-serve.
+  `resolve` denies `blocked` first, then unclaimed.
+- opencode CI in every ADORSYS-GIS repo authenticates this way via a reusable
+  workflow. Full detail: the `lightbridge-repo-auth` memory + repo `docs/`.
+
+## The `x-oidc-*` downstream contract (ADR-0011)
+
+After JWT verification Authorino stamps a fixed header set. Use these names
+downstream — don't invent new ones without an ADR.
+
+| Header | Loki label? | Source |
+|---|---|---|
+| `x-oidc-user-id` | yes (`user_id`) | `auth.identity.sub` |
+| `x-oidc-azp` | yes (`azp`) | `auth.identity.azp` |
+| `x-oidc-user-name`, `-iss`, `-roles-realm`, `-resource-access`, `-scope`, `-jti`, `-email`, `-name` | no (body only) | JWT claims |
+
+Alongside identity, Authorino stamps the **rate-limit descriptors**
+`x-account-id` / `x-org-id` / `x-billing-plan` (ADR-0021).
+
+## Rate-limit tiers (ADR-0021 / ADR-0035)
+
+Keyed on `x-account-id` (burst **and** monthly µ$ budget — both **per-person**
+since ADR-0035) + `x-billing-plan`. Static via Helm (`rateLimitBudgeting.plans`),
+no dynamic OPA.
+
+| Plan | Monthly budget | Req/min | Tokens/min |
+|---|---|---|---|
+| `free` | $50 | 200 | 1,000,000 |
+| `pro` | $200 | 400 | 2,000,000 |
+| `service` | uncapped | 600 | 2,000,000 |
+| `internal` | uncapped | 600 | 2,000,000 |
+
+## The `/mcp/*` carve-out (ADR-0038)
+
+MCP routes are the **one** exception to Authorino. An Envoy route-level
+`SecurityPolicy` *displaces* the gateway-attached Authorino policy whole, so JWT
+verification on `/mcp/*` is Envoy's native `jwt_authn` filter (same Keycloak
+issuer); the gateway serves the RFC 9728 discovery surface unauthenticated and
+re-stamps `x-oidc-*` via `claimToHeaders`. Rate-limit descriptors are **not**
+stamped on MCP routes. See [10 MCP](10-mcp.md).
+
+> ⚠️ **Failure mode to remember:** a missing `sharedSecretRef` secret makes the
+> whole AuthConfig `not-Ready` → the gateway returns **404 platform-wide** (this
+> is what the OPA-removal/`lightbridge-opa-auth` prune caused). Provision the SM
+> property *before* releasing anything that adds an AuthConfig dependency.
+
+→ Related: [03 Gateway request paths](03-gateway-components.md) · [07 Secrets](07-data-secrets.md) · [10 MCP](10-mcp.md)

--- a/docs/architecture/05-auth-identity.md
+++ b/docs/architecture/05-auth-identity.md
@@ -98,7 +98,7 @@ flowchart TB
     RA --> DB
     CTL -->|"claim --owner-id --account-id --plan"| RA
     OIDC -->|"runner mints token<br/>(audience = org Source URL)"| A
-    A -->|"github-actions JWT →<br/>GET /v1/resolve(owner_id)"| RA
+    A -->|"github-actions JWT →<br/>POST /v1/resolve (owner_id)"| RA
     RA -->|"account_id + plan, or 403"| A
 
     classDef own fill:#eaf3ea,stroke:#4a8a4a;

--- a/docs/architecture/06-networking-tls.md
+++ b/docs/architecture/06-networking-tls.md
@@ -131,7 +131,7 @@ internal CA — a plaintext client gets `connection reset by peer`.
 
 ```mermaid
 flowchart LR
-    LCC["LibreChat"]:::own -->|"REDIS_PASSWORD + TLS"| R["redis-ha-redis.redis-system:6379"]:::ext
+    LCC["LibreChat"]:::own -->|"REDIS_PASSWORD + TLS"| R["redis-ha-haproxy.redis-system:6379<br/>(master-router, not the round-robin redis-ha-redis)"]:::ext
     RL["Envoy ratelimit"]:::own -->|"REDIS_TLS=true + REDIS_TLS_CACERT"| R
     classDef own fill:#eaf3ea,stroke:#4a8a4a;
     classDef ext fill:#eee,stroke:#888,stroke-dasharray:4 3;

--- a/docs/architecture/06-networking-tls.md
+++ b/docs/architecture/06-networking-tls.md
@@ -1,0 +1,144 @@
+# 06 · Networking & TLS
+
+How traffic enters, how pods are allowed (or denied) to talk, and how
+certificates are issued. The Hetzner cluster runs **Cilium with a
+default-deny-egress baseline** — the single most common source of "silent
+crashloop" incidents — so it gets the most attention here.
+
+## Ingress paths
+
+```mermaid
+flowchart TB
+    NET["🌐 Internet"]:::ext
+    LB["Hetzner Cloud LB · 46.225.38.138<br/><i>targets WORKERS only;<br/>use-private-ip: true</i>"]:::ext
+
+    subgraph cluster["home-remote (Hetzner k3s)"]
+        TRAEFIK["Traefik (external)<br/>IngressClass traefik<br/><i>non-gateway ingresses</i>"]:::ext
+        EGW["Envoy data plane<br/>(core-gateway)"]:::own
+
+        subgraph hosts["Host-based routing on the gateway"]
+            H1["ai.camer.digital → LibreChat"]:::own
+            H2["api.ai.camer.digital → /v1 (Authorino)"]:::own
+            H3["api.ai.camer.digital/mcp/* → MCP (native JWT)"]:::own
+        end
+    end
+
+    KC["auth.verif.fyi → Keycloak<br/>(separate cluster)"]:::ext
+
+    NET --> LB
+    LB --> TRAEFIK
+    LB --> EGW
+    EGW --> H1 & H2 & H3
+    H1 -.OIDC.-> KC
+
+    classDef own fill:#eaf3ea,stroke:#4a8a4a;
+    classDef ext fill:#eee,stroke:#888,stroke-dasharray:4 3;
+```
+
+> **LB gotcha:** the 3 control-plane nodes carry
+> `node.kubernetes.io/exclude-from-external-load-balancers`, so the LB only
+> targets workers. LB Services need
+> `load-balancer.hetzner.cloud/use-private-ip: "true"` (cp-1 has a stale
+> providerID and is an unusable target).
+
+## The Cilium deny-egress model
+
+Every app namespace (`apps`/`data`/`observability`/`platform` and the
+`converse-*` set) carries a manual `allow-dns` policy — so **every pod is
+egress-deny-by-default**. Anything reaching the API server or external object
+storage crashloops until it gets an *additive* allow.
+
+```mermaid
+flowchart TB
+    POD["any pod"]:::own
+    DNS["✅ allow-dns<br/>(DNS → kube-system)"]:::ok
+    DENY["⛔ everything else<br/>DENIED by default"]:::deny
+
+    POD --> DNS
+    POD --> DENY
+
+    subgraph additive["Additive CiliumNetworkPolicy (per app, via deps overlay)"]
+        API["toEntities: [kube-apiserver]<br/><i>operators, ksm, grafana-operator, Alloy</i>"]:::ok
+        S3A["toFQDNs: '*.your-objectstorage.com'<br/><i>mimir, loki, tempo</i>"]:::ok
+        SAME["allow-same-namespace<br/><i>Mimir memberlist gossip :7946</i>"]:::ok
+        OTLP["ingress :4317/:4318 fromEntities: [cluster]<br/><i>Alloy OTLP receiver</i>"]:::ok
+    end
+
+    DENY -.->|"unblocked by"| additive
+
+    classDef own fill:#eaf3ea,stroke:#4a8a4a;
+    classDef ok fill:#eafaea,stroke:#4a8a4a;
+    classDef deny fill:#fbeaea,stroke:#a54a4a;
+```
+
+> ⚠️ **A plain k8s `NetworkPolicy` `ipBlock` does NOT match on Cilium** — node IPs
+> carry `remote-node`/`host` identity. Always use a **`CiliumNetworkPolicy`** with
+> `toEntities`/`toFQDNs`. Classic symptom: pod hangs ~32 s, then a 0-`initialDelay`
+> liveness probe kills it → looks like a silent exit-2 CrashLoop.
+
+### The Mimir ring trap (ordering-sensitive)
+
+Mimir forms its ingester/store-gateway ring via memberlist gossip. If the pods
+start *before* the `allow-same-namespace` policy exists, they exhaust join
+retries → the distributor logs `InstancesCount <= 0` → **every remote-write
+500s and Mimir silently stores nothing**.
+
+Two-layer guard:
+1. `allow-same-namespace` ships from **this repo** at sync wave **-3** (before the
+   wave -2 stores) via the `observability-secrets` child.
+2. Mimir `memberlist.rejoin_interval: 1m` self-heals the residual race.
+
+## TLS issuance
+
+Two issuers, two trust models — both via cert-manager (installed by `home-os`).
+
+```mermaid
+flowchart LR
+    subgraph external["External / public"]
+        ACME["in-chart ns ACME Issuer<br/>(core-gateway, gateway.acmeHttp01)"]:::own
+        LE["Let's Encrypt<br/>HTTP-01 via gatewayHTTPRoute"]:::ext
+        ACME --> LE --> PUBCERT["api.ai.camer.digital cert"]:::own
+    end
+    subgraph internal["Internal / first-party"]
+        CA["self-signed-ca ClusterIssuer<br/>'Home SSegning Root CA'<br/>(home-os)"]:::ext
+        CA --> INTCERT["core-gateway-internal cert<br/>+ redis-ha client trust"]:::own
+    end
+    subgraph ingress["Webhook / app ingress"]
+        HTTP["cert-home-cert-http ClusterIssuer"]:::ext
+        HTTP --> WHCERT["repo-auth.ai.camer.digital cert<br/>(deps overlay)"]:::own
+    end
+
+    classDef own fill:#eaf3ea,stroke:#4a8a4a;
+    classDef ext fill:#eee,stroke:#888,stroke-dasharray:4 3;
+```
+
+| Surface | Issuer | Mechanism |
+|---|---|---|
+| `api.ai.camer.digital` (gateway external) | in-chart ns ACME `Issuer` | HTTP-01 via `gatewayHTTPRoute` solver (no DNS token) |
+| `core-gateway-internal` (internal plane) | `self-signed-ca` | Home Root CA — same trust model as redis-ha (TLS-only) |
+| Ingress hosts (e.g. repo-auth webhook) | `cert-home-cert-http` | Per-app `Certificate` from the deps overlay |
+
+> The retired `cert-home-cert-envoy` issuer and DNS-01/wildcard
+> (`cert-cloudflare`, needs a missing `cloudflare-secret`) are **not** in the
+> active path. The deps overlay owning a host's `Certificate` is why charts drop
+> their `cert-manager.io/cluster-issuer` ingress annotation (ADR-0018).
+
+## redis-ha: TLS-only consumption
+
+redis-ha (deployed by `home-os`) is **TLS-only** (`port 0` / `tls-port 6379`,
+`tls-auth-clients no`). Every consumer must connect over TLS *and* trust the
+internal CA — a plaintext client gets `connection reset by peer`.
+
+```mermaid
+flowchart LR
+    LCC["LibreChat"]:::own -->|"REDIS_PASSWORD + TLS"| R["redis-ha-redis.redis-system:6379"]:::ext
+    RL["Envoy ratelimit"]:::own -->|"REDIS_TLS=true + REDIS_TLS_CACERT"| R
+    classDef own fill:#eaf3ea,stroke:#4a8a4a;
+    classDef ext fill:#eee,stroke:#888,stroke-dasharray:4 3;
+```
+
+Each consumer namespace needs its own `redis-ha-redis-auth` Secret (via
+ExternalSecret) plus a cert-manager `Certificate` from `self-signed-ca`
+(`ca.crt` only) for the CA trust.
+
+→ Related: [07 Data & secrets](07-data-secrets.md) · [08 Observability](08-observability.md)

--- a/docs/architecture/07-data-secrets.md
+++ b/docs/architecture/07-data-secrets.md
@@ -1,0 +1,133 @@
+# 07 · Data & secrets
+
+Where state lives and how secrets get into pods. Almost all the *storage*
+infrastructure is owned externally — this repo defines the **consumers** (CRs,
+ExternalSecrets, backup jobs) and references the platform by name.
+
+## Stateful data map
+
+```mermaid
+flowchart TB
+    subgraph owned["Defined by this repo (consumers)"]
+        LC["LibreChat"]:::own
+        MONGO["MongoDB<br/>(librechat-app)"]:::own
+        MEILI["Meilisearch<br/>(librechat-search)"]:::own
+        REPOAUTH["lightbridge-repo-auth"]:::own
+        LGTM["Mimir / Loki / Tempo"]:::own
+        MBK["mongodb-backup CronJob"]:::own
+    end
+
+    subgraph external["Owned externally (the actual engines)"]
+        CNPGOP["CNPG operator + Barman<br/>cnpg-system"]:::ext
+        LBDB["lightbridge-db cluster<br/>(CNPG) + repoauth Database CR"]:::ext
+        REDIS["redis-ha · redis-system<br/>(TLS-only)"]:::ext
+        S3["Hetzner Object Storage<br/>bucket: ssegning-k8s-state"]:::ext
+    end
+
+    LC --> MONGO
+    LC --> MEILI
+    LC -->|sessions| REDIS
+    LC -->|files| S3
+    REPOAUTH -->|"Database CR + managed role"| LBDB
+    LBDB --- CNPGOP
+    LGTM -->|blocks| S3
+    MONGO --> MBK --> S3
+    LBDB -->|Barman backup| S3
+
+    classDef own fill:#eaf3ea,stroke:#4a8a4a;
+    classDef ext fill:#eee,stroke:#888,stroke-dasharray:4 3;
+```
+
+| Store | Engine | Who owns it | This repo defines |
+|---|---|---|---|
+| Chat data | MongoDB | in-chart (`librechat-app`) | the StatefulSet + `mongodb-backup` |
+| Chat search | Meilisearch | in-chart (`librechat-search`) | the deployment |
+| Sessions / ratelimit counters | redis-ha | `home-os` | consumer config + auth Secret only |
+| `lightbridge-repo-auth` DB | CNPG Postgres | external operator | a `Database` CR + managed role on the **existing** `lightbridge-db` cluster (not a new pod) |
+| Metrics / logs / traces | Mimir / Loki / Tempo | in-chart (`observability`) | the charts (data → S3) |
+| Object storage | Hetzner S3 (Ceph-RGW) | Hetzner | bucket prefixes + creds reference |
+
+### Object storage layout (one bucket, prefixes per tenant)
+
+```mermaid
+flowchart LR
+    BUCKET["🪣 ssegning-k8s-state<br/>endpoint: nbg1.your-objectstorage.com<br/>region: us-east-1"]:::ext
+    BUCKET --> P1["mimirblocks/<br/><i>(alphanumeric-only prefix)</i>"]
+    BUCKET --> P2["loki/"]
+    BUCKET --> P3["tempo/"]
+    BUCKET --> P4["cnpg backups/"]
+    BUCKET --> P5["librechat files/"]
+    BUCKET --> P6["mongodb backups/"]
+    classDef ext fill:#eee,stroke:#888,stroke-dasharray:4 3;
+```
+
+> `mimir.storage_prefix` must be **alphanumeric-only** (no `/`) → `mimirblocks`.
+
+## Secret flow (ESO + `ssegning-aws`)
+
+The External Secrets Operator (installed externally) syncs from one
+cluster-scoped `ClusterSecretStore` — `ssegning-aws`. This repo **owns the
+`ExternalSecret` CRs in-chart**; the old wholesale `secrets` Application was
+removed (2026-06-04).
+
+```mermaid
+flowchart TB
+    AWS["AWS Secrets Manager<br/>(behind ssegning-aws store)"]:::ext
+    subgraph keys["Two key namespaces"]
+        K1["ai/camer/digital/prod/env<br/><i>APP secrets (one prop each)</i>"]:::ext
+        K2["prod/meta/test-app<br/><i>PLATFORM secrets (S3, redis pw)</i>"]:::ext
+    end
+    ESO["External Secrets Operator<br/>external-secrets ns"]:::ext
+
+    subgraph charts["In-chart ExternalSecret CRs (this repo)"]
+        ES1["ai-models-backends (provider keys)"]:::own
+        ES2["librechat-app"]:::own
+        ES3["observability-secrets"]:::own
+        ES4["lightbridge-repo-auth + db-role"]:::own
+        ES5["environments/prod/deps/* overlays"]:::own
+    end
+
+    K8S["k8s Secrets in each namespace"]:::own
+
+    AWS --> K1 & K2
+    K1 --> ESO
+    K2 --> ESO
+    charts -->|reference store by name| ESO
+    ESO --> K8S
+
+    classDef own fill:#eaf3ea,stroke:#4a8a4a;
+    classDef ext fill:#eee,stroke:#888,stroke-dasharray:4 3;
+```
+
+### Ownership split (who owns which secret)
+
+| Scope | Key | Examples | Owner CR |
+|---|---|---|---|
+| **App** | `ai/camer/digital/prod/env` | provider API keys, repo-auth webhook secret, internal token, GitHub App PEM | in-chart `ExternalSecret` |
+| **Platform** | `prod/meta/test-app` | S3 backup creds, redis password | in-chart `ExternalSecret` |
+
+> ⚠️ **Re-home a secret in-chart *before* retiring its provisioner.** Pruning the
+> old `secrets` app cascade-deleted `lightbridge-opa-auth` → gateway outage. And
+> an ESO `{{ }}` template inside a `tpl`'d string must be escaped
+> (`{{ "{{ .password }}" }}`) so Helm passes it through to ESO untouched.
+
+## What this repo does NOT own (consumed by name)
+
+```mermaid
+flowchart LR
+    subgraph repo["ai-helm references"]
+        R1["Database CR"] -.-> E1["CNPG operator (cnpg-system)"]
+        R2["ExternalSecret"] -.-> E2["ESO + ssegning-aws (external-secrets)"]
+        R3["REDIS_* env"] -.-> E3["redis-ha (redis-system, home-os)"]
+        R4["ingressClassName: traefik"] -.-> E4["Traefik (traefik ns)"]
+        R5["cluster-issuer annotations"] -.-> E5["cert-manager + ClusterIssuers (home-os)"]
+        R6["OpenTelemetryCollector CR"] -.-> E6["otel-operator (opentelemetry-system)"]
+    end
+    classDef e fill:#eee,stroke:#888,stroke-dasharray:4 3;
+    class E1,E2,E3,E4,E5,E6 e;
+```
+
+Don't re-add operators/stores/issuers for any of these — they're provisioned by
+the companion repos. This repo only declares the CRs they reconcile.
+
+→ Related: [04 GitOps (secret-bearing umbrellas)](04-gitops-deployment.md) · [06 Networking & TLS](06-networking-tls.md)

--- a/docs/architecture/07-data-secrets.md
+++ b/docs/architecture/07-data-secrets.md
@@ -15,11 +15,11 @@ flowchart TB
         REPOAUTH["lightbridge-repo-auth"]:::own
         LGTM["Mimir / Loki / Tempo"]:::own
         MBK["mongodb-backup CronJob"]:::own
+        LBDB["lightbridge-db cluster (CNPG Cluster CR)<br/>charts/lightbridge-db + repoauth Database CR"]:::own
     end
 
     subgraph external["Owned externally (the actual engines)"]
-        CNPGOP["CNPG operator + Barman<br/>cnpg-system"]:::ext
-        LBDB["lightbridge-db cluster<br/>(CNPG) + repoauth Database CR"]:::ext
+        CNPGOP["CNPG operator + Barman plugin<br/>cnpg-system"]:::ext
         REDIS["redis-ha · redis-system<br/>(TLS-only)"]:::ext
         S3["Hetzner Object Storage<br/>bucket: ssegning-k8s-state"]:::ext
     end
@@ -29,7 +29,7 @@ flowchart TB
     LC -->|sessions| REDIS
     LC -->|files| S3
     REPOAUTH -->|"Database CR + managed role"| LBDB
-    LBDB --- CNPGOP
+    LBDB -->|reconciled by| CNPGOP
     LGTM -->|blocks| S3
     MONGO --> MBK --> S3
     LBDB -->|Barman backup| S3
@@ -43,7 +43,7 @@ flowchart TB
 | Chat data | MongoDB | in-chart (`librechat-app`) | the StatefulSet + `mongodb-backup` |
 | Chat search | Meilisearch | in-chart (`librechat-search`) | the deployment |
 | Sessions / ratelimit counters | redis-ha | `home-os` | consumer config + auth Secret only |
-| `lightbridge-repo-auth` DB | CNPG Postgres | external operator | a `Database` CR + managed role on the **existing** `lightbridge-db` cluster (not a new pod) |
+| `lightbridge-repo-auth` DB | CNPG Postgres | **repo-owned** Cluster (`charts/lightbridge-db`); reconciled by the external CNPG operator | the `lightbridge-db` `Cluster` CR + a `repoauth` `Database` CR + managed role (not a new pod) |
 | Metrics / logs / traces | Mimir / Loki / Tempo | in-chart (`observability`) | the charts (data → S3) |
 | Object storage | Hetzner S3 (Ceph-RGW) | Hetzner | bucket prefixes + creds reference |
 

--- a/docs/architecture/08-observability.md
+++ b/docs/architecture/08-observability.md
@@ -1,0 +1,118 @@
+# 08 · Observability
+
+The LGTM stack, how telemetry is collected, and how every request is attributed
+back to a user. Deployed by the `observability` App-of-Apps orchestrator
+(ADR-0020), namespace `observability`, enforced `privileged` Pod Security.
+Source ADRs: **0004** (operator + dashboards-as-code), **0005/0046** (per-user
+attribution), **0008** (Python dashboards), **0045** (scrape-first sourcing).
+
+## The pipeline
+
+```mermaid
+flowchart BT
+    subgraph sources["Telemetry sources"]
+        WL["workload /metrics<br/>(Service/PodMonitor)"]:::own
+        KSM["kube-state-metrics<br/><i>honorLabels: true</i>"]:::own
+        NE["node-exporter"]:::own
+        LOGS["pod logs (/var/log)"]:::own
+        GWLOG["Envoy access log (OTLP)"]:::own
+        TRACE["core-gateway -traces<br/>OTel collector"]:::own
+    end
+
+    subgraph collect["Collection · wave -1"]
+        ALLOY["Alloy (DaemonSet)<br/>ServiceMonitor/PodMonitor discovery<br/>log tail · OTLP :4317/:4318 receiver<br/>ai_gateway_user_attribution stage"]:::own
+    end
+
+    subgraph store["Storage · wave -2 → S3"]
+        MIMIR["Mimir<br/>metrics"]:::own
+        LOKI["Loki<br/>logs"]:::own
+        TEMPO["Tempo<br/>traces :3200"]:::own
+    end
+
+    GRAF["Grafana (stateless, emptyDir)<br/>+ grafana-operator (external mode)<br/>wave 0 / dashboards wave 1"]:::own
+
+    WL --> ALLOY
+    KSM --> ALLOY
+    NE --> ALLOY
+    LOGS --> ALLOY
+    GWLOG --> ALLOY
+    TRACE --> ALLOY
+    ALLOY --> MIMIR
+    ALLOY --> LOKI
+    ALLOY --> TEMPO
+    MIMIR --> GRAF
+    LOKI --> GRAF
+    TEMPO --> GRAF
+
+    classDef own fill:#eaf3ea,stroke:#4a8a4a;
+```
+
+| Layer | Components | Notes |
+|---|---|---|
+| **Collection** | Alloy (DaemonSet) | One agent: metrics scrape + log tail + OTLP receiver. Needs API-server egress *and* OTLP ingress allows ([06](06-networking-tls.md)) |
+| **Storage** | Mimir, Loki, Tempo | All persist blocks to Hetzner S3; sync wave -2 |
+| **Visualisation** | Grafana + grafana-operator | Grafana is **stateless** (ADR-0023); dashboards/folders pushed by the operator |
+
+## Per-user attribution (ADR-0005 / ADR-0046)
+
+The thread that ties an LLM request to a person: JWT → Authorino headers →
+Envoy access log → Alloy → Loki labels.
+
+```mermaid
+flowchart LR
+    JWT["Keycloak JWT"]:::ext
+    AUTH["Authorino<br/>stamp x-oidc-user-id, x-oidc-azp"]:::own
+    ENVOY["Envoy access log (OTLP)<br/>fields → OTLP attributes (ADR-0046)"]:::own
+    ALLOY["Alloy ai_gateway_user_attribution stage<br/>flatten attributes envelope<br/>promote user_id/azp/model labels<br/>pin service_name=envoy-ai-gateway"]:::own
+    LOKI["Loki streams<br/>{user_id, azp, model}"]:::own
+    DASH["per-user usage dashboard"]:::own
+
+    JWT --> AUTH --> ENVOY --> ALLOY --> LOKI --> DASH
+
+    classDef own fill:#eaf3ea,stroke:#4a8a4a;
+    classDef ext fill:#eee,stroke:#888,stroke-dasharray:4 3;
+```
+
+> ⚠️ Two attribution traps, both fixed and worth remembering:
+> - Envoy's OTel access-log sink emits `format.json` fields as **OTLP attributes,
+>   not the log body** — a top-level `| json` finds nothing. Alloy must flatten the
+>   `attributes` envelope and anchor on `service_name=envoy-ai-gateway`.
+> - Alloy pod-log labels must come from **K8s service discovery**, never from
+>   regex-on-the-line — any line mentioning a `/var/log/pods/...` path would
+>   otherwise overwrite the stream's `namespace`/`pod` labels.
+
+## Dashboards as code (ADR-0004 / ADR-0008 / ADR-0045)
+
+```mermaid
+flowchart LR
+    PY["tools/dashboards/*.py<br/>(grafana-foundation-sdk)"]:::own
+    JSON["generated JSON<br/>(committed; CI drift-checked)"]:::own
+    CR["GrafanaDashboard / GrafanaFolder CRs<br/>(observability-dashboards)"]:::own
+    OP["grafana-operator (external mode)"]:::own
+    G["Grafana"]:::own
+
+    PY -->|"uv run dashboards build"| JSON --> CR --> OP --> G
+
+    classDef own fill:#eaf3ea,stroke:#4a8a4a;
+```
+
+- **Scrape-first (ADR-0045):** no board without verified metrics; API-verified
+  gnetIds only; bespoke boards (per-user usage, ratelimit, Authorino) as code.
+- Stateless Grafana means **every folder needs a `resyncPeriod`** or a pod roll
+  wipes it → `folderRef` dashboards 400 until the operator restarts.
+- The dashboard Python is the **only runnable code** in the repo; after editing
+  `.py` you must `dashboards build` + commit the JSON (CI fails otherwise).
+
+## Why the sync-wave order is load-bearing
+
+```mermaid
+flowchart LR
+    S["-3 secrets +<br/>allow-same-namespace"] --> ST["-2 stores<br/>(Mimir/Loki/Tempo)"] --> C["-1 collectors<br/>(Alloy)"] --> V["0/1 Grafana +<br/>dashboards"]
+    classDef w fill:#eaf3ea,stroke:#4a8a4a;
+    class S,ST,C,V w;
+```
+
+Collectors before stores = dropped data; visualisation before either = empty
+boards. The postmortem of violating this is `MONITORING_FIX.md`.
+
+→ Related: [06 Networking (egress allows)](06-networking-tls.md) · [05 Auth (attribution headers)](05-auth-identity.md)

--- a/docs/architecture/09-model-serving.md
+++ b/docs/architecture/09-model-serving.md
@@ -57,6 +57,11 @@ flowchart LR
     classDef t fill:#eaf3ea,stroke:#4a8a4a;
 ```
 
+**Per-model overrides:** a model can override the plan defaults with its own
+`rateLimitBudgeting:` block in `charts/ai-models/values.yaml` — e.g. the
+`adorsys-*` brand models use a unified lower budget rather than the table above.
+The plan tiers are the default; the per-model block wins where present.
+
 Cost is metered natively (`llmRequestCosts` token extraction) — no Python/Lua hop.
 
 ## The self-hosted model (home GPU)

--- a/docs/architecture/09-model-serving.md
+++ b/docs/architecture/09-model-serving.md
@@ -1,0 +1,117 @@
+# 09 · Model serving
+
+How an OpenAI-compatible model id resolves to actual inference — provider
+fan-out for the cloud models, plus the one self-hosted model on the home GPU.
+Source ADRs: **0012** (orchestrator split), **0022/0028/0029/0030/0032**
+(self-hosted serving), **0035** (per-person budgets).
+
+## Fan-out: one model id → one route → one backend
+
+```mermaid
+flowchart TB
+    REQ["client: model='adorsys-reviewer-pro'"]:::ext
+    subgraph orch["ai-models orchestrator (ApplicationSet)"]
+        AS["List generator: 1 child App per model"]:::ctrl
+    end
+    subgraph leaf["per-model leaf (charts/ai-model)"]
+        ROUTE["AIGatewayRoute<br/>model id → backend"]:::own
+        BUDGET["BackendTrafficPolicy<br/>burst + monthly budget by plan"]:::own
+    end
+    subgraph backends["AIServiceBackends (ai-models-backends)"]
+        FW["Fireworks · fw-01/02"]:::ext
+        DI["DeepInfra · deepinfra-01/02"]:::ext
+        GA["Google AI · google-ai-studio-01/02"]:::ext
+        VL["vllm-local-01 → Qwen3-4B (standby)"]:::gpu
+        LL["llama-local-01 → Qwen3.5-4B 🟢"]:::gpu
+    end
+
+    REQ --> AS --> ROUTE --> BUDGET --> backends
+
+    classDef own fill:#eaf3ea,stroke:#4a8a4a;
+    classDef ctrl fill:#e8eef7,stroke:#4a6fa5;
+    classDef ext fill:#eee,stroke:#888,stroke-dasharray:4 3;
+    classDef gpu fill:#f7e8f0,stroke:#a54a81;
+```
+
+- **Adding a model is a list edit** in `charts/ai-models/values.yaml` → the
+  ApplicationSet generates a new child Application (route + budget). No new chart.
+- Models are **branded aliases** over provider backends — e.g. `adorsys-reviewer`
+  → MiniMax M2.7, `adorsys-reviewer-pro` → GLM-5, `adorsys-coder-pro` → GLM-5.1.
+  ~30 models are live across Fireworks / DeepInfra / Google AI + the 2 local ones.
+- The catalog clients see is `ai-models-info` — an OpenRouter-shape
+  `/v1/models/info` static endpoint (ADR-0015).
+
+## Budget & burst, per model
+
+Every leaf's `BackendTrafficPolicy` enforces the plan tiers from
+`rateLimitBudgeting.plans`, keyed on `x-account-id` + `x-billing-plan`:
+
+```mermaid
+flowchart LR
+    subgraph tiers["plan → limits (per person, ADR-0035)"]
+        FREE["free · $50/mo · 200 rpm · 1M tpm"]:::t
+        PRO["pro · $200/mo · 400 rpm · 2M tpm"]:::t
+        SVC["service · uncapped · 600 rpm · 2M tpm"]:::t
+        INT["internal · uncapped · 600 rpm · 2M tpm"]:::t
+    end
+    classDef t fill:#eaf3ea,stroke:#4a8a4a;
+```
+
+Cost is metered natively (`llmRequestCosts` token extraction) — no Python/Lua hop.
+
+## The self-hosted model (home GPU)
+
+The **one** sanctioned `homeCluster: true` workload (ADR-0022): it must run on the
+cluster ArgoCD itself runs on because it needs the home GPU (A2000 12 GB).
+
+```mermaid
+flowchart TB
+    subgraph poc["ns: converse-poc (home GPU cluster)"]
+        subgraph ss["StatefulSet (bjw-template) — LIVE"]
+            LS["llama-server (llama.cpp)<br/>Qwen3.5-4B UD-Q4_K_XL GGUF<br/>native --api-key · /v1 · /health<br/>128k ctx · 4 slots · ~52 tok/s"]:::gpu
+        end
+        PVC["RWX PVC (pre-seeded GGUF)"]:::own
+        SEED["seed Job"]:::own
+        ING["Ingress"]:::own
+        SEED --> PVC --> LS
+        LS --> ING
+    end
+
+    GW["Envoy AI Gateway<br/>(home-remote)"]:::own
+    ING -->|"federated as qwen3-5-4b-local (/v1)"| GW
+
+    classDef own fill:#eaf3ea,stroke:#4a8a4a;
+    classDef gpu fill:#f7e8f0,stroke:#a54a81;
+```
+
+### Two engines, two shapes
+
+```mermaid
+flowchart LR
+    subgraph llama["llama.cpp (LIVE · qwen3-5)"]
+        L1["ONE container<br/>llama-server"]:::gpu
+        L2["native --api-key<br/>(no proxy needed)"]:::gpu
+        L1 --- L2
+    end
+    subgraph vllm["vLLM (standby · qwen3-4b)"]
+        V1["huggingfaceserver (vLLM + LMCache)"]:::gpu
+        V2["+ Caddy auth-proxy sidecar<br/>(huggingfaceserver ignores VLLM_API_KEY)"]:::gpu
+        V1 --- V2
+    end
+    classDef gpu fill:#f7e8f0,stroke:#a54a81;
+```
+
+| | llama.cpp (`model-serving-qwen3-5`) 🟢 | vLLM (`model-serving-qwen3-4b`) |
+|---|---|---|
+| Model | Qwen3.5-4B Q4 (GGUF) | Qwen3-4B (BF16) |
+| Containers | 1 (native `--api-key`) | 2 (vLLM + Caddy auth-proxy) |
+| Status | **LIVE** since 2026-06-08 | standby / rollback |
+| ADRs | 0030, 0032 | 0029, 0030 |
+
+Pricing for owned hardware is **cost-recovery** (€/hour TCO → weighted per-token,
+ADR-0028), not flat-zero. The model-agnostic "deploy the next one" checklist and
+per-model capacity papers live in
+[`../self-hosted-model-serving.md`](../self-hosted-model-serving.md) and
+[`../models/`](../models/qwen3.5-4b-q4.md).
+
+→ Related: [03 Gateway request path](03-gateway-components.md) · [05 Auth & tiers](05-auth-identity.md)

--- a/docs/architecture/10-mcp.md
+++ b/docs/architecture/10-mcp.md
@@ -1,0 +1,130 @@
+# 10 · MCP servers
+
+How Model Context Protocol tool servers are exposed through the gateway — the
+OAuth discovery carve-out, and the in-cluster proxy modes that make flaky
+external MCPs behave. Source ADRs: **0038** (OAuth discovery), **0040**
+(proxiedExternal Caddy), **0041** (openresty request rewrite). Namespace
+`converse-mcp`, orchestrator `charts/mcps`, leaf `charts/mcp`.
+
+## The MCP catalog
+
+```mermaid
+flowchart TB
+    GW["Envoy AI Gateway<br/>/mcp/* (native jwt_authn)"]:::own
+
+    subgraph self["Self-hosted (in-cluster, plain HTTP)"]
+        BRAVE["brave<br/>mcp/brave-search"]:::own
+        TF["terraform<br/>hashicorp/terraform-mcp-server"]:::own
+    end
+    subgraph proxied["proxiedExternal (in-cluster proxy → external TLS)"]
+        CTX["context7 → mcp.context7.com<br/><i>engine: caddy</i>"]:::own
+        REF["refero → api.refero.design<br/><i>caddy + Content-Type rewrite</i>"]:::own
+        FC["firecrawl → mcp.firecrawl.dev<br/><i>engine: openresty + protocol pin</i>"]:::own
+    end
+
+    EXT["external MCP services"]:::ext
+
+    GW --> BRAVE & TF
+    GW --> CTX & REF & FC
+    CTX -.TLS.-> EXT
+    REF -.TLS.-> EXT
+    FC -.TLS.-> EXT
+
+    classDef own fill:#eaf3ea,stroke:#4a8a4a;
+    classDef ext fill:#eee,stroke:#888,stroke-dasharray:4 3;
+```
+
+| MCP | Mode | Proxy engine | Upstream |
+|---|---|---|---|
+| `brave` | selfHosted | — | in-cluster image |
+| `terraform` | selfHosted | — | in-cluster image |
+| `context7` | proxiedExternal | caddy | `mcp.context7.com` |
+| `refero` | proxiedExternal | caddy | `api.refero.design` |
+| `firecrawl` | proxiedExternal | openresty | `mcp.firecrawl.dev` (`/v2/mcp`) |
+
+## The OAuth carve-out (ADR-0038)
+
+`/mcp/*` is the one place Authorino is bypassed. Each `MCPRoute` carries
+`securityPolicy.oauth`, and an Envoy route-level `SecurityPolicy` **displaces**
+the gateway-attached Authorino policy *whole* (no merge).
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant C as MCP client (opencode)
+    participant GW as Envoy gateway
+    participant KC as Keycloak
+
+    Note over C,GW: Discovery surface — served UNAUTHENTICATED
+    C->>GW: GET /.well-known/oauth-protected-resource/mcp/(name)
+    GW-->>C: 200 RFC 9728 metadata (resource + AS aliases)
+    C->>GW: POST /mcp/(name) (no token)
+    GW-->>C: 401 WWW-Authenticate: resource_metadata=...
+    C->>KC: OAuth flow → Keycloak JWT
+    C->>GW: POST /mcp/(name) (Bearer JWT)
+    GW->>GW: native jwt_authn (Keycloak issuer)<br/>claimToHeaders → x-oidc-* (ADR-0011)
+    GW->>GW: route to in-cluster MCP backend
+    GW-->>C: tool result
+```
+
+- JWT verification = Envoy's native `jwt_authn` (same Keycloak issuer as Authorino).
+- The gateway serves discovery itself: the path-insertion form
+  `/.well-known/oauth-protected-resource/mcp/(name)`, AS-metadata aliases, the 401
+  `resource_metadata` challenge, plus a non-spec path-appended alias.
+- `claimToHeaders` re-stamps the `x-oidc-*` set (caveat: object/array claims
+  arrive base64url(JSON), not plain JSON).
+- **No rate-limit descriptors** on `/mcp/*` — no MCP rate limiting today.
+
+## Why external MCPs go through in-cluster proxies (ADR-0040)
+
+Direct external-TLS MCP backends were unfixable at the Envoy layer. The three
+distinct failures and their fix:
+
+```mermaid
+flowchart TB
+    subgraph problems["Why direct Envoy TLS backends failed"]
+        P1["AIEG stamps empty-SNI<br/>dummy.transport_socket<br/>(BackendTLSPolicy never reaches it)"]:::warn
+        P2["BoringSSL rejects context7's<br/>ECDSA cert (BAD_ECC_CERT)"]:::warn
+        P3["refero mislabels JSON as<br/>text/event-stream → empty tools<br/>(AIEG #2218)"]:::warn
+        P4["firecrawl prepends empty SSE event<br/>for protocol 2025-11-25 → 500<br/>(AIEG #2219)"]:::warn
+    end
+
+    subgraph fix["Fix: per-MCP in-cluster normalizing proxy"]
+        CADDY["Caddy (caddy:2-alpine)<br/>Go TLS handles ECDSA ✅<br/>injects Bearer (header_up)<br/>refero: rewrite Content-Type (header_down)"]:::own
+        ORS["openresty (nginx+Lua)<br/>rewrite_by_lua_block:<br/>pin request protocolVersion → 2025-06-18<br/>inject Bearer via os.getenv"]:::own
+    end
+
+    P1 --> CADDY
+    P2 --> CADDY
+    P3 --> CADDY
+    P4 --> ORS
+
+    classDef warn fill:#fbeaea,stroke:#a54a4a;
+    classDef own fill:#eaf3ea,stroke:#4a8a4a;
+```
+
+```mermaid
+flowchart LR
+    MCPR["MCPRoute"]:::own -->|plain HTTP| PROXY["in-cluster proxy<br/>(Caddy or openresty)"]:::own
+    PROXY -->|"TLS + credential + rewrites"| UP["external MCP"]:::ext
+    classDef own fill:#eaf3ea,stroke:#4a8a4a;
+    classDef ext fill:#eee,stroke:#888,stroke-dasharray:4 3;
+```
+
+The proxy turns an unreliable external TLS backend into a **reliable in-cluster
+plain-HTTP backend** — identical to brave/terraform from Envoy's view. The
+ADR-0039 `EnvoyPatchPolicy` was removed.
+
+> ⚠️ **Token-bind race (`MCP_TOKEN`):** env vars from `secretKeyRef` bind at pod
+> start and never refresh. A proxy that beats ESO with `optional: true` captures
+> an **empty** token forever (`Bearer `) → upstream rejects every request as
+> "Invalid API key". Guard: `charts/mcp` renders `MCP_TOKEN` with `optional:
+> false`, so a keyed proxy **waits** in `ContainerCreating` for ESO. A keyless
+> MCP disables `externalSecret` and proxies anonymously.
+>
+> ⚠️ **The openresty/Caddy engine choices are INTERIM.** Drop the firecrawl
+> openresty engine once AIEG's SSE parser skips non-response events (#2219); drop
+> refero's `rewriteResponseContentType` once #2218 lands. Full diagnosis:
+> [`../2026-06-10-mcp-external-server-proxy-debug.md`](../2026-06-10-mcp-external-server-proxy-debug.md).
+
+→ Related: [05 Auth (carve-out)](05-auth-identity.md) · [06 Networking & TLS](06-networking-tls.md)

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -103,6 +103,6 @@ flowchart LR
   (Keycloak, Redis, cert-manager, ESO, CNPG operator, object storage, providers).
 - **Pink** — runs on the home GPU cluster (the `homeCluster: true` exception).
 
-> **Accuracy note.** Diagrams reflect `release-2026.06.14-v03`. Coder
+> **Accuracy note.** Diagrams reflect `release-2026.06.14-v09`. Coder
 > (old ADR-0019) was **removed** (ADR-0027) and does not appear here, despite
 > lingering mentions in some older `docs/` files.

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,0 +1,108 @@
+# Architecture documentation suite
+
+A **layered**, mermaid-based map of the Camer Digital AI platform deployed by
+this repository. Each layer zooms in one level — read top-down, stop when you
+have the resolution you need.
+
+> This is a *navigation hub*. The single-page system map lives at
+> [`../architecture.md`](../architecture.md); the formal arc42 description at
+> [`../arc42.md`](../arc42.md); the source-of-truth for every *why* is the
+> [ADR index](../adr/README.md). This suite sits between them — enough depth to
+> understand each subsystem, every diagram in mermaid so it renders inline.
+
+## How the layers fit together
+
+This suite follows the **C4 model** (Context → Container → Component) for the
+static structure, then breaks out the cross-cutting subsystems each on its own
+page. arc42 is the formal frame around all of it.
+
+```mermaid
+flowchart TB
+    subgraph L0["Entry points"]
+        FRONT["architecture.md<br/><i>single-page system map</i>"]
+        ARC["arc42.md<br/><i>formal 12-section description</i>"]
+    end
+
+    subgraph C4["C4 static structure (this suite)"]
+        L1["01 · Context<br/><i>who & what's outside</i>"]
+        L2["02 · Containers<br/><i>deployable units by namespace</i>"]
+        L3["03 · Gateway components<br/><i>the request path</i>"]
+        L1 --> L2 --> L3
+    end
+
+    subgraph SUB["Cross-cutting subsystems (this suite)"]
+        D04["04 · GitOps & deployment"]
+        D05["05 · Auth & identity"]
+        D06["06 · Networking & TLS"]
+        D07["07 · Data & secrets"]
+        D08["08 · Observability"]
+        D09["09 · Model serving"]
+        D10["10 · MCP servers"]
+    end
+
+    FRONT --> C4
+    ARC --> C4
+    L2 --> SUB
+
+    classDef entry fill:#e8eef7,stroke:#4a6fa5,color:#1a2a40;
+    classDef c4 fill:#eaf3ea,stroke:#4a8a4a,color:#1a401a;
+    classDef sub fill:#f7f0e8,stroke:#a5814a,color:#402e1a;
+    class FRONT,ARC entry;
+    class L1,L2,L3 c4;
+    class D04,D05,D06,D07,D08,D09,D10 sub;
+```
+
+## The pages
+
+| # | Page | Zoom level | Answers |
+|---|---|---|---|
+| 01 | [Context](01-context.md) | C4 L1 | Who uses the platform; what external systems it depends on |
+| 02 | [Containers](02-containers.md) | C4 L2 | What's deployed, in which namespace, on which cluster |
+| 03 | [Gateway components](03-gateway-components.md) | C4 L3 | How one request traverses the gateway |
+| 04 | [GitOps & deployment](04-gitops-deployment.md) | infra | How charts become running workloads; sync waves; releases |
+| 05 | [Auth & identity](05-auth-identity.md) | security | Dual-plane auth, the three identity surfaces, the `x-oidc-*` contract |
+| 06 | [Networking & TLS](06-networking-tls.md) | infra | Ingress, the Hetzner LB, Cilium deny-egress, certificate issuance |
+| 07 | [Data & secrets](07-data-secrets.md) | infra | Mongo, CNPG, Redis, object storage, the ESO secret flow |
+| 08 | [Observability](08-observability.md) | platform | The LGTM pipeline, Alloy collection, per-user attribution |
+| 09 | [Model serving](09-model-serving.md) | platform | Provider fan-out + the self-hosted GPU model; budget tiers |
+| 10 | [MCP servers](10-mcp.md) | platform | MCP routing, the OAuth carve-out, the external-proxy modes |
+
+## C4 ↔ arc42 ↔ this suite
+
+The same system, described in three complementary frames:
+
+| C4 level | arc42 section | This suite |
+|---|---|---|
+| L1 System Context | §3 Context & scope | [01 Context](01-context.md) |
+| L2 Container | §5.1 Building blocks (level 1) | [02 Containers](02-containers.md) |
+| L3 Component | §5.3 Building blocks (level 3), §6 Runtime | [03 Gateway components](03-gateway-components.md) |
+| Deployment | §7 Deployment view | [04 GitOps](04-gitops-deployment.md) |
+| (crosscutting) | §8 Crosscutting concepts | [05](05-auth-identity.md)–[10](10-mcp.md) |
+
+## Conventions used in every diagram
+
+A consistent visual language across the suite:
+
+```mermaid
+flowchart LR
+    OWN["owned by this repo"]:::own
+    CTRL["control object<br/>(ArgoCD App/AppSet)"]:::ctrl
+    EXT["external / consumed<br/>(not deployed here)"]:::ext
+    GPU["self-hosted on home GPU"]:::gpu
+    OWN --> CTRL --> EXT --> GPU
+
+    classDef own fill:#eaf3ea,stroke:#4a8a4a,color:#1a401a;
+    classDef ctrl fill:#e8eef7,stroke:#4a6fa5,color:#1a2a40;
+    classDef ext fill:#eee,stroke:#888,color:#333,stroke-dasharray:4 3;
+    classDef gpu fill:#f7e8f0,stroke:#a54a81,color:#401a2e;
+```
+
+- **Solid green** — a chart/workload this repo owns and deploys.
+- **Blue** — an ArgoCD control object (`Application` / `ApplicationSet`).
+- **Dashed grey** — an external system this repo only *references* by name
+  (Keycloak, Redis, cert-manager, ESO, CNPG operator, object storage, providers).
+- **Pink** — runs on the home GPU cluster (the `homeCluster: true` exception).
+
+> **Accuracy note.** Diagrams reflect `release-2026.06.14-v03`. Coder
+> (old ADR-0019) was **removed** (ADR-0027) and does not appear here, despite
+> lingering mentions in some older `docs/` files.

--- a/docs/authorino-service-account-bypass.md
+++ b/docs/authorino-service-account-bypass.md
@@ -4,6 +4,16 @@
 **App:** `security-policies` (in `charts/apps/values.yaml`)
 **Authorino API:** `authorino.kuadrant.io/v1beta3`
 
+> ⚠️ **HISTORICAL — OPA was removed on 2026-06-04 (ADR-0021).** The
+> `lightbridge-validation` HTTP metadata source and the `enforce-valid-key`
+> authorization step described below were **deleted** from the AuthConfig; a
+> valid Keycloak JWT is now the authorization boundary (no per-request policy
+> hop). The `serviceAccountClients` allowlist and `_skipForServiceAccounts`
+> markers are kept but **inert** (reserved for possible future burst control).
+> This doc is retained as a record of the SA-skip mechanism (ADR-0003 era). For
+> the current model read [`architecture/05-auth-identity.md`](./architecture/05-auth-identity.md)
+> and [ADR-0021](./adr/0021-burst-budget-billing-and-dual-plane-authconfigs.md).
+
 ## What this does
 
 Allows specific Authorino AuthConfig **steps** (metadata, authorization) to be

--- a/docs/cnpg-native-backup/CNPG-BACKUP-SETUP.md
+++ b/docs/cnpg-native-backup/CNPG-BACKUP-SETUP.md
@@ -41,7 +41,7 @@ The solution uses:
 | CNPG operator | ✅ | v0.27.1 in `cnpg-system` |
 | barman-cloud plugin | ✅ | v0.5.0 in `cnpg-system` |
 | ObjectStore CRD | ✅ | `objectstores.barmancloud.cnpg.io` |
-| MinIO/S3 | ✅ | `s3://ai-ops-backups/lightbridge-cnpg-backups/` |
+| Hetzner Object Storage (S3) | ✅ | `s3://ssegning-k8s-state/lightbridge-main-db` |
 
 ### Phase 2: Create S3 Credentials Secret
 
@@ -74,8 +74,8 @@ metadata:
   namespace: converse
 spec:
   configuration:
-    destinationPath: s3://ai-ops-backups/lightbridge-cnpg-backups/
-    endpointURL: https://s3.ssegning.me
+    destinationPath: s3://ssegning-k8s-state/lightbridge-main-db
+    endpointURL: https://nbg1.your-objectstorage.com
     s3Credentials:
       accessKeyId:
         name: lightbridge-cnpg-s3
@@ -96,8 +96,8 @@ metadata:
   namespace: converse
 spec:
   configuration:
-    destinationPath: s3://ai-ops-backups/lightbridge-cnpg-backups/
-    endpointURL: https://s3.ssegning.me
+    destinationPath: s3://ssegning-k8s-state/lightbridge-main-db
+    endpointURL: https://nbg1.your-objectstorage.com
     s3Credentials:
       accessKeyId:
         name: lightbridge-cnpg-s3

--- a/docs/cnpg-native-backup/CNPG-BACKUP-SETUP.md
+++ b/docs/cnpg-native-backup/CNPG-BACKUP-SETUP.md
@@ -124,7 +124,7 @@ spec:
   instances: 2
   imageName: ghcr.io/cloudnative-pg/postgresql:18.1-system-trixie
   storage:
-    storageClass: linode-block-storage
+    storageClass: hcloud-volumes
     size: 5Gi
   # ADD THIS SECTION - enables WAL archiving
   plugins:
@@ -150,7 +150,7 @@ spec:
     name: lightbridge-usage-db
     major: 17
   storage:
-    storageClass: linode-block-storage
+    storageClass: hcloud-volumes
     size: 10Gi
   postgresql:
     shared_preload_libraries:

--- a/docs/cnpg-native-backup/README.md
+++ b/docs/cnpg-native-backup/README.md
@@ -2,6 +2,15 @@
 
 A comprehensive guide to understanding how CloudNativePG (CNPG) backups work with the Barman Cloud plugin, including the complete architecture and configuration.
 
+> ⚠️ **Live store = Hetzner Object Storage** (bucket `ssegning-k8s-state`,
+> endpoint `nbg1.your-objectstorage.com`, secret `lightbridge-cnpg-s3`). The
+> pre-Hetzner MinIO (`s3.ssegning.me`, bucket `ai-ops-backups`, the in-cluster
+> `minio` namespace) is **decommissioned**, and the `lightbridge-usage-db` was
+> dropped. The endpoints/paths in the examples below are updated, but any
+> residual `mc ls myminio/ai-ops-backups/…` or `-n minio` command refers to the
+> old setup — point `mc` at `nbg1.your-objectstorage.com`. **Source of truth for
+> the actual backup config:** `charts/lightbridge-db/values.yaml`.
+
 ## Table of Contents
 
 1. [Core Concepts](#core-concepts)
@@ -317,8 +326,8 @@ metadata:
 spec:
   retentionPolicy: 180d
   configuration:
-    destinationPath: s3://ai-ops-backups/lightbridge-main-db/
-    endpointURL: https://s3.ssegning.me
+    destinationPath: s3://ssegning-k8s-state/lightbridge-main-db
+    endpointURL: https://nbg1.your-objectstorage.com
     s3Credentials:
       accessKeyId:
         name: lightbridge-cnpg-s3
@@ -488,8 +497,8 @@ spec:
                                     │ Uploads/Downloads
                                     ▼
 ┌─────────────────────────────────────────────────────────────────────────┐
-│                           S3 / MinIO                                    │
-│                           https://s3.ssegning.me                        │
+│                    S3 (Hetzner Object Storage)                          │
+│                  https://nbg1.your-objectstorage.com                    │
 ├─────────────────────────────────────────────────────────────────────────┤
 │                                                                         │
 │  s3://ai-ops-backups/lightbridge-main-db/                              │

--- a/docs/cnpg-native-backup/README.md
+++ b/docs/cnpg-native-backup/README.md
@@ -229,7 +229,7 @@ flowchart TB
 ┌─────────────────────────────────────────────────────────────────┐
 │                     PostgreSQL Pod                              │
 │  name: lightbridge-main-db-1                                    │
-│  PVC: 5Gi (linode-block-storage)                                │
+│  PVC: 5Gi (hcloud-volumes)                                      │
 │  ├── /var/lib/postgresql/data (PGDATA)                          │
 │  └── /var/lib/postgresql/wal (WAL)                              │
 │                                                                 │
@@ -274,7 +274,7 @@ metadata:
 spec:
   instances: 2
   storage:
-    storageClass: linode-block-storage  # Storage class
+    storageClass: hcloud-volumes  # Storage class (Hetzner default)
     size: 5Gi                           # PVC size
 ```
 

--- a/docs/cnpg-native-backup/lightbridge-db-recovery-runbook.md
+++ b/docs/cnpg-native-backup/lightbridge-db-recovery-runbook.md
@@ -391,7 +391,7 @@ kubectl delete pvc -n converse -l postgresql.cnpg.io/cluster=lightbridge-main-db
 | lightbridge-main-db | s3://ai-ops-backups/lightbridge-main-db/ | lightbridge-main-db |
 | lightbridge-usage-db | s3://ai-ops-backups/lightbridge-usage-db/ | lightbridge-usage-db |
 
-**MinIO Endpoint:** https://s3.ssegning.me
+**S3 Endpoint:** https://nbg1.your-objectstorage.com (Hetzner Object Storage)
 
 ---
 

--- a/docs/cnpg-native-backup/lightbridge-db-recovery-runbook.md
+++ b/docs/cnpg-native-backup/lightbridge-db-recovery-runbook.md
@@ -273,7 +273,7 @@ spec:
   instances: 2
   imageName: ghcr.io/cloudnative-pg/postgresql:18.1-system-trixie
   storage:
-    storageClass: linode-block-storage
+    storageClass: hcloud-volumes
     size: "5Gi"
   plugins:
     - name: barman-cloud.cloudnative-pg.io

--- a/docs/cnpg-native-backup/lightbridge-main-db-restore.yaml
+++ b/docs/cnpg-native-backup/lightbridge-main-db-restore.yaml
@@ -9,7 +9,7 @@ spec:
   instances: 2
   imageName: ghcr.io/cloudnative-pg/postgresql:18.1-system-trixie
   storage:
-    storageClass: linode-block-storage
+    storageClass: hcloud-volumes
     size: 5Gi
   resources:
     limits:

--- a/docs/cnpg-native-backup/lightbridge-usage-db-restore.yaml
+++ b/docs/cnpg-native-backup/lightbridge-usage-db-restore.yaml
@@ -13,7 +13,7 @@ spec:
     name: lightbridge-usage-db
     major: 17
   storage:
-    storageClass: linode-block-storage
+    storageClass: hcloud-volumes
     size: 10Gi
   resources:
     limits:

--- a/docs/keycloak-audience-operations.md
+++ b/docs/keycloak-audience-operations.md
@@ -12,7 +12,6 @@ This document outlines the standard operating procedures for configuring and man
 
 ### Authorized Clients
 The following clients are managed within this environment:
-*   `coder`
 *   `converse`
 *   `converse-frontend`
 *   `lightbridge-api-key`

--- a/docs/mongodb-restoration-guide.md
+++ b/docs/mongodb-restoration-guide.md
@@ -41,7 +41,7 @@ The production restoration is carried out using a standalone Kubernetes Pod depl
 The restoration is automated through a multi-stage `Pod` execution defined in `recoveries/librechat/mongorestore-pod.yaml`:
 
 1. **Backup Download (Init Container: `download-backup`)**:
-   - Uses `minio/mc` to pull the backup from S3-compatible storage (`s3.ssegning.me`).
+   - Uses `minio/mc` to pull the backup from S3-compatible storage (`nbg1.your-objectstorage.com`, Hetzner Object Storage).
    - Credentials are provided via the `librechat-s3-config` secret.
    - The backup `mongodb-backup/all-databases_20260415_020035.gz` is downloaded to a shared volume at `/backup/backup.archive`.
 

--- a/docs/observability-dashboards.md
+++ b/docs/observability-dashboards.md
@@ -180,26 +180,7 @@ now lives in Grafana on top of Tempo.
 
 ---
 
-### 2.5 Coder
-
-**What it is:** Cloud development environment platform.
-
-**Current state:** No dashboards.
-
-**Instrumentation plan:**
-
-1. Coder exposes Prometheus metrics at `/metrics` on port 2112 by default.
-   Add a `ServiceMonitor` targeting the `coder` service on port `2112`.
-
-2. Use gnetId `19261` (Coder) for the dashboard. Key metrics:
-   - Active workspaces
-   - Build success/failure rate
-   - Agent connection latency
-   - Resource usage per workspace template
-
----
-
-### 2.6 Envoy AI Gateway (AIEG)
+### 2.5 Envoy AI Gateway (AIEG)
 
 **What it is:** The AI-specific gateway layer that routes requests to AI model
 backends, handles token counting, and enforces rate limits.
@@ -220,7 +201,7 @@ the AI Gateway extension (`aieg`) has its own metrics that are not yet captured.
 
 ---
 
-### 2.7 Authorino
+### 2.6 Authorino
 
 **What it is:** The authentication/authorization proxy for the API gateway.
 
@@ -239,7 +220,7 @@ the AI Gateway extension (`aieg`) has its own metrics that are not yet captured.
 
 ---
 
-### 2.8 OpenCode K8s Agent
+### 2.7 OpenCode K8s Agent
 
 **What it is:** The AI-powered cluster health monitor CronJob.
 
@@ -266,7 +247,6 @@ the AI Gateway extension (`aieg`) has its own metrics that are not yet captured.
 | 🔴 High | Envoy AI Gateway metrics | Low | Token usage and routing visibility |
 | 🟡 Medium | LibreChat + MongoDB | Medium | User-facing service health |
 | 🟡 Medium | Authorino | Low | Auth latency directly affects API response time |
-| 🟡 Medium | Coder | Low | ServiceMonitor already supported upstream |
 | 🟢 Low | Converse UI (nginx) | Low | Frontend availability signal |
 | 🟢 Low | OpenCode Agent | Low | Operational nicety, not critical path |
 

--- a/docs/observability-dashboards.md
+++ b/docs/observability-dashboards.md
@@ -79,7 +79,11 @@ and how.
 
 ---
 
-### 2.1 Lightbridge Backend (API, MCP, Usage)
+### 2.1 Lightbridge Backend (API, MCP)
+
+> Note: `usage.enabled: false` and `opa.enabled: false` in `charts/lightbridge`
+> — the usage sub-service and OPA are not running today, so the usage/OPA metrics
+> below are aspirational, not live.
 
 **What it is:** The core authorization and billing service. Handles
 authorization and usage tracking. (OPA was removed 2026-06-04, ADR-0021 — a
@@ -241,7 +245,7 @@ the AI Gateway extension (`aieg`) has its own metrics that are not yet captured.
 
 | Priority | Component | Effort | Impact |
 |----------|-----------|--------|--------|
-| 🔴 High | Lightbridge (API + Usage) | Medium | Every API request passes through here |
+| 🔴 High | Lightbridge (API) | Medium | Every API request passes through here |
 | 🔴 High | Envoy AI Gateway metrics | Low | Token usage and routing visibility |
 | 🟡 Medium | LibreChat + MongoDB | Medium | User-facing service health |
 | 🟡 Medium | Authorino | Low | Auth latency directly affects API response time |

--- a/docs/observability-dashboards.md
+++ b/docs/observability-dashboards.md
@@ -79,10 +79,11 @@ and how.
 
 ---
 
-### 2.1 Lightbridge Backend (API, OPA, MCP, Usage)
+### 2.1 Lightbridge Backend (API, MCP, Usage)
 
-**What it is:** The core authorization and billing service. Handles API key
-validation, OPA policy evaluation, and usage tracking.
+**What it is:** The core authorization and billing service. Handles
+authorization and usage tracking. (OPA was removed 2026-06-04, ADR-0021 — a
+valid Keycloak JWT is now the authorization boundary.)
 
 **Why it matters:** Every AI API request passes through Lightbridge. Latency
 spikes or error rate increases here directly impact end users.
@@ -96,7 +97,6 @@ spikes or error rate increases here directly impact end users.
    exposes `/metrics` via the `metrics` feature of `actix-web-prom` or similar).
    If not yet instrumented, add `prometheus` crate metrics for:
    - Request rate and latency per endpoint (`http_requests_total`, `http_request_duration_seconds`)
-   - OPA policy evaluation latency
    - API key validation cache hit/miss ratio
    - Active database connections
 
@@ -108,7 +108,6 @@ spikes or error rate increases here directly impact end users.
 3. **Dashboard** — Once metrics flow, use gnetId `19924` (Rust service metrics)
    or build a custom dashboard tracking:
    - API key validation rate and error rate
-   - OPA policy decision latency (p50/p95/p99)
    - Usage DB write latency
    - Active connections per service
 
@@ -215,8 +214,7 @@ the AI Gateway extension (`aieg`) has its own metrics that are not yet captured.
 2. Key metrics:
    - Auth evaluation rate and latency per `AuthConfig`
    - Cache hit/miss ratio
-   - External metadata fetch latency (the Lightbridge OPA calls)
-   - Denial rate per policy
+   - Denial rate per AuthConfig
 
 ---
 
@@ -243,7 +241,7 @@ the AI Gateway extension (`aieg`) has its own metrics that are not yet captured.
 
 | Priority | Component | Effort | Impact |
 |----------|-----------|--------|--------|
-| 🔴 High | Lightbridge (API + OPA) | Medium | Every API request passes through here |
+| 🔴 High | Lightbridge (API + Usage) | Medium | Every API request passes through here |
 | 🔴 High | Envoy AI Gateway metrics | Low | Token usage and routing visibility |
 | 🟡 Medium | LibreChat + MongoDB | Medium | User-facing service health |
 | 🟡 Medium | Authorino | Low | Auth latency directly affects API response time |

--- a/docs/observability-fix-no-data-dashboards.md
+++ b/docs/observability-fix-no-data-dashboards.md
@@ -133,8 +133,6 @@ Each CNPG instance runs a metrics exporter on port `9187` (named `metrics`),
 but no PodMonitor existed, so the CNPG dashboard had no data. `.spec.monitoring.
 enablePodMonitor` is deprecated, so manual PodMonitors are used instead.
 
-- **`charts/coder-db/values.yaml`** — added a `PodMonitor` for the `coder-cnpg`
-  cluster (selector `cnpg.io/cluster: coder-cnpg`, port `metrics`).
 - **`charts/apps/values.yaml`** (lightbridge resources list) — added
   `PodMonitor`s for `lightbridge-main-db` and `lightbridge-usage-db` (selector
   `cnpg.io/cluster: <name>`, port `metrics`).

--- a/docs/observability-stack.md
+++ b/docs/observability-stack.md
@@ -36,7 +36,8 @@
 > namespace `observability` on Hetzner Object Storage via the App-of-Apps
 > orchestrator (`charts/observability`, ADR-0020); current chart versions are
 > mimir-distributed 5.8.0 / loki 7.0.0 / tempo 1.24.4. For the *current* topology
-> and the answers to "why N pods?", read the next section.
+> and the answers to "why N pods?", read the next section — or the canonical
+> mermaid map at [`architecture/08-observability.md`](./architecture/08-observability.md).
 
 ## Topology & component rationale (current)
 

--- a/docs/observability-stack.md
+++ b/docs/observability-stack.md
@@ -32,8 +32,10 @@
 ---
 
 > ⚠️ **Parts of "What Was Done" below are historical** (Linode Object Storage,
-> namespace `monitoring`, chart versions 5.3.0/6.6.0). The stack now lives in
-> namespace `observability` on Hetzner Object Storage via the App-of-Apps
+> the MinIO endpoint `s3.ssegning.me`, `linode-block-storage` PVCs, namespace
+> `monitoring`, chart versions 5.3.0/6.6.0 — all pre-Hetzner). The stack now lives
+> in namespace `observability` on **Hetzner Object Storage**
+> (`nbg1.your-objectstorage.com`, bucket `ssegning-k8s-state`) via the App-of-Apps
 > orchestrator (`charts/observability`, ADR-0020); current chart versions are
 > mimir-distributed 5.8.0 / loki 7.0.0 / tempo 1.24.4. For the *current* topology
 > and the answers to "why N pods?", read the next section — or the canonical
@@ -79,7 +81,7 @@ Four new ArgoCD Applications were added to `charts/apps/values.yaml`, plus an up
 - **Namespace:** `monitoring`
 - **Sync wave:** `-1` (deploys before Grafana)
 - **Components deployed:** ingester, distributor, querier, query-frontend, store-gateway, compactor, alertmanager, nginx gateway
-- **Storage:** S3-compatible backend (configurable — currently points to Linode Object Storage; can be swapped to MinIO)
+- **Storage:** S3-compatible backend (historically Linode Object Storage / MinIO `s3.ssegning.me`; **now Hetzner Object Storage** `nbg1.your-objectstorage.com`, bucket `ssegning-k8s-state`)
 - **Buckets:** `converse-mimir-blocks`, `converse-mimir-alertmanager`, `converse-mimir-ruler`
 - **Secrets required:** `mimir-s3` (keys: `MIMIR_S3_ACCESS_KEY_ID`, `MIMIR_S3_SECRET_ACCESS_KEY`)
 - **ResourceQuota & LimitRange:** Expanded in `extraObjects` to accommodate the full LGTM stack (16 CPU limit, 24 Gi memory, 40 pods)

--- a/docs/observability-storage-retention.md
+++ b/docs/observability-storage-retention.md
@@ -33,7 +33,8 @@ External Secrets Operator (ESO):
 ### 1.2 Local Persistent Volumes
 
 In addition to object storage, each stateful component uses a local PVC
-(Linode Block Storage) as a write-ahead buffer and WAL:
+(the cluster default StorageClass — `hcloud-volumes` on Hetzner) as a
+write-ahead buffer and WAL:
 
 | Component | PVC Size | Purpose |
 |-----------|----------|---------|

--- a/docs/observability-storage-retention.md
+++ b/docs/observability-storage-retention.md
@@ -10,8 +10,9 @@
 
 ### 1.1 Object Storage Backend
 
-All three telemetry stores share a single S3-compatible bucket (`monitoring` on
-`s3.ssegning.me`) with prefix-based namespace isolation:
+All three telemetry stores share a single S3-compatible bucket
+(`ssegning-k8s-state` on Hetzner Object Storage, `nbg1.your-objectstorage.com`)
+with prefix-based namespace isolation:
 
 | Store | S3 Prefix | Data Type |
 |-------|-----------|-----------|
@@ -334,7 +335,7 @@ less query fan-out; smaller window = more frequent compaction cycles.
 
 ### 3.1 Primary Backup: S3 Object Storage
 
-The S3 bucket (`monitoring` on `s3.ssegning.me`) is the primary durable store
+The S3 bucket (`ssegning-k8s-state` on Hetzner Object Storage) is the primary durable store
 for all telemetry data. Backup strategy depends on the S3 provider's
 capabilities:
 

--- a/docs/opencode-well-known.md
+++ b/docs/opencode-well-known.md
@@ -391,8 +391,9 @@ client config above).
 - ADR-0038 — the gateway `/mcp/*` routes + OAuth the remote MCPs target
 - ADR-0009 — humans use Lightbridge self-service for API keys; the
   opencode CLI flow is the desktop complement
-- ADR-0003 — SA-skip-OPA via `azp`; opencode tokens have
-  `azp=opencode-cli` so they go through full OPA validation (humans)
+- ADR-0003 — SA-skip-OPA via `azp` (historical: OPA was removed 2026-06-04,
+  ADR-0021; a valid Keycloak JWT now suffices, so opencode tokens with
+  `azp=opencode-cli` are accepted without a policy hop)
 - `charts/librechat-opencode-wellknown/values.yaml` — the JSON content
   source
 - `charts/keycloak-baseline/values.yaml` — where the `opencode-cli`

--- a/docs/python-dashboard-generation.md
+++ b/docs/python-dashboard-generation.md
@@ -76,7 +76,7 @@ both, identical workflow.
 | Layout | When | OUTPUT_PATH target |
 |---|---|---|
 | **B (central)** | Cross-app dashboards (per-user AI Gateway, total cost per user, GitOps overview) | `charts/observability-dashboards/files/<area>/<name>.json` |
-| **A (chart-local)** | App-specific (LibreChat user activity, Coder workspace health) | `charts/<chart>/files/dashboards/<name>.json` |
+| **A (chart-local)** | App-specific (LibreChat user activity, per-model gateway usage) | `charts/<chart>/files/dashboards/<name>.json` |
 
 The grafana-operator picks both up — it reconciles every `GrafanaDashboard`
 CR regardless of which chart shipped it. The choice is purely about

--- a/docs/secret-management/bootstrap-secrets-inventory.md
+++ b/docs/secret-management/bootstrap-secrets-inventory.md
@@ -46,7 +46,6 @@ mindmap
       argocd-gitops-repo
       argocd-webhook-secret
     Platform Authentication
-      lightbridge-opa-auth
       authz-tls
     AI Model API Keys
       OpenAI API Keys
@@ -82,7 +81,6 @@ Secrets for platform-level authentication and authorization.
 
 | Secret Name | Namespace | Type | Keys | Description |
 |-------------|-----------|------|------|-------------|
-| `lightbridge-opa-auth` | converse | Opaque | `credentials` | Basic auth for OPA validation |
 | `authz-tls` | converse-gateway | Opaque | `ca.crt`, `tls.crt`, `tls.key` | TLS certificates for authorization |
 
 ### Category 3: AI Model API Keys
@@ -127,7 +125,6 @@ Secrets for platform-level authentication and authorization.
 
 | Secret Name | Namespace | Type | Keys | Description |
 |-------------|-----------|------|------|-------------|
-| `lightbridge-opa-auth` | converse-gateway | Opaque | `credentials` | OPA validation credentials |
 | `authz-tls` | converse-gateway | Opaque | `ca.crt`, `tls.crt`, `tls.key` | TLS certificates for authorization |
 
 ### Category 6: Database Credentials
@@ -207,32 +204,6 @@ kubectl create secret generic argocd-webhook-secret \
 ```
 
 ### Platform Authentication
-
-#### lightbridge-opa-auth
-
-```yaml
-apiVersion: v1
-kind: Secret
-metadata:
-  name: lightbridge-opa-auth
-  namespace: converse
-  labels:
-    app.kubernetes.io/component: authorization
-    platform.ai.camer.digital/type: bootstrap
-type: Opaque
-stringData:
-  credentials: <base64-encoded-basic-auth>
-```
-
-**Creation Command:**
-```bash
-# Generate basic auth credentials
-CREDENTIALS=$(echo -n "username:password" | base64)
-
-kubectl create secret generic lightbridge-opa-auth \
-  --from-literal=credentials="$CREDENTIALS" \
-  -n converse
-```
 
 #### authz-tls
 
@@ -423,12 +394,6 @@ kubectl create secret generic argocd-gitops-repo \
 kubectl create secret generic argocd-webhook-secret \
   --from-literal=secret="$(openssl rand -hex 32)" \
   -n argocd
-
-echo "Creating platform authentication secrets..."
-CREDENTIALS=$(echo -n "admin:$(openssl rand -base64 24)" | base64)
-kubectl create secret generic lightbridge-opa-auth \
-  --from-literal=credentials="$CREDENTIALS" \
-  -n converse
 
 echo "Creating AI model API key secrets..."
 kubectl create secret generic openai-api-key \

--- a/docs/secret-management/bootstrap-secrets-inventory.md
+++ b/docs/secret-management/bootstrap-secrets-inventory.md
@@ -61,7 +61,6 @@ mindmap
     Database Credentials
       PostgreSQL Credentials
       MongoDB Credentials
-      Coder DB Credentials
     Backup Credentials
       S3 Backup Credentials
       Keycloak Backup
@@ -139,7 +138,6 @@ Database connection credentials for platform services.
 |-------------|-----------|------|------|-------------|
 | `lightbridge-main-db-app` | converse | Opaque | 11 keys | Main PostgreSQL credentials |
 | `lightbridge-usage-db-app` | converse | Opaque | 11 keys | Usage DB credentials |
-| `coder-db-credentials` | coder | Opaque | `username`, `password`, `database` | Coder database credentials |
 
 ### Category 7: Backup Credentials
 
@@ -362,33 +360,6 @@ stringData:
 kubectl create secret generic librechat-mongodb-uri \
   --from-literal=MONGO_URI="mongodb://user:pass@mongodb:27017/librechat" \
   -n librechat
-```
-
-#### coder-db-credentials
-
-```yaml
-apiVersion: v1
-kind: Secret
-metadata:
-  name: coder-db-credentials
-  namespace: coder
-  labels:
-    app.kubernetes.io/component: database
-    platform.ai.camer.digital/type: bootstrap
-type: Opaque
-stringData:
-  username: coder
-  password: <secure-password>
-  database: coder
-```
-
-**Creation Command:**
-```bash
-kubectl create secret generic coder-db-credentials \
-  --from-literal=username="coder" \
-  --from-literal=password="$(openssl rand -base64 32)" \
-  --from-literal=database="coder" \
-  -n coder
 ```
 
 ### Backup Credentials


### PR DESCRIPTION
## 1. Summary

This PR changes:

- Adds a **layered, mermaid-based architecture documentation suite** under `docs/architecture/` — a navigation hub + 10 pages following the C4 model (context → container → component) plus one page per cross-cutting subsystem (GitOps/deployment, auth/identity, networking/TLS, data/secrets, observability, model serving, MCP).
- Refreshes **`docs/arc42.md`** (ASCII → mermaid throughout, brought current to `release-2026.06.14-v03`) and **`docs/architecture.md`** (rewritten as a concise mermaid front-door that routes into the suite); updates the `docs/README.md` index.
- Sweeps **stale references** from current-state docs: **Coder** (removed by ADR-0027 — chart, `coder-db`, Keycloak client, secret), **pre-Hetzner storage** (`linode-block-storage` → `hcloud-volumes`), and **OPA** (removed 2026-06-04, ADR-0021 — Keycloak JWT is the boundary).

It solves:

- The architecture docs were ASCII-only and partly stale (Coder still shown though removed; pre-Hetzner namespaces/storage; OPA shown as a live request-path component; no repo-auth/converse-ui). Source of truth for the documented decisions: the [ADR index](https://github.com/ADORSYS-GIS/ai-helm/blob/main/docs/adr/README.md). Related standing work: #134 (standardize Kubernetes/Helm/ArgoCD runtime patterns).

---

## 2. Intent

The intent of this PR is:

> Give the platform a comprehensive, elegant, **navigable** architecture reference that renders inline on GitHub (every diagram in mermaid, layered so a reader stops at whatever resolution they need), and to retire stale references so the current-state docs match the live system. Documentation-only — no chart, template, or workflow changes.

---

## 3. Scope

### In Scope

- New `docs/architecture/` suite (11 files) + refreshed `docs/arc42.md`, `docs/architecture.md`, `docs/README.md`.
- Stale-reference removal (Coder / pre-Hetzner storage / OPA) across current-state docs only.

### Out of Scope

- **ADRs** — immutable; supersession (ADR-0027 supersedes 0019; ADR-0021 records OPA removal) is the mechanism, so stale terms in ADRs are left as-is.
- **Dated change-logs / audits / migrations** — left as legitimate point-in-time history.
- Any chart/template/workflow change (this PR touches `docs/` only; verified `git diff --stat origin/main` is docs-only).

---

## 4. Verification

I verified this change by:

- [x] Running automated tests
- [x] Running manual tests
- [ ] Checking logs
- [ ] Checking metrics
- [ ] Testing error cases
- [ ] Testing permissions/security behavior
- [ ] Testing rollback or failure behavior, if relevant

Commands run:

```bash
# Render-validate every mermaid block with the mermaid CLI (local Chrome)
mmdc -i <each-extracted-block>.mmd -o out.svg   # 49 blocks
# Relative-link check across all new/edited docs
# Code-fence parity check
# Confirm the PR diff is docs-only (no charts/.github), ADR-0049 preserved
git diff --stat origin/main..HEAD
```

Results:

```text
validated 49 mermaid blocks, 0 failed
link check done   (no broken relative links)
fence parity: all files even (no stray code fences)
diff vs origin/main: 26 files, docs/ only; ADR-0049 present; no .github/charts changes
```

---

## 5. Screenshots / Evidence

- Mermaid validation: 49/49 blocks render with `@mermaid-js/mermaid-cli`.
- This branch was cut **fresh from `origin/main`** and only this session's 3 docs commits were cherry-picked, so the diff is strictly documentation (the original working branch carried unrelated, already-merged commits and is not used as the base).

---

## 6. Risk Assessment

Risk level:

* [x] Low
* [ ] Medium
* [ ] High

Potential risks:

* Documentation drift if subsystems change after merge (inherent to docs).

Mitigation:

* Diagrams are dated to `release-2026.06.14-v03` and cross-linked to the ADRs/CLAUDE.md; the suite is the canonical map so future changes have one place to update.

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [ ] Generating code
* [ ] Refactoring
* [ ] Generating tests
* [ ] Drafting documentation
* [ ] Reviewing the diff
* [ ] Not used

> AI drafted the documentation and diagrams, cross-checked the chart/namespace inventory against `charts/{apps,ai-models,librechart,observability,mcps}/values.yaml`, and render-validated all mermaid.

Human verification:

* [ ] I understand every meaningful change in this PR
* [ ] I checked generated code manually
* [ ] I checked generated tests manually
* [ ] I removed unsupported AI assumptions
* [ ] I accept responsibility for this PR

> (Maintainer to confirm the boxes above on review.)

---

## 8. Reviewer Focus

Please focus your review on:

* [ ] Correctness
* [x] Architecture
* [ ] Security
* [ ] Performance
* [ ] Tests
* [x] Maintainability
* [ ] Product intent
* [ ] Edge cases

> Specifically: are the diagrams accurate to the live system, and is the suite layering/navigation useful?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
