### PR TITLE
fix(lightbridge-db): provision s3_region_name so CNPG backups stop failing

### DIFF
--- a/charts/lightbridge-db/values.yaml
+++ b/charts/lightbridge-db/values.yaml
@@ -75,10 +75,16 @@ resources:
   # The old store pointed at the now-decommissioned MinIO (s3.ssegning.me,
   # bucket ai-ops-backups). It now uses Hetzner Object Storage (Ceph-RGW):
   # shared bucket `ssegning-k8s-state`, endpoint nbg1.your-objectstorage.com,
-  # same pattern Keycloak's CNPG backup uses. NO `region` field — it isn't in
-  # the barmancloud ObjectStore schema (a literal there breaks ArgoCD's diff:
-  # ".spec.configuration.region: field not declared in schema"), and the working
-  # Keycloak store omits it (Ceph-RGW doesn't require it).
+  # same pattern Keycloak's CNPG backup uses. NO top-level `region` field — it
+  # isn't in the barmancloud ObjectStore schema (a literal there breaks ArgoCD's
+  # diff: ".spec.configuration.region: field not declared in schema").
+  # ⚠️ The barman-cloud plugin's defaulting webhook DOES inject an
+  # `s3Credentials.region` ref → {name: lightbridge-cnpg-s3, key: s3_region_name}
+  # server-side (the valid per-credential field), and reads that key at backup
+  # time — so the `lightbridge-cnpg-s3` Secret MUST carry `s3_region_name`
+  # (provisioned as a literal in charts/lightbridge-secrets) or every
+  # ScheduledBackup fails `missing key s3_region_name`. Left undeclared here so
+  # ArgoCD doesn't diff the webhook-owned default.
   # No trailing slash on destinationPath (MinIO/Ceph ListObjectsV2 quirk).
   # ────────────────────────────────────────────────────────────────────
   - |

--- a/charts/lightbridge-secrets/templates/externalsecret.yaml
+++ b/charts/lightbridge-secrets/templates/externalsecret.yaml
@@ -26,6 +26,19 @@ spec:
   target:
     name: {{ $name }}
     creationPolicy: Owner
+    {{- with $cfg.literals }}
+    # Static, non-secret values merged INTO the materialised Secret alongside the
+    # fetched `data` keys (mergePolicy: Merge — Replace would drop the fetched
+    # creds). Used for store metadata the AWS backend doesn't carry, e.g. the
+    # barman `s3_region_name` the ObjectStore's webhook-defaulted region ref reads.
+    template:
+      engineVersion: v2
+      mergePolicy: Merge
+      data:
+        {{- range $k, $v := . }}
+        {{ $k }}: {{ $v | quote }}
+        {{- end }}
+    {{- end }}
   data:
     {{- range $cfg.data }}
     - secretKey: {{ .secretKey | quote }}

--- a/charts/lightbridge-secrets/values.yaml
+++ b/charts/lightbridge-secrets/values.yaml
@@ -33,7 +33,17 @@ externalSecrets:
         property: lightbridge_opa_password
   # CNPG barman backup credentials (Hetzner Object Storage). Same creds the
   # Keycloak CNPG backup uses — platform secret under prod/meta/test-app.
+  #
+  # `s3_region_name` is a STATIC literal (not in the AWS store): the barman-cloud
+  # ObjectStore's defaulting webhook injects an `s3Credentials.region` ref →
+  # {name: lightbridge-cnpg-s3, key: s3_region_name} that the chart never
+  # declares, and the plugin then reads that key at backup time. Without it every
+  # ScheduledBackup fails `missing key s3_region_name, inside secret
+  # lightbridge-cnpg-s3`. us-east-1 is the Ceph-RGW-accepted convention used
+  # repo-wide (mimir/loki/tempo). Merged via target.template (mergePolicy: Merge).
   lightbridge-cnpg-s3:
+    literals:
+      s3_region_name: us-east-1
     data:
       - secretKey: s3_access_key_id
         key: prod/meta/test-app


### PR DESCRIPTION
## 1. Summary

This PR changes:

- `charts/lightbridge-secrets`: provision a static `s3_region_name: us-east-1` literal into the `lightbridge-cnpg-s3` Secret (new optional `literals` map on the ExternalSecret template, merged via `target.template` / `mergePolicy: Merge`).
- `charts/lightbridge-db`: documentation-only — explain the webhook-injected `s3Credentials.region` → `s3_region_name` dependency on the barman `ObjectStore`.

It solves:

