### PR TITLE
fix(lightbridge-db): throttle backup upload (jobs:1 + gzip) — Hetzner SlowDown on UploadPart

### DIFF
--- a/charts/lightbridge-db/values.yaml
+++ b/charts/lightbridge-db/values.yaml
@@ -120,6 +120,17 @@ resources:
       configuration:
         destinationPath: s3://ssegning-k8s-state/lightbridge-main-db
         endpointURL: https://nbg1.your-objectstorage.com
+        # ⚠️ Throttle the backup UPLOAD. The retention prune above was one symptom;
+        # the backup itself ALSO failed — Hetzner Object Storage returns `SlowDown`
+        # on the parallel multipart UploadPart calls and barman gives up after 4
+        # retries ("Backup failed uploading data ... UploadPart ... reached max
+        # retries: 4"). WAL archiving (single PUTs) and Keycloak's backups to the
+        # SAME bucket succeed, so it's lightbridge's parallel upload tripping the
+        # per-request-rate limit, not a bucket outage. jobs:1 serialises the upload
+        # (one UploadPart stream) and gzip shrinks it (fewer parts) → under the limit.
+        data:
+          jobs: 1
+          compression: gzip
         s3Credentials:
           accessKeyId:
             name: lightbridge-cnpg-s3


### PR DESCRIPTION
## Summary

Follow-up to [#481](https://github.com/ADORSYS-GIS/ai-helm/pull/481). #481 fixed the retention-prune throttling, but live testing showed the **backup itself still fails** — for a related but distinct reason. This actually unblocks the backup.

## Root cause (verified live)

The barman **parallel multipart upload** trips Hetzner Object Storage's per-request-rate limit:

```
ERROR: Upload error: (SlowDown) when calling the UploadPart operation (reached max retries: 4)
ERROR: Backup failed uploading data (... UploadPart ... SlowDown)
```

Evidence it's the *upload rate*, not a bucket outage:
- WAL archiving (single PUTs) succeeds continuously.
- **Keycloak's CNPG backups to the same bucket (`ssegning-k8s-state`) complete every 4h.**
- Only lightbridge's parallel multipart upload (on the standby `lightbridge-main-db-2`) trips `SlowDown`.

## Change (`charts/lightbridge-db/values.yaml`, ObjectStore `configuration.data`)

- **`jobs: 1`** — serialise the upload (one `UploadPart` stream instead of the default parallel workers) → much lower request rate.
- **`compression: gzip`** — smaller upload → fewer parts → fewer `UploadPart` calls.

Both keep the backup under Hetzner's rate limit. Restore is unaffected (barman records per-backup compression).

## AI Usage Declaration

- [x] AI was used. Claude Code (Opus 4.8) diagnosed the `UploadPart`/`SlowDown` failure from the standby's `plugin-barman-cloud` logs and made the change.
- **Verified:** the exact stderr (`Backup failed uploading data ... UploadPart ... reached max retries: 4`) on `lightbridge-main-db-2`; `helm template` shows `data.jobs: 1` + `compression: gzip`; `helm lint` 0 failed.

## Verification

- `helm template` → ObjectStore `configuration.data.{jobs: 1, compression: gzip}`; `helm lint` 0 failed.
- **Post-merge:** I'll trigger an on-demand backup and confirm it reaches `completed` (the prune is already healthy on the 7d window from #481).
