### PR TITLE
feat(lightbridge-ci): wire GitHub App credentials from prod/codeintel/env

### DIFF
--- a/charts/lightbridge-code-intelligence/README.md
+++ b/charts/lightbridge-code-intelligence/README.md
@@ -28,15 +28,18 @@ ESO-provisioned `lightbridge-codeintel-db-role` Secret.
 
 ## Secrets
 
-App-owned `ExternalSecret`s resolve against the `ssegning-aws` `ClusterSecretStore`
-(properties under `ai/camer/digital/prod/env`):
+App-owned `ExternalSecret`s resolve against the `ssegning-aws` `ClusterSecretStore`. The GitHub
+App credentials live in the dedicated SM secret `prod/codeintel/env`; the rest under the legacy
+`ai/camer/digital/prod/env`:
 
-| Secret | Property | Consumed as |
-|---|---|---|
-| `lightbridge-ci-github` | `lightbridge_ci_github_webhook_secret` | `GITHUB_WEBHOOK_SECRET` |
-| `lightbridge-ci-auth` | `lightbridge_ci_better_auth_secret` | `BETTER_AUTH_SECRET` — _transitional_, outgoing better-auth image; OIDC uses no secret |
-| `lightbridge-ci-neo4j-auth` | `lightbridge_ci_neo4j_password` | Neo4j password |
-| `lightbridge-codeintel-db-role` | `codeintel_db_password` | DB password (provisioned by `charts/lightbridge-db`) |
+| Secret | SM key | Property | Consumed as |
+|---|---|---|---|
+| `lightbridge-ci-github` | `prod/codeintel/env` | `github_webhook_secret` | `GITHUB_WEBHOOK_SECRET` |
+| `lightbridge-ci-github` | `prod/codeintel/env` | `github_app_id` | `GITHUB_APP_ID` |
+| `lightbridge-ci-github` | `prod/codeintel/env` | `github_app_private_key` | `GITHUB_APP_PRIVATE_KEY` |
+| `lightbridge-ci-auth` | `ai/camer/digital/prod/env` | `lightbridge_ci_better_auth_secret` | `BETTER_AUTH_SECRET` — _transitional_, outgoing better-auth image; OIDC uses no secret |
+| `lightbridge-ci-neo4j-auth` | `ai/camer/digital/prod/env` | `lightbridge_ci_neo4j_password` | Neo4j password |
+| `lightbridge-codeintel-db-role` | — | `codeintel_db_password` | DB password (provisioned by `charts/lightbridge-db`) |
 
 ## Ingress
 

--- a/charts/lightbridge-code-intelligence/templates/externalsecret.yaml
+++ b/charts/lightbridge-code-intelligence/templates/externalsecret.yaml
@@ -1,11 +1,17 @@
 {{- $store := .Values.secrets.secretStore }}
 {{- $refresh := .Values.secrets.refreshInterval }}
 {{- $key := .Values.secrets.remoteKey }}
+{{- $codeintelKey := .Values.secrets.codeintelKey }}
 {{- $wave := .Values.syncWave.secrets | quote }}
 # App-owned secrets pulled from the ssegning-aws ClusterSecretStore. Target Secret names
 # are `<release>-{github,auth,neo4j-auth}` so the bjw workloads can secretKeyRef them.
 # (The codeintel DB role password lives in charts/lightbridge-db, since CNPG needs it at
 # DB-sync-wave to set the managed role.)
+#
+# The `-github` secret carries the registered GitHub App's credentials (App ID + RSA private
+# key + webhook signing secret), all sourced from the dedicated `prod/codeintel/env` SM secret
+# (`$codeintelKey`). The control plane uses App ID + private key to mint installation tokens
+# (read repo contents, post reviews) and the webhook secret to verify `X-Hub-Signature-256`.
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
@@ -24,8 +30,16 @@ spec:
   data:
     - secretKey: webhook-secret
       remoteRef:
-        key: {{ $key }}
+        key: {{ $codeintelKey }}
         property: {{ .Values.secrets.githubWebhookProperty }}
+    - secretKey: app-id
+      remoteRef:
+        key: {{ $codeintelKey }}
+        property: {{ .Values.secrets.githubAppIdProperty }}
+    - secretKey: app-private-key
+      remoteRef:
+        key: {{ $codeintelKey }}
+        property: {{ .Values.secrets.githubAppPrivateKeyProperty }}
 {{- /* TRANSITIONAL: the `-auth` secret feeds the outgoing better-auth web image. The OIDC web
        image (ADR-0014) is a PUBLIC client (PKCE, no client secret); drop this once it's live. */}}
 ---

--- a/charts/lightbridge-code-intelligence/values.yaml
+++ b/charts/lightbridge-code-intelligence/values.yaml
@@ -10,14 +10,21 @@
 # Namespace is `converse` (the lightbridge family namespace), matching the CNPG cluster.
 
 # ── App-owned ExternalSecrets (templates/externalsecret.yaml) ────────────────
-# Resolve against the ssegning-aws ClusterSecretStore. Properties live under
-# remoteRef key ai/camer/digital/prod/env.
+# Resolve against the ssegning-aws ClusterSecretStore. Legacy properties live under
+# remoteRef key ai/camer/digital/prod/env; the GitHub App credentials live under the
+# dedicated prod/codeintel/env (codeintelKey).
 secrets:
   secretStore: ssegning-aws
   refreshInterval: 1h
   remoteKey: ai/camer/digital/prod/env
