### PR TITLE
fix(lightbridge-db): declare pgvector extension on codeintel Database

### DIFF
--- a/charts/lightbridge-db/Chart.yaml
+++ b/charts/lightbridge-db/Chart.yaml
@@ -6,5 +6,5 @@ description: |
   of the lightbridge App-of-Apps orchestrator (ADR-0019). The usage DB is
   dropped (usage component removed).
 type: application
-version: 0.1.0
+version: 0.2.0
 appVersion: "1.0.0"

--- a/charts/lightbridge-db/values.yaml
+++ b/charts/lightbridge-db/values.yaml
@@ -204,10 +204,11 @@ resources:
   # managed `codeintel` role above, plus the role's basic-auth Secret
   # (username + password) consumed by BOTH CNPG (passwordSecret) and the
   # control plane. Mirrors the repoauth pattern (ADR-0047).
-  # NOTE(pgvector): semantic search needs the `vector` extension, which the
-  # current CNPG image does not ship — declare it on this Database once the
-  # cluster image bundles pgvector (see charts/lightbridge-code-intelligence).
-  # Double-escaped tpl braces leave `{{ .password }}` for ESO (CLAUDE.md trap).
+  # pgvector: semantic search (charts/lightbridge-code-intelligence migration 0004) needs the
+  # `vector` extension. The `codeintel` role is NOT a superuser, so its `CREATE EXTENSION` is
+  # permission-denied — CNPG creates it as superuser via the Database CRD's declarative
+  # `spec.extensions` (the image bundles pgvector). With it present, the migration's
+  # `CREATE EXTENSION IF NOT EXISTS vector` is a no-op.
   # ────────────────────────────────────────────────────────────────────
   - |
     apiVersion: postgresql.cnpg.io/v1
@@ -224,6 +225,9 @@ resources:
       name: codeintel
       owner: codeintel
       ensure: present
+      extensions:
+        - name: vector
+          ensure: present
   - |
     apiVersion: external-secrets.io/v1
     kind: ExternalSecret


### PR DESCRIPTION
## Summary

The v11 rollout (epic #5) surfaced a real bug: the control plane's migration `0004_code_chunks` runs `CREATE EXTENSION IF NOT EXISTS vector`, but the `codeintel` CNPG role is **not a superuser** → `permission denied to create extension "vector"` → control-plane **CrashLoopBackOff**.

Fix: CNPG creates the extension as superuser via the `codeintel` Database CRD's declarative `spec.extensions`. The `postgresql:18.4` image bundles pgvector (the error was *permission*, not *availability*), so this just needs CNPG to run the `CREATE EXTENSION` privileged. Once present, the app migration's `IF NOT EXISTS` is a no-op.

**Source of truth:** epic https://github.com/vymalo/lightbridge-code-intelligence/issues/5; migration `services/control-plane/migrations/0004_code_chunks.sql`.

## Verification

- [x] `helm template` renders the `extensions: [{name: vector, ensure: present}]` block on the codeintel Database.
- [x] `helm lint` → 0 failed.
- [ ] CNPG reconciles + control-plane recovers (pending release + repoint).

## AI Usage Declaration

AI was used for:
* [x] Understanding existing code
* [x] Generating code
* [x] Drafting documentation

Human verification:
* [x] I diagnosed the crashloop from the control-plane logs (permission denied to create extension)
* [x] I accept responsibility for this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)