### PR TITLE
feat(lightbridge-ci): enable OpenCode review (adorsys-reviewer-pro)

### DIFF
--- a/charts/lightbridge-code-intelligence/Chart.yaml
+++ b/charts/lightbridge-code-intelligence/Chart.yaml
@@ -12,8 +12,8 @@ description: |
   matching the librechat-app pattern; ExternalSecrets are chart templates resolving
   against the ssegning-aws ClusterSecretStore; ingress is Traefik + cert-home-cert-http.
 type: application
-version: 0.3.3
-appVersion: "0.3.3"
+version: 0.4.0
+appVersion: "0.4.0"
 dependencies:
   - name: bjw-template
     version: "4.6.2"

--- a/charts/lightbridge-code-intelligence/templates/externalsecret.yaml
+++ b/charts/lightbridge-code-intelligence/templates/externalsecret.yaml
@@ -140,20 +140,15 @@ spec:
         embeddings-api-key: "{{ `{{ .openaiKey }}` }}"
 {{- if .Values.agents.llm.enabled }}
         # OpenCode's @ai-sdk/openai-compatible posts to `{baseURL}/chat/completions`, so DO include
-        # /v1 (ADR-0021). Only present when review is enabled.
+        # /v1 (ADR-0021). Only present when review is enabled. Model + base URL are chart literals;
+        # the key reuses the gateway key (no SM property for the model).
         llm-base-url: {{ .Values.agents.llm.baseUrl | quote }}
         llm-api-key: "{{ `{{ .openaiKey }}` }}"
-        llm-model: "{{ `{{ .llmModel }}` }}"
+        llm-model: {{ .Values.agents.llm.model | quote }}
 {{- end }}
   data:
     - secretKey: openaiKey
       remoteRef:
         key: {{ $key }}
         property: {{ .Values.secrets.openaiKeyProperty }}
-{{- if .Values.agents.llm.enabled }}
-    - secretKey: llmModel
-      remoteRef:
-        key: {{ $codeintelKey }}
-        property: {{ .Values.secrets.agentLlmModelProperty }}
-{{- end }}
 {{- end }}

--- a/charts/lightbridge-code-intelligence/values.yaml
+++ b/charts/lightbridge-code-intelligence/values.yaml
@@ -33,11 +33,11 @@ secrets:
   # model live in the dedicated prod/codeintel/env SM secret; the embeddings/LLM API key reuses the
   # shared eaig gateway key in ai/camer/digital/prod/env.
   #
-  # OPERATOR TODO before agents work in prod — add to Secrets Manager:
-  #   prod/codeintel/env:  agent_runner_token  = <random 32+ char bearer>
-  #   prod/codeintel/env:  agent_llm_model     = <eaig chat model, e.g. qwen3-...>  (omit → review off)
+  # OPERATOR TODO (one-time): in Secrets Manager prod/codeintel/env set
+  #   agent_runner_token = <random 32+ char bearer>   (done — agents are live)
+  # The review chat model is NOT here — it's a plain chart literal (agents.llm.model); the LLM API
+  # key reuses the shared eaig gateway key (converse_openai_api_key in ai/camer/digital/prod/env).
   agentRunnerTokenProperty: agent_runner_token
-  agentLlmModelProperty: agent_llm_model
   openaiKeyProperty: converse_openai_api_key
 
 # ── Agent execution (epic #5): per-task Jobs in an isolated namespace ─────────
@@ -58,12 +58,13 @@ agents:
     baseUrl: https://core-gateway-internal.envoy-gateway-system.svc.cluster.local
     model: qwen3-embedding-8b
   llm:
-    # OpenCode review (slice 5). OFF by default so the first rollout is indexing-only and does not
-    # depend on `agent_llm_model` existing in SM (a missing SM property fails the whole ExternalSecret,
-    # which would take embeddings down with it). Flip to true AFTER setting agent_llm_model in SM.
-    enabled: false
+    # OpenCode review (slice 5). ON — the agent posts automated PR reviews (ticket #48).
+    enabled: true
     # WITH /v1 (OpenCode posts to {baseURL}/chat/completions).
     baseUrl: https://core-gateway-internal.envoy-gateway-system.svc.cluster.local/v1
+    # The eaig chat model the reviewer uses. A plain literal (not a secret) — change it here, no SM.
+    # The gateway serves a purpose-named `adorsys-reviewer`/`-pro`.
+    model: adorsys-reviewer-pro
 
 syncWave:
   secrets: "0"


### PR DESCRIPTION
## Summary

Turns on the OpenCode PR-review pipeline (slice 5/6, built+deployed but gated):
- `agents.llm.enabled: true`
- `agents.llm.model: adorsys-reviewer-pro` — the eaig gateway's purpose-named reviewer model, as a **plain chart literal** (not a secret). Dropped the `agent_llm_model` SM pull; the agent-secrets ExternalSecret now templates `llm-model` from the chart and reuses the gateway key for `llm-api-key`.

The dispatcher already injects `LLM_*` into Jobs (vymalo#40) and the internal-CA trust for OpenCode is wired (`NODE_EXTRA_CA_CERTS`, vymalo#45), so the runner spawns OpenCode against the HTTPS eaig gateway and posts a validated PR review.

**Source of truth:** vymalo/lightbridge-code-intelligence#48 (enable review), epic #5, ADR-0021/0022.

## Verification

- [x] `helm template` → agent-secrets carries `llm-model: "adorsys-reviewer-pro"` + `llm-base-url`, no `llmModel` SM pull.
- [x] `helm lint` → 0 failed.
- [ ] Live: a test PR gets an OpenCode review comment (validating after release/repoint; will also confirm OpenCode's `@ai-sdk/openai-compatible` npm fetch has egress).

## AI Usage Declaration

AI was used for:
* [x] Generating code
* [x] Drafting documentation

Human verification:
* [x] I picked the model (adorsys-reviewer-pro) from the gateway's live catalog
* [x] I accept responsibility for this PR