### PR TITLE
feat(lightbridge-code-intelligence): GitOps-managed image-updater activation

### DIFF
--- a/charts/apps/values.yaml
+++ b/charts/apps/values.yaml
@@ -1118,6 +1118,26 @@ applications:
     destination:
       namespace: converse
 
+  # --- Lightbridge Code Intelligence — image-updater activation (control object) ---
+  # The CRD-based argocd-image-updater controller only acts on an Application when
+  # an ImageUpdater CR selects it. That CR is an argocd control object (it must live
+  # in the in-cluster argocd namespace where the controller watches), so this entry
+  # is controlPlane: true (ADR-0017) — the CR lands in-cluster/argocd, not home-remote.
+  # GitOps-native replacement for the previously hand-applied CR in home-os
+  # charts/argocd-image-updater (that chart is a manual `helm upgrade`, not synced).
+  - name: lightbridge-code-intelligence-imageupdater
+    finalizers:
+      - resources-finalizer.argocd.argoproj.io
+    controlPlane: true
+    source:
+      repoURL: https://github.com/ADORSYS-GIS/ai-helm
+      targetRevision: release-2026.06.19-v07
+      path: charts/lightbridge-code-intelligence-imageupdater
+      helm:
+        releaseName: lightbridge-ci-imageupdater
+    destination:
+      namespace: argocd
+
   # --- Converse UI ---
   - name: converse-ui
     finalizers:

--- a/charts/lightbridge-code-intelligence-imageupdater/Chart.yaml
+++ b/charts/lightbridge-code-intelligence-imageupdater/Chart.yaml
@@ -1,0 +1,25 @@
+apiVersion: v2
+name: lightbridge-code-intelligence-imageupdater
+description: |
+  GitOps-managed argocd-image-updater `ImageUpdater` CR(s) that activate the
+  CRD-based controller for the Lightbridge Code Intelligence Application
+  (aii-lightbridge-code-intelligence).
+
+  Deployed as a control-plane object (ADR-0017): the app entry in charts/apps
+  sets `controlPlane: true`, so this lands in the in-cluster `argocd` namespace
+  where the image-updater controller (watch.namespaces=argocd-image-updater,argocd)
+  reconciles it. The per-image update config (image-list, update-strategy,
+  cosign, git write-back) lives on the TARGET Application's annotations
+  (charts/apps/values.yaml); this CR just selects it via `useAnnotations: true`.
+
+  Replaces the previously hand-applied CR in home-os charts/argocd-image-updater
+  (that chart is a manual `helm upgrade`, not GitOps — so the CR never synced).
+type: application
+version: 1.0.0
+appVersion: "1.0.0"
+keywords:
+  - lightbridge
+  - argocd-image-updater
+  - control-plane
+maintainers:
+  - name: ai-helm

--- a/charts/lightbridge-code-intelligence-imageupdater/templates/imageupdater.yaml
+++ b/charts/lightbridge-code-intelligence-imageupdater/templates/imageupdater.yaml
@@ -1,0 +1,23 @@
+{{- /*
+One ImageUpdater CR per .Values.imageUpdaters entry, created in this release's
+namespace — which is the in-cluster `argocd` namespace because the charts/apps
+entry that deploys this chart is `controlPlane: true` (ADR-0017). The CRD-based
+image-updater controller watches argocd + argocd-image-updater, so the CR is
+reconciled there.
+*/ -}}
+{{- range .Values.imageUpdaters }}
+---
+apiVersion: argocd-image-updater.argoproj.io/v1alpha1
+kind: ImageUpdater
+metadata:
+  name: {{ .name }}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ .name }}
+    app.kubernetes.io/component: image-updater
+    app.kubernetes.io/part-of: lightbridge-code-intelligence
+    app.kubernetes.io/managed-by: {{ $.Release.Service | default "Helm" }}
+spec:
+  applicationRefs:
+    {{- toYaml .applicationRefs | nindent 4 }}
+{{- end }}

