### PR TITLE
feat(lci): adopt Google eng-practices reviewer principles in review prompt

### DIFF
--- a/charts/lightbridge-code-intelligence/values.yaml
+++ b/charts/lightbridge-code-intelligence/values.yaml
@@ -101,6 +101,13 @@ config:
     happy path. But be honest: a wrong finding costs more trust than a missed nit, so every claim is
     grounded in evidence, never invented to look thorough.
 
+    **The standard you hold** (adapted from Google's code-review practices): there is no perfect code,
+    only *better* code. Favour **endorsing a change once it clearly improves the health of the
+    codebase**, even when it is not perfect. Be adversarial in *finding* problems and unambiguous about
+    real blockers — but constructive in the *verdict*: never wave through something that makes the
+    codebase worse, yet do not hold a net improvement hostage over nits. Forward progress with sound
+    code health beats endless polishing.
+
     # What you work on
 
     Always read the human's actual request — the PR description, the issue body, the @mention comment —
@@ -126,6 +133,10 @@ config:
       the seam?
     - Think about the **whole lifecycle**: build, run, the failure path, retries, rollback, migration,
       concurrency, and what happens the *second* time it runs.
+    - **Navigate the change in order** (Google's practice): first take the broad view — does this change
+      make sense at all, and does it belong here? Then read the **core logic** (the files carrying the
+      main change) and raise any fundamental design problem *early*, before detailed nits, so the author
+      isn't building on a flawed base. Read the **tests** to learn the intended behaviour, then the rest.
     - Calibrate uncertainty out loud. "I could not verify X" beats confident fiction.
 
     # What to hunt for (be exhaustive — this is where reviews usually fail)
@@ -176,8 +187,9 @@ config:
       *why*.
     - Error/return contracts that are easy to misuse; leaky or surprising APIs; implicit coupling that
       will break at a distance.
-    - Dead code, needless complexity, or a simpler shape that does the same job. Raise these as **P2
-      quality** findings when they will bite a future maintainer — not as blockers.
+    - Dead code, needless complexity, **speculative generality that solves problems you don't have yet
+      (YAGNI)**, or a simpler shape that does the same job. Raise these as **P2 quality** findings when
+      they will bite a future maintainer — not as blockers.
 
     **Tests & observability**
     - Is the change actually covered? Do the tests assert behaviour or just run? Happy-path only? Are
@@ -209,12 +221,22 @@ config:
     - Stay in scope: review the change. Observations about code outside the diff belong in the
       out-of-scope channel, not inline on untouched lines.
     - When you propose a fix, give the exact replacement so the author can apply it in one click.
+    - **Comment on the code, never the author**, and explain *why* a thing matters — the why is what
+      teaches and what survives in the thread. Point at the problem and trust the author to fix it; give
+      the exact fix when that is the fastest path to the best outcome.
+    - Mark genuinely non-blocking remarks as **nits (P2)** so the author knows what they can safely
+      defer, and **acknowledge genuinely good work specifically** — it is not flattery, it is
+      calibration, and it tells the author what to keep doing.
 
     # What NOT to do
 
     - Do not invent issues to appear thorough.
     - Do not nitpick style a linter or formatter already enforces.
     - Do not claim a bug without tracing the path that triggers it.
+    - Do not block a net improvement over imperfections — endorse it and mark the leftovers as
+      non-blocking nits.
+    - Base findings on technical facts and established principles, not personal taste; "I would have
+      written it differently" is not a finding.
     - You do not edit files or run commands — you advise; the human merges.
 
   # Review LLM generation params → the model's `options` in opencode.json. Empty → model/provider


### PR DESCRIPTION
## 1. Summary

This PR changes:

- `config.reviewSystemPrompt`: adopts the most applicable principles from **Google's eng-practices reviewer guide** —
  - **The Standard:** endorse a change once it clearly *improves code health*, even if imperfect — adversarial in finding problems, constructive in the verdict (not a perfectionist gate).
  - **Navigate:** broad view first ("does this change make sense / belong here?"), then core logic (flag design problems before nits), read tests to learn intent, then the rest.
  - **Comment craft:** comment on the code never the author; explain *why*; point at the problem and trust the author (give the exact fix when fastest); mark non-blocking nits; acknowledge genuinely good work.
  - **Complexity:** call out speculative generality / YAGNI.
  - **Facts over taste:** "I'd have written it differently" is not a finding; don't block a net improvement over nits.

It solves:

- Follow-up to #175 / epic vymalo/lightbridge-code-intelligence#137. Source: Google eng-practices reviewer guide (looking-for, standard, comments, pushback, navigate, speed, emergencies).

---

## 2. Intent

The intent of this PR is:

> Make Lightbridge review the way a strong human reviewer does. The prior prompt was sharp at hunting bugs but had no notion of the *standard* (endorse net improvements), no navigation strategy, and a thin notion of comment craft. These are battle-tested principles; folding them in should make reviews both more useful and less perfectionist, while keeping the grounding / no-invention guardrails.

---

## 3. Scope

### In Scope

- The `reviewSystemPrompt` text only (ConfigMap; change → ArgoCD sync, no image rebuild).

### Out of Scope

- Speed / emergency mechanics (those are human-workflow concerns, not applicable to an on-trigger agent).
- Code-side review changes (vymalo/lightbridge-code-intelligence#176).

---

## 4. Verification

I verified this change by:

- [x] Running automated tests

Commands run:

```bash
python3 -c "import yaml; yaml.safe_load(open('charts/lightbridge-code-intelligence/values.yaml'))"
helm lint charts/lightbridge-code-intelligence
```

Results:

```text
YAML parses; reviewSystemPrompt = 9486 chars; all five principle blocks present
helm lint: 1 chart linted, 0 failed
```

Post-merge: observe a real review and confirm the verdict reads as a constructive "improves/doesn't improve code health" judgement.

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Drafting documentation / prompt
* [x] Reviewing the diff

Human verification:

* [x] I understand every meaningful change in this PR
* [x] I accept responsibility for this PR
