### PR TITLE
feat(orchestrators): migrate ai-models + librechart to OCI (#448)

### DIFF
--- a/charts/ai-models/templates/applicationset.yaml
+++ b/charts/ai-models/templates/applicationset.yaml
@@ -23,7 +23,7 @@ spec:
         elements:
           # ── Backends (shared infra) — sync-wave -1 ────────────────────
           - appName: {{ printf "%s-backends" .Release.Name | quote }}
-            chartPath: charts/ai-models-backends
+            chartName: ai-models-backends
             syncWave: "-1"
             valuesYaml: |-
 {{ (dict "backends" .Values.backends "externalSecrets" .Values.externalSecrets) | toYaml | indent 14 }}
@@ -34,7 +34,7 @@ spec:
           # /v1/models/info). Per-env overrides should hit that leaf
           # chart directly via ai-gitops rather than this orchestrator.
           - appName: {{ printf "%s-info" .Release.Name | quote }}
-            chartPath: charts/ai-models-info
+            chartName: ai-models-info
             syncWave: "1"
             valuesYaml: |-
 {{- $infoValues := dict
@@ -47,7 +47,7 @@ spec:
 {{- if not (eq $modelConfig.enabled false) }}
           # ── Model: {{ $modelName }} — sync-wave 0 ───────────────────────
           - appName: {{ printf "%s-%s" $.Release.Name $modelName | quote }}
-            chartPath: charts/ai-model
+            chartName: ai-model
             syncWave: "0"
             valuesYaml: |-
 {{- $childValues := dict
@@ -75,9 +75,12 @@ spec:
     spec:
       project: {{ .Values.argocd.project | quote }}
       source:
-        repoURL: {{ .Values.argocd.repoURL | quote }}
-        targetRevision: {{ .Values.argocd.targetRevision | quote }}
-        path: '{{ "{{ .chartPath }}" }}'
+        # OCI chart-float (ADR-0055): full chart path in repoURL + chart "." (#453).
+        # chartRegistry is Helm-substituted; {{ "{{ .chartName }}" }} is expanded
+        # per-element by the AppSet controller → oci://…/charts/<chartName>.
+        repoURL: '{{ .Values.argocd.chartRegistry }}/{{ "{{ .chartName }}" }}'
+        chart: "."
+        targetRevision: {{ .Values.argocd.chartVersionRange | quote }}
         helm:
           releaseName: '{{ "{{ .appName }}" }}'
           values: |

--- a/charts/ai-models/values.yaml
+++ b/charts/ai-models/values.yaml
@@ -16,11 +16,12 @@ argocd:
   namespace: argocd
   # ArgoCD project the children belong to.
   project: ai
-  # Source repo + branch for the leaf charts (ai-models-backends, ai-model).
-  # Deploys are tag-based: pinned to the immutable release tag below (main is
-  # never a deploy target). See the canonical note in charts/apps/values.yaml.
-  repoURL: https://github.com/ADORSYS-GIS/ai-helm
-  targetRevision: release-2026.06.22-v02
+  # OCI chart-float (ADR-0055): children source the leaf charts (ai-models-backends,
+  # ai-models-info, ai-model) from the OCI registry on a floating semver range —
+  # full chart path in repoURL + chart "." (the applicationset builds
+  # `<chartRegistry>/<chartName>`). Replaces the old tag-pinned ai-helm path source.
+  chartRegistry: oci://ghcr.io/adorsys-gis/charts
+  chartVersionRange: ">=0.0.0"
   destination:
     # The home-remote cluster every child Application targets. This repo's
     # invariant (ADR-0017) is that workloads NEVER deploy to the cluster

--- a/charts/apps/values.yaml
+++ b/charts/apps/values.yaml
@@ -1261,17 +1261,11 @@ applications:
     # object). The ApplicationSet must land in-cluster/argocd where the
     # controller watches it; its child Applications deploy workloads to
     # home-remote. See ADR-0017.
+    # OCI mode (ADR-0055): orchestrator chart floats from OCI so its ApplicationSet
+    # + children config deploy continuously; children also source leaf charts from OCI.
     controlPlane: true
-    source:
-      repoURL: https://github.com/ADORSYS-GIS/ai-helm
-      targetRevision: release-2026.06.22-v02
-      path: charts/librechart
-      helm:
-        releaseName: librechat
-        # No storageClass override — PVCs use the cluster's default
-        # StorageClass (the leaf charts default to null).
-        valuesObject: {}
-
+    chart: librechart
+    releaseName: librechat
     destination:
       namespace: converse-chat
 
@@ -1313,14 +1307,11 @@ applications:
     # object). The ApplicationSet must land in-cluster/argocd where the
     # controller watches it; its child Applications deploy workloads to
     # home-remote. See ADR-0017.
+    # OCI mode (ADR-0055): orchestrator chart floats from OCI so its ApplicationSet
+    # + children config deploy continuously; children also source leaf charts from OCI.
     controlPlane: true
-    source:
-      repoURL: https://github.com/ADORSYS-GIS/ai-helm
-      targetRevision: release-2026.06.22-v02
-      path: charts/ai-models
-      helm:
-        releaseName: models
-        valuesObject: { }
+    chart: ai-models
+    releaseName: models
     destination:
       namespace: converse
 

--- a/charts/librechart/templates/applicationset.yaml
+++ b/charts/librechart/templates/applicationset.yaml
@@ -25,7 +25,7 @@ spec:
 {{- range $child := .Values.children }}
 {{- if not (eq $child.enabled false) }}
           - appName: {{ $child.name | quote }}
-            chartPath: {{ $child.chartPath | quote }}
+            chartName: {{ $child.chartName | quote }}
             syncWave: {{ $child.syncWave | quote }}
 {{- end }}
 {{- end }}
@@ -39,9 +39,10 @@ spec:
     spec:
       project: {{ .Values.argocd.project | quote }}
       source:
-        repoURL: {{ .Values.argocd.repoURL | quote }}
-        targetRevision: {{ .Values.argocd.targetRevision | quote }}
-        path: '{{ "{{ .chartPath }}" }}'
+        # OCI chart-float (ADR-0055): full chart path in repoURL + chart "." (#453).
+        repoURL: '{{ .Values.argocd.chartRegistry }}/{{ "{{ .chartName }}" }}'
+        chart: "."
+        targetRevision: {{ .Values.argocd.chartVersionRange | quote }}
         helm:
           releaseName: '{{ "{{ .appName }}" }}'
       destination:

--- a/charts/librechart/values.yaml
+++ b/charts/librechart/values.yaml
@@ -15,11 +15,11 @@ argocd:
   namespace: argocd
   # ArgoCD project the children belong to.
   project: ai
-  # Source repo + branch for the leaf charts.
-  # Deploys are tag-based: pinned to the immutable release tag below (main is
-  # never a deploy target). See the canonical note in charts/apps/values.yaml.
-  repoURL: https://github.com/ADORSYS-GIS/ai-helm
-  targetRevision: release-2026.06.22-v02
+  # OCI chart-float (ADR-0055): children source the leaf charts from the OCI
+  # registry on a floating semver range — full chart path in repoURL + chart "."
+  # (the applicationset builds `<chartRegistry>/<chartName>`).
+  chartRegistry: oci://ghcr.io/adorsys-gis/charts
+  chartVersionRange: ">=0.0.0"
   destination:
     # The home-remote cluster every child Application targets. Repo
     # invariant (ADR-0017): workloads NEVER deploy to the cluster ArgoCD
@@ -43,17 +43,19 @@ argocd:
 # ordering), but keeping low-to-high here for readability.
 # ────────────────────────────────────────────────────────────────────────
 children:
+  # chartName = the OCI chart name (was chartPath: charts/<name>). The
+  # applicationset sources oci://<chartRegistry>/<chartName> @ range (ADR-0055).
   - name: librechat-search
-    chartPath: charts/librechat-search
+    chartName: librechat-search
     syncWave: "-1"
     enabled: true
 
   - name: librechat-app
-    chartPath: charts/librechat-app
+    chartName: librechat-app
     syncWave: "0"
     enabled: true
 
   - name: librechat-opencode-wellknown
-    chartPath: charts/librechat-opencode-wellknown
+    chartName: librechat-opencode-wellknown
     syncWave: "1"
     enabled: true


### PR DESCRIPTION
## 1. Summary

Migrate the two remaining **List-generator orchestrators** (`ai-models`, `librechart`) to OCI chart-float, using the recipe proven live on `mcps`.

- **charts/apps**: `models` + `librechat` orchestrator apps → `chart: ai-models` / `chart: librechart` (OCI float).
- **applicationset.yaml** (both): child source path-based → OCI — `chartPath` → `chartName`; `template.spec.source` → `repoURL: '<chartRegistry>/{{ .chartName }}'` + `chart: "."` + `targetRevision: <range>`.
- **values.yaml** (both): `argocd.repoURL`/`targetRevision` → `chartRegistry`/`chartVersionRange`; librechart children `chartPath` → `chartName`.

Solves: ADR-0055 cutover https://github.com/ADORSYS-GIS/ai-helm/issues/448 (orchestrator tier).

---

## 2. Intent

> mcps proved the ApplicationSet→OCI pattern live. These two are the same shape (model serving + LibreChat). Children: ai-models-backends/ai-models-info/ai-model and librechat-search/-app/-opencode-wellknown — all published to OCI.

---

## 3. Scope

### In Scope
- ai-models + librechart orchestrators + their child source model.

### Out of Scope
- observability + lightbridge (App-of-Apps shape — separate PRs); critical flat apps.

---

## 4. Verification

I verified this change by:

- [x] Running automated tests

Commands run:

```bash
helm template x charts/apps          # aii-models/aii-librechat → OCI Source A
helm template a charts/ai-models     # AppSet child source → oci://…/charts/{{ .chartName }}, chartNames ai-model(s*)
helm template l charts/librechart    # AppSet child source OCI, chartNames librechat-*
helm show chart oci://…/charts/{ai-models,ai-model,librechart,librechat-app,…}   # all resolve
helm lint charts/apps charts/ai-models charts/librechart   # 0 failed
```

Results:

```text
All 8 charts (2 orchestrators + 6 leaves) resolve from OCI.
aii-models Source A: oci://ghcr.io/adorsys-gis/charts/ai-models chart "." >=0.0.0.
Both AppSets: child source oci://…/charts/{{ .chartName }} chart "." >=0.0.0; chartNames correct. Lint 0 failed.
```

---

## 5. Screenshots / Evidence

- Same pattern validated live on `mcps` (orchestrator floated, all children Synced/Healthy from OCI).
- Auto-deploys (root tracks `main`); will validate each child (model apps + librechat-*) Synced/Healthy post-merge.

---

## 6. Risk Assessment

Risk level:

* [ ] Low
* [x] Medium
* [ ] High

Potential risks:

* Touches model serving + the LibreChat chat UI source model; children re-sync from path@v02 → OCI (ArgoCD re-syncs, content identical — leaf charts unchanged since v02). Low-traffic window.
* Eventual-consistency: orchestrators briefly float to the pre-merge chart until CI republishes — old template valid.

Mitigation:

* Same recipe proven on mcps; revert restores path sources; will validate every child live post-merge.

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [x] Reviewing the diff

Human verification:

* [ ] I understand every meaningful change in this PR
* [ ] I checked generated code manually
* [ ] I accept responsibility for this PR

> _Human-verification boxes left for the accountable owner (@stephane-segning)._

---

## 8. Reviewer Focus

* [x] Correctness
* [x] Architecture
