### PR TITLE
feat(lightbridge-ci): qwen3 embeddings over HTTPS gateway + internal CA

### DIFF
--- a/charts/apps/values.yaml
+++ b/charts/apps/values.yaml
@@ -1070,7 +1070,7 @@ applications:
       # ServerSideDiff ignores those server-owned fields so the app reads Synced.
       argocd.argoproj.io/compare-options: ServerSideDiff=true
       # Two images in one app, aliased `cp` (control-plane) + `web`.
-      argocd-image-updater.argoproj.io/image-list: cp=ghcr.io/vymalo/lightbridge-control-plane,web=ghcr.io/vymalo/lightbridge-web
+      argocd-image-updater.argoproj.io/image-list: cp=ghcr.io/vymalo/lightbridge-control-plane,disp=ghcr.io/vymalo/lightbridge-control-plane,web=ghcr.io/vymalo/lightbridge-web
       # ── control-plane ──
       argocd-image-updater.argoproj.io/cp.update-strategy: newest-build
       argocd-image-updater.argoproj.io/cp.allow-tags: regexp:^sha-[0-9a-f]+$
@@ -1080,6 +1080,16 @@ applications:
       argocd-image-updater.argoproj.io/cp.signature-type: cosign
       argocd-image-updater.argoproj.io/cp.cosign.certificate-oidc-issuer: https://token.actions.githubusercontent.com
       argocd-image-updater.argoproj.io/cp.cosign.certificate-identity-regexp: ^https://github\.com/vymalo/lightbridge-code-intelligence/\.github/workflows/build-images\.yml@.*$
+      # ── dispatcher (SAME image as control-plane, role-selected) — keeps its tag in lockstep so it
+      #    never lags the control-plane on a build (it's not a pod image-updater would otherwise see). ──
+      argocd-image-updater.argoproj.io/disp.update-strategy: newest-build
+      argocd-image-updater.argoproj.io/disp.allow-tags: regexp:^sha-[0-9a-f]+$
+      argocd-image-updater.argoproj.io/disp.force-update: "true"
+      argocd-image-updater.argoproj.io/disp.helm.image-name: lci.controllers.dispatcher.containers.main.image.repository
+      argocd-image-updater.argoproj.io/disp.helm.image-tag: lci.controllers.dispatcher.containers.main.image.tag
+      argocd-image-updater.argoproj.io/disp.signature-type: cosign
+      argocd-image-updater.argoproj.io/disp.cosign.certificate-oidc-issuer: https://token.actions.githubusercontent.com
+      argocd-image-updater.argoproj.io/disp.cosign.certificate-identity-regexp: ^https://github\.com/vymalo/lightbridge-code-intelligence/\.github/workflows/build-images\.yml@.*$
       # ── web ──
       argocd-image-updater.argoproj.io/web.update-strategy: newest-build
       argocd-image-updater.argoproj.io/web.allow-tags: regexp:^sha-[0-9a-f]+$

--- a/charts/lightbridge-code-intelligence/Chart.yaml
+++ b/charts/lightbridge-code-intelligence/Chart.yaml
@@ -12,8 +12,8 @@ description: |
   matching the librechat-app pattern; ExternalSecrets are chart templates resolving
   against the ssegning-aws ClusterSecretStore; ingress is Traefik + cert-home-cert-http.
 type: application
-version: 0.3.2
-appVersion: "0.3.2"
+version: 0.3.3
+appVersion: "0.3.3"
 dependencies:
   - name: bjw-template
     version: "4.6.2"

--- a/charts/lightbridge-code-intelligence/templates/agents-rbac.yaml
+++ b/charts/lightbridge-code-intelligence/templates/agents-rbac.yaml
@@ -14,6 +14,33 @@ metadata:
   labels:
     app.kubernetes.io/part-of: lightbridge-platform
     app.kubernetes.io/managed-by: {{ .Release.Name }}
+{{- if .Values.agents.caSecret }}
+---
+# A throwaway leaf cert from the internal CA issuer — we only want its `ca.crt` (the self-signed-ca
+# root), which the runner mounts to trust the eaig gateway's HTTPS endpoint (same CA LibreChat uses).
+# Issued into the agents namespace so the Job can mount it without cross-namespace copying.
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ .Values.agents.caSecret }}
+  namespace: {{ $ns }}
+  annotations:
+    argocd.argoproj.io/sync-wave: {{ $wave }}
+spec:
+  secretName: {{ .Values.agents.caSecret }}
+  commonName: {{ .Values.agents.caSecret }}
+  dnsNames:
+    - {{ .Values.agents.caSecret }}
+  duration: 8760h
+  renewBefore: 720h
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: self-signed-ca
+    kind: ClusterIssuer
+    group: cert-manager.io
+{{- end }}
 ---
 # Identity the agent Job pods run as. It needs NO cluster permissions — the runner only talks to the
 # control plane over HTTP (bearer-authenticated), never to the Kubernetes API (trust boundary).