-  githubWebhookProperty: lightbridge_ci_github_webhook_secret
   neo4jPasswordProperty: lightbridge_ci_neo4j_password
+  # GitHub App credentials (registered app for vymalo/lightbridge-code-intelligence). All three
+  # live in the dedicated SM secret prod/codeintel/env so app config stays isolated from the
+  # shared legacy bucket.
+  codeintelKey: prod/codeintel/env
+  githubAppIdProperty: github_app_id
+  githubAppPrivateKeyProperty: github_app_private_key
+  githubWebhookProperty: github_webhook_secret
   # The OIDC web image needs NO client secret (PUBLIC client + PKCE, ADR-0014). The property
   # below is TRANSITIONAL — still consumed by the outgoing better-auth image; remove once the
   # OIDC web image is confirmed live.
@@ -75,6 +82,19 @@ lci:
                 secretKeyRef:
                   name: '{{ .Release.Name }}-github'
                   key: webhook-secret
+            # GitHub App auth (mint installation tokens for the read API + posting reviews).
+            # Absent either, the control plane skips installation-token features but still
+            # serves webhooks/JWT-protected reads (github::GithubApp::from_env → None).
+            GITHUB_APP_ID:
+              valueFrom:
+                secretKeyRef:
+                  name: '{{ .Release.Name }}-github'
+                  key: app-id
+            GITHUB_APP_PRIVATE_KEY:
+              valueFrom:
+                secretKeyRef:
+                  name: '{{ .Release.Name }}-github'
+                  key: app-private-key
             # DATABASE_URL reuses the CNPG cluster; $(DB_PASSWORD) is interpolated by the
             # kubelet, and `dependsOn` makes bjw emit DB_PASSWORD first.
             DB_PASSWORD:


### PR DESCRIPTION
## 1. Summary

This PR changes:

- The `lightbridge-code-intelligence` chart now sources the registered **GitHub App** credentials (App ID, RSA private key, webhook signing secret) from a dedicated AWS Secrets Manager secret, `prod/codeintel/env`, isolated from the shared legacy bucket.
- `templates/externalsecret.yaml`: the `-github` ExternalSecret pulls `github_app_id` / `github_app_private_key` / `github_webhook_secret`, exposing `app-id` / `app-private-key` / `webhook-secret` keys.
- `values.yaml`: add `codeintelKey` + property names; wire `GITHUB_APP_ID` and `GITHUB_APP_PRIVATE_KEY` into the control-plane container alongside `GITHUB_WEBHOOK_SECRET`.
- `README.md`: secrets table lists the SM key per property.

It solves:

- Source of truth: the control plane gained GitHub App auth (App JWT → installation token) in [vymalo/lightbridge-code-intelligence#19](https://github.com/vymalo/lightbridge-code-intelligence/pull/19); this provisions the matching prod secrets so the read API and review-posting can mint installation tokens. Architecture: [ADR-0014](https://github.com/vymalo/lightbridge-code-intelligence/blob/main/docs/adr/0014-keycloak-oidc-resource-server.md).

---

## 2. Intent

> Provision the registered GitHub App's credentials into prod via ExternalSecrets, kept in a dedicated `prod/codeintel/env` SM secret so app config stays isolated from the shared legacy bucket. Absent either var the control plane degrades gracefully (`github::GithubApp::from_env → None`) — webhooks + JWT-protected reads still serve.

---

## 3. Scope

### In Scope

- The `-github` ExternalSecret + control-plane env wiring for GitHub App auth.

### Out of Scope

- Cutting the `release-*` chart tag and the home-os repoint (the actual prod deploy) — a separate, deliberate step.
- Removing the transitional better-auth `-auth` secret (tracked for OIDC cleanup).

---

## 4. Verification

I verified this change by:

- [x] Running manual tests
- [x] Testing error cases

Commands run:

```bash
helm dependency build charts/lightbridge-code-intelligence
helm template lightbridge-ci charts/lightbridge-code-intelligence
```

Results:

```text
ExternalSecret lightbridge-ci-github emits three remoteRefs, all keyed prod/codeintel/env:
  webhook-secret      → github_webhook_secret
  app-id              → github_app_id
  app-private-key     → github_app_private_key
control-plane Deployment env resolves GITHUB_APP_ID / GITHUB_APP_PRIVATE_KEY / GITHUB_WEBHOOK_SECRET
  to the lightbridge-ci-github secret keys.
CI: helm lint + Gitleaks + Trivy green.
```

---

## 5. Screenshots / Evidence

- Rendered manifests via `helm template` (above). No secret values are committed — only ExternalSecret references to the SM store.

---

## 6. Risk Assessment

Risk level:

* [x] Low

Potential risks:

* The webhook-secret source moves from the legacy key to `prod/codeintel/env`; the SM secret must contain all three properties before this syncs.

Mitigation:

* Control plane fails closed on a missing webhook secret (rejects unsigned deliveries) and degrades gracefully without App ID/key — no data loss.

---

## 7. AI Usage Declaration

AI was used for:

* [x] Generating code
* [x] Reviewing the diff

Human verification:

* [x] I understand every meaningful change in this PR
* [x] I checked generated code manually
* [x] I accept responsibility for this PR
