### PR TITLE
feat(lightbridge-code-intelligence): image-updater + git write-back deploy

### DIFF
--- a/charts/apps/values.yaml
+++ b/charts/apps/values.yaml
@@ -1091,6 +1091,15 @@ applications:
       argocd-image-updater.argoproj.io/git-repository: https://github.com/vymalo/lightbridge-code-intelligence.git
       argocd-image-updater.argoproj.io/write-back-target: helmvalues:deploy/envs/production/values.yaml
       argocd-image-updater.argoproj.io/git-credentials: secret:argocd/github-app-creds--vymalo
+      # ── argocd-notifications → GitHub Deployment status. `vymalo` is the
+      # notifier service (GitHub App installation on the vymalo org); the
+      # on-deployed / on-deploy-failed triggers + ssegning.me annotation
+      # contract are defined in home-os charts/argocd. ──
+      notifications.argoproj.io/subscribe.on-deployed.vymalo: ""
+      notifications.argoproj.io/subscribe.on-deploy-failed.vymalo: ""
+      notifications.ssegning.me/github-repo-url: https://github.com/vymalo/lightbridge-code-intelligence
+      notifications.ssegning.me/github-revision: main
+      notifications.ssegning.me/environment-url: https://code-intelligence.ai.camer.digital
     sources:
       # Source A — the chart. release-pinned like every ai-helm app; the release
       # script swaps this tag on each cut. Image tags come from Source B's $values.

--- a/charts/apps/values.yaml
+++ b/charts/apps/values.yaml
@@ -1050,36 +1050,62 @@ applications:
   # vymalo/lightbridge-code-intelligence): Rust control plane + Next.js web console
   # + Neo4j. Postgres/pgvector is REUSED from the lightbridge-main-db CNPG cluster via
   # a dedicated `codeintel` role + database (charts/lightbridge-db). Plain workload →
-  # home-remote (default). ⚠️ App images (ghcr.io/vymalo/lightbridge-*) are placeholders
-  # until the app repo's CI publishes them; bump the tags here once they ship.
+  # home-remote (default).
+  #
+  # CONTINUOUS DEPLOY — argocd-image-updater + git write-back (vymalo-shop pattern).
+  # Multi-source: the chart is release-pinned (Source A), but the two image tags are
+  # read from the APP repo's main via a $values source (Source B). image-updater picks
+  # the newest *signed* sha-<gitsha> from GHCR and commits it back into that file, which
+  # ArgoCD then auto-syncs — so deploys don't need an ai-helm release. The selecting
+  # ImageUpdater CR lives in home-os (charts/argocd-image-updater). Image tags are
+  # therefore NOT set here; they live in the app repo at
+  # deploy/envs/production/values.yaml (image-updater owns them).
   - name: lightbridge-code-intelligence
-    # Enabled for sync: the pinned images now exist and are public —
-    # ghcr.io/vymalo/lightbridge-{control-plane,web}:0.1.0, published by
-    # vymalo/lightbridge-code-intelligence release v0.1.0.
     finalizers:
       - resources-finalizer.argocd.argoproj.io
