### PR TITLE
docs(architecture): redis master-router deep-dive (election, failover, gotchas)

### DIFF
--- a/docs/architecture/06-networking-tls.md
+++ b/docs/architecture/06-networking-tls.md
@@ -141,4 +141,71 @@ Each consumer namespace needs its own `redis-ha-redis-auth` Secret (via
 ExternalSecret) plus a cert-manager `Certificate` from `self-signed-ca`
 (`ca.crt` only) for the CA trust.
 
+### Why the master-router (not the round-robin Service)
+
+redis-ha is a Sentinel cluster: one **master** (accepts writes) + one **replica**
+(`replica-read-only` → rejects writes). The `redis-ha-redis` Service round-robins
+**both**, so a write-consumer's connection lands on the read-only replica ~50 % of the
+time → `READONLY You can't write against a read only replica` (hit LibreChat
+cache/leader-election and the rate-limiter's counters). Neither consumer speaks
+Sentinel, so **HAProxy (`redis-ha-haproxy`) does master discovery for them**: it
+health-checks both pods over TLS and routes only to the one reporting `role:master`,
+re-electing automatically on failover.
+
+**Master election** — the HAProxy health check, every ~2 s, over TLS:
+
+```mermaid
+sequenceDiagram
+    participant H as HAProxy check
+    participant R as redis pod
+    H->>R: TLS connect (tcp-check connect ssl, verify CA)
+    H->>R: AUTH password (rendered into config at startup)
+    R-->>H: +OK
+    H->>R: PING
+    R-->>H: +PONG
+    H->>R: INFO replication
+    R-->>H: role:master  or  role:slave
+    alt contains role:master
+        H->>H: server UP — eligible (gets traffic)
+    else role:slave
+        H->>H: server DOWN — excluded (expected for the replica)
+    end
+```
+
+**Failover** — Sentinel promotes the replica; HAProxy re-points, no client change:
+
+```mermaid
+sequenceDiagram
+    participant App as Consumer
+    participant HAP as HAProxy
+    participant M as redis-0 master
+    participant S as Sentinels
+    participant R as redis-1 replica
+    Note over M: master dies / node reboot
+    HAP--xM: health check fails → DOWN
+    S->>R: quorum reached → promote redis-1
+    R->>R: now role:master
+    HAP->>R: next check role:master → UP
+    App->>HAP: write → routed to the new master
+```
+
+**⚠️ HAProxy-for-TLS-Redis gotchas** (in `home-os charts/home-apps/redis-ha`):
+
+| Gotcha | Fix |
+|---|---|
+| Checks are cleartext by default → hit the TLS-only port → `Layer7 timeout` | `tcp-check connect ssl` + `check-ssl` |
+| Crashloops on boot-DNS / uses stale pod IPs after a pod cycles (`Layer4 timeout`) | `init-addr last,libc,none` + a `resolvers` (`parse-resolv-conf`) section + `resolve-prefer ipv4` |
+| `${ENV}` is **not** expanded inside `tcp-check send` → literal password sent → `+OK` times out | render the password into the config at startup (an `awk` literal substitution into tmpfs — never in the ConfigMap) |
+| `bind ssl crt` needs key+cert in one PEM | cert-manager `additionalOutputFormats: [{type: CombinedPEM}]` |
+
+**Verify** (`home-remote` kubeconfig): a replica showing `DOWN` is expected — only the
+master is `UP`; `backend 'redis_master' has no server available!` means no master is
+reachable (failover in progress, or a check regression — revisit the gotchas).
+
+```bash
+HP=$(kubectl -n redis-system get po -l app.kubernetes.io/controller=haproxy -o name | head -1)
+kubectl -n redis-system logs "$HP" | grep -iE "is UP|is DOWN|no server available" | tail
+kubectl -n converse logs -l app.kubernetes.io/name=librechat-app --since=10m | grep -ic READONLY   # 0 = healthy
+```
+
 → Related: [07 Data & secrets](07-data-secrets.md) · [08 Observability](08-observability.md)


### PR DESCRIPTION
## 1. Summary

This PR changes:
- Expands the **redis-ha master-router** section of `docs/architecture/06-networking-tls.md` with the operational depth the suite was missing — all in mermaid.

It solves:
- Source: https://github.com/ADORSYS-GIS/ai-helm/pull/399 — this extends that layered architecture suite, documenting the durable redis write-routing fix shipped in `release-2026.06.08-v08`.

## 2. Intent

> The suite already covered the redis topology + consumer contract, but not *why* the master-router exists or how to operate/debug it. This adds the master-election health-check sequence, the failover sequence, the hard-won HAProxy-for-TLS-Redis gotchas, and a verification runbook — so the next person debugging redis writes has the full picture in the architecture docs. Builds on #399.

## 3. Scope

### In Scope
- `docs/architecture/06-networking-tls.md` — new "Why the master-router" subsection: 2 mermaid sequence diagrams (election + failover), a gotchas table, a verify runbook.

### Out of Scope
- The chart itself (lives in home-os `charts/home-apps/redis-ha`, already deployed). Docs only — no ai-helm chart/manifest changes.

## 4. Verification

I verified this change by:
- [x] Running manual tests
- [x] Checking logs

Commands run:
```bash
# docs-only (no chart render); mermaid fences balanced (sequenceDiagram, alt/end)
kubectl -n redis-system logs <haproxy> | grep -iE \"is UP|is DOWN|no server available\"
kubectl -n converse logs -l app.kubernetes.io/name=librechat-app --since=10m | grep -ic READONLY
```

Results:
```text
HAProxy: redis-0 (master) UP, redis-1 (replica) DOWN-by-design; LibreChat READONLY count = 0; stable ~6 days.
```

## 6. Risk Assessment
Risk level:
- [x] Low

Potential risks:
- Docs only; no runtime impact.

## 7. AI Usage Declaration
AI was used for:
- [x] Drafting documentation

Human verification:
- [x] I understand every meaningful change in this PR
- [x] I accept responsibility for this PR