### PR TITLE
docs(cd): drop the make-package-public prereq — ArgoCD reads private OCI (#448)

### DIFF
--- a/docs/continuous-delivery.md
+++ b/docs/continuous-delivery.md
@@ -38,11 +38,14 @@ which supersedes the tag-based release model ([ADR-0031](./adr/0031-tag-based-de
 
 1. **Create the private repo `adorsys-gis/ai-helm-values`.** Seed it from this repo's
    `environments/` tree (copy `base/` + `prod/`), then add per-app value files (Phase B).
-2. **Make the OCI charts package public.** First `helm push` creates
-   `ghcr.io/adorsys-gis/charts` as **private**; flip it to public in the GHCR package
-   settings (`gh api -X PATCH /orgs/adorsys-gis/packages/container/charts/visibility ...`
-   or the UI). Charts carry no secrets (ESO injects at sync) → public means ArgoCD needs
-   **no** credential to pull charts.
+2. **OCI charts package visibility — NOT a required step.** Chart *pulls* need no
+   special handling: this org defaults new GHCR packages to **public** (verified — the
+   first `publish_all` run pushed 27/27 charts and `charts/core-gateway` came out
+   `visibility=public`, anonymous `helm show chart` works), **and** even a private
+   package is fine — ArgoCD on this cluster already pulls private GHCR/OCI packages with
+   its existing registry creds (the `vymalo` / `vaam-store` Apps prove it). So there is
+   no public-flip prerequisite and no new chart-pull credential. (Charts carry no secrets
+   regardless — ESO injects at sync.)
 3. **Two credentials for the PRIVATE values repo** (provisioned via ESO, like every other
    secret here — see CLAUDE.md "Where the cluster's actual state lives"):
    - **Write** — a GitHub App with `contents:write` on `adorsys-gis/ai-helm-values`,
@@ -58,10 +61,14 @@ which supersedes the tag-based release model ([ADR-0031](./adr/0031-tag-based-de
 
 Do these in order; each is safe because nothing references the new pieces until the flip.
 
-**Phase A — publish.** Merge this branch to `main`. Confirm the OCI workflow publishes:
+**Phase A — publish.** ✅ Done — the machinery merged (PR #447) and the first
+`publish_all` run pushed 27/27 charts. Confirm any time:
 `helm show chart oci://ghcr.io/adorsys-gis/charts/<chart> --version <v>` resolves, and the
 pulled `.tgz` contains the vendored subcharts (`charts/common*.tgz`, `charts/bjw-template*.tgz`).
-Make the package public (Prereq 2).
+No package-visibility step is needed (Prereq 2). ⚠️ Note: a brand-new workflow does
+not run on the push that introduces it — the first publish was a manual
+`workflow_dispatch` with `publish_all: true`; subsequent `charts/**` merges publish
+the changed charts automatically.
 
 **Phase B — seed values.** For each app you will migrate, create
 `environments/<env>/values/<app>.yaml` in `ai-helm-values` with **just the image-tag field**


### PR DESCRIPTION
## 1. Summary

This PR changes:

- `docs/continuous-delivery.md`: drops the "make the OCI charts package public" cutover prereq and the "public so ArgoCD needs no credential" framing.
- Records that ArgoCD on this cluster already pulls **private** GHCR/OCI packages via its existing registry creds (the `vymalo` / `vaam-store` Apps), so package visibility is never load-bearing — and the org defaults packages to public anyway.
- Marks Phase A (publish) done and documents the "a new workflow doesn't run on the push that introduces it" gotcha (first publish was a manual `workflow_dispatch publish_all`).

It solves:

- Ticket #448 (continuous-delivery cutover — remaining steps), Epic #445. Follows merged PR #447.

---

## 2. Intent

The intent of this PR is:

> Correct an operational overstatement in the runbook surfaced during the first live publish: the maintainer pointed out ArgoCD already reads private packages (vymalo/vaam pattern), so gating the cutover on package visibility / a chart-pull credential is wrong. This keeps the cutover runbook accurate before apps are flipped.

---

## 3. Scope

### In Scope

- Documentation correction only (`docs/continuous-delivery.md`).

### Out of Scope

- Any chart/template change; flipping apps to OCI mode; creating `ai-helm-values`; provisioning creds (tracked in #448).

---

## 4. Verification

I verified this change by:

- [x] Running manual tests
- [ ] Running automated tests
- [ ] Checking logs
- [ ] Checking metrics
- [ ] Testing error cases
- [ ] Testing permissions/security behavior
- [ ] Testing rollback or failure behavior, if relevant

Commands run:

```bash
# Evidence the correction is grounded (from the first publish_all run #27966880301):
gh api orgs/adorsys-gis/packages/container/charts%2Fcore-gateway -q .visibility   # -> public
helm registry logout ghcr.io; helm show chart oci://ghcr.io/adorsys-gis/charts/core-gateway --version 0.1.131  # anonymous -> resolves
```

Results:

```text
visibility=public ; anonymous helm show chart resolved (name/type/version)
27/27 charts pushed in the first publish_all run
```

---

## 5. Screenshots / Evidence

- First publish run: https://github.com/ADORSYS-GIS/ai-helm/actions/runs/27966880301
- Doc-only change; no runtime effect.

---

## 6. Risk Assessment

Risk level:

* [x] Low
* [ ] Medium
* [ ] High

Potential risks:

* None — documentation only.

Mitigation:

* N/A.

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [ ] Generating code
* [ ] Refactoring
* [ ] Generating tests
* [x] Drafting documentation
* [x] Reviewing the diff
* [ ] Not used

Human verification:

* [x] I understand every meaningful change in this PR
* [ ] I checked generated code manually
* [ ] I checked generated tests manually
* [ ] I removed unsupported AI assumptions
* [x] I accept responsibility for this PR

> _Human-verification boxes left for the accountable owner (@stephane-segning) — not ticked by the agent that authored the change._

---

## 8. Reviewer Focus

Please focus your review on:

* [ ] Correctness
* [ ] Architecture
* [ ] Security
* [ ] Performance
* [ ] Tests
* [x] Maintainability
* [x] Product intent
* [ ] Edge cases
