### PR TITLE
fix(apps): move lightbridge-code-intelligence image write-back to ai-helm-values (ADR-0055)

### DIFF
--- a/charts/apps/values.yaml
+++ b/charts/apps/values.yaml
@@ -1075,14 +1075,21 @@ applications:
   # a dedicated `codeintel` role + database (charts/lightbridge-db). Plain workload →
   # home-remote (default).
   #
-  # CONTINUOUS DEPLOY — argocd-image-updater + git write-back (vymalo-shop pattern).
-  # Multi-source: the chart is release-pinned (Source A), but the two image tags are
-  # read from the APP repo's main via a $values source (Source B). image-updater picks
-  # the newest *signed* sha-<gitsha> from GHCR and commits it back into that file, which
-  # ArgoCD then auto-syncs — so deploys don't need an ai-helm release. The selecting
-  # ImageUpdater CR lives in home-os (charts/argocd-image-updater). Image tags are
-  # therefore NOT set here; they live in the app repo at
-  # deploy/envs/production/values.yaml (image-updater owns them).
+  # CONTINUOUS DEPLOY — argocd-image-updater + git write-back (converse-ui pattern).
+  # Multi-source: the chart is a git-path source on main (Source A), but the three
+  # image tags are read from ai-helm-values via a $values source (Source B).
+  # image-updater picks the newest *signed* sha-<gitsha> from GHCR and commits it back
+  # into that file, which ArgoCD then auto-syncs — so deploys don't need an ai-helm
+  # release. The selecting ImageUpdater CR is rendered by charts/imageupdater. Image
+  # tags are therefore NOT set here; they live in ai-helm-values at
+  # environments/prod/values/lightbridge-code-intelligence.yaml (image-updater owns them).
+  # ⚠️ Write-back moved OFF the vymalo repo (2026-06-23): vymalo `main` became
+  # PR-protected (1 review required), so the bot's direct push was rejected (GH006)
+  # and write-back silently FROZE (app stayed Synced/Healthy on a stale sha). The
+  # ai-helm-values repo's main is unprotected (the values repo exists for exactly
+  # this) → the bot direct-commits again, same as converse-ui. (PR #461's OCI
+  # migration was NOT the cause — Source A's form is independent of the Source B
+  # push; #463's git-path revert is kept since it matches converse-ui's proven shape.)
   - name: lightbridge-code-intelligence
     finalizers:
       - resources-finalizer.argocd.argoproj.io
@@ -1122,18 +1129,16 @@ applications:
       argocd-image-updater.argoproj.io/web.signature-type: cosign
       argocd-image-updater.argoproj.io/web.cosign.certificate-oidc-issuer: https://token.actions.githubusercontent.com
       argocd-image-updater.argoproj.io/web.cosign.certificate-identity-regexp: ^https://github\.com/vymalo/lightbridge-code-intelligence/\.github/workflows/build-images\.yml@.*$
-      # ── git write-back → the app repo's main (public repo, so only the commit
-      # needs creds: the shared vymalo GitHub App, same as vymalo-shop). ──
+      # ── git write-back → ai-helm-values main (PRIVATE; the org-wide adorsys-gis
+      # GitHub App commits, and ArgoCD reads Source B via the same repo-creds —
+      # exactly like converse-ui). Unprotected branch → the bot can direct-commit. ──
       argocd-image-updater.argoproj.io/write-back-method: git
       argocd-image-updater.argoproj.io/git-branch: main
-      argocd-image-updater.argoproj.io/git-repository: https://github.com/vymalo/lightbridge-code-intelligence.git
-      # Leading slash = path absolute from the git repo ROOT. Without it a `helmvalues:`
-      # target resolves relative to the app's chart SOURCE path
-      # (charts/lightbridge-code-intelligence), so image-updater writes a wrong nested
-      # file (charts/lightbridge-code-intelligence/deploy/...). vymalo/opfs dodge this
-      # only because their chart is OCI (no source path); ours is path-based → slash required.
-      argocd-image-updater.argoproj.io/write-back-target: helmvalues:/deploy/envs/production/values.yaml
-      argocd-image-updater.argoproj.io/git-credentials: secret:argocd/github-app-creds--vymalo
+      argocd-image-updater.argoproj.io/git-repository: https://github.com/adorsys-gis/ai-helm-values.git
+      # Leading slash = path absolute from the git repo ROOT (without it a `helmvalues:`
+      # target resolves relative to the app's chart SOURCE path).
+      argocd-image-updater.argoproj.io/write-back-target: helmvalues:/environments/prod/values/lightbridge-code-intelligence.yaml
+      argocd-image-updater.argoproj.io/git-credentials: secret:argocd/github-app-creds--adorsys-gis
       # ── argocd-notifications → GitHub Deployment status. `vymalo` is the
       # notifier service (GitHub App installation on the vymalo org); the
       # on-deployed / on-deploy-failed triggers + ssegning.me annotation
@@ -1145,23 +1150,20 @@ applications:
       notifications.ssegning.me/environment-url: https://code-intelligence.ai.camer.digital
     sources:
       # Source A — the chart, as a GIT-PATH source tracking ai-helm `main`
