### PR TITLE
feat(lci): map config.model.fallbackModel -> review.fallback_model (#166)

### DIFF
--- a/charts/lightbridge-code-intelligence/templates/config.yaml
+++ b/charts/lightbridge-code-intelligence/templates/config.yaml
@@ -55,6 +55,7 @@ data:
 {{- if ne (toString $cfg.model.topP) "" }}{{- $_ := set $rev "top_p" $cfg.model.topP }}{{- end }}
 {{- if ne (toString $cfg.model.maxTokens) "" }}{{- $_ := set $rev "max_tokens" $cfg.model.maxTokens }}{{- end }}
 {{- if ne (toString $cfg.model.maxTurns) "" }}{{- $_ := set $rev "max_turns" $cfg.model.maxTurns }}{{- end }}
+{{- if ne (toString $cfg.model.fallbackModel) "" }}{{- $_ := set $rev "fallback_model" $cfg.model.fallbackModel }}{{- end }}
 {{- $_ := set $ag "review" $rev }}
 apiVersion: v1
 kind: ConfigMap

--- a/charts/lightbridge-code-intelligence/values.yaml
+++ b/charts/lightbridge-code-intelligence/values.yaml
@@ -107,6 +107,10 @@ config:
     # Max agent turns per review (ADR-0037 loop). Empty → the runner's built-in default (40).
     # → agent.json `review.max_turns`.
     maxTurns: ""
+    # Secondary review model to fail over to when the primary times out / errs out a turn (ADR-0039).
+    # Empty → single-model (no failover). → agent.json `review.fallback_model`. Set per-env in
+    # ai-helm-values to a DIFFERENT alias than the primary so a primary-path outage actually fails over.
+    fallbackModel: ""
 
   # PR feedback the control plane applies (FILE-ONLY knobs — no env equivalent).
   review:


### PR DESCRIPTION
Exposes the secondary review model (ADR-0039 LLM failover) via the chart so an env sets it in ai-helm-values. Empty default = no failover (unchanged). Motivated by dogfood run 7c15f9bb (6.3-min gateway spike, no fallback). Verified: helm lint passes.