### PR TITLE
fix(lightbridge-code-intelligence): rename Neo4j NEO4J_PASSWORD env (config crash)

### DIFF
--- a/charts/lightbridge-code-intelligence/values.yaml
+++ b/charts/lightbridge-code-intelligence/values.yaml
@@ -206,14 +206,17 @@ lci:
             tag: "5.26-community"
             pullPolicy: IfNotPresent
           env:
-            NEO4J_PASSWORD:
+            # NOT prefixed `NEO4J_`: the neo4j image maps every NEO4J_* env var to a config
+            # setting, so a literal NEO4J_PASSWORD becomes the unknown setting `password` and
+            # fails strict_validation at startup. This is just the helper for NEO4J_AUTH.
+            LB_NEO4J_PASSWORD:
               valueFrom:
                 secretKeyRef:
                   name: '{{ .Release.Name }}-neo4j-auth'
                   key: password
             NEO4J_AUTH:
-              dependsOn: NEO4J_PASSWORD
-              value: "neo4j/$(NEO4J_PASSWORD)"
+              dependsOn: LB_NEO4J_PASSWORD
+              value: "neo4j/$(LB_NEO4J_PASSWORD)"
             NEO4J_server_memory_pagecache_size: "512M"
           probes:
             liveness:


### PR DESCRIPTION
## 1. Summary

This PR changes:

- Rename the Neo4j helper env var `NEO4J_PASSWORD` → `LB_NEO4J_PASSWORD` (and the `NEO4J_AUTH` reference).

It solves:

- **Source of truth:** in-cluster Neo4j CrashLoopBackOff after the read-only/PVC issues were resolved — pod log: `Failed to read config: Unrecognized setting. No declared setting with name: PASSWORD`.

---

## 2. Intent

The intent of this PR is:

> The neo4j image maps every `NEO4J_*` env var to a config setting and runs strict validation, so the helper var `NEO4J_PASSWORD` was interpreted as an unknown setting `password` and crashed startup. It was only ever used to build `NEO4J_AUTH`; rename it to a non-`NEO4J_` prefix so neo4j ignores it. (The control-plane container's own `NEO4J_PASSWORD` is unaffected — it isn't passed to the neo4j image.)

---

## 3. Scope

### In Scope
- The neo4j container's password env var.

### Out of Scope
- control-plane/web; the VCT change (already merged, #427).

---

## 4. Verification

I verified this change by:

- [x] Running automated tests
- [ ] Running manual tests
- [x] Checking logs
- [ ] Checking metrics
- [x] Testing error cases
- [ ] Testing permissions/security behavior
- [ ] Testing rollback or failure behavior, if relevant

Commands run:

```bash
helm lint charts/lightbridge-code-intelligence --strict
helm template x charts/lightbridge-code-intelligence | grep -A1 'name: NEO4J_AUTH'
kubectl --context hetzner-prod -n converse logs lightbridge-ci-neo4j-0   # the config-validation crash
```

Results:

```text
helm lint 0 failed; renders LB_NEO4J_PASSWORD then NEO4J_AUTH=neo4j/$(LB_NEO4J_PASSWORD); no NEO4J_PASSWORD in the neo4j container.
pre-fix neo4j log: "Unrecognized setting. No declared setting with name: PASSWORD".
```

---

## 5. Screenshots / Evidence

- See section 4. readOnly:false + the PVC bind are already resolved; this is the last neo4j blocker.

---

## 6. Risk Assessment

Risk level:

* [x] Low
* [ ] Medium
* [ ] High

Potential risks:

* None beyond the env rename.

Mitigation:

* Single env var; `NEO4J_AUTH` (the special var neo4j uses for the initial password) is unchanged in meaning.

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [ ] Refactoring
* [ ] Generating tests
* [x] Drafting documentation
* [x] Reviewing the diff
* [ ] Not used

Human verification:

* [x] I understand every meaningful change in this PR
* [x] I checked generated code manually
* [x] I checked generated tests manually
* [x] I removed unsupported AI assumptions
* [x] I accept responsibility for this PR

---

## 8. Reviewer Focus

Please focus your review on:

* [x] Correctness
* [ ] Security
* [ ] Performance
* [ ] Tests
* [ ] Maintainability
* [ ] Product intent
* [ ] Edge cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)
