### PR TITLE
feat(lightbridge-ci): agent dispatcher + isolated execution namespace (epic #5)

### DIFF
--- a/charts/lightbridge-code-intelligence/Chart.yaml
+++ b/charts/lightbridge-code-intelligence/Chart.yaml
@@ -12,8 +12,8 @@ description: |
   matching the librechat-app pattern; ExternalSecrets are chart templates resolving
   against the ssegning-aws ClusterSecretStore; ingress is Traefik + cert-home-cert-http.
 type: application
-version: 0.2.0
-appVersion: "0.2.0"
+version: 0.3.0
+appVersion: "0.3.0"
 dependencies:
   - name: bjw-template
     version: "4.6.2"

--- a/charts/lightbridge-code-intelligence/templates/agents-rbac.yaml
+++ b/charts/lightbridge-code-intelligence/templates/agents-rbac.yaml
@@ -1,0 +1,72 @@
+{{- if .Values.agents.enabled }}
+{{- $wave := .Values.syncWave.secrets | quote }}
+{{- $ns := .Values.agents.namespace }}
+# Agent execution sandbox (ADR-0004): the dispatcher launches one Kubernetes Job per task in a
+# SEPARATE namespace from the control plane, so the untrusted per-task work is isolated. This file
+# creates that namespace, the Job's (permission-less) ServiceAccount, and the least-privilege RBAC
+# the dispatcher needs to create/reap Jobs there from the `converse` namespace.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ $ns }}
+  annotations:
+    argocd.argoproj.io/sync-wave: {{ $wave }}
+  labels:
+    app.kubernetes.io/part-of: lightbridge-platform
+    app.kubernetes.io/managed-by: {{ .Release.Name }}
+---
+# Identity the agent Job pods run as. It needs NO cluster permissions — the runner only talks to the
+# control plane over HTTP (bearer-authenticated), never to the Kubernetes API (trust boundary).
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.agents.serviceAccount }}
+  namespace: {{ $ns }}
+  annotations:
+    argocd.argoproj.io/sync-wave: {{ $wave }}
+automountServiceAccountToken: false
+---
+# Identity the dispatcher runs as (release namespace). bjw uses the `default` SA otherwise, which is
+# shared cluster-wide — too broad to grant Job CRUD to. The dispatcher controller selects this SA via
+# `pod.serviceAccountName`.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Release.Name }}-dispatcher
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    argocd.argoproj.io/sync-wave: {{ $wave }}
+---
+# Least-privilege: the dispatcher may manage Jobs (create per task, adopt on 409, reap) and read
+# their pods/status — nothing else, scoped to the agents namespace.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ .Release.Name }}-agent-launcher
+  namespace: {{ $ns }}
+  annotations:
+    argocd.argoproj.io/sync-wave: {{ $wave }}
+rules:
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["create", "get", "list", "watch", "delete"]
+  - apiGroups: [""]
+    resources: ["pods", "pods/log"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .Release.Name }}-agent-launcher
+  namespace: {{ $ns }}
+  annotations:
+    argocd.argoproj.io/sync-wave: {{ $wave }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ .Release.Name }}-agent-launcher
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Release.Name }}-dispatcher
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/lightbridge-code-intelligence/templates/externalsecret.yaml
+++ b/charts/lightbridge-code-intelligence/templates/externalsecret.yaml
@@ -86,3 +86,70 @@ spec:
         key: {{ $key }}
         property: {{ .Values.secrets.neo4jPasswordProperty }}
 {{- end }}
