### PR TITLE
feat(lci): manage the agent-runner image via image-updater (cosign-pinned)

### DIFF
--- a/charts/apps/values.yaml
+++ b/charts/apps/values.yaml
@@ -467,8 +467,9 @@ applications:
       # declares, which otherwise show a permanent cosmetic OutOfSync + selfHeal churn.
       # ServerSideDiff ignores those server-owned fields so the app reads Synced.
       argocd.argoproj.io/compare-options: ServerSideDiff=true
-      # Two images in one app, aliased `cp` (control-plane) + `web`.
-      argocd-image-updater.argoproj.io/image-list: cp=ghcr.io/vymalo/lightbridge-control-plane,disp=ghcr.io/vymalo/lightbridge-control-plane,poll=ghcr.io/vymalo/lightbridge-control-plane,web=ghcr.io/vymalo/lightbridge-web
+      # Images aliased: cp/disp/poll (control-plane, role-selected), web, and runner
+      # (the one-shot agent-runner image the dispatcher launches per task).
+      argocd-image-updater.argoproj.io/image-list: cp=ghcr.io/vymalo/lightbridge-control-plane,disp=ghcr.io/vymalo/lightbridge-control-plane,poll=ghcr.io/vymalo/lightbridge-control-plane,web=ghcr.io/vymalo/lightbridge-web,runner=ghcr.io/vymalo/lightbridge-agent-runner
       # ── control-plane ──
       argocd-image-updater.argoproj.io/cp.update-strategy: newest-build
       argocd-image-updater.argoproj.io/cp.allow-tags: regexp:^sha-[0-9a-f]+$
@@ -507,6 +508,19 @@ applications:
       argocd-image-updater.argoproj.io/web.signature-type: cosign
       argocd-image-updater.argoproj.io/web.cosign.certificate-oidc-issuer: https://token.actions.githubusercontent.com
       argocd-image-updater.argoproj.io/web.cosign.certificate-identity-regexp: ^https://github\.com/vymalo/lightbridge-code-intelligence/\.github/workflows/build-images\.yml@.*$
+      # ── agent-runner (the one-shot Job image the dispatcher launches; NOT a pod in
+      #    this chart, so it's a single combined `repo:tag` env value, not a split
+      #    image.repository/.tag). Uses `helm.image-spec` to write the whole ref into
+      #    the dispatcher's AGENT_RUNNER_IMAGE env. Same cosign identity (one build
+      #    workflow signs every image). Keeps the runner in lockstep with the
+      #    control-plane instead of floating on `:latest`. ──
+      argocd-image-updater.argoproj.io/runner.update-strategy: newest-build
+      argocd-image-updater.argoproj.io/runner.allow-tags: regexp:^sha-[0-9a-f]+$
+      argocd-image-updater.argoproj.io/runner.force-update: "true"
+      argocd-image-updater.argoproj.io/runner.helm.image-spec: lci.controllers.dispatcher.containers.main.env.AGENT_RUNNER_IMAGE
+      argocd-image-updater.argoproj.io/runner.signature-type: cosign
+      argocd-image-updater.argoproj.io/runner.cosign.certificate-oidc-issuer: https://token.actions.githubusercontent.com
+      argocd-image-updater.argoproj.io/runner.cosign.certificate-identity-regexp: ^https://github\.com/vymalo/lightbridge-code-intelligence/\.github/workflows/build-images\.yml@.*$
       # ── git write-back → ai-helm-values main (PRIVATE; the org-wide adorsys-gis
       # GitHub App commits, and ArgoCD reads Source B via the same repo-creds —
       # exactly like converse-ui). Unprotected branch → the bot can direct-commit. ──

--- a/charts/lightbridge-code-intelligence/values.yaml
+++ b/charts/lightbridge-code-intelligence/values.yaml
@@ -43,8 +43,11 @@ agents:
   enabled: true
   namespace: lightbridge-agents
   serviceAccount: lightbridge-agent
-  # The runner image the dispatcher launches per task. Pinned tag; bump on release (not
-  # image-updater-managed — it isn't a pod in this chart, it's an env value the dispatcher reads).
+  # NOTE: unused/vestigial — bjw renders the dispatcher env against the sub-chart scope where
+  # top-level `agents.*` isn't visible, so the LIVE runner image is the dispatcher's
+  # AGENT_RUNNER_IMAGE env literal (controllers.dispatcher) below, NOT this. That env value IS
+  # image-updater-managed now (charts/apps `runner` alias, helm.image-spec) → pinned to a sha- tag
+  # in ai-helm-values and bumped per build. Kept here only as documentation; keep in sync.
   runnerImage: ghcr.io/vymalo/lightbridge-agent-runner:latest
   # The gateway only serves embeddings/chat on the HTTPS `core-gateway-internal` ClusterIP (the HTTP
   # LoadBalancer 308-redirects / 404s by Host). Its cert is from ClusterIssuer/self-signed-ca, so the
@@ -515,6 +518,9 @@ lci:
             # the top-level `agents` values aren't visible. Keep in sync with the `agents:` block.
             AGENT_NAMESPACE: "lightbridge-agents"
             AGENT_SERVICE_ACCOUNT: "lightbridge-agent"
+            # image-updater-managed (charts/apps `runner` alias via helm.image-spec): prod pins this
+            # to a sha- tag in ai-helm-values and bumps it per signed build. `:latest` is only the
+            # defaults-render fallback.
             AGENT_RUNNER_IMAGE: "ghcr.io/vymalo/lightbridge-agent-runner:latest"
             # Secret (agents ns) whose ca.crt the runner mounts to trust the HTTPS gateway.
             AGENT_CA_SECRET: "lightbridge-agent-ca"


### PR DESCRIPTION
## Summary

Bring the **agent-runner image under argocd-image-updater** — it was floating on `:latest` (unmanaged, not cosign-verified at deploy, free to drift from the control-plane).

- **`charts/apps`** — add a `runner` alias to the LCI app's `image-list`. The other four images split `image.repository`/`.tag`; the runner image is a single combined env string (the dispatcher reads `AGENT_RUNNER_IMAGE`), so it uses **`helm.image-spec`** to write the whole `repo:tag` ref. Same `newest-build` + `allow-tags: ^sha-` + cosign-identity policy as the rest.
- **`charts/lightbridge-code-intelligence`** — fix the now-stale "not image-updater-managed" comments; document that `agents.runnerImage` is vestigial and the live value is the dispatcher's `AGENT_RUNNER_IMAGE` env.

**Source of truth:** follow-up to the per-run cost/model attribution work — pairs with [adorsys-gis/ai-helm-values#11](https://github.com/adorsys-gis/ai-helm-values/pull/11) (pins `AGENT_RUNNER_IMAGE` to `sha-450c50b`) and the runner change in [vymalo/lightbridge-code-intelligence#193](https://github.com/vymalo/lightbridge-code-intelligence/pull/193). User request this session: "lightbridge-agent-runner isn't already added on image-updater?" — it wasn't; this adds it. Merge with #11.

## Verification

- [x] Running automated tests / lint

```
helm lint charts/apps charts/lightbridge-code-intelligence   # 0 failed
helm template … | grep runner.   # 7 runner.* annotations on the Application; image-spec → the env path
```

## AI Usage Declaration

AI was used for:
* [x] Understanding existing code
* [x] Generating code
* [x] Drafting documentation
* [x] Reviewing the diff

Human verification:
* [x] I understand every meaningful change in this PR
* [x] I checked generated code manually
* [x] I accept responsibility for this PR
