### PR TITLE
fix(apps): OCI source must use full chart path in repoURL + chart "." (#448)

### DIFF
--- a/charts/apps/templates/applications.yaml
+++ b/charts/apps/templates/applications.yaml
@@ -58,7 +58,14 @@ spec:
   {{- $valuesFile := .valuesFile | default (printf "environments/%s/values/%s.yaml" $env .name) }}
   {{- $helm := dict "releaseName" (.releaseName | default .name) "valueFiles" (list (printf "$values/%s" $valuesFile)) "ignoreMissingValueFiles" true }}
   {{- with .valuesObject }}{{- $_ := set $helm "valuesObject" . }}{{- end }}
-  {{- $chartSource := dict "repoURL" $.Values.argocd.chartRegistry "chart" .chart "targetRevision" ($.Values.argocd.chartVersionRange | default ">=0.0.0") "helm" $helm }}
+  {{- /* OCI Helm: the chart name is part of the repoURL PATH (chart: "."), not a
+         separate `chart:` field. With a registry repoURL + `chart:`, ArgoCD lists
+         tags at the registry path (`<registry>/tags/list`) — the wrong, non-existent
+         repo — and 403s on semver-range resolution. Full-path repoURL + `chart: "."`
+         is the form every working OCI app on the cluster uses (kserve, grafana-operator,
+         arc-runners) and the one verified to resolve a range. */}}
+  {{- $chartRepoURL := printf "%s/%s" (trimSuffix "/" $.Values.argocd.chartRegistry) .chart }}
+  {{- $chartSource := dict "repoURL" $chartRepoURL "chart" "." "targetRevision" ($.Values.argocd.chartVersionRange | default ">=0.0.0") "helm" $helm }}
   {{- $valuesSource := dict "repoURL" $.Values.argocd.valuesRepoURL "targetRevision" ($.Values.argocd.valuesTargetRevision | default "main") "ref" "values" }}
   {{- $ociSources := list $chartSource $valuesSource }}
   {{- if .depsOverlay }}{{- $ociSources = append $ociSources $depsSource }}{{- end }}


### PR DESCRIPTION
## 1. Summary

This PR changes `charts/apps/templates/applications.yaml`: OCI-mode Source A now renders **`repoURL: oci://<chartRegistry>/<chart>` + `chart: "."`** instead of `repoURL: <chartRegistry>` + `chart: <name>`.

It solves:

- The OCI-chart-float blocker found validating https://github.com/ADORSYS-GIS/ai-helm/pull/452: `aii-mongodb-backup` went `ComparisonError` because ArgoCD resolved the `>=0.0.0` range by listing tags at the **registry** path (`…/adorsys-gis/charts/tags/list`, a non-existent repo) → 403. Source of truth: https://github.com/ADORSYS-GIS/ai-helm/issues/448, ADR-0055.

---

## 2. Intent

> For OCI Helm, the chart name is part of the repoURL **path**, addressed with `chart: "."` — not a separate `chart:` field against the registry root. This is the form every working OCI app on the cluster uses (kserve, grafana-operator, arc-runners) and the one I verified resolves a semver range. My original template had the registry+chart shape, which mis-targets tag-listing.

---

## 3. Scope

### In Scope
- The OCI Source A `repoURL`/`chart` rendering in the apps template.

### Out of Scope
- Apps without `chart:` (unchanged); the home-os OCI-repo registration (#67) — now moot, see note.

---

## 4. Verification

I verified this change by:

- [x] Running automated tests
- [x] Running manual tests
- [x] Testing on the live cluster

Commands run:

```bash
helm template x charts/apps   # aii-mongodb-backup Source A → repoURL .../charts/mongodb-backup, chart: "."
helm lint charts/apps          # 0 failed
# live isolated test (admin@homeos): an Application with the new form resolved >=0.0.0
#   → SYNC=OutOfSync, digest sha256:301063…, no ComparisonError
# anon tag-list .../charts/mongodb-backup/tags/list → {"tags":["0.1.3"]}
```

Results:

```text
Render: Source A repoURL=oci://ghcr.io/adorsys-gis/charts/mongodb-backup chart="." rev=">=0.0.0";
        converse-ui (no chart:) unchanged; lint 0 failed.
Live isolated test app with the new form RESOLVED the range (OutOfSync + real digest, no error) —
the form the current failing app lacked.
```

---

## 5. Screenshots / Evidence

- Live test: `zz-test-oci-float` resolved `>=0.0.0` → digest, then deleted.
- Working precedents: kserve / grafana-operator / arc-runners (full-path OCI repoURL).

### Going-live note
Inert until the root resolves a commit carrying it. Brings the fix to `aii-mongodb-backup` once on the root's revision (next release+repoint, or the planned move to continuous).

---

## 6. Risk Assessment

Risk level:

* [x] Low

Potential risks:

* Template-level change to OCI source rendering; only affects apps that set `chart:` (today just mongodb-backup). Verified render + live resolution.

Mitigation:

* Single-line dict change; revert is trivial; non-`chart:` apps untouched.

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [x] Reviewing the diff

Human verification:

* [ ] I understand every meaningful change in this PR
* [ ] I checked generated code manually
* [ ] I accept responsibility for this PR

> _Human-verification boxes left for the accountable owner (@stephane-segning)._

---

## 8. Reviewer Focus

* [x] Correctness
* [x] Architecture
