### PR TITLE
feat(apps): migrate the last 3 tag-pinned apps to OCI — fleet complete (#448)

### DIFF
--- a/charts/apps/values.yaml
+++ b/charts/apps/values.yaml
@@ -1154,9 +1154,11 @@ applications:
     sources:
       # Source A — the chart. release-pinned like every ai-helm app; the release
       # script swaps this tag on each cut. Image tags come from Source B's $values.
-      - repoURL: https://github.com/ADORSYS-GIS/ai-helm
-        targetRevision: release-2026.06.22-v02
-        path: charts/lightbridge-code-intelligence
+      # OCI chart-float (ADR-0055): Source A (the chart) floats from OCI; Source B
+      # (the vymalo $values + image write-back) is unchanged below.
+      - repoURL: oci://ghcr.io/adorsys-gis/charts/lightbridge-code-intelligence
+        chart: "."
+        targetRevision: ">=0.0.0"
         helm:
           releaseName: lightbridge-ci
           valueFiles:
@@ -1336,9 +1338,10 @@ applications:
       - resources-finalizer.argocd.argoproj.io
     homeCluster: true
     source:
-      repoURL: https://github.com/ADORSYS-GIS/ai-helm
-      targetRevision: release-2026.06.22-v02
-      path: charts/model-serving-qwen3-4b
+      # OCI chart-float (ADR-0055): in-place .source swap; valuesObject untouched.
+      repoURL: oci://ghcr.io/adorsys-gis/charts/model-serving-qwen3-4b
+      chart: "."
+      targetRevision: ">=0.0.0"
       helm:
         releaseName: model-serving-qwen3-4b
         valuesObject: { }
@@ -1370,9 +1373,10 @@ applications:
       - resources-finalizer.argocd.argoproj.io
     homeCluster: true
     source:
-      repoURL: https://github.com/ADORSYS-GIS/ai-helm
-      targetRevision: release-2026.06.22-v02
-      path: charts/model-serving-qwen3-5
+      # OCI chart-float (ADR-0055): in-place .source swap; valuesObject untouched.
+      repoURL: oci://ghcr.io/adorsys-gis/charts/model-serving-qwen3-5
+      chart: "."
+      targetRevision: ">=0.0.0"
       helm:
         releaseName: model-serving-qwen3-5
         valuesObject: { }


### PR DESCRIPTION
## 1. Summary

A pre-finalization audit found **3 apps still pinned to the release tag**; this migrates them with minimal in-place `.source` swaps (content identical, value blocks untouched), completing the OCI/continuous cutover for the entire fleet.

- **lightbridge-code-intelligence**: Source A (chart) → `oci://…/charts/lightbridge-code-intelligence` + `chart: "."` + range. **Source B (the vymalo `$values` + existing cosign image write-back) is unchanged.**
- **model-serving-qwen3-4b** (standby, `enabled: false`) → OCI `.source` swap.
- **model-serving-qwen3-5** (LIVE GPU model, `homeCluster`) → OCI `.source` swap; `valuesObject` + `homeCluster` untouched.

Solves the tail of https://github.com/ADORSYS-GIS/ai-helm/issues/448 — after this, **no chart source references the release tag**.

---

## 2. Intent

> Finish the fleet. These three were the last tag-pinned apps. Source-swaps only (charts unchanged since v02). lci's write-back stays pointed at vymalo (its own repo); the GPU model's workload is untouched (control-plane source-swap).

---

## 3. Scope

### In Scope
- The 3 apps' `.source` → OCI. lci Source B unchanged.

### Out of Scope
- Finalization (delete ai-helm `environments/`, retire `tools/release.sh`, drop the vestigial `selfTargetRevision`, CLAUDE.md) — separate follow-up PR once this is validated.

---

## 4. Verification

I verified this change by:

- [x] Running automated tests

Commands run:

```bash
helm show chart oci://…/charts/{lightbridge-code-intelligence,model-serving-qwen3-4b,model-serving-qwen3-5}  # 0.7.20 / 0.4.1 / 0.1.3
helm template x charts/apps   # lci: OCI Source A + vymalo Source B; qwen3-5: OCI source (valuesObject intact)
grep release-2026.06.22-v02 charts/apps/values.yaml   # only the vestigial selfTargetRevision default remains
helm lint charts/apps   # 0 failed
```

Results:

```text
lci: sources [oci://…/charts/lightbridge-code-intelligence chart "." >=0.0.0] + [ref: values → vymalo repo].
qwen3-5: oci://…/charts/model-serving-qwen3-5 chart "." >=0.0.0; valuesObject + homeCluster intact.
No chart source on the release tag; lint 0 failed.
```

---

## 5. Screenshots / Evidence

- ⚠️ `model-serving-qwen3-5` is the LIVE self-hosted GPU model — source-swap only (chart unchanged), but I'll validate it Synced/Healthy + the model still serving immediately after merge.
- Auto-deploys (root tracks main).

---

## 6. Risk Assessment

Risk level:

* [ ] Low
* [x] Medium
* [ ] High

Potential risks:

* Touches the live GPU model + lci. Source-swaps (content identical). The GPU workload is a control-plane source change; lci's write-back is unchanged.

Mitigation:

* valuesObjects untouched; same recipe across the fleet; revert restores prior sources; validate live post-merge.

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [x] Reviewing the diff

Human verification:

* [ ] I understand every meaningful change in this PR
* [ ] I checked generated code manually
* [ ] I accept responsibility for this PR

> _Human-verification boxes left for the accountable owner (@stephane-segning)._

---

## 8. Reviewer Focus

* [x] Correctness
* [x] Edge cases
