### PR TITLE
feat(lightbridge): wire Grafana dashboards + metrics scraping + grafana_ro role (ADR-0046)

### DIFF
--- a/charts/apps/values.yaml
+++ b/charts/apps/values.yaml
@@ -547,7 +547,7 @@ applications:
     destination:
       namespace: converse
 
-  # ── Lightbridge observability — Grafana dashboards-as-code (ADR-0043) ──
+  # ── Lightbridge observability — Grafana dashboards-as-code (ADR-0046) ──
   # Deploys the dashboards-as-code chart that lives in the APPLICATION repo
   # (vymalo/lightbridge-code-intelligence, PUBLIC → no repo-creds needed), NOT in
   # ai-helm: a GrafanaFolder + GrafanaDashboard CRs (imported by the grafana

--- a/charts/apps/values.yaml
+++ b/charts/apps/values.yaml
@@ -547,6 +547,34 @@ applications:
     destination:
       namespace: converse
 
+  # ── Lightbridge observability — Grafana dashboards-as-code (ADR-0043) ──
+  # Deploys the dashboards-as-code chart that lives in the APPLICATION repo
+  # (vymalo/lightbridge-code-intelligence, PUBLIC → no repo-creds needed), NOT in
+  # ai-helm: a GrafanaFolder + GrafanaDashboard CRs (imported by the grafana
+  # operator) + a read-only Postgres GrafanaDatasource. Lands in `observability`
+  # where the operator watches. No images → no image-updater. The metrics
+  # scraping (ServiceMonitors) + the grafana_ro DB role live with the workload
+  # (lightbridge-code-intelligence / lightbridge-db); this app is dashboards only.
+  - name: lightbridge-observability
+    finalizers:
+      - resources-finalizer.argocd.argoproj.io
+    sources:
+      # Source A — the dashboards chart from the app repo @ main (continuous).
+      - repoURL: https://github.com/vymalo/lightbridge-code-intelligence
+        targetRevision: main
+        path: deploy/observability
+        helm:
+          releaseName: lightbridge-observability
+          valueFiles:
+            - $values/environments/prod/values/lightbridge-observability.yaml
+          ignoreMissingValueFiles: true
+      # Source B — env-specific values from ai-helm-values main.
+      - repoURL: https://github.com/adorsys-gis/ai-helm-values
+        targetRevision: main
+        ref: values
+    destination:
+      namespace: observability
+
   # --- argocd-image-updater activation (control object, ADR-0055) ---
   # The CRD-based argocd-image-updater controller only acts on an Application when
   # an ImageUpdater CR selects it. Those CRs are argocd control objects (they must

--- a/charts/lightbridge-code-intelligence/templates/servicemonitor.yaml
+++ b/charts/lightbridge-code-intelligence/templates/servicemonitor.yaml
@@ -1,0 +1,50 @@
+{{- /*
+ServiceMonitors for the control-plane /metrics endpoints, discovered by Alloy
+(prometheus.operator.servicemonitors "cluster"). We use ServiceMonitors rather than PodMonitors
+because the bjw-s pods declare no containerPort — a PodMonitor would have no port to match, whereas a
+Service routes by numeric targetPort and its Endpoints give the ServiceMonitor a concrete target.
+
+  - serve role  → the control-plane Service (:8080, port name `http`); /metrics shares that port.
+  - dispatcher  → the dispatcher metrics Service (:9090, port name `metrics`) added in values.
+
+OFF by default (chart CI has no monitoring.coreos.com CRDs); the prod values enable it. Powers the
+Operations dashboard (deploy/observability in the lightbridge-code-intelligence repo).
+*/}}
+{{- if .Values.metrics.serviceMonitors.enabled }}
+{{- $fullname := .Values.lci.fullnameOverride }}
+{{- $wave := .Values.syncWave.app | quote }}
+{{- $interval := .Values.metrics.serviceMonitors.interval | default "30s" }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ $fullname }}-control-plane
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    argocd.argoproj.io/sync-wave: {{ $wave }}
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: {{ $fullname }}
+      app.kubernetes.io/service: {{ $fullname }}-control-plane
+  endpoints:
+    - port: http
+      path: /metrics
+      interval: {{ $interval }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ $fullname }}-dispatcher
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    argocd.argoproj.io/sync-wave: {{ $wave }}
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: {{ $fullname }}
+      app.kubernetes.io/service: {{ $fullname }}-dispatcher
+  endpoints:
+    - port: metrics
+      path: /metrics
+      interval: {{ $interval }}
+{{- end }}

