### PR TITLE
fix(apps): lci back to git-path Source A — OCI broke image-updater write-back (#448)

### DIFF
--- a/charts/apps/values.yaml
+++ b/charts/apps/values.yaml
@@ -1144,13 +1144,17 @@ applications:
       notifications.ssegning.me/github-revision: main
       notifications.ssegning.me/environment-url: https://code-intelligence.ai.camer.digital
     sources:
-      # Source A — the chart. release-pinned like every ai-helm app; the release
-      # script swaps this tag on each cut. Image tags come from Source B's $values.
-      # OCI chart-float (ADR-0055): Source A (the chart) floats from OCI; Source B
-      # (the vymalo $values + image write-back) is unchanged below.
-      - repoURL: oci://ghcr.io/adorsys-gis/charts/lightbridge-code-intelligence
-        chart: "."
-        targetRevision: ">=0.0.0"
+      # Source A — the chart, as a GIT-PATH source tracking ai-helm `main`
+      # (continuous, like everything else — no tag). ⚠️ NOT OCI on purpose: this
+      # app has argocd-image-updater git write-back (Source B → the vymalo repo),
+      # and image-updater CANNOT introspect/update the image params on an OCI
+      # `chart: "."` source — migrating Source A to OCI (PR #461) silently froze
+      # write-back (stuck on an old sha while newer signed builds piled up).
+      # Keep it git-path so write-back works. (converse-ui is the same shape: a
+      # git chart source + write-back.) ADR-0055.
+      - repoURL: https://github.com/ADORSYS-GIS/ai-helm
+        targetRevision: main
+        path: charts/lightbridge-code-intelligence
         helm:
           releaseName: lightbridge-ci
           valueFiles:


### PR DESCRIPTION
## 1. Summary

Revert `lightbridge-code-intelligence`'s chart source (Source A) from an OCI `chart: "."` source back to a **git-path source tracking `main`**. Source B (the vymalo `$values` + image write-back) is unchanged.

It solves: **"aii-lightbridge-code-intelligence is broken."** Migrating its Source A to OCI (#461) silently broke argocd-image-updater's git write-back — it can't introspect/update helm image params on an OCI chart source. The app stayed Synced/Healthy and served 200, but was frozen on a stale image while newer builds piled up. Source of truth: https://github.com/ADORSYS-GIS/ai-helm/issues/448.

---

## 2. Intent

> Restore lci's continuous image write-back. The chart still tracks `main` (continuous), just via a git-path source so image-updater works. lci is the deliberate non-OCI exception — same shape as converse-ui (a git chart source + write-back). General rule: never put `chart:`/OCI on an app that uses argocd-image-updater git write-back.

---

## 3. Scope

### In Scope
- lci Source A: OCI `chart: "."` → git-path (`repoURL: ai-helm`, `path: charts/lightbridge-code-intelligence`, `targetRevision: main`).

### Out of Scope
- Source B (vymalo write-back, unchanged); every other app (those have no git write-back, so OCI is fine).

---

## 4. Verification

I verified this change by:

- [x] Running automated tests
- [x] Testing on the live cluster (root-caused)

Commands run / evidence:

```text
- vymalo deploy/envs/production/values.yaml write-back commits: frequent until 2026-06-22T13:35Z, then STOPPED.
- #461 (lci→OCI) merged 2026-06-22T21:19Z. Next build sha-80ee138 created 22:15Z → never written back.
- Deployed = sha-59e98bd; newest signed build = sha-80ee138 (cosign .sig present → signing not the gate).
- ImageUpdater CR Ready (3 images, checked) but no write-back + no error logged → OCI source not introspectable.
- helm template x charts/apps → lci Source A now git-path @ main + Source B vymalo ref:values. lint 0 failed.
```

---

## 5. Screenshots / Evidence

- Post-merge: image-updater should resume on lci and promote `sha-80ee138` (commit to the vymalo values file → ArgoCD syncs → pods roll). Will verify the write-back commit lands + pods update.

---

## 6. Risk Assessment

Risk level:

* [x] Low

Potential risks:

* Source-swap (OCI→git-path), same chart content (charts/lightbridge-code-intelligence on `main`). Restores prior working behavior.

Mitigation:

* Render + lint verified; revert restores OCI form if ever needed.

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [x] Reviewing the diff

Human verification:

* [ ] I understand every meaningful change in this PR
* [ ] I checked generated code manually
* [ ] I accept responsibility for this PR

> _Human-verification boxes left for the accountable owner (@stephane-segning)._

---

## 8. Reviewer Focus

* [x] Correctness