-    source:
-      repoURL: https://github.com/ADORSYS-GIS/ai-helm
-      # Must track the current release tag (like sibling ai-helm apps) — the bare base
-      # tag predates this chart, so it would 404 the path. The release script swaps this
-      # on each cut along with selfTargetRevision.
-      targetRevision: release-2026.06.19-v06
-      path: charts/lightbridge-code-intelligence
-      helm:
-        releaseName: lightbridge-ci
-        valuesObject:
-          lci:
-            controllers:
-              control-plane:
-                containers:
-                  main:
-                    image:
-                      tag: "0.1.0"
-              web:
-                containers:
-                  main:
-                    image:
-                      tag: "0.1.0"
+    additionalAnnotations:
+      # Two images in one app, aliased `cp` (control-plane) + `web`.
+      argocd-image-updater.argoproj.io/image-list: cp=ghcr.io/vymalo/lightbridge-control-plane,web=ghcr.io/vymalo/lightbridge-web
+      # ── control-plane ──
+      argocd-image-updater.argoproj.io/cp.update-strategy: newest-build
+      argocd-image-updater.argoproj.io/cp.allow-tags: regexp:^sha-[0-9a-f]+$
+      argocd-image-updater.argoproj.io/cp.force-update: "true"
+      argocd-image-updater.argoproj.io/cp.helm.image-name: lci.controllers.control-plane.containers.main.image.repository
+      argocd-image-updater.argoproj.io/cp.helm.image-tag: lci.controllers.control-plane.containers.main.image.tag
+      argocd-image-updater.argoproj.io/cp.signature-type: cosign
+      argocd-image-updater.argoproj.io/cp.cosign.certificate-oidc-issuer: https://token.actions.githubusercontent.com
+      argocd-image-updater.argoproj.io/cp.cosign.certificate-identity-regexp: ^https://github\.com/vymalo/lightbridge-code-intelligence/\.github/workflows/build-images\.yml@.*$
+      # ── web ──
+      argocd-image-updater.argoproj.io/web.update-strategy: newest-build
+      argocd-image-updater.argoproj.io/web.allow-tags: regexp:^sha-[0-9a-f]+$
+      argocd-image-updater.argoproj.io/web.force-update: "true"
+      argocd-image-updater.argoproj.io/web.helm.image-name: lci.controllers.web.containers.main.image.repository
+      argocd-image-updater.argoproj.io/web.helm.image-tag: lci.controllers.web.containers.main.image.tag
+      argocd-image-updater.argoproj.io/web.signature-type: cosign
+      argocd-image-updater.argoproj.io/web.cosign.certificate-oidc-issuer: https://token.actions.githubusercontent.com
+      argocd-image-updater.argoproj.io/web.cosign.certificate-identity-regexp: ^https://github\.com/vymalo/lightbridge-code-intelligence/\.github/workflows/build-images\.yml@.*$
+      # ── git write-back → the app repo's main (public repo, so only the commit
+      # needs creds: the shared vymalo GitHub App, same as vymalo-shop). ──
+      argocd-image-updater.argoproj.io/write-back-method: git
+      argocd-image-updater.argoproj.io/git-branch: main
+      argocd-image-updater.argoproj.io/git-repository: https://github.com/vymalo/lightbridge-code-intelligence.git
+      argocd-image-updater.argoproj.io/write-back-target: helmvalues:deploy/envs/production/values.yaml
+      argocd-image-updater.argoproj.io/git-credentials: secret:argocd/github-app-creds--vymalo
+    sources:
+      # Source A — the chart. release-pinned like every ai-helm app; the release
+      # script swaps this tag on each cut. Image tags come from Source B's $values.
+      - repoURL: https://github.com/ADORSYS-GIS/ai-helm
+        targetRevision: release-2026.06.19-v06
+        path: charts/lightbridge-code-intelligence
+        helm:
+          releaseName: lightbridge-ci
+          valueFiles:
+            - $values/deploy/envs/production/values.yaml
+          ignoreMissingValueFiles: true
+      # Source B — image tags from the app repo's main; image-updater commits here.
+      - repoURL: https://github.com/vymalo/lightbridge-code-intelligence.git
+        targetRevision: main
+        ref: values
     destination:
       namespace: converse
 

--- a/charts/lightbridge-code-intelligence/values.yaml
+++ b/charts/lightbridge-code-intelligence/values.yaml
@@ -52,7 +52,9 @@ lci:
         main:
           image:
             repository: ghcr.io/vymalo/lightbridge-control-plane
-            # TODO(images): placeholder until vymalo/lightbridge-code-intelligence CI ships it.
+            # Default/fallback only. The deployed tag is OVERRIDDEN at sync time by the
+            # app repo's deploy/envs/production/values.yaml ($values source), which
+            # argocd-image-updater owns — see charts/apps/values.yaml + the app repo.
             tag: "0.1.0"
             pullPolicy: IfNotPresent
           env:

--- a/charts/lightbridge-code-intelligence/values.yaml
+++ b/charts/lightbridge-code-intelligence/values.yaml
@@ -124,6 +124,9 @@ lci:
         main:
           image:
             repository: ghcr.io/vymalo/lightbridge-web
+            # Default/fallback only. The deployed tag is OVERRIDDEN at sync time by the
+            # app repo's deploy/envs/production/values.yaml ($values source), which
+            # argocd-image-updater owns — see charts/apps/values.yaml + the app repo.
             tag: "0.1.0"
             pullPolicy: IfNotPresent
           env:


