### PR TITLE
chore(lightbridge-code-intelligence): ServerSideDiff to stop selfHeal churn

### DIFF
--- a/charts/apps/values.yaml
+++ b/charts/apps/values.yaml
@@ -1064,6 +1064,11 @@ applications:
     finalizers:
       - resources-finalizer.argocd.argoproj.io
     additionalAnnotations:
+      # SSA dry-run diff: ESO and the CNPG/StatefulSet controllers stamp defaulted
+      # fields (on the ExternalSecrets + the Neo4j StatefulSet) that the chart never
+      # declares, which otherwise show a permanent cosmetic OutOfSync + selfHeal churn.
+      # ServerSideDiff ignores those server-owned fields so the app reads Synced.
+      argocd.argoproj.io/compare-options: ServerSideDiff=true
       # Two images in one app, aliased `cp` (control-plane) + `web`.
       argocd-image-updater.argoproj.io/image-list: cp=ghcr.io/vymalo/lightbridge-control-plane,web=ghcr.io/vymalo/lightbridge-web
       # ── control-plane ──


### PR DESCRIPTION
## 1. Summary

**Source of truth:** follow-up to ADORSYS-GIS/ai-helm#432 — https://github.com/ADORSYS-GIS/ai-helm/pull/432 (merged, v09). Live verification showed the LBCI app permanently `OutOfSync` with selfHeal churn.

This PR changes:

- Adds `argocd.argoproj.io/compare-options: ServerSideDiff=true` to the `aii-lightbridge-code-intelligence` app annotations.

It solves:

- The app's control-plane/web Deployments are Synced and serving, but the 3 ExternalSecrets + the Neo4j StatefulSet sit permanently OutOfSync because ESO and the StatefulSet controller stamp defaulted fields the chart never declares → cosmetic OutOfSync + selfHeal churn. ServerSideDiff makes the diff ignore server-owned fields (same fix the vaam apps use).

---

## 2. Intent

> Stop the cosmetic diff noise so the app reads Synced and ArgoCD stops re-applying on every reconcile. Purely a comparison-option change — no workload change.

---

## 3. Scope

### In Scope

- One annotation on the LBCI app.

### Out of Scope

- Any workload/image change (the image-updater loop is working as of v09).

---

## 4. Verification

Command run:

```bash
helm template rel charts/apps | yq 'select(.metadata.name=="aii-lightbridge-code-intelligence") | .metadata.annotations["argocd.argoproj.io/compare-options"]'
helm lint charts/apps
```

Result:

```text
ServerSideDiff=true
1 chart(s) linted, 0 chart(s) failed
```

Live evidence (pre-fix): app `OutOfSync`/`Progressing`; OutOfSync resources = `StatefulSet/lightbridge-ci-neo4j` + `ExternalSecret/lightbridge-ci-{auth,github,neo4j-auth}`; Deployments already `Synced`.

I verified this change by:

- [x] Confirming the rendered annotation
- [x] `helm lint charts/apps`

---

## 6. Risk Assessment

Risk level: **Low** — comparison-only; takes effect after a release cut + `ai-apps-v2` roll. No rollback concern (revert the annotation).

---

## 7. AI Usage Declaration

AI was used for:

- [x] Understanding existing code
- [x] Generating code
- [x] Reviewing the diff

Human verification:

- [ ] I understand every meaningful change in this PR
- [ ] I accept responsibility for this PR

---

## 8. Reviewer Focus

- [x] Correctness