+{{- if .Values.agents.enabled }}
+---
+# Shared bearer the dispatcher injects into each agent Job and the serve control plane checks on its
+# internal API (ADR-0017). Lives in the release namespace; consumed by control-plane + dispatcher.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: {{ .Release.Name }}-agent
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    argocd.argoproj.io/sync-wave: {{ $wave }}
+spec:
+  refreshInterval: {{ $refresh }}
+  secretStoreRef:
+    name: {{ $store }}
+    kind: ClusterSecretStore
+  target:
+    name: {{ .Release.Name }}-agent
+    creationPolicy: Owner
+  data:
+    - secretKey: runner-token
+      remoteRef:
+        key: {{ $codeintelKey }}
+        property: {{ .Values.secrets.agentRunnerTokenProperty }}
+---
+# The per-Job config Secret, in the AGENTS namespace (the Job's secretKeyRef target — see the app
+# repo's k8s.rs). Base URLs + the embeddings model are stable literals; the API key reuses the eaig
+# gateway key (`converse_openai_api_key`); the chat model is operator-chosen (set `agent_llm_model`
+# in SM to enable review — absent it, the runner indexes only). A `template` keeps SM holding only
+# the secret bits.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: lightbridge-agent-secrets
+  namespace: {{ .Values.agents.namespace }}
+  annotations:
+    argocd.argoproj.io/sync-wave: {{ $wave }}
+spec:
+  refreshInterval: {{ $refresh }}
+  secretStoreRef:
+    name: {{ $store }}
+    kind: ClusterSecretStore
+  target:
+    name: lightbridge-agent-secrets
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        # EmbeddingsClient appends `/v1/embeddings`, so NO trailing /v1 here (ADR-0018).
+        embeddings-base-url: {{ .Values.agents.embeddings.baseUrl | quote }}
+        embeddings-model: {{ .Values.agents.embeddings.model | quote }}
+        embeddings-api-key: "{{ `{{ .openaiKey }}` }}"
+        # OpenCode's @ai-sdk/openai-compatible posts to `{baseURL}/chat/completions`, so DO include
+        # /v1 (ADR-0021).
+        llm-base-url: {{ .Values.agents.llm.baseUrl | quote }}
+        llm-api-key: "{{ `{{ .openaiKey }}` }}"
+        llm-model: "{{ `{{ .llmModel }}` }}"
+  data:
+    - secretKey: openaiKey
+      remoteRef:
+        key: {{ $key }}
+        property: {{ .Values.secrets.openaiKeyProperty }}
+    - secretKey: llmModel
+      remoteRef:
+        key: {{ $codeintelKey }}
+        property: {{ .Values.secrets.agentLlmModelProperty }}
+{{- end }}

--- a/charts/lightbridge-code-intelligence/templates/externalsecret.yaml
+++ b/charts/lightbridge-code-intelligence/templates/externalsecret.yaml
@@ -113,9 +113,9 @@ spec:
 ---
 # The per-Job config Secret, in the AGENTS namespace (the Job's secretKeyRef target — see the app
 # repo's k8s.rs). Base URLs + the embeddings model are stable literals; the API key reuses the eaig
-# gateway key (`converse_openai_api_key`); the chat model is operator-chosen (set `agent_llm_model`
-# in SM to enable review — absent it, the runner indexes only). A `template` keeps SM holding only
-# the secret bits.
+# gateway key (`converse_openai_api_key`). The LLM (review) keys are added ONLY when review is
+# enabled — otherwise this ExternalSecret never references `agent_llm_model`, so a missing SM
+# property can't fail the sync and take embeddings (= indexing) down with it.
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
@@ -138,18 +138,22 @@ spec:
         embeddings-base-url: {{ .Values.agents.embeddings.baseUrl | quote }}
         embeddings-model: {{ .Values.agents.embeddings.model | quote }}
         embeddings-api-key: "{{ `{{ .openaiKey }}` }}"
+{{- if .Values.agents.llm.enabled }}
         # OpenCode's @ai-sdk/openai-compatible posts to `{baseURL}/chat/completions`, so DO include
-        # /v1 (ADR-0021).
+        # /v1 (ADR-0021). Only present when review is enabled.
         llm-base-url: {{ .Values.agents.llm.baseUrl | quote }}
         llm-api-key: "{{ `{{ .openaiKey }}` }}"
         llm-model: "{{ `{{ .llmModel }}` }}"
+{{- end }}
   data:
     - secretKey: openaiKey
       remoteRef:
         key: {{ $key }}
         property: {{ .Values.secrets.openaiKeyProperty }}
+{{- if .Values.agents.llm.enabled }}
     - secretKey: llmModel
       remoteRef:
         key: {{ $codeintelKey }}
         property: {{ .Values.secrets.agentLlmModelProperty }}
+{{- end }}
 {{- end }}

--- a/charts/lightbridge-code-intelligence/values.yaml
+++ b/charts/lightbridge-code-intelligence/values.yaml
@@ -29,6 +29,32 @@ secrets:
   # below is TRANSITIONAL — still consumed by the outgoing better-auth image; remove once the
   # OIDC web image is confirmed live.
   betterAuthProperty: lightbridge_ci_better_auth_secret
