### PR TITLE
feat(lightbridge-code-intelligence): enable the app now that 0.1.0 images are published

### DIFF
--- a/charts/apps/values.yaml
+++ b/charts/apps/values.yaml
@@ -1057,11 +1057,9 @@ applications:
   # home-remote (default). ⚠️ App images (ghcr.io/vymalo/lightbridge-*) are placeholders
   # until the app repo's CI publishes them; bump the tags here once they ship.
   - name: lightbridge-code-intelligence
-    # Staged (not synced) until the app images are published: the values below pin
-    # ghcr.io/vymalo/lightbridge-* tags that don't exist yet, so enabling this before
-    # vymalo/lightbridge-code-intelligence#7 publishes them (e.g. a v0.1.0 tag) would leave
-    # both Deployments in ImagePullBackOff. Flip to enabled once the images exist.
-    enabled: false
+    # Enabled for sync: the pinned images now exist and are public —
+    # ghcr.io/vymalo/lightbridge-{control-plane,web}:0.1.0, published by
+    # vymalo/lightbridge-code-intelligence release v0.1.0.
     finalizers:
       - resources-finalizer.argocd.argoproj.io
     source:


### PR DESCRIPTION
## 1. Summary

This PR changes:

- Removes the `enabled: false` stage gate from the `lightbridge-code-intelligence` Application in `charts/apps`, so ArgoCD syncs it.

It solves:

- **Source of truth:** the deployment was staged in https://github.com/ADORSYS-GIS/ai-helm/pull/420 specifically until images existed; they now do — published by https://github.com/vymalo/lightbridge-code-intelligence/releases/tag/v0.1.0.

---

## 2. Intent

The intent of this PR is:

> Bring the Lightbridge Code Intelligence deployment online. #420 deliberately gated it (`enabled: false`) to avoid ImagePullBackOff before the images existed; the pinned `ghcr.io/vymalo/lightbridge-{control-plane,web}:0.1.0` images are now published and **public**, so the gate can be lifted.

---

## 3. Scope

### In Scope

- Re-enable the app (drop `enabled: false`).

### Out of Scope

- Any chart/image changes (the chart and `0.1.0` pin are unchanged from #420).
- pgvector enablement (still deferred per #420).

---

## 4. Verification

I verified this change by:

- [x] Running automated tests
- [ ] Running manual tests
- [ ] Checking logs
- [ ] Checking metrics
- [ ] Testing error cases
- [x] Testing permissions/security behavior
- [ ] Testing rollback or failure behavior, if relevant

Commands run:

```bash
helm lint charts/apps --strict
helm template apps charts/apps | grep aii-lightbridge-code-intelligence   # renders again
gh api users/vymalo/packages/container/lightbridge-control-plane --jq .visibility   # public
```

Results:

```text
charts/apps: 0 failed; Application aii-lightbridge-code-intelligence renders → project ai,
  home-remote, ns converse, image tag 0.1.0.
GHCR: lightbridge-control-plane and lightbridge-web both have tag 0.1.0, visibility=public.
```

---

## 5. Screenshots / Evidence

- Image tags + visibility confirmed via the GHCR API (section 4). Rollback = re-add `enabled: false`.

---

## 6. Risk Assessment

Risk level:

* [ ] Low
* [x] Medium
* [ ] High

Potential risks:

* This actually deploys the app to the cluster; the control plane/web are still skeletons (auth `/auth/verify` returns 501, no indexing yet).

Mitigation:

* Images are public (no pull-secret dependency); the CNPG `codeintel` role/db and ExternalSecrets ship in the same family; control-plane is single-replica; rollback is a one-line revert.

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [ ] Refactoring
* [ ] Generating tests
* [x] Drafting documentation
* [x] Reviewing the diff
* [ ] Not used

Human verification:

* [x] I understand every meaningful change in this PR
* [x] I checked generated code manually
* [x] I checked generated tests manually
* [x] I removed unsupported AI assumptions
* [x] I accept responsibility for this PR

---

## 8. Reviewer Focus

Please focus your review on:

* [ ] Correctness
* [x] Architecture
* [ ] Security
* [ ] Performance
* [ ] Tests
* [ ] Maintainability
* [x] Product intent
* [ ] Edge cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)
