### PR TITLE
feat(observability): migrate the observability orchestrator to OCI (#448)

### DIFF
--- a/charts/apps/values.yaml
+++ b/charts/apps/values.yaml
@@ -124,17 +124,16 @@ applications:
   # orchestrator. controlPlane: true — it emits Application CRs, so it targets
   # in-cluster/argocd; the children it renders target home-remote and carry
   # the privileged PodSecurity label. See ADR-0020.
+  # OCI mode (ADR-0055): orchestrator chart floats from OCI so its App-of-Apps
+  # children config deploys continuously. Children source upstream charts
+  # (grafana/prometheus) by version, the observability-dashboards leaf from OCI,
+  # and the secrets/deps overlays from ai-helm-values@main (see charts/observability).
   - name: observability
     finalizers:
       - resources-finalizer.argocd.argoproj.io
     controlPlane: true
-    source:
-      repoURL: https://github.com/ADORSYS-GIS/ai-helm
-      targetRevision: release-2026.06.22-v02
-      path: charts/observability
-      helm:
-        releaseName: observability
-        valuesObject: {}
+    chart: observability
+    releaseName: observability
     destination:
       namespace: observability
 

--- a/charts/observability/values.yaml
+++ b/charts/observability/values.yaml
@@ -24,10 +24,12 @@ argocd:
   # Namespace the child Application CRs live in (where ArgoCD watches them).
   namespace: argocd
   project: ai
-  # This repo, source for the local leaf charts + the secrets overlay.
-  # Deploy branch now → release tag next, never main (see charts/apps note).
-  repoURL: https://github.com/ADORSYS-GIS/ai-helm
-  targetRevision: release-2026.06.22-v02
+  # depsOverlay source (ADR-0055) for the child deps overlays (alloy /
+  # kube-state-metrics / grafana-operator / grafana): the values repo @ main.
+  # Leaf charts come from OCI per-child (see each child's `source`); the
+  # observability-secrets overlay sets its own values-repo source too.
+  repoURL: https://github.com/adorsys-gis/ai-helm-values
+  targetRevision: main
   destination:
     # home-remote cluster (ADR-0017 guard). Children may override .namespace
     # but all observability children use `observability`.
@@ -65,8 +67,10 @@ children:
     finalizers:
       - resources-finalizer.argocd.argoproj.io
     source:
-      repoURL: https://github.com/ADORSYS-GIS/ai-helm
-      targetRevision: release-2026.06.22-v02
+      # Deps overlay (ExternalSecrets + the allow-same-namespace NetworkPolicy) —
+      # from the values repo @ main (ADR-0055), like the other environments/ deps.
+      repoURL: https://github.com/adorsys-gis/ai-helm-values
+      targetRevision: main
       path: environments/prod/deps/observability-secrets
     destination:
       namespace: observability
@@ -1925,9 +1929,10 @@ children:
     additionalAnnotations:
       argocd.argoproj.io/sync-wave: "1"
     source:
-      repoURL: https://github.com/ADORSYS-GIS/ai-helm
-      targetRevision: release-2026.06.22-v02
-      path: charts/observability-dashboards
+      # OCI chart-float (ADR-0055): full chart path in repoURL + chart "." (#453).
+      repoURL: oci://ghcr.io/adorsys-gis/charts/observability-dashboards
+      chart: "."
+      targetRevision: ">=0.0.0"
       helm:
         releaseName: observability-dashboards
     destination:


### PR DESCRIPTION
## 1. Summary

Migrate the **observability** App-of-Apps orchestrator (ADR-0020) to OCI / values-repo.

- **charts/apps**: `observability` orchestrator app → `chart: observability` (OCI float).
- **observability-dashboards** child (the one ai-helm leaf chart) → OCI source (`oci://…/charts/observability-dashboards` + `chart: "."` + range).
- **observability-secrets** child (a deps/kustomize overlay, not a chart) → `ai-helm-values @ main`.
- `argocd.repoURL`/`targetRevision` (drives the alloy / kube-state-metrics / grafana-operator / grafana `depsOverlay` sources) → `ai-helm-values @ main`.

Most children source **upstream** charts (grafana/prometheus) by version — untouched. Solves the orchestrator tier of https://github.com/ADORSYS-GIS/ai-helm/issues/448.

---

## 2. Intent

> Same end-state as the AppSet orchestrators, adapted to App-of-Apps: the ai-helm-sourced pieces (the dashboards leaf chart, the secrets/deps overlays) move to OCI / the values repo; the orchestrator chart floats from OCI so its children config deploys continuously. Upstream-chart children are already version-pinned and unaffected.

---

## 3. Scope

### In Scope
- observability orchestrator app + its ai-helm-sourced children (dashboards, secrets, deps overlays).

### Out of Scope
- lightbridge (separate PR); upstream-chart children (unchanged).

---

## 4. Verification

I verified this change by:

- [x] Running automated tests

Commands run:

```bash
helm template x charts/apps          # aii-observability → OCI Source A
helm template o charts/observability # dashboards → OCI; secrets + 4 deps overlays → ai-helm-values@main
helm show chart oci://…/charts/{observability,observability-dashboards}   # 1.0.108 / 0.1.18
helm lint charts/apps charts/observability   # 0 failed
```

Results:

```text
aii-observability: OCI Source A (chart: observability).
observability-dashboards child: oci://…/charts/observability-dashboards chart "." >=0.0.0.
observability-secrets + alloy/ksm/grafana-operator/grafana deps: ai-helm-values @ main.
Upstream children (mimir/loki/tempo/grafana/…) unchanged. Lint 0 failed.
```

---

## 5. Screenshots / Evidence

- Same recipe validated live on mcps + applied to ai-models/librechart (#457).
- Auto-deploys (root tracks main); will validate the observability children Synced/Healthy + dashboards present post-merge.

---

## 6. Risk Assessment

Risk level:

* [ ] Low
* [x] Medium
* [ ] High

Potential risks:

* Touches the monitoring stack's orchestrator + dashboards/secrets sources. Internal (no end-user impact). Deps overlays already verified byte-identical in ai-helm-values.

Mitigation:

* Upstream children untouched; revert restores prior sources; will validate live.

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [x] Reviewing the diff

Human verification:

* [ ] I understand every meaningful change in this PR
* [ ] I checked generated code manually
* [ ] I accept responsibility for this PR

> _Human-verification boxes left for the accountable owner (@stephane-segning)._

---

## 8. Reviewer Focus

* [x] Correctness
* [x] Architecture
