### PR TITLE
fix(lightbridge-ci): FQDN for CONTROL_PLANE_INTERNAL_URL (cross-namespace)

### DIFF
--- a/charts/lightbridge-code-intelligence/Chart.yaml
+++ b/charts/lightbridge-code-intelligence/Chart.yaml
@@ -12,8 +12,8 @@ description: |
   matching the librechat-app pattern; ExternalSecrets are chart templates resolving
   against the ssegning-aws ClusterSecretStore; ingress is Traefik + cert-home-cert-http.
 type: application
-version: 0.3.0
-appVersion: "0.3.0"
+version: 0.3.1
+appVersion: "0.3.1"
 dependencies:
   - name: bjw-template
     version: "4.6.2"

--- a/charts/lightbridge-code-intelligence/values.yaml
+++ b/charts/lightbridge-code-intelligence/values.yaml
@@ -375,7 +375,10 @@ lci:
             AGENT_NAMESPACE: "lightbridge-agents"
             AGENT_SERVICE_ACCOUNT: "lightbridge-agent"
             AGENT_RUNNER_IMAGE: "ghcr.io/vymalo/lightbridge-agent-runner:latest"
-            CONTROL_PLANE_INTERNAL_URL: "http://{{ .Release.Name }}-control-plane:8080"
+            # FQDN, not the bare Service name: the runner Jobs run in the lightbridge-agents
+            # namespace, so a same-namespace short name would not resolve to the control-plane
+            # Service in `converse`.
+            CONTROL_PLANE_INTERNAL_URL: "http://{{ .Release.Name }}-control-plane.{{ .Release.Namespace }}.svc.cluster.local:8080"
           probes:
             liveness:
               enabled: true


### PR DESCRIPTION
## Summary

First real dispatch (v12) surfaced this: every agent Job failed with `requesting task context`. The runner Jobs run in the `lightbridge-agents` namespace but call back to the control-plane Service in `converse`; the bare `lightbridge-ci-control-plane:8080` only resolves same-namespace → DNS failure (not auth). Fixed to the FQDN `…-control-plane.{{ .Release.Namespace }}.svc.cluster.local:8080`.

**Source of truth:** epic https://github.com/vymalo/lightbridge-code-intelligence/issues/5; ADR-0017 (runner ↔ control-plane callback).

## Verification

- [x] `helm template` renders `http://lightbridge-ci-control-plane.converse.svc.cluster.local:8080`.
- [x] `helm lint` → 0 failed.
- [ ] Agent Jobs reach the control plane (pending release + repoint).

## AI Usage Declaration

AI was used for:
* [x] Generating code
* [x] Drafting documentation

Human verification:
* [x] I diagnosed it from the runner logs (DNS / cross-namespace, not auth)
* [x] I accept responsibility for this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)