--- a/charts/lightbridge-code-intelligence/values.yaml
+++ b/charts/lightbridge-code-intelligence/values.yaml
@@ -150,6 +150,16 @@ syncWave:
   secrets: "0"
   app: "2"
 
+# ── metrics scraping ─────────────────────────────────────────────────────────
+# ServiceMonitors that point Alloy (prometheus.operator.servicemonitors) at the control-plane's
+# /metrics (serve role :8080) and the dispatcher's (:9090). OFF in chart defaults so a defaults-only
+# render (helm lint / chart CI, no monitoring.coreos.com CRDs) emits nothing; the prod values turn it
+# on. Powers the Operations dashboard (deploy/observability, lightbridge-code-intelligence repo).
+metrics:
+  serviceMonitors:
+    enabled: false
+    interval: 30s
+
 # ── bjw-s app-template (v4) instance ─────────────────────────────────────────
 lci:
   # Force the fullname so resource/service names are deterministic `lightbridge-ci-*`
@@ -631,6 +641,15 @@ lci:
           port: 7687
         http:
           port: 7474
+    # Metrics-only Service for the dispatcher role (METRICS_ADDR :9090). The serve role's /metrics is
+    # already on the control-plane Service (:8080); the dispatcher/poller have no Service otherwise, so
+    # this gives the ServiceMonitor (templates/servicemonitor.yaml) a stable Endpoints target. The
+    # dispatcher pod declares no containerPort, but a Service routes by numeric targetPort regardless.
+    dispatcher:
+      controller: dispatcher
+      ports:
+        metrics:
+          port: 9090
 
   # DEPLOYMENT-SPECIFIC: ingress is OFF by default — the ingress class, cert-manager cluster-issuer,
   # public hostnames, and TLS secrets are all env-specific, so the FULL ingress config (enabled: true +

--- a/charts/lightbridge-db/values.yaml
+++ b/charts/lightbridge-db/values.yaml
@@ -70,7 +70,7 @@ resources:
             passwordSecret:
               name: lightbridge-codeintel-db-role
           # Read-only login role for Grafana (the lightbridge-observability dashboards query Postgres
-          # directly — agent runs are one-shot Jobs and can't be scraped, ADR-0043). Member of the
+          # directly — agent runs are one-shot Jobs and can't be scraped, ADR-0046). Member of the
           # built-in `pg_read_all_data` role (PG14+) so it gets SELECT on every table with NO writes
           # and no per-table grants to maintain. Password from the basic-auth Secret below.
           - name: grafana_ro

--- a/charts/lightbridge-db/values.yaml
+++ b/charts/lightbridge-db/values.yaml
@@ -69,6 +69,17 @@ resources:
             login: true
             passwordSecret:
               name: lightbridge-codeintel-db-role
+          # Read-only login role for Grafana (the lightbridge-observability dashboards query Postgres
+          # directly — agent runs are one-shot Jobs and can't be scraped, ADR-0043). Member of the
+          # built-in `pg_read_all_data` role (PG14+) so it gets SELECT on every table with NO writes
+          # and no per-table grants to maintain. Password from the basic-auth Secret below.
+          - name: grafana_ro
+            ensure: present
+            login: true
+            inRoles:
+              - pg_read_all_data
+            passwordSecret:
+              name: lightbridge-grafana-ro-db-role
   # ────────────────────────────────────────────────────────────────────
   # barman-cloud ObjectStore — MODERNISED TO HETZNER OBJECT STORAGE.
   #
@@ -254,3 +265,38 @@ resources:
           remoteRef:
             key: ai/camer/digital/prod/env
             property: codeintel_db_password
