### PR TITLE
feat(mcps): migrate the mcps orchestrator + children to OCI (ADR-0055 pilot, #448)

### DIFF
--- a/charts/apps/values.yaml
+++ b/charts/apps/values.yaml
@@ -1397,17 +1397,17 @@ applications:
   # controlPlane: true — the ApplicationSet must land in-cluster/argocd where
   # the controller watches it; the children it generates deploy workloads to
   # home-remote (converse-mcp). See ADR-0017 + ADR-0027.
+  # OCI mode (ADR-0055): the mcps ORCHESTRATOR chart floats from OCI, so its
+  # ApplicationSet template + children config deploy continuously. The emitted
+  # children (one per MCP) also source the leaf chart from OCI (see
+  # charts/mcps/templates/applicationset.yaml + values argocd.chartRegistry).
+  # First orchestrator migrated to OCI — pattern for ai-models/librechart/etc.
   - name: mcps
     finalizers:
       - resources-finalizer.argocd.argoproj.io
     controlPlane: true
-    source:
-      repoURL: https://github.com/ADORSYS-GIS/ai-helm
-      targetRevision: release-2026.06.22-v02
-      path: charts/mcps
-      helm:
-        releaseName: mcps
-        valuesObject: { }
+    chart: mcps
+    releaseName: mcps
     destination:
       namespace: converse-mcp
 

--- a/charts/mcps/templates/applicationset.yaml
+++ b/charts/mcps/templates/applicationset.yaml
@@ -26,7 +26,7 @@ spec:
 {{- if not (eq $mcpConfig.enabled false) }}
           # ── MCP: {{ $mcpName }} ──────────────────────────────────────────
           - appName: {{ printf "%s-%s" $.Release.Name $mcpName | quote }}
-            chartPath: charts/mcp
+            chartName: mcp
             valuesYaml: |-
 {{- $childValues := dict
       "mcp" $mcpConfig.mcp
@@ -45,9 +45,13 @@ spec:
     spec:
       project: {{ .Values.argocd.project | quote }}
       source:
-        repoURL: {{ .Values.argocd.repoURL | quote }}
-        targetRevision: {{ .Values.argocd.targetRevision | quote }}
-        path: '{{ "{{ .chartPath }}" }}'
+        # OCI chart-float (ADR-0055): the leaf chart's name is part of the repoURL
+        # PATH with chart: "." (full-path form — see ai-helm #453). chartRegistry is
+        # Helm-substituted here; {{ "{{ .chartName }}" }} is expanded per-element by
+        # the AppSet controller → oci://ghcr.io/adorsys-gis/charts/mcp.
+        repoURL: '{{ .Values.argocd.chartRegistry }}/{{ "{{ .chartName }}" }}'
+        chart: "."
+        targetRevision: {{ .Values.argocd.chartVersionRange | quote }}
         helm:
           releaseName: '{{ "{{ .appName }}" }}'
           values: |

--- a/charts/mcps/values.yaml
+++ b/charts/mcps/values.yaml
@@ -11,11 +11,12 @@
 argocd:
   namespace: argocd
   project: ai
-  # Source repo for the leaf chart (charts/mcp). Deploys are tag-based: pinned to
-  # the immutable release tag below (main is never a deploy target). See the
-  # canonical note in charts/apps/values.yaml.
-  repoURL: https://github.com/ADORSYS-GIS/ai-helm
-  targetRevision: release-2026.06.22-v02
+  # OCI chart-float (ADR-0055): children source the leaf chart (mcp) from the OCI
+  # registry on a floating semver range — full chart path in repoURL + chart "."
+  # (the applicationset template builds `<chartRegistry>/<chartName>`). Replaces
+  # the old tag-pinned ai-helm path source; the orchestrator now floats on main.
+  chartRegistry: oci://ghcr.io/adorsys-gis/charts
+  chartVersionRange: ">=0.0.0"
   destination:
     # Every child Application targets home-remote (ADR-0017). The destination
     # helper hard-fails the render if this resolves to in-cluster unless


### PR DESCRIPTION
## 1. Summary

This PR migrates the **mcps orchestrator** (and the children it fans out) to OCI chart-float — the first orchestrator on continuous delivery.

- **charts/apps**: the `mcps` orchestrator app → `chart: mcps` (OCI float) so its ApplicationSet template + children config deploy continuously (was `path: charts/mcps` @ `v02`).
- **charts/mcps/templates/applicationset.yaml**: child source path-based → OCI — list element `chartPath: charts/mcp` → `chartName: mcp`; `template.spec.source` → `repoURL: '<chartRegistry>/{{ .chartName }}'` + `chart: "."` + `targetRevision: <range>` (full-path form per #453). `{{ .chartName }}` is expanded per-element by the AppSet controller → `oci://…/charts/mcp`.
- **charts/mcps/values.yaml**: `argocd.repoURL`/`targetRevision` (tag) → `chartRegistry` + `chartVersionRange`.

It solves:

- Proves the **ApplicationSet→OCI** pattern for the remaining orchestrators (ai-models, librechart, observability, lightbridge) and lets us eventually delete the duplicate `environments/`. Source of truth: https://github.com/ADORSYS-GIS/ai-helm/issues/448, ADR-0055.

---

## 2. Intent

> The remaining cutover work is the orchestrators. mcps is the lowest-risk one (self-contained MCP proxies, low-traffic). Migrating it on a low-traffic window validates the pattern: orchestrator chart floats from OCI → emits an ApplicationSet whose children also float from OCI. MCP children have no `$values`/deps and use off-the-shelf proxy images (caddy/openresty) → pure chart-float, no write-back.

---

## 3. Scope

### In Scope
- mcps orchestrator app → OCI; its ApplicationSet child source → OCI; its argocd knobs.

### Out of Scope
- The other 4 orchestrators (same pattern, follow after this validates); critical apps (core-gateway, security-policies).

---

## 4. Verification

I verified this change by:

- [x] Running automated tests

Commands run:

```bash
helm show chart oci://ghcr.io/adorsys-gis/charts/{mcp,mcps}   # mcp 1.0.11, mcps 2.0.98 (resolvable)
helm template x charts/apps   # aii-mcps → OCI chart: mcps + $values, controlPlane/argocd
helm template m charts/mcps   # ApplicationSet template.spec.source → oci://…/charts/{{ .chartName }} chart "." >=0.0.0
helm lint charts/apps charts/mcps   # 0 failed
```

Results:

```text
aii-mcps orchestrator app: OCI Source A (chart: mcps) + ref:values, dest in-cluster/argocd.
ApplicationSet children: repoURL oci://ghcr.io/adorsys-gis/charts/{{ .chartName }}, chart ".", >=0.0.0; chartName mcp for all (brave/context7/firecrawl/refero/terraform).
mcp + mcps charts resolvable from OCI. Lint 0 failed.
```

---

## 5. Screenshots / Evidence

- Same OCI-float form proven live on `aii-mongodb-backup` / `aii-imageupdater`.
- Going live (post-merge): publish-charts-oci republishes `mcps` → the orchestrator floats to it → emits OCI children. Brief eventual-consistency window (orchestrator floats to the old mcps chart until the new one publishes — old template still valid). Will verify each `mcps-*` child Synced/Healthy + MCP `tools/list` works.

---

## 6. Risk Assessment

Risk level:

* [ ] Low
* [x] Medium
* [ ] High

Potential risks:

* Touches the MCP fleet's source model; children transition from path@v02 to OCI source (ArgoCD re-syncs). Low-traffic window chosen.
* Eventual-consistency: the orchestrator briefly floats to the pre-merge mcps chart until CI republishes — harmless (old template works).

Mitigation:

* MCP proxies are non-critical + low-traffic; revert restores path-based sources. Will validate every `mcps-*` child live post-merge (init 200 / tools/list).

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [x] Reviewing the diff

Human verification:

* [ ] I understand every meaningful change in this PR
* [ ] I checked generated code manually
* [ ] I accept responsibility for this PR

> _Human-verification boxes left for the accountable owner (@stephane-segning)._

---

## 8. Reviewer Focus

* [x] Correctness
* [x] Architecture
* [x] Edge cases
