### PR TITLE
fix(lightbridge-code-intelligence): Neo4j StatefulSet sync-wave 0 (unblock PVC bind)

### DIFF
--- a/charts/lightbridge-code-intelligence/values.yaml
+++ b/charts/lightbridge-code-intelligence/values.yaml
@@ -170,8 +170,13 @@ lci:
     neo4j:
       type: statefulset
       replicas: 1
+      # Sync-wave 0 (NOT 2) so the StatefulSet applies in the SAME wave as its data PVC
+      # (bjw renders the PVC with no wave annotation → wave 0). Otherwise ArgoCD health-gates
+      # the WaitForFirstConsumer PVC (which can't bind until a pod mounts it) before applying
+      # the StatefulSet (the pod) → permanent deadlock. Same wave = both applied together →
+      # the pod schedules → the PVC binds.
       annotations:
-        argocd.argoproj.io/sync-wave: "2"
+        argocd.argoproj.io/sync-wave: "0"
       # Govern the StatefulSet with the neo4j Service (rather than the default fullname,
       # which has no matching Service). Single replica → the ClusterIP service is reached
       # at lightbridge-ci-neo4j:7687.


### PR DESCRIPTION
## 1. Summary

This PR changes:

- `charts/lightbridge-code-intelligence`: move the **Neo4j StatefulSet** to `argocd.argoproj.io/sync-wave: "0"` (was `"2"`), so it applies in the same wave as its data PVC.

It solves:

- **Source of truth:** in-cluster deadlock after https://github.com/ADORSYS-GIS/ai-helm/pull/424 rolled out — ArgoCD parked at *"waiting for healthy state of PersistentVolumeClaim/lightbridge-ci"*; the StatefulSet never updated, so neo4j kept CrashLoopBackOff.

---

## 2. Intent

The intent of this PR is:

> Break the PVC↔StatefulSet sync-wave deadlock. The bjw-rendered data PVC has no sync-wave (→ wave 0); the StatefulSet was wave 2. ArgoCD health-gates the wave-0 PVC — a `WaitForFirstConsumer` volume that can only bind once a pod mounts it — before applying the wave-2 StatefulSet (the pod). That never resolves: PVC stays `Pending`, the StatefulSet stays on the old `readOnlyRootFilesystem: true` spec, neo4j keeps crashing on read-only `/var/lib/neo4j/conf`. Same wave = both apply together → the pod schedules → the PVC binds.

---

## 3. Scope

### In Scope

- One-line sync-wave change on the neo4j StatefulSet.

### Out of Scope

- control-plane/web (still wave 2; no PVCs, unaffected).
- The broader `Replace=true` syncPolicy behavior (separate hardening if we want it).

---

## 4. Verification

I verified this change by:

- [x] Running automated tests
- [ ] Running manual tests
- [x] Checking logs
- [ ] Checking metrics
- [x] Testing error cases
- [ ] Testing permissions/security behavior
- [ ] Testing rollback or failure behavior, if relevant

Commands run:

```bash
helm lint charts/lightbridge-code-intelligence --strict
helm template x charts/lightbridge-code-intelligence -n converse | grep -A2 'kind: StatefulSet'
# observed deadlock in-cluster:
kubectl --context hetzner-prod -n converse get pvc lightbridge-ci   # Pending (WaitForFirstConsumer)
kubectl --context admin@homeos -n argocd get application aii-lightbridge-code-intelligence -o jsonpath='{.status.operationState.message}'
```

Results:

```text
helm lint: 0 charts failed; rendered Neo4j StatefulSet now has sync-wave "0" (PVC has none → also wave 0).
in-cluster (pre-fix): PVC lightbridge-ci = Pending; app msg = "waiting for healthy state of /PersistentVolumeClaim/lightbridge-ci"; StatefulSet live readOnlyRootFilesystem=true.
```

---

## 5. Screenshots / Evidence

- See section 4. control-plane + web are Running; neo4j is the only stuck pod, blocked on this wave deadlock.

---

## 6. Risk Assessment

Risk level:

* [x] Low
* [ ] Medium
* [ ] High

Potential risks:

* Neo4j now deploys in wave 0 (before control-plane/web in wave 2) — which is fine; it's a dependency.

Mitigation:

* Single-line change; secrets are also wave 0 (pods retry briefly if a secret lags); instant rollback by reverting the release.

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [ ] Refactoring
* [ ] Generating tests
* [x] Drafting documentation
* [x] Reviewing the diff
* [ ] Not used

Human verification:

* [x] I understand every meaningful change in this PR
* [x] I checked generated code manually
* [x] I checked generated tests manually
* [x] I removed unsupported AI assumptions
* [x] I accept responsibility for this PR

---

## 8. Reviewer Focus

Please focus your review on:

* [x] Correctness
* [ ] Security
* [ ] Performance
* [ ] Tests
* [ ] Maintainability
* [x] Product intent
* [ ] Edge cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)