### PR DESCRIPTION
## 1. Summary

**Source of truth:** coordinated 3-repo deployment change. Companion PRs:
- vymalo/lightbridge-code-intelligence: https://github.com/vymalo/lightbridge-code-intelligence/pull/8 (write-back values file + cosign signing)
- WhyThatFunction/home-os: https://github.com/WhyThatFunction/home-os/pull/61 (ImageUpdater selector CR)


This PR changes:

- `charts/apps/values.yaml` — converts the `lightbridge-code-intelligence` Application to **multi-source** and adds the **argocd-image-updater** annotation block + **git write-back**.
- `charts/apps/values.yaml` — also subscribes the app to **argocd-notifications** (on-deployed / on-deploy-failed → GitHub Deployment status, `vymalo` service).
- `charts/lightbridge-code-intelligence/values.yaml` — clarifies the chart's default image tag is a fallback (overridden at sync time).

It solves:

- The live LBCI app deploys from hardcoded `0.1.0` tags requiring a manual edit + an ai-helm release per bump. This adopts the image-updater + write-back pattern already used by `vymalo-shop` / `vaam` in `home-os`.

---

## 2. Intent

> Keep ai-helm's immutable-release-tag discipline for the **chart**, but let **image tags** flow continuously. Source A (the chart) stays release-pinned; Source B reads the image tags from the app repo's `main` (`$values`). image-updater picks the newest **signed** `sha-<gitsha>` from GHCR, verifies the cosign identity, and commits the tag back to the app repo — which ArgoCD auto-syncs. No ai-helm release per deploy.

---

## 3. Scope

### In Scope

- Multi-source LBCI Application (chart `$values` from `vymalo/lightbridge-code-intelligence:main`).
- image-updater annotations: `image-list` (cp+web), `newest-build` over `^sha-[0-9a-f]+$`, per-image cosign verification, helm value-path mapping, git write-back via `secret:argocd/github-app-creds--vymalo`.
- argocd-notifications subscriptions + ssegning.me Deployment-status annotations (repo-url / revision=main / environment-url).

### Out of Scope

- The `ImageUpdater` selector CR → **WhyThatFunction/home-os** PR (required to activate these annotations).
- The write-back values file + cosign signing → **vymalo/lightbridge-code-intelligence#8**.

---

## 4. Verification

Commands run:

```bash
helm template rel charts/apps | yq 'select(.metadata.name=="aii-lightbridge-code-intelligence")'
helm lint charts/apps
helm lint charts/lightbridge-code-intelligence
helm template lightbridge-ci charts/lightbridge-code-intelligence \
  -f <app-repo>/deploy/envs/production/values.yaml | grep 'image: ghcr.io/vymalo'
```

Results:

```text
# Application renders sources[] (chart release-pinned + $values ref) + the full
# argocd-image-updater.argoproj.io/* annotation set; cosign identity regexp
# round-trips correctly (\\. in YAML). No inline image tags remain.
1 chart(s) linted, 0 chart(s) failed   (charts/apps)
1 chart(s) linted, 0 chart(s) failed   (charts/lightbridge-code-intelligence)
image: ghcr.io/vymalo/lightbridge-control-plane:sha-773abea
image: ghcr.io/vymalo/lightbridge-web:sha-773abea
```

I verified this change by:

- [x] Running manual tests (helm template + lint)
- [x] Reviewing the diff

---

## 6. Risk Assessment

Risk level: **Low / Medium**

Potential risks:

- Activation depends on the **home-os** ImageUpdater CR and the `vymalo` GitHub App having **Contents: write** on the app repo; until then the app simply syncs the seeded tag (no regression).
- The release script bumps `targetRevision` by literal string swap — confirmed compatible with the new `sources[]` block (render-check passes).

Mitigation:

- Merge order: app-repo (#8) → this → home-os, then cut an ai-helm release and apply `ai-apps-v2`.

---

## 7. AI Usage Declaration

AI was used for:

- [x] Understanding existing code
- [x] Generating code
- [x] Reviewing the diff

Human verification:

- [ ] I understand every meaningful change in this PR
- [ ] I accept responsibility for this PR

> ⚠️ Author: please confirm the human-verification boxes before merge (governance requirement).

---

## 8. Reviewer Focus

- [x] Correctness
- [x] Architecture
- [x] Security