-      # (continuous, like everything else — no tag). ⚠️ NOT OCI on purpose: this
-      # app has argocd-image-updater git write-back (Source B → the vymalo repo),
-      # and image-updater CANNOT introspect/update the image params on an OCI
-      # `chart: "."` source — migrating Source A to OCI (PR #461) silently froze
-      # write-back (stuck on an old sha while newer signed builds piled up).
-      # Keep it git-path so write-back works. (converse-ui is the same shape: a
-      # git chart source + write-back.) ADR-0055.
+      # (continuous, like everything else — no tag). Kept git-path to match the
+      # proven converse-ui write-back shape (a git chart source + a $values
+      # write-back source). OCI was never the write-back blocker — branch
+      # protection on the old vymalo target was (see the header note). ADR-0055.
       - repoURL: https://github.com/ADORSYS-GIS/ai-helm
         targetRevision: main
         path: charts/lightbridge-code-intelligence
         helm:
           releaseName: lightbridge-ci
           valueFiles:
-            - $values/deploy/envs/production/values.yaml
+            - $values/environments/prod/values/lightbridge-code-intelligence.yaml
           ignoreMissingValueFiles: true
-      # Source B — image tags from the app repo's main; image-updater commits here.
-      - repoURL: https://github.com/vymalo/lightbridge-code-intelligence.git
+      # Source B — image tags from ai-helm-values main; image-updater commits here.
+      - repoURL: https://github.com/adorsys-gis/ai-helm-values
         targetRevision: main
         ref: values
     destination:


### PR DESCRIPTION
## Summary

Fixes the frozen continuous-delivery write-back for **aii-lightbridge-code-intelligence**, part of the ADR-0055 continuous-delivery epic ([#445](https://github.com/ADORSYS-GIS/ai-helm/issues/445)).

argocd-image-updater had silently stopped promoting new lci images. The controller was working correctly — detecting each newer signed `sha-<gitsha>`, editing the values file, committing — but the **push was rejected**:

```
git push origin main → GH006: Protected branch update failed for refs/heads/main.
remote: Changes must be made through a pull request.
```

`vymalo/lightbridge-code-intelligence` `main` became **PR-protected** (1 review required) at `2026-06-22T17:34Z`, so the bot could no longer direct-commit the written-back tag. The app stayed `Synced/Healthy` serving HTTP 200 — only the deploy of new images was stuck (deployed `sha-59e98bd`; newest signed `sha-80ee138` never promoted).

This was **not** caused by the OCI chart migration ([#461](https://github.com/ADORSYS-GIS/ai-helm/pull/461)) — Source A's form is independent of the Source B write-back push (#461 merely correlated in time), and [#463](https://github.com/ADORSYS-GIS/ai-helm/pull/463)'s git-path revert did not fix it (kept, since it matches the proven converse-ui shape).

## Change

Relocate lci's write-back + `$values` source from the now-protected vymalo repo to the **unprotected `adorsys-gis/ai-helm-values`** repo — exactly the converse-ui shape (org-wide `adorsys-gis` GitHub App commits; ArgoCD reads it via the same `github-app-creds--adorsys-gis` repo-creds).

- Image tags now live at `ai-helm-values:/environments/prod/values/lightbridge-code-intelligence.yaml` (seeded from the vymalo file at the current tag — [seed commit](https://github.com/ADORSYS-GIS/ai-helm-values/commit/f1d66279966256a66cf0a9584895acc84a56c975)).
- Write-back annotations: `git-repository` → `ai-helm-values.git`, `git-credentials` → `github-app-creds--adorsys-gis`, `write-back-target` → the new path.
- Source A (chart) stays git-path on ai-helm `main`; `valueFiles` points at the new `$values` path. Source B `repoURL` → ai-helm-values.
- GitHub Deployment-status notifications still target the vymalo app repo (where the code lives) — unchanged.
- The old `deploy/envs/production/values.yaml` in the vymalo repo is now orphaned; left in place, harmless.

## AI Usage Declaration

- [x] AI was used to author this change.
- **What:** Claude Code (Opus 4.8) root-caused the frozen write-back from the image-updater controller logs (`argocd-image-updater` ns) and the vymalo branch-protection state, then rewrote the lci app entry + seeded the values file.
- **Verified by maintainer:** the GH006 push rejection in the controller logs, the branch-protection timestamp, and the render below.

## Verification

- `helm template x charts/apps` renders cleanly; the `aii-lightbridge-code-intelligence` Application shows:
  - `write-back-target: helmvalues:/environments/prod/values/lightbridge-code-intelligence.yaml`
  - `git-repository: https://github.com/adorsys-gis/ai-helm-values.git`, `git-credentials: secret:argocd/github-app-creds--adorsys-gis`
  - Source A `valueFiles: $values/environments/prod/values/lightbridge-code-intelligence.yaml`; Source B `repoURL: …/ai-helm-values`, `ref: values`.
- Seed file committed to `ai-helm-values` main (unprotected → bot push succeeds).
- **Post-merge:** image-updater's next cycle should write `sha-80ee138` (newest signed) into the new file and lci pods roll. Will confirm the write-back commit lands + pods update.
