### PR TITLE
feat(lci): richer, less-timid review prompt — quality as a first-class dimension

### DIFF
--- a/charts/lightbridge-code-intelligence/values.yaml
+++ b/charts/lightbridge-code-intelligence/values.yaml
@@ -168,6 +168,17 @@ config:
     - N+1 queries, unbounded loops or recursion, hot-path allocations, blocking IO on an async path,
       missing pagination or limits, accidental O(n^2).
 
+    **Maintainability & design (the quality of the change itself, not only its correctness)**
+    - Does the change fit the existing design, or bolt on a parallel way of doing the same thing?
+      Duplicated logic that should reuse an existing helper; an abstraction at the wrong layer.
+    - Readability that will cost the next reader: misleading names, a function doing three things,
+      control flow that hides the happy path, magic values, comments that explain *what* instead of
+      *why*.
+    - Error/return contracts that are easy to misuse; leaky or surprising APIs; implicit coupling that
+      will break at a distance.
+    - Dead code, needless complexity, or a simpler shape that does the same job. Raise these as **P2
+      quality** findings when they will bite a future maintainer — not as blockers.
+
     **Tests & observability**
     - Is the change actually covered? Do the tests assert behaviour or just run? Happy-path only? Are
       the failure modes tested?
@@ -180,14 +191,21 @@ config:
 
     # How to report
 
-    - Be **terse and high-signal** — a human should grasp each finding in seconds. State what is wrong,
-      why it matters, and, when you can, the exact fix.
-    - One finding per real issue. **No praise, no restating the code, no hedging, no filler.** If the
-      change is genuinely sound, say so in one line and stop — silence beats noise.
+    - Be **high-signal and substantive** — every line earns its place, but do not be so terse that the
+      review says nothing. The author should come away understanding both what is wrong AND your read on
+      the change's design and quality.
+    - Lead each finding with what is wrong, why it matters, and — when you can — the exact fix. One
+      finding per real issue. **No filler, no hedging, no restating the code back.**
+    - Review **all dimensions**, not just bugs and security: correctness, security, **quality /
+      maintainability**, style, performance. A change can be bug-free and still be worth comment because
+      it will be hard to live with — raise that as a P2 quality finding rather than staying silent.
+    - Your **summary is a real verdict, not a one-liner**: give the design read on the change — what it
+      does well, what is risky, and what you would want addressed — in a few sentences. Specific, earned
+      praise is fine; empty praise is not.
     - Triage honestly: **P0** must-fix (bugs, data loss, security), **P1** should-fix, **P2**
-      minor/nit. Do not inflate to look useful and do not bury a blocker among nits. **Security
-      findings start at P0.** Give each finding a category (security / correctness / quality / style /
-      performance).
+      minor / maintainability / nit. Do not inflate to look useful and do not bury a blocker among nits.
+      **Security findings start at P0.** Give each finding a category (security / correctness / quality /
+      style / performance).
     - Stay in scope: review the change. Observations about code outside the diff belong in the
       out-of-scope channel, not inline on untouched lines.
     - When you propose a fix, give the exact replacement so the author can apply it in one click.


### PR DESCRIPTION
## 1. Summary

This PR changes:

- `config.reviewSystemPrompt` for Lightbridge: adds a **Maintainability & design** hunt section (fit-with-design, duplicated logic, readability cost, misuse-prone contracts, needless complexity — raised as P2 quality findings).
- Reframes "How to report": **high-signal AND substantive**, review **all dimensions**, and the **summary is a real verdict** (a few sentences of design read) instead of a one-line "looks fine, no blockers".

It solves:

- vymalo/lightbridge-code-intelligence#175 (source-of-truth ticket), under epic vymalo/lightbridge-code-intelligence#137. Live evidence: `vymalo/vymalo-shop#240`/`#241` reviews read "blunt / meh".

---

## 2. Intent

The intent of this PR is:

> Make reviews **useful**, not just safe. The current prompt optimises hard for terseness, producing minimal "one P1, no blockers" verdicts that give the author no read on the change's design. This adds code-quality/maintainability as a first-class dimension and a substantive verdict — while keeping the no-invention / no-linter-nitpick / in-scope guardrails so it doesn't become noisy.

---

## 3. Scope

### In Scope

- The `reviewSystemPrompt` text only (mounted ConfigMap; change → ArgoCD sync, no image rebuild).

### Out of Scope

- The code-side coverage gate / prior-review context (vymalo/lightbridge-code-intelligence#176).
- Model / turn-budget / resilience knobs.

---

## 4. Verification

I verified this change by:

- [x] Running automated tests
- [ ] Running manual tests
- [ ] Checking logs
- [ ] Checking metrics
- [ ] Testing error cases
- [ ] Testing permissions/security behavior
- [ ] Testing rollback or failure behavior, if relevant

Commands run:

```bash
python3 -c "import yaml; yaml.safe_load(open('charts/lightbridge-code-intelligence/values.yaml'))"
helm lint charts/lightbridge-code-intelligence
```

Results:

```text
YAML parses; reviewSystemPrompt = 7722 chars; Maintainability + substantive-verdict present
helm lint: 1 chart linted, 0 failed
```

Post-merge smoke (ArgoCD sync, then trigger a re-review on a real PR) is the remaining manual check.

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Drafting documentation / prompt
* [x] Reviewing the diff

Human verification:

* [x] I understand every meaningful change in this PR
* [x] I accept responsibility for this PR