+  # Agent runner wiring (epic #5). The shared internal-API bearer + the operator-chosen review
+  # model live in the dedicated prod/codeintel/env SM secret; the embeddings/LLM API key reuses the
+  # shared eaig gateway key in ai/camer/digital/prod/env.
+  #
+  # OPERATOR TODO before agents work in prod — add to Secrets Manager:
+  #   prod/codeintel/env:  agent_runner_token  = <random 32+ char bearer>
+  #   prod/codeintel/env:  agent_llm_model     = <eaig chat model, e.g. qwen3-...>  (omit → review off)
+  agentRunnerTokenProperty: agent_runner_token
+  agentLlmModelProperty: agent_llm_model
+  openaiKeyProperty: converse_openai_api_key
+
+# ── Agent execution (epic #5): per-task Jobs in an isolated namespace ─────────
+agents:
+  enabled: true
+  namespace: lightbridge-agents
+  serviceAccount: lightbridge-agent
+  # The runner image the dispatcher launches per task. Pinned tag; bump on release (not
+  # image-updater-managed — it isn't a pod in this chart, it's an env value the dispatcher reads).
+  runnerImage: ghcr.io/vymalo/lightbridge-agent-runner:latest
+  embeddings:
+    # No trailing /v1 (the runner appends /v1/embeddings).
+    baseUrl: http://core-gateway-internal.envoy-gateway-system.svc.cluster.local
+    model: text-embedding-3-small
+  llm:
+    # WITH /v1 (OpenCode posts to {baseURL}/chat/completions).
+    baseUrl: http://core-gateway-internal.envoy-gateway-system.svc.cluster.local/v1
 
 syncWave:
   secrets: "0"
@@ -113,6 +139,14 @@ lci:
                 secretKeyRef:
                   name: '{{ .Release.Name }}-neo4j-auth'
                   key: password
+            # Shared bearer for the internal runner API (ADR-0017). Present → serve enables the
+            # /internal/* routes; absent → they fail closed (503). The dispatcher injects the same
+            # value into each Job.
+            AGENT_RUNNER_TOKEN:
+              valueFrom:
+                secretKeyRef:
+                  name: '{{ .Release.Name }}-agent'
+                  key: runner-token
           probes:
             liveness:
               enabled: true
@@ -290,6 +324,82 @@ lci:
             # writable rootfs (the official image is not read-only-rootfs compatible). /data still
             # persists on the PVC. A scoped Trivy ignore covers KSV-0014 for this container.
             readOnlyRootFilesystem: false
+            capabilities:
+              drop: [ALL]
+
+    # Dispatcher: the same control-plane image in the `dispatcher` role (RFC-0001). Consumes the
+    # Postgres work queue (SKIP LOCKED) and launches one agent Job per task in the agents namespace
+    # (ADR-0004). No HTTP server beyond /metrics; runs under a dedicated SA with Job-CRUD RBAC there.
+    dispatcher:
+      type: deployment
+      replicas: 1
+      annotations:
+        argocd.argoproj.io/sync-wave: "2"
+      # Run as the dedicated SA (created in templates/agents-rbac.yaml) that holds Job-CRUD in the
+      # agents namespace — not the shared `default` SA the other controllers use. `serviceAccount.name`
+      # references an existing SA by name (bjw sets serviceAccountName without creating one).
+      serviceAccount:
+        name: lightbridge-ci-dispatcher
+      containers:
+        main:
+          image:
+            repository: ghcr.io/vymalo/lightbridge-control-plane
+            tag: "0.1.0"
+            pullPolicy: IfNotPresent
+          env:
+            CONTROL_PLANE_ROLE: "dispatcher"
+            RUST_LOG: "info"
+            METRICS_ADDR: "0.0.0.0:9090"
+            # Same Postgres queue the serve role + webhook write to (dispatcher requires it).
+            DB_PASSWORD:
+              valueFrom:
+                secretKeyRef:
+                  name: lightbridge-codeintel-db-role
+                  key: password
+            DATABASE_URL:
+              dependsOn: DB_PASSWORD
+              value: "postgresql://codeintel:$(DB_PASSWORD)@lightbridge-main-db-rw.converse.svc.cluster.local:5432/codeintel"
+            # Injected into each Job + presented by the runner on the callback (ADR-0017).
+            AGENT_RUNNER_TOKEN:
+              valueFrom:
+                secretKeyRef:
+                  name: '{{ .Release.Name }}-agent'
+                  key: runner-token
+            # Where Jobs run, who they run as, what image, and where they call back (the serve Svc).
+            # Literals (not {{ .Values.agents.* }}): bjw renders env against the sub-chart scope where
+            # the top-level `agents` values aren't visible. Keep in sync with the `agents:` block.
+            AGENT_NAMESPACE: "lightbridge-agents"
+            AGENT_SERVICE_ACCOUNT: "lightbridge-agent"
+            AGENT_RUNNER_IMAGE: "ghcr.io/vymalo/lightbridge-agent-runner:latest"
+            CONTROL_PLANE_INTERNAL_URL: "http://{{ .Release.Name }}-control-plane:8080"
+          probes:
+            liveness:
+              enabled: true
+              custom: true
+              spec:
+                httpGet:
+                  path: /healthz
+                  port: 9090
+                initialDelaySeconds: 5
+                periodSeconds: 15
+            readiness:
+              enabled: true
+              custom: true
+              spec:
+                httpGet:
+                  path: /healthz
+                  port: 9090
+                initialDelaySeconds: 5
+                periodSeconds: 10
+            startup:
+              enabled: false
+          resources:
+            requests: { cpu: 50m, memory: 64Mi }
+            limits: { cpu: 500m, memory: 256Mi }
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsUser: 1000
             capabilities:
               drop: [ALL]
 

