### PR TITLE
feat(ai-models): back adorsys-reviewer-pro with GLM-5.2 (1M ctx + rate card)

### DIFF
--- a/charts/ai-models/values.yaml
+++ b/charts/ai-models/values.yaml
@@ -906,12 +906,12 @@ models:
 
   adorsys-reviewer-pro:
     kind: text
-    # Backing: DeepInfra · zai-org/GLM-5 — thorough agentic reviewer.
+    # Backing: DeepInfra · zai-org/GLM-5.2 — thorough agentic reviewer.
     rateLimitBudgeting:
       free: 15
       pro: 50
     info:
-      displayName: "Adorsys Reviewer Pro (GLM-5)"
+      displayName: "Adorsys Reviewer Pro (GLM-5.2)"
       contextLength: 202752
       maxOutputTokens: 131072
       supportedParameters: *spReasoning
@@ -924,10 +924,10 @@ models:
     backends:
       deepinfra-01:
         <<: *deepinfraBackendPrimary
-        modelNameOverride: "zai-org/GLM-5"
+        modelNameOverride: "zai-org/GLM-5.2"
       deepinfra-02:
         <<: *deepinfraBackendSecondary
-        modelNameOverride: "zai-org/GLM-5"
+        modelNameOverride: "zai-org/GLM-5.2"
 
   adorsys-frontend:
     # Backing: DeepInfra · nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning — an OPEN

--- a/charts/ai-models/values.yaml
+++ b/charts/ai-models/values.yaml
@@ -912,15 +912,15 @@ models:
       pro: 50
     info:
       displayName: "Adorsys Reviewer Pro (GLM-5.2)"
-      contextLength: 202752
+      contextLength: 1048576
       maxOutputTokens: 131072
       supportedParameters: *spReasoning
     pricing:
       strategy: weighted
       standard:
-        inputPer1M: 0.60
-        cachedInputPer1M: 0.12
-        outputPer1M: 2.08
+        inputPer1M: 0.95
+        cachedInputPer1M: 0.18
+        outputPer1M: 3.00
     backends:
       deepinfra-01:
         <<: *deepinfraBackendPrimary


### PR DESCRIPTION
## 1. Summary

This PR changes:

- Re-points the `adorsys-reviewer-pro` model brand (`charts/ai-models/values.yaml`) from DeepInfra `zai-org/GLM-5` to `zai-org/GLM-5.2` on both backends, and updates its `displayName` + comment.
- Corrects the catalog metadata for the new SKU: `contextLength` 202,752 → **1,048,576** (GLM-5.2's 1M window).
- Corrects pricing to the GLM-5.2 rate card: `inputPer1M` 0.60 → **0.95**, `cachedInputPer1M` 0.12 → **0.18**, `outputPer1M` 2.08 → **3.00** (per 1M tokens).

It solves:

- Source of truth: maintainer request in-session + DeepInfra GLM-5.2 rate card. (No tracking ticket — please link one if required by governance.)

---

## 2. Intent

The intent of this PR is:

> Move the thorough agentic-review tier (`adorsys-reviewer-pro`) onto the newest GLM generation. GLM-5.2 is a distinct SKU rather than a tag bump — it carries a 1M-token context window and a higher rate card — so the catalog's `contextLength` and `pricing` must change with it, otherwise per-request cost accounting (ADR-0021 budgeting) would be computed against stale numbers. The cheaper `adorsys-reviewer` (MiniMax M2.7) is intentionally left as-is.

---

## 3. Scope

### In Scope

- `adorsys-reviewer-pro` model id, display name, context length, and pricing.

### Out of Scope

- `rateLimitBudgeting` for reviewer-pro (kept at free: 15 / pro: 50 — deliberately deferred; the 1M context vs. budget sizing is a noted future-work item).
- The GLM-5.1 entries (`glm-5p1`, `adorsys-planner-pro`, `adorsys-coder-pro`) and every other catalog model.
- Image tags / per-env values (those live in `ai-helm-values`; this is a structural chart default per ADR-0012).

---

## 4. Verification

I verified this change by:

- [x] Running manual tests
- [ ] Running automated tests
- [ ] Checking logs
- [ ] Checking metrics
- [ ] Testing error cases
- [ ] Testing permissions/security behavior
- [ ] Testing rollback or failure behavior, if relevant

Commands run:

```bash
helm dep build charts/ai-models
helm template x charts/ai-models --dry-run
```

Results:

```text
RENDER OK  (orchestrator ApplicationSet renders cleanly with the updated values)
```

---

## 5. Screenshots / Evidence

* N/A — values-only change; render check above is the evidence.

---

## 6. Risk Assessment

Risk level:

* [x] Low

Potential risks:

* If DeepInfra's published GLM-5.2 rate card differs from the values used here, per-request cost accounting would be slightly off.

Mitigation:

* Pricing taken directly from the maintainer-supplied GLM-5.2 rate card ($0.95 in / $0.18 cached / $3.00 out, 1,048,576 ctx).

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [x] Drafting documentation

Human verification:

* [x] I understand every meaningful change in this PR
* [x] I checked generated code manually
* [x] I accept responsibility for this PR

---

## 8. Reviewer Focus

Please focus your review on:

* [x] Correctness
* [x] Product intent
