### PR TITLE
feat(apps): mongodb-backup OCI-chart-float pilot (#448)

### DIFF
--- a/charts/apps/values.yaml
+++ b/charts/apps/values.yaml
@@ -1276,26 +1276,29 @@ applications:
   - name: mongodb-backup
     finalizers:
       - resources-finalizer.argocd.argoproj.io
-    source:
-      repoURL: https://github.com/ADORSYS-GIS/ai-helm
-      targetRevision: release-2026.06.22
-      path: charts/mongodb-backup
-      helm:
-        releaseName: mongodb-backup
-        valuesObject:
-          mongodb-backup:
-            s3:
-              secretName: librechat-s3-config
-            controllers:
-              main:
-                cronjob:
-                  successfulJobsHistory: 3
-                  failedJobsHistory: 3
-                  startingDeadlineSeconds: 30
-                initContainers:
-                  exporter:
-                    env:
-                      MONGODB_URI: mongodb://librechat-db-0.librechat-db-headless:27017, #librechat-db-1.librechat-db-headless:27017/?replicaSet=rs0
+    # ADR-0055 OCI-chart-float pilot. Consume charts/mongodb-backup from the OCI
+    # registry on a floating semver range (Source A = argocd.chartRegistry @
+    # chartVersionRange), with per-env values from ai-helm-values via $values
+    # (Source B). No image write-back here (the backup image is static) — this
+    # validates the `chart:` OCI path that converse-ui's external chart couldn't.
+    # Once live, a merge that republishes charts/mongodb-backup auto-floats this
+    # app to the new version on the next reconcile (no release/repoint needed).
+    chart: mongodb-backup
+    releaseName: mongodb-backup
+    valuesObject:
+      mongodb-backup:
+        s3:
+          secretName: librechat-s3-config
+        controllers:
+          main:
+            cronjob:
+              successfulJobsHistory: 3
+              failedJobsHistory: 3
+              startingDeadlineSeconds: 30
+            initContainers:
+              exporter:
+                env:
+                  MONGODB_URI: mongodb://librechat-db-0.librechat-db-headless:27017, #librechat-db-1.librechat-db-headless:27017/?replicaSet=rs0
     destination:
       namespace: converse-chat
 


### PR DESCRIPTION
## 1. Summary

This PR changes:

- `charts/apps` **mongodb-backup**: flip from a path-based, tag-pinned `source` to **OCI mode** by setting `chart: mongodb-backup`. The template then emits Source A = `oci://ghcr.io/adorsys-gis/charts/mongodb-backup` on a **floating semver range** (`>=0.0.0`; resolves to the published `0.1.3` today) + Source B = `ref: values` → the private `ai-helm-values` repo. `valuesObject` + `releaseName` preserved; per-env values via `$values/environments/prod/values/mongodb-backup.yaml` (`ignoreMissingValueFiles` → chart defaults until seeded).

It solves:

- Validates the **OCI chart-float** half of ADR-0055 — the `chart:` path the converse-ui pilot (#451) couldn't exercise (its chart is external). Ticket #448, Epic #445.

---

## 2. Intent

> Prove that an ai-helm chart published to OCI can be consumed by a child Application on a floating semver range, with values from the values repo — and that republishing the chart auto-floats the app to the new version (no release/repoint). mongodb-backup is the lowest-blast-radius candidate (an isolated backup CronJob, non-user-facing). No image write-back here — the backup image is static, so this isolates the chart-float mechanism.

---

## 3. Scope

### In Scope
- mongodb-backup only: source → `chart:` OCI mode (Source A OCI + Source B `$values`).

### Out of Scope
- Image write-back (none for this app); other apps; orchestrators; retiring `release.sh`.

---

## 4. Verification

I verified this change by:

- [x] Running automated tests
- [x] Running manual tests

Commands run:

```bash
helm show chart oci://ghcr.io/adorsys-gis/charts/mongodb-backup   # name mongodb-backup, version 0.1.3
helm lint charts/apps                                              # 0 failed
helm template x charts/apps                                        # aii-mongodb-backup renders
```

Results:

```text
aii-mongodb-backup: 2 sources — Source A repoURL oci://ghcr.io/adorsys-gis/charts,
  chart mongodb-backup, targetRevision >=0.0.0, helm{releaseName, valuesObject,
  valueFiles $values/environments/prod/values/mongodb-backup.yaml, ignoreMissingValueFiles};
  Source B ref: values → ai-helm-values @ main. destination home-remote/converse-chat.
OCI registry resolves mongodb-backup 0.1.3 → the >=0.0.0 range floats to it.
```

---

## 5. Screenshots / Evidence

- OCI chart: `oci://ghcr.io/adorsys-gis/charts/mongodb-backup` (0.1.3, published by the publish-charts-oci workflow).

### Going-live note (post-merge, maintainer)
Inert until the root resolves a commit carrying it (root pins `release-2026.06.22`). To validate live, get this onto the root's revision (cut/point a release that includes it **or** the deferred step: point the root at `main` for full continuous delivery — which would also end the per-flip release dance). Then confirm `aii-mongodb-backup` is `Synced`/`Healthy` resolving Source A to the OCI chart version.

---

## 6. Risk Assessment

Risk level:

* [x] Low
* [ ] Medium
* [ ] High

Potential risks:

* If the OCI chart didn't resolve / the range matched nothing, the app would error — mitigated: verified `helm show chart` resolves `0.1.3` and `>=0.0.0` includes it; `ignoreMissingValueFiles` covers the (intentionally unseeded) `$values` file.
* Lowest blast radius: an isolated backup CronJob, non-user-facing.

Mitigation:

* Single-app scope; inert until released; rollback = revert this PR (or pin `chartVersionRange`/revert the root).

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [x] Reviewing the diff

Human verification:

* [ ] I understand every meaningful change in this PR
* [ ] I checked generated code manually
* [ ] I accept responsibility for this PR

> _Human-verification boxes left for the accountable owner (@stephane-segning)._

---

## 8. Reviewer Focus

* [x] Correctness
* [x] Architecture
* [x] Product intent
