### PR TITLE
docs: single source of truth — CLAUDE.md, with AGENTS.md + copilot as pointers

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,17 +1,19 @@
 <!-- ai-governance:stanza -->
-<!-- BEGIN: AI Governance stanza (managed by ADORSYS-GIS/ai-governance) -->
-## AI Governance
+# Copilot instructions
 
-AI may accelerate the work, but humans own intent, verification, and consequences.
-AI output is not truth: review AI-generated code as untrusted, and never submit work you cannot explain.
+**Single source of truth → [`../CLAUDE.md`](../CLAUDE.md).**
 
-When opening issues or pull requests in this repo:
+All agent and contributor guidance for this repository — repo conventions,
+architecture entry points, commands, tooling rules, cluster gotchas, and the
+**AI Governance** rules — lives in [`CLAUDE.md`](../CLAUDE.md). This file is only
+a pointer so the guidance exists in exactly one place and never drifts.
+GitHub Copilot: load and follow [`../CLAUDE.md`](../CLAUDE.md).
 
-- Use the provided **issue forms** (Epic, User Story, Dev Ticket) and the **pull request template** — do not open blank issues/PRs.
-- Fill in the **AI Usage Declaration** honestly (what AI was used for, what you verified).
-- Include a **source-of-truth link** (a URL or `#123` reference). No source of truth means the work is not ready.
-- Provide **verification evidence** (commands, logs, links, or checked verification boxes). No evidence means it is not done.
+**AI Governance:** see the "AI Governance" section of [`CLAUDE.md`](../CLAUDE.md).
+Full doctrine: https://adorsys-gis.github.io/ai-governance/
 
-Source of truth and full doctrine: https://adorsys-gis.github.io/ai-governance/
-This stanza is intentionally thin — read the site; do not duplicate the doctrine here.
-<!-- END: AI Governance stanza -->
+<!--
+  The `ai-governance:stanza` marker above is intentional: it tells
+  ADORSYS-GIS/ai-governance's sync-templates script the stanza is already handled
+  here, so it won't re-append a duplicate. The canonical stanza lives in CLAUDE.md.
+-->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,17 +1,23 @@
 <!-- ai-governance:stanza -->
-<!-- BEGIN: AI Governance stanza (managed by ADORSYS-GIS/ai-governance) -->
-## AI Governance
+# AGENTS.md
 
-AI may accelerate the work, but humans own intent, verification, and consequences.
-AI output is not truth: review AI-generated code as untrusted, and never submit work you cannot explain.
+**Single source of truth → [`CLAUDE.md`](./CLAUDE.md).**
 
-When opening issues or pull requests in this repo:
+Every piece of agent and contributor guidance for this repository — repo
+conventions, the architecture entry points, common commands, tooling rules, the
+hard-won cluster gotchas, and the **AI Governance** rules — lives in
+[`CLAUDE.md`](./CLAUDE.md). This file is deliberately only a pointer, so the
+guidance exists in exactly one place and can never drift.
 
-- Use the provided **issue forms** (Epic, User Story, Dev Ticket) and the **pull request template** — do not open blank issues/PRs.
-- Fill in the **AI Usage Declaration** honestly (what AI was used for, what you verified).
-- Include a **source-of-truth link** (a URL or `#123` reference). No source of truth means the work is not ready.
-- Provide **verification evidence** (commands, logs, links, or checked verification boxes). No evidence means it is not done.
+> **Whatever agent you are — Claude, opencode, Codex, Cursor, Gemini, Copilot, …
+> — read [`CLAUDE.md`](./CLAUDE.md).** `AGENTS.md` and `CLAUDE.md` are two doors
+> to the same room; open whichever your tool prefers.
 