+  # ────────────────────────────────────────────────────────────────────
+  # grafana_ro role password (read-only DB user for the Grafana dashboards).
+  # basic-auth Secret consumed by CNPG (passwordSecret on the managed role above)
+  # to SET the role's password. The SAME password is also surfaced into the
+  # `observability` namespace for the GrafanaDatasource (see ai-helm-values
+  # environments/prod/deps/observability-secrets) — both read this one SM property.
+  # ⚠️ Requires a new `codeintel_grafana_ro_db_password` property in the
+  # ai/camer/digital/prod/env Secrets Manager bucket.
+  # ────────────────────────────────────────────────────────────────────
+  - |
+    apiVersion: external-secrets.io/v1
+    kind: ExternalSecret
+    metadata:
+      name: lightbridge-grafana-ro-db-role
+      namespace: converse
+      annotations:
+        argocd.argoproj.io/sync-wave: "1"
+    spec:
+      refreshInterval: 1h
+      secretStoreRef:
+        kind: ClusterSecretStore
+        name: ssegning-aws
+      target:
+        name: lightbridge-grafana-ro-db-role
+        creationPolicy: Owner
+        template:
+          type: kubernetes.io/basic-auth
+          data:
+            username: "grafana_ro"
+            password: "{{ "{{ .password }}" }}"
+      data:
+        - secretKey: password
+          remoteRef:
+            key: ai/camer/digital/prod/env
+            property: codeintel_grafana_ro_db_password


### PR DESCRIPTION
## Summary

Wires the Lightbridge Grafana observability stack that was committed but never deployed (ADR-0046 in the app repo). Three changes:

1. **`charts/apps/values.yaml`** — new **`lightbridge-observability`** ArgoCD Application sourcing the **public** `vymalo/lightbridge-code-intelligence` repo's `deploy/observability` chart (+ `ai-helm-values`), into the `observability` namespace. No images → no image-updater.
2. **`charts/lightbridge-code-intelligence`** — **ServiceMonitors** (off by default) for the serve role (`control-plane` Service `:8080` `/metrics`) and the dispatcher (`:9090`), plus a metrics-only Service for the dispatcher. ServiceMonitor rather than PodMonitor because the bjw-s pods declare **no containerPort** — a Service routes by numeric `targetPort` and gives Alloy's `prometheus.operator.servicemonitors` a concrete Endpoints target.
3. **`charts/lightbridge-db`** — a least-privilege **`grafana_ro`** CNPG managed role (member of `pg_read_all_data` → SELECT only, no writes, no per-table grants) + its basic-auth ExternalSecret, so Grafana can read the operational tables the Postgres dashboards query.

## Why

The dashboards-as-code chart was an orphan (no Application referenced it) and `/metrics` was never scraped. Most dashboards read **Postgres** directly (the review agent runs as a one-shot Job and can't be scraped — ADR-0037/0043), so the read-only DB role + datasource matter more than the metrics path.

## ⚠️ Manual prerequisite

Add a **`codeintel_grafana_ro_db_password`** property to the `ai/camer/digital/prod/env` Secrets Manager bucket **before** this syncs — both the CNPG role's `passwordSecret` and the datasource ExternalSecret read it.

## Depends on / pairs with

- `ai-helm-values#feat/lci-observability-wiring` (the prod values + datasource secret) — **merge together**.
- `vymalo/lightbridge-code-intelligence` [#187](https://github.com/vymalo/lightbridge-code-intelligence/pull/187) (the dashboards). No hard dependency — the 5 existing dashboards deploy regardless; `review-quality` + the enriched panels appear once #187 merges and the app resyncs.

## Verification

```
helm lint charts/apps charts/lightbridge-code-intelligence charts/lightbridge-db   # 0 failed
helm template … | grep aii-lightbridge-observability                               # Application renders
helm template charts/lightbridge-code-intelligence                                 # ServiceMonitor count 0 (default)
helm template … --set metrics.serviceMonitors.enabled=true                         # 2 ServiceMonitors; selectors match rendered Service labels
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
