### PR TITLE
fix(lightbridge-code-intelligence): Neo4j writable rootfs + restore 10Gi PVC

### DIFF
--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -26,3 +26,17 @@ misconfigurations:
     paths:
       - "keycloak-baseline/templates/realm-configmap.yaml"
       - "librechat-app/templates/configmap.yaml"
+  - id: KSV-0014
+    # KSV-0014 "readOnlyRootFilesystem" — the neo4j StatefulSet container needs a
+    # WRITABLE rootfs: the official neo4j image entrypoint renders its config to
+    # /var/lib/neo4j/conf at startup, so readOnlyRootFilesystem:true crashes it
+    # (verified in-cluster: "/var/lib/neo4j/conf/neo4j.conf: Read-only file system").
+    # /data still persists on a PVC. The lightbridge-code-intelligence control-plane and
+    # web containers DO keep readOnlyRootFilesystem:true — only neo4j is exempt. The
+    # workloads are rendered by the bjw-template subchart (aliased `lci`).
+    statement: >-
+      Neo4j requires a writable rootfs (its entrypoint writes /var/lib/neo4j/conf at
+      startup); /data persists on a PVC. Only the neo4j container is exempt — the
+      control-plane and web containers keep readOnlyRootFilesystem:true.
+    paths:
+      - "lightbridge-code-intelligence/charts/lci/templates/common.yaml"

--- a/charts/lightbridge-code-intelligence/values.yaml
+++ b/charts/lightbridge-code-intelligence/values.yaml
@@ -229,7 +229,10 @@ lci:
             limits: { cpu: "1", memory: 2Gi }
           securityContext:
             allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
+            # Neo4j writes its rendered config to /var/lib/neo4j/conf at startup, so it needs a
+            # writable rootfs (the official image is not read-only-rootfs compatible). /data still
+            # persists on the PVC. A scoped Trivy ignore covers KSV-0014 for this container.
+            readOnlyRootFilesystem: false
             capabilities:
               drop: [ALL]
 
@@ -288,15 +291,15 @@ lci:
           hosts:
             - code-intelligence-api.ai.camer.digital
 
-  # Neo4j /data + the read-only-rootfs scratch dirs are all emptyDir. /data is NON-PERSISTENT
-  # for now: a standalone PVC for the StatefulSet deadlocks ArgoCD on WaitForFirstConsumer
-  # storage (the PVC can't bind until the pod mounts it, but ArgoCD won't apply the pod until
-  # the PVC is healthy). The graph rebuilds on indexing; restore a volumeClaimTemplate later.
-  # advancedMounts scope each volume to one container.
+  # Neo4j /data on a persistent PVC; the read-only-rootfs scratch dirs (below) are emptyDir.
+  # The standalone PVC binds fine on home-remote (WaitForFirstConsumer — slow to bind, ~minutes,
+  # but not a deadlock). advancedMounts scope each volume to one container.
   persistence:
     data:
       enabled: true
-      type: emptyDir
+      type: persistentVolumeClaim
+      accessMode: ReadWriteOnce
+      size: 10Gi
       advancedMounts:
         neo4j:
           main:


### PR DESCRIPTION
## 1. Summary

This PR changes:

- `charts/lightbridge-code-intelligence`: set `readOnlyRootFilesystem: false` on the **neo4j** container only (control-plane + web keep `true`).
- Restore Neo4j `/data` from the v06 `emptyDir` stopgap back to a **10Gi PVC**.
- `.trivyignore.yaml`: add a scoped `KSV-0014` ignore for the neo4j workload.

It solves:

- **Source of truth:** in-cluster Neo4j CrashLoopBackOff observed after deploying https://github.com/ADORSYS-GIS/ai-helm/pull/420 — pod log: `/var/lib/neo4j/conf/neo4j.conf: Read-only file system`.

---

## 2. Intent

The intent of this PR is:

> Get `lightbridge-ci-neo4j` to start. The official neo4j image's entrypoint renders its config to `/var/lib/neo4j/conf` at startup, so `readOnlyRootFilesystem: true` crashes it — verified from the pod log. Neo4j is a database that needs a writable rootfs (the official chart doesn't use a read-only one); the control-plane and web containers keep `readOnlyRootFilesystem: true`. `/data` returns to a persistent PVC now that we've confirmed it binds (slow WaitForFirstConsumer, not the deadlock I first suspected).

---

## 3. Scope

### In Scope

- Neo4j container security context + the data volume; one scoped Trivy ignore.

### Out of Scope

- control-plane/web security contexts (unchanged, still `readOnlyRootFilesystem: true`).
- Restoring a proper StatefulSet `volumeClaimTemplate` (follow-up; the standalone PVC works).

---

## 4. Verification

I verified this change by:

- [x] Running automated tests
- [ ] Running manual tests
- [x] Checking logs
- [ ] Checking metrics
- [x] Testing error cases
- [x] Testing permissions/security behavior
- [ ] Testing rollback or failure behavior, if relevant

Commands run:

```bash
helm dependency build charts/lightbridge-code-intelligence
helm lint charts/lightbridge-code-intelligence --strict
helm template x charts/lightbridge-code-intelligence -n converse
trivy config <chart> --ignorefile .trivyignore.yaml --severity HIGH,CRITICAL --exit-code 1
kubectl --context hetzner-prod -n converse logs lightbridge-ci-neo4j-0 --previous   # the crash log
```

Results:

```text
helm lint: 0 charts failed; helm template: renders (neo4j readOnlyRootFilesystem:false, /data on 10Gi PVC,
  control-plane + web still readOnlyRootFilesystem:true)
trivy: exit 0 — KSV-0014 suppressed for lightbridge-code-intelligence/charts/lci/templates/common.yaml
pod log (pre-fix): "/var/lib/neo4j/conf/neo4j.conf: Read-only file system"
```

---

## 5. Screenshots / Evidence

- The crash log and the `helm`/`trivy` outputs are in section 4. control-plane + web were already `Running` in-cluster; neo4j was the only CrashLoopBackOff.

---

## 6. Risk Assessment

Risk level:

* [x] Low
* [ ] Medium
* [ ] High

Potential risks:

* neo4j runs without a read-only rootfs (it still drops ALL caps, no privilege escalation, runs as uid 7474 non-root).

Mitigation:

* Scope is the neo4j container only; the Trivy ignore is path-scoped + justified; `/data` persists on a PVC.

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [ ] Refactoring
* [ ] Generating tests
* [x] Drafting documentation
* [x] Reviewing the diff
* [ ] Not used

Human verification:

* [x] I understand every meaningful change in this PR
* [x] I checked generated code manually
* [x] I checked generated tests manually
* [x] I removed unsupported AI assumptions
* [x] I accept responsibility for this PR

---

## 8. Reviewer Focus

Please focus your review on:

* [x] Correctness
* [x] Security
* [ ] Performance
* [ ] Tests
* [ ] Maintainability
* [ ] Product intent
* [ ] Edge cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)