-Source of truth and full doctrine: https://adorsys-gis.github.io/ai-governance/
-This stanza is intentionally thin — read the site; do not duplicate the doctrine here.
-<!-- END: AI Governance stanza -->
+**AI Governance:** see the "AI Governance" section of [`CLAUDE.md`](./CLAUDE.md).
+Full doctrine: https://adorsys-gis.github.io/ai-governance/
+
+<!--
+  The `ai-governance:stanza` marker above is intentional: it tells
+  ADORSYS-GIS/ai-governance's sync-templates script the stanza is already handled
+  here, so it won't re-append a duplicate. The canonical stanza lives in CLAUDE.md.
+-->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,11 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+This file is the **single source of truth** for agent and contributor guidance in
+this repository. It is written for Claude Code (claude.ai/code) but applies to
+**every** coding agent — [`AGENTS.md`](./AGENTS.md) and
+[`.github/copilot-instructions.md`](./.github/copilot-instructions.md) are thin
+pointers back here so the guidance lives in exactly one place and never drifts.
+Read whichever entry point your tool prefers; they all resolve to this document.
 
 ## Repo type
 


### PR DESCRIPTION
## 1. Summary

This PR changes:

- Declares **`CLAUDE.md` the single source of truth** for all agent/contributor guidance (its opening line now says so).
- Rewrites **`AGENTS.md`** as a thin pointer to `CLAUDE.md` (no duplicated content).
- Rewrites **`.github/copilot-instructions.md`** the same way — it was byte-identical to `AGENTS.md`.

It solves:

- `AGENTS.md` and `.github/copilot-instructions.md` were identical 1 KB copies of the AI Governance stanza that already lives in `CLAUDE.md` — three places to keep in sync that would inevitably drift. Source of truth for the governance content + the sync mechanism that created the copies: https://github.com/ADORSYS-GIS/ai-governance (doctrine: https://adorsys-gis.github.io/ai-governance/).

---

## 2. Intent

The intent of this PR is:

> One canonical agent guide (`CLAUDE.md`), with every other agent entry point pointing to it, so guidance never diverges between files. Each agent reads whichever door it prefers; they resolve to the same room.

---

## 3. Scope

### In Scope

- `CLAUDE.md` intro line (declares it canonical).
- `AGENTS.md` and `.github/copilot-instructions.md` → pointers.

### Out of Scope

- The actual guidance content (unchanged; it already lived in `CLAUDE.md`).
- Any chart/template change.

---

## 4. Verification

I verified this change by:

- [x] Running manual tests
- [ ] Running automated tests
- [ ] Checking logs
- [ ] Checking metrics
- [ ] Testing error cases
- [ ] Testing permissions/security behavior
- [ ] Testing rollback or failure behavior, if relevant

Commands run:

```bash
# All three files still carry the ai-governance:stanza marker, so
# ADORSYS-GIS/ai-governance's sync-templates won't re-append a duplicate stanza.
grep -l 'ai-governance:stanza' AGENTS.md .github/copilot-instructions.md CLAUDE.md
# Pointer links resolve to CLAUDE.md.
```

Results:

```text
AGENTS.md, .github/copilot-instructions.md, CLAUDE.md all retain the marker
AGENTS.md -> ./CLAUDE.md (resolves); copilot-instructions.md -> ../CLAUDE.md (resolves)
```

---

## 5. Screenshots / Evidence

- The canonical AI Governance stanza remains in `CLAUDE.md` (with the marker at the same location); the two pointer files keep the marker so the governance sync treats the stanza as already handled. No governance-gate behaviour changes (the gate checks PR bodies, not these files).

---

## 6. Risk Assessment

Risk level:

* [x] Low
* [ ] Medium
* [ ] High

Potential risks:

* A future ai-governance sync could re-append a stanza if the marker were removed.

Mitigation:

* The `ai-governance:stanza` marker is kept (with an explanatory comment) in both pointer files; sync only appends when the marker is absent.

---

## 7. AI Usage Declaration

AI was used for:

* [x] Refactoring
* [x] Drafting documentation
* [ ] Generating code
* [ ] Generating tests
* [ ] Not used

> AI consolidated the duplicated files and verified the marker/link invariants.

Human verification:

* [ ] I understand every meaningful change in this PR
* [ ] I checked generated code manually
* [ ] I accept responsibility for this PR

> (Maintainer to confirm on review.)

---

## 8. Reviewer Focus

Please focus your review on:

* [x] Maintainability
* [ ] Correctness
* [ ] Architecture
* [ ] Security
* [ ] Performance
* [ ] Tests

> Specifically: is `CLAUDE.md`-as-single-source-of-truth the desired direction, and is keeping the `ai-governance:stanza` marker in the pointers the right call vs letting the sync manage them?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