- **Source of truth:** in-cluster `ScheduledBackup lightbridge-main-db-daily` failing every run. Latest run `postgresql.cnpg.io/v1 Backup lightbridge-main-db-daily-20260618020000` errored:
  ```
  rpc error: code = Unknown desc = missing key s3_region_name, inside secret lightbridge-cnpg-s3
  ```
  Regression surfaced after the schema-invalid top-level `region` literal was removed in https://github.com/ADORSYS-GIS/ai-helm/commit/47a4ce1508d3ca51b978f96fb1559aa78497844c.

---

## 2. Intent

The intent of this PR is:

> Make CNPG backups for `lightbridge-main-db` succeed again. The barman-cloud plugin's **defaulting webhook** injects an `s3Credentials.region` ref → `{name: lightbridge-cnpg-s3, key: s3_region_name}` into the live `ObjectStore` server-side (the valid per-credential field — distinct from the schema-invalid top-level `configuration.region` literal removed in `47a4ce1`). The plugin then reads that key at backup time, but the `lightbridge-cnpg-s3` Secret only carried `s3_access_key_id` / `s3_secret_access_key`, so every backup aborted before uploading. Adding `s3_region_name` (us-east-1 — the Ceph-RGW convention used repo-wide for mimir/loki/tempo) satisfies the read. The region ref is left **undeclared** in the chart so ArgoCD doesn't diff the webhook-owned default.

---

## 3. Scope

### In Scope

- The `lightbridge-cnpg-s3` ExternalSecret + a reusable `literals` (static, non-secret values) mechanism on the lightbridge-secrets template.
- A clarifying comment on the lightbridge-db `ObjectStore`.

### Out of Scope

- Declaring `s3Credentials.region` in the `ObjectStore` chart (intentionally left to the webhook default to avoid an ArgoCD diff).
- Keycloak's CNPG backup (its store has no region ref injected — unaffected).
- Cutting the release tag (separate step, after merge).

---

## 4. Verification

I verified this change by:

- [x] Running automated tests
- [x] Running manual tests
- [x] Checking logs
- [ ] Checking metrics
- [x] Testing error cases
- [ ] Testing permissions/security behavior
- [ ] Testing rollback or failure behavior, if relevant

Commands run:

```bash
# Live diagnosis (Hetzner home-remote)
kubectl -n converse get objectstore lightbridge-main-db -o jsonpath='{.spec.configuration.s3Credentials}'
kubectl -n converse get secret lightbridge-cnpg-s3 -o jsonpath='{.data}'   # key NAMES only
kubectl get crd objectstores.barmancloud.cnpg.io -o json   # confirm s3Credentials.region is a SecretKeySelector

# Chart gates
helm lint charts/lightbridge-secrets/
helm template x charts/lightbridge-secrets/ -n converse
helm template x charts/lightbridge-db/ -n converse --dry-run
```

Results:

```text
# Live ObjectStore already carries the webhook-injected region ref:
{"accessKeyId":{...},"region":{"key":"s3_region_name","name":"lightbridge-cnpg-s3"},"secretAccessKey":{...}}
# Live Secret keys (names only) — region key absent → the failure:
['s3_access_key_id', 's3_secret_access_key']
# CRD: s3Credentials.region present (SecretKeySelector: required key + name)

1 chart(s) linted, 0 chart(s) failed
# rendered ExternalSecret now emits target.template { mergePolicy: Merge, data: { s3_region_name: "us-east-1" } }
# entries without `literals` render unchanged (no stray template block)
lightbridge-db: renders OK
```

---

## 5. Screenshots / Evidence

* Error: `Backup lightbridge-main-db-daily-20260618020000` → `missing key s3_region_name, inside secret lightbridge-cnpg-s3`
* Live `ObjectStore.spec.configuration.s3Credentials.region` = `{key: s3_region_name, name: lightbridge-cnpg-s3}` (webhook default; chart never declared it)

---

## 6. Risk Assessment

Risk level:

* [x] Low
* [ ] Medium
* [ ] High

Potential risks:

* If `mergePolicy: Merge` were wrong, the fetched S3 creds could be dropped from the Secret.

Mitigation:

* `mergePolicy: Merge` (not the default `Replace`) keeps the fetched `data` keys; verified in the rendered output. `literals` is opt-in — only `lightbridge-cnpg-s3` uses it; every other ExternalSecret renders byte-identical.

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [ ] Refactoring
* [ ] Generating tests
* [x] Drafting documentation
* [x] Reviewing the diff
* [ ] Not used

Human verification:

* [x] I understand every meaningful change in this PR
* [x] I checked generated code manually
* [ ] I checked generated tests manually
* [x] I removed unsupported AI assumptions
* [x] I accept responsibility for this PR

---

## 8. Reviewer Focus

Please focus your review on:

* [x] Correctness
* [ ] Architecture
* [ ] Security
* [ ] Performance
* [ ] Tests
* [x] Maintainability
* [ ] Product intent
* [x] Edge cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)
