### PR TITLE
feat(apps): migrate core-gateway + security-policies to OCI (#448)

### DIFF
--- a/charts/apps/values.yaml
+++ b/charts/apps/values.yaml
@@ -543,9 +543,12 @@ applications:
     finalizers:
       - resources-finalizer.argocd.argoproj.io
     source:
-      repoURL: https://github.com/ADORSYS-GIS/ai-helm
-      targetRevision: release-2026.06.22-v02
-      path: charts/core-gateway
+      # OCI chart-float (ADR-0055): full chart path in repoURL + chart "." (#453).
+      # Minimal in-place .source swap — the large inline valuesObject below is
+      # untouched. No depsOverlay on this app, so it renders as a single source.
+      repoURL: oci://ghcr.io/adorsys-gis/charts/core-gateway
+      chart: "."
+      targetRevision: ">=0.0.0"
       helm:
         releaseName: core-gateway
         valuesObject:
@@ -602,9 +605,13 @@ applications:
     # metadata endpoint. Folded in as a second (kustomize) source.
     depsOverlay: environments/prod/deps/security-policies
     source:
-      repoURL: https://github.com/ADORSYS-GIS/ai-helm
-      targetRevision: release-2026.06.22-v02
-      path: charts/kuadrant-policies
+      # OCI chart-float (ADR-0055): full chart path in repoURL + chart "." (#453).
+      # Minimal in-place .source swap — the large inline AuthConfig valuesObject
+      # below is untouched. depsOverlay still appends Source B from the values
+      # repo (argocd.depsRepoURL @ depsTargetRevision = ai-helm-values @ main).
+      repoURL: oci://ghcr.io/adorsys-gis/charts/kuadrant-policies
+      chart: "."
+      targetRevision: ">=0.0.0"
       helm:
         releaseName: security-policies
         valuesObject:


### PR DESCRIPTION
## 1. Summary

Migrate the two **critical flat apps** — `core-gateway` (the production Envoy gateway) and `security-policies` (the Authorino / rate-limit config) — to OCI chart-float.

Done as **minimal in-place `.source` swaps** (change `repoURL`/`chart`/`targetRevision`; leave the large inline `valuesObject`s completely untouched) — safer than the `chart:` shorthand which would re-indent the ~430-line AuthConfig.

- **core-gateway**: `.source` → `oci://…/charts/core-gateway` + `chart: "."` + range. No depsOverlay → single source.
- **security-policies**: `.source` → `oci://…/charts/kuadrant-policies` + `chart: "."` + range; its `depsOverlay` still appends Source B from the values repo (`ai-helm-values @ main`, per #455).

**Completes the OCI/continuous cutover for the entire fleet.** Source of truth: https://github.com/ADORSYS-GIS/ai-helm/issues/448, ADR-0055.

---

## 2. Intent

> Final apps. They're the highest-blast-radius (live auth gateway), so: source-swap only (chart content identical — charts unchanged since v02), value blocks untouched, low-traffic window. After this, every app is on OCI/continuous and the finalization (delete the duplicate `environments/`, retire `release.sh`) can proceed.

---

## 3. Scope

### In Scope
- core-gateway + security-policies `.source` → OCI.

### Out of Scope
- The inline value blocks (untouched); the finalization (separate).

---

## 4. Verification

I verified this change by:

- [x] Running automated tests

Commands run:

```bash
helm show chart oci://…/charts/{core-gateway,kuadrant-policies}   # 0.1.131 / 1.1.18
helm template x charts/apps   # core-gateway single OCI source; security-policies OCI A + deps B (ai-helm-values@main)
helm lint charts/apps          # 0 failed; 19 flat Applications (unchanged)
```

Results:

```text
aii-core-gateway: single source, oci://…/charts/core-gateway chart "." >=0.0.0; valuesObject intact.
aii-security-policies: sources [oci://…/charts/kuadrant-policies chart "." >=0.0.0]
  + [ai-helm-values @ main path environments/prod/deps/security-policies]; AuthConfig valuesObject intact.
Lint 0 failed.
```

---

## 5. Screenshots / Evidence

- Same OCI-float form validated live across mcps + all orchestrators.
- ⚠️ Highest blast radius (live auth gateway). Merge in the low-traffic window; I'll validate `aii-core-gateway` + `aii-security-policies` Synced/Healthy and an end-to-end gateway auth check immediately after.

---

## 6. Risk Assessment

Risk level:

* [ ] Low
* [ ] Medium
* [x] High

Potential risks:

* The production gateway + Authorino config. Source-swap only (chart content identical to v02; value blocks byte-identical). Worst case: revert this PR / pin back, gateway returns to the prior chart.

Mitigation:

* valuesObjects untouched (verified render); same recipe proven across the fleet; merge in low-traffic window; immediate live validation + revert-ready.

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [x] Reviewing the diff

Human verification:

* [ ] I understand every meaningful change in this PR
* [ ] I checked generated code manually
* [ ] I accept responsibility for this PR

> _Human-verification boxes left for the accountable owner (@stephane-segning) — especially given this touches the live gateway/auth._

---

## 8. Reviewer Focus

* [x] Correctness
* [x] Security
* [x] Edge cases