--- a/charts/lightbridge-code-intelligence/values.yaml
+++ b/charts/lightbridge-code-intelligence/values.yaml
@@ -48,20 +48,22 @@ agents:
   # The runner image the dispatcher launches per task. Pinned tag; bump on release (not
   # image-updater-managed — it isn't a pod in this chart, it's an env value the dispatcher reads).
   runnerImage: ghcr.io/vymalo/lightbridge-agent-runner:latest
-  # Use the HTTP LoadBalancer gateway Service (matches LibreChat's RAG_OPENAI_BASEURL) — the
-  # `core-gateway-internal` ClusterIP is HTTPS-only (443) and needs the internal CA, which the runner
-  # doesn't mount. This plain-HTTP gateway is the known-working in-cluster path.
+  # The gateway only serves embeddings/chat on the HTTPS `core-gateway-internal` ClusterIP (the HTTP
+  # LoadBalancer 308-redirects / 404s by Host). Its cert is from ClusterIssuer/self-signed-ca, so the
+  # runner mounts that CA (caSecret below) and trusts it — see k8s.rs AGENT_CA_SECRET + embeddings.rs.
+  caSecret: lightbridge-agent-ca
   embeddings:
-    # No trailing /v1 (the runner appends /v1/embeddings).
-    baseUrl: http://envoy-converse-gateway-core-gateway-c480b207.envoy-gateway-system.svc.cluster.local
-    model: text-embedding-3-small
+    # No trailing /v1 (the runner appends /v1/embeddings). The gateway serves qwen3-embedding-8b
+    # (4096-dim, matched by migration 0005); it does NOT serve text-embedding-3-small.
+    baseUrl: https://core-gateway-internal.envoy-gateway-system.svc.cluster.local
+    model: qwen3-embedding-8b
   llm:
     # OpenCode review (slice 5). OFF by default so the first rollout is indexing-only and does not
     # depend on `agent_llm_model` existing in SM (a missing SM property fails the whole ExternalSecret,
     # which would take embeddings down with it). Flip to true AFTER setting agent_llm_model in SM.
     enabled: false
     # WITH /v1 (OpenCode posts to {baseURL}/chat/completions).
-    baseUrl: http://envoy-converse-gateway-core-gateway-c480b207.envoy-gateway-system.svc.cluster.local/v1
+    baseUrl: https://core-gateway-internal.envoy-gateway-system.svc.cluster.local/v1
 
 syncWave:
   secrets: "0"
@@ -378,6 +380,8 @@ lci:
             AGENT_NAMESPACE: "lightbridge-agents"
             AGENT_SERVICE_ACCOUNT: "lightbridge-agent"
             AGENT_RUNNER_IMAGE: "ghcr.io/vymalo/lightbridge-agent-runner:latest"
+            # Secret (agents ns) whose ca.crt the runner mounts to trust the HTTPS gateway.
+            AGENT_CA_SECRET: "lightbridge-agent-ca"
             # FQDN, not the bare Service name: the runner Jobs run in the lightbridge-agents
             # namespace, so a same-namespace short name would not resolve to the control-plane
             # Service in `converse`.


### PR DESCRIPTION
## Summary

Wire the agent indexer to the embedding model the eaig gateway actually serves. The gateway exposes **qwen3-embedding-8b (4096-dim)** on the **HTTPS** `core-gateway-internal` ClusterIP only (the HTTP LB 308-redirects/404s; text-embedding-3-small isn't configured there). 

- `agents.embeddings`: model `qwen3-embedding-8b`, baseUrl the HTTPS gateway.
- A cert-manager **Certificate** from `ClusterIssuer/self-signed-ca` in the agents namespace → its `ca.crt` is the gateway's trust anchor (same CA LibreChat uses). The dispatcher passes `AGENT_CA_SECRET` so the runner mounts it and trusts the gateway (k8s.rs + embeddings.rs in the paired app PR).

**Source of truth:** epic https://github.com/vymalo/lightbridge-code-intelligence/issues/5 + paired app PR https://github.com/vymalo/lightbridge-code-intelligence/pull/42 (migration 0005 → vector(4096) + CA trust). Verified the gateway behaviour live (qwen3 200 / text-embedding-3-small 404).

## Verification

- [x] `helm template` renders the Certificate (issuer self-signed-ca), `AGENT_CA_SECRET`, qwen3 model + HTTPS baseUrl.
- [x] `helm lint` → 0 failed.
- [ ] Live indexing run (after both PRs + release/repoint).

## AI Usage Declaration

AI was used for:
* [x] Generating code
* [x] Drafting documentation

Human verification:
* [x] I verified the gateway model/endpoint + the self-signed-ca CA chain live
* [x] I accept responsibility for this PR