### PR TITLE
fix(lightbridge-code-intelligence): absolute image-updater write-back path

### DIFF
--- a/charts/apps/values.yaml
+++ b/charts/apps/values.yaml
@@ -1089,7 +1089,12 @@ applications:
       argocd-image-updater.argoproj.io/write-back-method: git
       argocd-image-updater.argoproj.io/git-branch: main
       argocd-image-updater.argoproj.io/git-repository: https://github.com/vymalo/lightbridge-code-intelligence.git
-      argocd-image-updater.argoproj.io/write-back-target: helmvalues:deploy/envs/production/values.yaml
+      # Leading slash = path absolute from the git repo ROOT. Without it a `helmvalues:`
+      # target resolves relative to the app's chart SOURCE path
+      # (charts/lightbridge-code-intelligence), so image-updater writes a wrong nested
+      # file (charts/lightbridge-code-intelligence/deploy/...). vymalo/opfs dodge this
+      # only because their chart is OCI (no source path); ours is path-based → slash required.
+      argocd-image-updater.argoproj.io/write-back-target: helmvalues:/deploy/envs/production/values.yaml
       argocd-image-updater.argoproj.io/git-credentials: secret:argocd/github-app-creds--vymalo
       # ── argocd-notifications → GitHub Deployment status. `vymalo` is the
       # notifier service (GitHub App installation on the vymalo org); the


### PR DESCRIPTION
## 1. Summary

**Source of truth:** https://github.com/ADORSYS-GIS/ai-helm/pull/430 (merged, cut as v08) — live verification of that change surfaced this write-back path defect.

This PR changes:

- `charts/apps/values.yaml` — the LBCI `write-back-target` annotation gets a **leading slash**: `helmvalues:deploy/...` → `helmvalues:/deploy/envs/production/values.yaml`.

It solves:

- After v08 activated image-updater, it correctly found the newest **signed** image (`sha-0c3e6e0`, cosign-verified) and pushed to the app repo — **but to the wrong path**: a stray `charts/lightbridge-code-intelligence/deploy/envs/production/values.yaml`, not the root `deploy/envs/production/values.yaml` that the `$values` source reads. So the promotion never reached the cluster.

---

## 2. Intent

> Per the image-updater docs (https://github.com/argoproj-labs/argocd-image-updater/blob/master/docs/basics/update-methods.md), a relative `helmvalues:` target resolves against the app's **chart source path** (`charts/lightbridge-code-intelligence`); a **leading `/`** makes it absolute from the git repo root. vymalo/opfs don't hit this because their image-bearing source is an OCI chart (no path); ours is a path-based chart, so the slash is required.

---

## 3. Scope

### In Scope

- One-line annotation fix (add leading slash).

### Out of Scope

- Removing the stray nested file already committed to the app repo's main → separate app-repo cleanup (after this rolls, so image-updater can't recreate it).

---

## 4. Verification

Command run:

```bash
helm template rel charts/apps | yq 'select(.metadata.name=="aii-lightbridge-code-intelligence") | .metadata.annotations["argocd-image-updater.argoproj.io/write-back-target"]'
helm lint charts/apps
```

Result:

```text
helmvalues:/deploy/envs/production/values.yaml
1 chart(s) linted, 0 chart(s) failed
```

Live evidence of the bug being fixed (the stray commit on app-repo main):

- https://github.com/vymalo/lightbridge-code-intelligence/commit/0ff2cca

I verified this change by:

- [x] Confirming the rendered annotation now has the leading slash
- [x] `helm lint charts/apps`
- [x] Reading the image-updater docs (relative = source-path-relative; leading `/` = repo-root-absolute)

---

## 6. Risk Assessment

Risk level: **Low**

- Annotation-only; takes effect after a release cut + `ai-apps-v2` roll. Then image-updater writes the correct root file and the app promotes to the newest signed sha.

---

## 7. AI Usage Declaration

AI was used for:

- [x] Understanding existing code
- [x] Generating code
- [x] Reviewing the diff

Human verification:

- [ ] I understand every meaningful change in this PR
- [ ] I accept responsibility for this PR

---

## 8. Reviewer Focus

- [x] Correctness
