### PR TITLE
feat(lightbridge): migrate the lightbridge orchestrator to OCI (#448)

### DIFF
--- a/charts/apps/values.yaml
+++ b/charts/apps/values.yaml
@@ -1026,17 +1026,16 @@ applications:
   # control object (it emits Application CRs) this entry is controlPlane: true —
   # the children themselves target home-remote. Name kept `lightbridge-backend`
   # so the root app entry's identity is stable.
+  # OCI mode (ADR-0055): orchestrator chart floats from OCI so its App-of-Apps
+  # children config deploys continuously. Children: secrets + db leaf charts from
+  # OCI, the app's upstream chart by version + its cert overlay from ai-helm-values
+  # (see charts/lightbridge values).
   - name: lightbridge-backend
     finalizers:
       - resources-finalizer.argocd.argoproj.io
     controlPlane: true
-    source:
-      repoURL: https://github.com/ADORSYS-GIS/ai-helm
-      targetRevision: release-2026.06.22-v02
-      path: charts/lightbridge
-      helm:
-        releaseName: lightbridge
-        valuesObject: {}
+    chart: lightbridge
+    releaseName: lightbridge
     destination:
       namespace: converse
 

--- a/charts/lightbridge/templates/applications.yaml
+++ b/charts/lightbridge/templates/applications.yaml
@@ -28,9 +28,10 @@ metadata:
 spec:
   project: {{ $a.project | quote }}
   source:
-    repoURL: {{ $a.repoURL | quote }}
-    targetRevision: {{ $a.targetRevision | quote }}
-    path: {{ .Values.secrets.chartPath | quote }}
+    # OCI chart-float (ADR-0055): full chart path in repoURL + chart "." (#453).
+    repoURL: {{ printf "%s/%s" $a.chartRegistry .Values.secrets.chartName | quote }}
+    chart: "."
+    targetRevision: {{ $a.chartVersionRange | quote }}
     helm:
       releaseName: {{ .Values.secrets.releaseName | quote }}
   destination:
@@ -55,9 +56,10 @@ metadata:
 spec:
   project: {{ $a.project | quote }}
   source:
-    repoURL: {{ $a.repoURL | quote }}
-    targetRevision: {{ $a.targetRevision | quote }}
-    path: {{ .Values.db.chartPath | quote }}
+    # OCI chart-float (ADR-0055): full chart path in repoURL + chart "." (#453).
+    repoURL: {{ printf "%s/%s" $a.chartRegistry .Values.db.chartName | quote }}
+    chart: "."
+    targetRevision: {{ $a.chartVersionRange | quote }}
     helm:
       releaseName: {{ .Values.db.releaseName | quote }}
   destination:

--- a/charts/lightbridge/values.yaml
+++ b/charts/lightbridge/values.yaml
@@ -13,11 +13,16 @@
 argocd:
   # ArgoCD project the children belong to.
   project: ai
-  # This repo, source for the secrets + db leaf charts + the cert overlay.
-  # Deploys are tag-based: pinned to the immutable release tag below (main is
-  # never a deploy target). See the canonical note in charts/apps/values.yaml.
-  repoURL: https://github.com/ADORSYS-GIS/ai-helm
-  targetRevision: release-2026.06.22-v02
+  # OCI chart-float (ADR-0055). Two sources of truth now:
+  #  • chartRegistry/chartVersionRange — the secrets + db leaf charts float from
+  #    OCI (full chart path in repoURL + chart "."; template builds
+  #    `<chartRegistry>/<chartName>`).
+  #  • repoURL/targetRevision — the app child's cert/deps overlay (Source B), now
+  #    the values repo @ main (where environments/ lives).
+  chartRegistry: oci://ghcr.io/adorsys-gis/charts
+  chartVersionRange: ">=0.0.0"
+  repoURL: https://github.com/adorsys-gis/ai-helm-values
+  targetRevision: main
   destination:
     # The home-remote cluster all children target. Repo invariant (ADR-0017):
     # workloads NEVER deploy to the cluster ArgoCD runs in. The destination
@@ -42,7 +47,7 @@ argocd:
 secrets:
   enabled: true
   appName: lightbridge-secrets
-  chartPath: charts/lightbridge-secrets
+  chartName: lightbridge-secrets   # OCI chart name (was chartPath: charts/<name>)
   releaseName: lightbridge-secrets
   syncWave: "0"
 
@@ -53,7 +58,7 @@ secrets:
 db:
   enabled: true
   appName: lightbridge-db
-  chartPath: charts/lightbridge-db
+  chartName: lightbridge-db   # OCI chart name (was chartPath: charts/<name>)
   releaseName: lightbridge-db
   syncWave: "1"
   # Ignore the CNPG operator's defaulted fields on the Cluster so it doesn't sit


### PR DESCRIPTION
## 1. Summary

Migrate the **lightbridge** App-of-Apps orchestrator (ADR-0026) to OCI / values-repo — the last orchestrator.

- **charts/apps**: `lightbridge-backend` orchestrator app → `chart: lightbridge` (OCI float).
- **secrets + db** children (ai-helm leaf charts) → OCI (`<chartRegistry>/<chartName>` + `chart: "."` + range); `chartPath` → `chartName`.
- **app** child: Source A (upstream Lightbridge chart @ `0.8.1`) unchanged; Source B (cert/deps overlay) → `ai-helm-values @ main`.
- `charts/lightbridge/values.yaml` argocd split: `chartRegistry`/`chartVersionRange` (OCI leaf children) + `repoURL`/`targetRevision` = `ai-helm-values`/`main` (app's deps overlay).

Completes the orchestrator tier of https://github.com/ADORSYS-GIS/ai-helm/issues/448 (mcps + ai-models + librechart + observability + lightbridge).

---

## 2. Intent

> Final orchestrator. Same end-state, adapted to lightbridge's 3-child App-of-Apps: the two ai-helm leaf charts (secrets, db) float from OCI; the app's upstream chart stays version-pinned and its deps overlay moves to the values repo.

---

## 3. Scope

### In Scope
- lightbridge orchestrator app + its 3 children's sources.

### Out of Scope
- The upstream Lightbridge chart version (unchanged); critical flat apps (core-gateway, security-policies).

---

## 4. Verification

I verified this change by:

- [x] Running automated tests

Commands run:

```bash
helm template x charts/apps      # aii-lightbridge-backend → OCI Source A
helm template lb charts/lightbridge   # secrets/db → OCI; app Source A upstream, Source B ai-helm-values@main
helm show chart oci://…/charts/{lightbridge,lightbridge-secrets,lightbridge-db}   # 1.0.78 / 1.0.3 / 0.2.7
helm lint charts/apps charts/lightbridge   # 0 failed
```

Results:

```text
aii-lightbridge-backend: OCI Source A (chart: lightbridge).
secrets → oci://…/charts/lightbridge-secrets; db → oci://…/charts/lightbridge-db (chart "." + >=0.0.0).
app: Source A https://adorsys-gis.github.io/lightbridge-authz chart lightbridge 0.8.1 (unchanged);
     Source B repoURL ai-helm-values targetRevision main path environments/prod/deps/lightbridge-backend.
Lint 0 failed.
```

---

## 5. Screenshots / Evidence

- Same recipe proven on mcps (live) + ai-models/librechart (#457) + observability (#458).
- Auto-deploys (root tracks main); will validate the 3 children Synced/Healthy + the lightbridge gateway backend reachable post-merge.

---

## 6. Risk Assessment

Risk level:

* [ ] Low
* [x] Medium
* [ ] High

Potential risks:

* Touches the lightbridge gateway-backend orchestrator. Children re-sync from path@v02 → OCI / values-repo (content identical — leaf charts + overlay unchanged). Low-traffic window.

Mitigation:

* Same recipe validated across the other orchestrators; revert restores prior sources; will validate live post-merge.

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [x] Reviewing the diff

Human verification:

* [ ] I understand every meaningful change in this PR
* [ ] I checked generated code manually
* [ ] I accept responsibility for this PR

> _Human-verification boxes left for the accountable owner (@stephane-segning)._

---

## 8. Reviewer Focus

* [x] Correctness
* [x] Architecture
