### PR TITLE
feat(apps): converse-ui CD pilot — image write-back to ai-helm-values (#448)

### DIFF
--- a/charts/apps/values.yaml
+++ b/charts/apps/values.yaml
@@ -1183,41 +1183,68 @@ applications:
     destination:
       namespace: argocd
 
-  # --- Converse UI ---
+  # --- Converse UI --- (ADR-0055 continuous-delivery pilot: image write-back)
+  # Multi-source (the lightbridge pattern, writing to ai-helm-values):
+  #   Source A — the external converse-frontends chart (unchanged pin).
+  #   Source B — a $values ref to ai-helm-values, where argocd-image-updater commits
+  #     the newest sha-<gitsha> build. Strategy: newest-build + allow-tags ^sha-…,
+  #     UNSIGNED (converse-frontends images are not cosign-signed — no .sig tags).
+  # The image block lives in the $values file (NOT inline) so write-back owns it —
+  # an inline tag in valuesObject would override the $values file and fight the
+  # writer. Activation CR: charts/imageupdater (imageUpdaters[]). Seed file:
+  # ai-helm-values:/environments/prod/values/converse-ui.yaml.
   - name: converse-ui
     finalizers:
       - resources-finalizer.argocd.argoproj.io
-    source:
-      repoURL: https://github.com/ADORSYS-GIS/converse-frontends
-      # Pinned to a commit for a reproducible release (was HEAD). External repo —
-      # bump this SHA deliberately when you want a newer converse-ui, then re-release.
-      targetRevision: 500dba11e91d1385135802db5898c961debfe6e2
-      path: charts/converse-frontend
-      helm:
-        releaseName: converse-ui
-        valuesObject:
-          conversefrontend:
-            controllers:
-              main:
-                podDisruptionBudget:
-                  # User-facing frontend: PDB ensures uptime during automated node maintenance.
-                  maxUnavailable: 1
-                containers:
-                  frontend:
-                    image:
-                      repository: ghcr.io/adorsys-gis/converse-frontends
-                      tag: sha-500dba1
-                      pullPolicy: IfNotPresent
-                    env:
-                      EXPO_PUBLIC_BACKEND_URL: "https://self-service.ai.camer.digital"
-                      EXPO_PUBLIC_USAGE_URL: "https://self-service.ai.camer.digital"
-                      EXPO_PUBLIC_ANALYTICS_URL: "https://analytics.ai.camer.digital"
-                      EXPO_PUBLIC_KEYCLOAK_ISSUER: "https://auth.verif.fyi/realms/camer-digital"
-                      EXPO_PUBLIC_KEYCLOAK_CLIENT_ID: "converse-frontend"
-                      EXPO_PUBLIC_KEYCLOAK_SCHEME: "self-service"
-                      # JWT Audience validation - ensures tokens are intended for this API
-                      EXPO_PUBLIC_KEYCLOAK_EXPECTED_AUDIENCE: "converse-frontend"
-                      EXPO_PUBLIC_KEYCLOAK_AUDIENCE_REQUIRED: "true"
+    additionalAnnotations:
+      argocd-image-updater.argoproj.io/image-list: frontend=ghcr.io/adorsys-gis/converse-frontends
+      argocd-image-updater.argoproj.io/frontend.update-strategy: newest-build
+      argocd-image-updater.argoproj.io/frontend.allow-tags: regexp:^sha-[0-9a-f]+$
+      argocd-image-updater.argoproj.io/frontend.force-update: "true"
+      argocd-image-updater.argoproj.io/frontend.helm.image-name: conversefrontend.controllers.main.containers.frontend.image.repository
+      argocd-image-updater.argoproj.io/frontend.helm.image-tag: conversefrontend.controllers.main.containers.frontend.image.tag
+      argocd-image-updater.argoproj.io/write-back-method: git
+      argocd-image-updater.argoproj.io/git-repository: https://github.com/adorsys-gis/ai-helm-values.git
+      argocd-image-updater.argoproj.io/git-branch: main
+      argocd-image-updater.argoproj.io/write-back-target: helmvalues:/environments/prod/values/converse-ui.yaml
+      argocd-image-updater.argoproj.io/git-credentials: secret:argocd/github-app-creds--adorsys-gis
+    sources:
+      # Source A — the external converse-frontends chart (unchanged pin).
+      - repoURL: https://github.com/ADORSYS-GIS/converse-frontends
+        # Pinned to a commit for a reproducible release (was HEAD). External repo —
+        # bump this SHA deliberately when you want a newer converse-ui, then re-release.
+        targetRevision: 500dba11e91d1385135802db5898c961debfe6e2
+        path: charts/converse-frontend
+        helm:
+          releaseName: converse-ui
+          # image.{repository,tag,pullPolicy} come from Source B's $values file
+          # (image-updater owns them). Keep static config (PDB, env) inline below.
+          valueFiles:
+            - $values/environments/prod/values/converse-ui.yaml
+          ignoreMissingValueFiles: true
+          valuesObject:
+            conversefrontend:
+              controllers:
+                main:
+                  podDisruptionBudget:
+                    # User-facing frontend: PDB ensures uptime during automated node maintenance.
+                    maxUnavailable: 1
+                  containers:
+                    frontend:
+                      env:
+                        EXPO_PUBLIC_BACKEND_URL: "https://self-service.ai.camer.digital"
+                        EXPO_PUBLIC_USAGE_URL: "https://self-service.ai.camer.digital"
+                        EXPO_PUBLIC_ANALYTICS_URL: "https://analytics.ai.camer.digital"
+                        EXPO_PUBLIC_KEYCLOAK_ISSUER: "https://auth.verif.fyi/realms/camer-digital"
+                        EXPO_PUBLIC_KEYCLOAK_CLIENT_ID: "converse-frontend"
+                        EXPO_PUBLIC_KEYCLOAK_SCHEME: "self-service"
+                        # JWT Audience validation - ensures tokens are intended for this API
+                        EXPO_PUBLIC_KEYCLOAK_EXPECTED_AUDIENCE: "converse-frontend"
+                        EXPO_PUBLIC_KEYCLOAK_AUDIENCE_REQUIRED: "true"
+      # Source B — image tag from ai-helm-values; image-updater commits here.
+      - repoURL: https://github.com/adorsys-gis/ai-helm-values
+        targetRevision: main
+        ref: values
     destination:
       namespace: converse
 

--- a/charts/imageupdater/values.yaml
+++ b/charts/imageupdater/values.yaml
@@ -20,3 +20,10 @@ imageUpdaters:
       # is an exact match.
       - namePattern: aii-lightbridge-code-intelligence
         useAnnotations: true
+  # ADR-0055 continuous-delivery pilot — converse-ui image write-back to
+  # ai-helm-values (newest-build, unsigned). Annotations live on the
+  # aii-converse-ui Application (charts/apps/values.yaml).
+  - name: converse-ui
+    applicationRefs:
+      - namePattern: aii-converse-ui
+        useAnnotations: true


### PR DESCRIPTION
## 1. Summary

This PR changes:

- `charts/apps` **converse-ui**: single `source` → multi-source. Source A = the external `converse-frontends` chart (pin unchanged) + a `$values` valueFiles ref + `ignoreMissingValueFiles`; Source B = `ref: values` → the private `ai-helm-values` repo. The image block is **moved out of the inline `valuesObject`** into the `$values` file so write-back owns it; static config (PDB, env) stays inline.
- argocd-image-updater write-back annotations on the entry: `frontend=ghcr.io/adorsys-gis/converse-frontends`, `newest-build`, `allow-tags: ^sha-[0-9a-f]+$`, **unsigned** (converse images carry no cosign `.sig`), write-back `git` → `ai-helm-values:/environments/prod/values/converse-ui.yaml`, creds = the org-wide `github-app-creds--adorsys-gis`.
- `charts/imageupdater`: activate `aii-converse-ui` (`imageUpdaters[]`).
- Seed (committed to `ai-helm-values`): `environments/prod/values/converse-ui.yaml` at `sha-500dba1`.

It solves:

- The first per-app cutover under ADR-0055 — ticket #448, Epic #445. Validates the **image write-back loop** into the new `ai-helm-values` repo (the highest-risk new piece). `converse-ui`'s chart is external, so this does **not** exercise OCI chart float (tracked separately under #448).

---

## 2. Intent

> Prove end-to-end that argocd-image-updater can commit a new image tag into the private `ai-helm-values` repo (via the org-wide `argocd-ssegning` cred) and ArgoCD picks it up — on a single, low-blast-radius app. converse-ui already has newer `sha-` builds in GHCR than the seeded `sha-500dba1`, so the first poll should produce a real write-back commit.

---

## 3. Scope

### In Scope
- converse-ui only: multi-source + write-back wiring, its activation CR, its seed file.

### Out of Scope
- OCI chart float (converse-ui's chart is external); other apps; orchestrators; retiring `release.sh`.

---

## 4. Verification

I verified this change by:

- [x] Running automated tests
- [x] Running manual tests
- [ ] Testing rollback or failure behavior, if relevant

Commands run:

```bash
helm lint charts/apps charts/imageupdater          # 0 failed
helm template x charts/apps                         # aii-converse-ui renders
```

Results:

```text
2 chart(s) linted, 0 chart(s) failed
aii-converse-ui: 2 sources (external chart + ref: values → ai-helm-values),
  image block absent from inline values (now in $values), write-back annotations
  present (image-list / write-back-target environments/prod/values/converse-ui.yaml /
  git-credentials github-app-creds--adorsys-gis); valueFiles path matches write-back-target.
imageupdater: ImageUpdater CR for converse-ui (namePattern aii-converse-ui) renders.
ai-helm-values: environments/prod/values/converse-ui.yaml seeded at sha-500dba1.
```

---

## 5. Screenshots / Evidence

- Seed file: https://github.com/ADORSYS-GIS/ai-helm-values/blob/main/environments/prod/values/converse-ui.yaml
- Newer builds exist (e.g. `sha-cdc3b77`) → first image-updater poll should write back.

### Going-live note (post-merge, maintainer)
This is **inert until the root resolves a commit carrying it** — the live root `ai-apps-v2` still pins `release-2026.06.21-v03` in home-os. To validate live: get this onto the root's revision (cut/point a release that includes it), then confirm `aii-converse-ui` is `Synced`/`Healthy` and watch for the image-updater write-back commit in `ai-helm-values`.

---

## 6. Risk Assessment

Risk level:

* [x] Low
* [ ] Medium
* [ ] High

Potential risks:

* Write-back lands an unsigned first-party tag (no cosign for converse images) — bounded by `allow-tags: ^sha-[0-9a-f]+$` (our CI's tag scheme) on a single non-critical frontend.
* If the `$values` file path / annotations mismatched, the app would render with chart-default image — mitigated by matching the valueFiles path to the write-back-target (verified).

Mitigation:

* Single-app scope; inert until released; rollback = `git revert` in `ai-helm-values` (or revert this PR).

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [x] Drafting documentation
* [x] Reviewing the diff

Human verification:

* [ ] I understand every meaningful change in this PR
* [ ] I checked generated code manually
* [ ] I accept responsibility for this PR

> _Human-verification boxes left for the accountable owner (@stephane-segning)._

---

## 8. Reviewer Focus

* [x] Correctness
* [x] Architecture
* [x] Product intent
