### PR TITLE
feat(lci): contextWindow knob → review.context_window (ADR-0045)

### DIFF
--- a/charts/lightbridge-code-intelligence/Chart.yaml
+++ b/charts/lightbridge-code-intelligence/Chart.yaml
@@ -12,7 +12,7 @@ description: |
   matching the librechat-app pattern; ExternalSecrets are chart templates resolving
   against the ssegning-aws ClusterSecretStore; ingress is Traefik + cert-home-cert-http.
 type: application
-version: 0.7.0
+version: 0.7.1
 appVersion: "0.7.0"
 dependencies:
   - name: bjw-template

--- a/charts/lightbridge-code-intelligence/templates/config.yaml
+++ b/charts/lightbridge-code-intelligence/templates/config.yaml
@@ -56,6 +56,7 @@ data:
 {{- if ne (toString $cfg.model.maxTokens) "" }}{{- $_ := set $rev "max_tokens" $cfg.model.maxTokens }}{{- end }}
 {{- if ne (toString $cfg.model.maxTurns) "" }}{{- $_ := set $rev "max_turns" $cfg.model.maxTurns }}{{- end }}
 {{- if ne (toString $cfg.model.fallbackModel) "" }}{{- $_ := set $rev "fallback_model" $cfg.model.fallbackModel }}{{- end }}
+{{- if ne (toString $cfg.model.contextWindow) "" }}{{- $_ := set $rev "context_window" $cfg.model.contextWindow }}{{- end }}
 {{- $_ := set $ag "review" $rev }}
 apiVersion: v1
 kind: ConfigMap

--- a/charts/lightbridge-code-intelligence/values.yaml
+++ b/charts/lightbridge-code-intelligence/values.yaml
@@ -111,6 +111,11 @@ config:
     # Empty → single-model (no failover). → agent.json `review.fallback_model`. Set per-env in
     # ai-helm-values to a DIFFERENT alias than the primary so a primary-path outage actually fails over.
     fallbackModel: ""
+    # Model context window in tokens (ADR-0045). → agent.json `review.context_window`. Empty → no
+    # budgeting (the agent sends the full history and would fail a 400 on overflow). Set per-env in
+    # ai-helm-values to the serving model's real window so the agent winds down + trims before overflow
+    # and finalizes (never discards findings) if it still overruns.
+    contextWindow: ""
 
   # PR feedback the control plane applies (FILE-ONLY knobs — no env equivalent).
   review:


### PR DESCRIPTION
Maps `config.model.contextWindow` → agent.json `review.context_window`, exposing the context-window budget from lightbridge #189 (ADR-0045) as an operator knob.

- Empty default → omitted from agent.json → no budgeting (unchanged behaviour).
- Set `config.model.contextWindow` per-env in ai-helm-values to the serving model's real token window; the agent then winds down + trims old tool output before overflow, and finalizes (never discards findings) if it still overruns.

Chart version 0.7.0 → 0.7.1.

Verified: `helm template --set config.model.contextWindow=128000` emits `"context_window":128000` in agent.json; without the override it is omitted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)