### PR TITLE
fix(lightbridge-db): backup every 6h + 7d retention (unblock the throttled prune)

### DIFF
--- a/charts/lightbridge-db/values.yaml
+++ b/charts/lightbridge-db/values.yaml
@@ -108,7 +108,15 @@ resources:
         argocd.argoproj.io/sync-wave: "1"
         argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
     spec:
-      retentionPolicy: "180d"
+      # 7-day recovery window. Was 180d, but the barman retention step
+      # (barman-cloud-backup-delete / -list) scans the WHOLE catalog, and a
+      # 180d catalog on Hetzner Object Storage grew big enough that Hetzner
+      # rate-limited the ListObjectsV2/GetObject calls (SlowDown / GatewayTimeout
+      # / 400, "reached max retries: 4") → "Unsafe to proceed with deletion due
+      # to failure reading backup catalog" → every scheduled backup failed (since
+      # ~2026-06-24). A 7d window keeps the catalog small → far fewer S3 calls per
+      # prune → no throttling. (Paired with the 6h schedule below.)
+      retentionPolicy: "7d"
       configuration:
         destinationPath: s3://ssegning-k8s-state/lightbridge-main-db
         endpointURL: https://nbg1.your-objectstorage.com
@@ -120,7 +128,10 @@ resources:
             name: lightbridge-cnpg-s3
             key: s3_secret_access_key
   # ────────────────────────────────────────────────────────────────────
-  # Daily scheduled backup (verbatim from the old flat app).
+  # Scheduled backup — every 6h (was daily). CNPG cron is 6-field
+  # (sec min hour dom mon dow); "0 0 */6 * * *" = 00:00 / 06:00 / 12:00 / 18:00.
+  # With the 7d retention above the catalog stays small enough that the
+  # post-backup retention prune doesn't get rate-limited by Hetzner S3.
   # ────────────────────────────────────────────────────────────────────
   - |
     apiVersion: postgresql.cnpg.io/v1
@@ -133,7 +144,7 @@ resources:
         argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
     spec:
       immediate: true
-      schedule: "0 0 2 * * *"
+      schedule: "0 0 */6 * * *"
       backupOwnerReference: self
       cluster:
         name: lightbridge-main-db


### PR DESCRIPTION
## Summary

Fixes the **lightbridge-main-db CNPG backup** (failing since ~2026-06-24) and applies the requested schedule/retention. Source: maintainer request (this thread).

## Root cause

WAL archiving works, but the post-backup **retention prune** (`barman-cloud-backup-delete` / `-list`) scans the *entire* catalog. With `retentionPolicy: 180d` the catalog on Hetzner Object Storage grew big enough that Hetzner **rate-limited** the `ListObjectsV2`/`GetObject` calls:

```
ERROR: (SlowDown) ListObjectsV2 ... reached max retries: 4
ERROR: (GatewayTimeout) GetObject ...
Unsafe to proceed with deletion due to failure reading backup catalog
```

→ barman exits 1/4 → every `ScheduledBackup` is marked `Failed` (and the periodic catalog-maintenance retries+fails every ~5 min). Not creds/config — pure S3 throttling driven by catalog size.

## Change (`charts/lightbridge-db/values.yaml`)

- **`retentionPolicy: 180d → 7d`** — keeps the catalog small so a prune lists/reads far fewer objects and stops tripping the rate limit. (= "delete data older than a week".)
- **`schedule: "0 0 2 * * *" → "0 0 */6 * * *"`** — every 6h (00/06/12/18). With 7d retention the catalog stays bounded.

> ⚠️ The **first** prune against the already-large 180d catalog may still throttle a few times before it shrinks; if it doesn't self-heal within a day, a one-off manual `barman-cloud-backup-delete` may be needed. I'll watch it after merge.

Not related to ADR-0056 (lightbridge-db has no inline `valuesObject`; its config stays in this chart).

## AI Usage Declaration

- [x] AI was used. Claude Code (Opus 4.8) diagnosed the failure from the barman plugin logs and made the change.
- **Verified:** the throttling errors in the `plugin-barman-cloud` sidecar logs; `helm template` shows `retentionPolicy: "7d"` + `schedule: "0 0 */6 * * *"`; `helm lint` 0 failed.

## Verification

- `helm template charts/lightbridge-db` → ObjectStore `retentionPolicy: "7d"`, ScheduledBackup `schedule: "0 0 */6 * * *"`.
- `helm lint` → 0 failed.
- Post-merge: lightbridge-db republishes to OCI, the orchestrator floats, the CRs update; will confirm a backup completes + the prune stops erroring.

---
(Companion: apprise-api OOM fixed separately in `ai-helm-values` — memory `512Mi → 1Gi`.)