--- a/charts/lightbridge-code-intelligence-imageupdater/values.yaml
+++ b/charts/lightbridge-code-intelligence-imageupdater/values.yaml
@@ -1,0 +1,13 @@
+# ImageUpdater CRs to render. Each one activates the CRD-based
+# argocd-image-updater controller for the listed Application(s); the actual
+# per-image update config (image-list / update-strategy / cosign / git
+# write-back) lives on the Application's own annotations, so `useAnnotations:
+# true` is all the CR needs. A list so more ai-helm apps can be activated here
+# later without a new chart.
+imageUpdaters:
+  - name: lightbridge-code-intelligence
+    applicationRefs:
+      # The `aii-` prefix is charts/apps `argocd.appNamePrefix`. A bare pattern
+      # is an exact match.
+      - namePattern: aii-lightbridge-code-intelligence
+        useAnnotations: true


### PR DESCRIPTION
## 1. Summary

**Source of truth:** follow-up to ADORSYS-GIS/ai-helm#429 (merged) — https://github.com/ADORSYS-GIS/ai-helm/pull/429. Live verification showed the LBCI workload deployed (images on `sha-773abea`) but image-updater never activated, because the selector `ImageUpdater` CR lived in the **manual** home-os `charts/argocd-image-updater` helm release (not GitOps), so WhyThatFunction/home-os#61 never synced.

This PR changes:

- New chart `charts/lightbridge-code-intelligence-imageupdater` — renders the `ImageUpdater` CR(s) (values-driven list).
- New `charts/apps` entry `lightbridge-code-intelligence-imageupdater` with `controlPlane: true` — deploys that CR into the in-cluster `argocd` namespace where the CRD-based controller watches (ADR-0017).

It solves:

- Makes image-updater activation **GitOps-managed** instead of a hand-applied / drift-prone manual helm step.

---

## 2. Intent

> The CRD-based argocd-image-updater controller only reconciles an Application when an `ImageUpdater` CR selects it. Put that CR under ArgoCD (like the Applications themselves) so it ships with a release and never needs a manual `helm upgrade`. The per-image config (image-list, newest-build, cosign, git write-back) stays on the target Application's annotations (#429); this CR just selects it via `useAnnotations: true`.

---

## 3. Scope

### In Scope

- The new CR chart + the control-plane app entry.

### Out of Scope

- Removing the now-redundant CR from the manual home-os chart → companion home-os PR (prevents a future `helm upgrade` conflict).
- The image-updater annotations / write-back themselves (#429, merged).

---

## 4. Verification

Commands run:

```bash
helm template lightbridge-ci-imageupdater charts/lightbridge-code-intelligence-imageupdater -n argocd
helm lint --strict charts/lightbridge-code-intelligence-imageupdater
helm template rel charts/apps | yq 'select(.metadata.name=="aii-lightbridge-code-intelligence-imageupdater") | .spec.destination'
helm lint charts/apps
```

Result:

```text
# CR renders in the argocd namespace selecting aii-lightbridge-code-intelligence (useAnnotations: true)
1 chart(s) linted, 0 chart(s) failed     # strict, new chart
# new Application → server=https://kubernetes.default.svc ns=argocd project=ai (in-cluster control object)
1 chart(s) linted, 0 chart(s) failed     # charts/apps
```

I verified this change by:

- [x] Running manual tests (helm template + lint, both charts)
- [x] Confirming the Application targets in-cluster/argocd (controlPlane)
- [x] Reviewing the diff

---

## 6. Risk Assessment

Risk level: **Low**

- New, isolated control object; takes effect only after the next release cut + `ai-apps-v2` roll.
- Safe no-op until a **signed** image exists (current `sha-773abea` is unsigned) and the `vymalo` GitHub App has `Contents: write`.
- Rollback: disable/remove the app entry (or set `enabled: false`).

---

## 7. AI Usage Declaration

AI was used for:

- [x] Understanding existing code
- [x] Generating code
- [x] Reviewing the diff

Human verification:

- [ ] I understand every meaningful change in this PR
- [ ] I accept responsibility for this PR

---

## 8. Reviewer Focus

- [x] Correctness
- [x] Architecture