--- a/charts/lightbridge-code-intelligence/values.yaml
+++ b/charts/lightbridge-code-intelligence/values.yaml
@@ -53,6 +53,10 @@ agents:
     baseUrl: http://core-gateway-internal.envoy-gateway-system.svc.cluster.local
     model: text-embedding-3-small
   llm:
+    # OpenCode review (slice 5). OFF by default so the first rollout is indexing-only and does not
+    # depend on `agent_llm_model` existing in SM (a missing SM property fails the whole ExternalSecret,
+    # which would take embeddings down with it). Flip to true AFTER setting agent_llm_model in SM.
+    enabled: false
     # WITH /v1 (OpenCode posts to {baseURL}/chat/completions).
     baseUrl: http://core-gateway-internal.envoy-gateway-system.svc.cluster.local/v1
 


### PR DESCRIPTION
## Summary

Wires the Lightbridge agent runner into prod so the full pipeline runs end-to-end: GitHub webhook → index (pgvector + Neo4j) → OpenCode review → validated PR write-back. Chart `0.2.0 → 0.3.0`.

- **`agents-rbac.yaml`** (new): the `lightbridge-agents` namespace (isolated per-task execution), the Job's permission-less ServiceAccount (`lightbridge-agent`, token automount off — the runner only talks to the control plane over HTTP), the dispatcher's dedicated SA, and a least-privilege Role/RoleBinding granting it Job + pod read/CRUD in **that namespace only**.
- **dispatcher controller**: the control-plane image in `CONTROL_PLANE_ROLE=dispatcher` — consumes the Postgres work queue and launches one Job per task. Dedicated SA; `/metrics` on :9090; carries `AGENT_NAMESPACE` / `AGENT_SERVICE_ACCOUNT` / `AGENT_RUNNER_IMAGE` + `CONTROL_PLANE_INTERNAL_URL` + `AGENT_RUNNER_TOKEN`.
- **control-plane (serve)**: + `AGENT_RUNNER_TOKEN` so the `/internal/*` runner API is enabled (fails closed without it).
- **ExternalSecrets**: `-agent` (shared `runner-token`) + `lightbridge-agent-secrets` (embeddings + LLM config) reusing the eaig gateway key.

**Source of truth:** epic https://github.com/vymalo/lightbridge-code-intelligence/issues/5 (slices 1–6 merged) + paired app-repo PR https://github.com/vymalo/lightbridge-code-intelligence/pull/40 (injects `LLM_*` into the Job).

## ⚠️ Operator TODO before this works in prod

Add to Secrets Manager (`prod/codeintel/env`):

| Property | Value |
|---|---|
| `agent_runner_token` | a random 32+ char bearer (shared between serve, dispatcher, Jobs) |
| `agent_llm_model` | the eaig chat model for the reviewer — **omit → indexing only, review disabled** |

Also pin a prod **agent-runner image tag** — `agents.runnerImage` defaults to `:latest`.

## Verification

- [x] `helm template lightbridge-ci .` renders cleanly — only the dispatcher uses the dedicated SA (3 default + 1 `lightbridge-ci-dispatcher`); RBAC, both ExternalSecrets, the namespace, and the dispatcher env all present.
- [x] `helm lint .` → 0 failed.
- [ ] Applied to a live cluster (not yet — template/lint only)

```
$ helm template … | rg "serviceAccountName:" | sort | uniq -c
   3       serviceAccountName: default
   1       serviceAccountName: lightbridge-ci-dispatcher
```

## AI Usage Declaration

AI was used for:
* [x] Generating code
* [x] Drafting documentation
* [x] Reviewing the diff

Human verification:
* [x] I understand every meaningful change in this PR
* [x] I checked the rendered manifests (helm template) manually
* [x] I verified the SA wiring against the bjw-s app-template source
* [x] I accept responsibility for this PR