### PR TITLE
feat(apps): migrate imageupdater to OCI mode (#448)

### DIFF
--- a/charts/apps/values.yaml
+++ b/charts/apps/values.yaml
@@ -1170,16 +1170,15 @@ applications:
   # The generic `imageupdater` chart renders ONE CR per app opted into write-back
   # (its imageUpdaters[] list); add an entry there + the write-back annotations on
   # the target app's entry to onboard a new continuous-delivery app.
+  # OCI mode (ADR-0055): the chart floats from oci://…/charts/imageupdater. Its
+  # imageUpdaters[] list is baked into the chart values, so adding an app = edit
+  # charts/imageupdater + merge (republish → float). Still controlPlane → argocd ns.
   - name: imageupdater
     finalizers:
       - resources-finalizer.argocd.argoproj.io
     controlPlane: true
-    source:
-      repoURL: https://github.com/ADORSYS-GIS/ai-helm
-      targetRevision: release-2026.06.22-v02
-      path: charts/imageupdater
-      helm:
-        releaseName: imageupdater
+    chart: imageupdater
+    releaseName: imageupdater
     destination:
       namespace: argocd
 


### PR DESCRIPTION
## 1. Summary

This PR changes `charts/apps`: flips **imageupdater** (the argocd-image-updater control-object app) from a path-based, tag-pinned source to **`chart: imageupdater`** (OCI float). Source A → `oci://ghcr.io/adorsys-gis/charts/imageupdater` @ `>=0.0.0` + `$values`; still `controlPlane` (argocd ns).

It solves:

- Continues the ADR-0055 cutover (https://github.com/ADORSYS-GIS/ai-helm/issues/448) — the last clean flat-app migration. The `imageUpdaters[]` list is baked into the chart, so onboarding stays "edit `charts/imageupdater` + merge".

---

## 2. Intent

> Dogfood OCI float for a control-plane app and finish the easy flat-app sweep (converse-ui write-back + mongodb-backup OCI float are already live). Source-swap only — same chart content (charts/imageupdater unchanged since v02), now floated from OCI.

---

## 3. Scope

### In Scope
- imageupdater app entry → OCI mode.

### Out of Scope
- Orchestrators (`charts/{observability,librechat,models,mcps,lightbridge}` — structural ApplicationSet change) and critical apps (`core-gateway`, `security-policies`) — handled separately, with sign-off.

---

## 4. Verification

I verified this change by:

- [x] Running automated tests

Commands run:

```bash
helm template x charts/apps   # aii-imageupdater → Source A oci://…/charts/imageupdater chart "." >=0.0.0 + $values, dest in-cluster/argocd
helm lint charts/apps          # 0 failed
```

Results:

```text
aii-imageupdater renders OCI full-path Source A + ref:values, controlPlane → argocd ns. Lint 0 failed.
OCI float form already verified live (mongodb-backup Synced/Healthy from oci://…/charts/mongodb-backup).
```

---

## 5. Screenshots / Evidence

- Same OCI-float mechanism proven live on `aii-mongodb-backup` (Synced/Healthy, resolved `0.1.3`).
- Auto-deploys on merge (root tracks `main`).

---

## 6. Risk Assessment

Risk level:

* [x] Low

Potential risks:

* Control object: a resolution hiccup would briefly pause image-updater (write-back) — but the OCI float form is proven and `ignoreMissingValueFiles` covers the (unseeded) `$values` file.

Mitigation:

* Source-swap, identical chart content; revert this PR / pin to restore.

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [x] Reviewing the diff

Human verification:

* [ ] I understand every meaningful change in this PR
* [ ] I checked generated code manually
* [ ] I accept responsibility for this PR

> _Human-verification boxes left for the accountable owner (@stephane-segning)._

---

## 8. Reviewer Focus

* [x] Correctness
