### PR TITLE
feat(dashboards): AI Gateway cost-by-model, actor-consumption, and users-tokens-cost boards (ADR-0008)

### DIFF
--- a/charts/observability-dashboards/files/envoy-ai-gateway/README.md
+++ b/charts/observability-dashboards/files/envoy-ai-gateway/README.md
@@ -64,3 +64,24 @@ uv run dashboards check       # what CI runs; fails on drift
 Keep `uid: envoy-ai-gateway-per-user` stable — changing it breaks bookmarks
 (and the epic's source-of-truth link). To prototype in Grafana, edit a *copy*
 in the UI, then port the change back into the generator module.
+
+## Sibling dashboards in this folder
+
+The `AI Gateway` folder now holds three cost/usage dashboards. They share the
+same Loki data path (above) and the helpers in
+`tools/dashboards/src/dashboards/envoy_ai_gateway/_shared.py`. All are GENERATED
+— edit the `.py`, then `uv run dashboards build` (commit the JSON).
+
+| File / UID | Source module | What it shows |
+|---|---|---|
+| `per-user.json` · `envoy-ai-gateway-per-user` | `per_user.py` | Real-time per-user activity (requests, tokens, latency, status, cost-by-channel). Default `now-1h`. |
+| `cost-by-model.json` · `envoy-ai-gateway-cost-by-model` | `cost_by_model.py` | **Cost × model, daily granularity** — stacked one-bar-per-day-per-model timeseries + per-model totals + share pie. Default `now-30d`; set the range to a month for monthly totals. Filters: `azp`, `model`. |
+| `actor-consumption.json` · `envoy-ai-gateway-actor-consumption` | `actor_consumption.py` | **Per-actor consumption** — pick one `actor` (the `display_name` label = a person's name for humans, the **repository** for CI), see cost over the range (≈ per month) + cost-per-day-by-model bars + which-models pie + cost-by-channel. Filters: `actor`, `azp`, `model`. |
+
+> **Daily granularity contract:** the cost-per-day panels pin the Loki query
+> `step` to `1d` with a `[1d]` window, so each bar is exactly one non-overlapping
+> calendar day — the resolution can't go finer (the "minimum granularity of
+> days" ask). ⚠️ A full 30-day cost query reads historical chunks from Hetzner
+> Object Storage; if that store is rate-limiting (`SlowDown`), the monthly view
+> can be slow or empty even though recent ranges are instant — see the Loki
+> read-path note in the cluster runbook.

--- a/charts/observability-dashboards/files/envoy-ai-gateway/README.md
+++ b/charts/observability-dashboards/files/envoy-ai-gateway/README.md
@@ -77,6 +77,7 @@ same Loki data path (above) and the helpers in
 | `per-user.json` · `envoy-ai-gateway-per-user` | `per_user.py` | Real-time per-user activity (requests, tokens, latency, status, cost-by-channel). Default `now-1h`. |
 | `cost-by-model.json` · `envoy-ai-gateway-cost-by-model` | `cost_by_model.py` | **Cost × model, daily granularity** — stacked one-bar-per-day-per-model timeseries + per-model totals + share pie. Default `now-30d`; set the range to a month for monthly totals. Filters: `azp`, `model`. |
 | `actor-consumption.json` · `envoy-ai-gateway-actor-consumption` | `actor_consumption.py` | **Per-actor consumption** — pick one `actor` (the `display_name` label = a person's name for humans, the **repository** for CI), see cost over the range (≈ per month) + cost-per-day-by-model bars + which-models pie + cost-by-channel. Filters: `actor`, `azp`, `model`. |
+| `user-tokens-cost.json` · `envoy-ai-gateway-user-tokens-cost` | `user_tokens_cost.py` | **Users x tokens x cost** — one table row per actor (requests · tokens · cost, via the `timeSeriesTable`+`organize`+`sortBy` transform chain) + per-day stacked cost/tokens-by-actor bars + cost/tokens leaderboards + a blended cost/1k-tokens stat. Filters: `azp`, `model`. |
 
 > **Daily granularity contract:** the cost-per-day panels pin the Loki query
 > `step` to `1d` with a `[1d]` window, so each bar is exactly one non-overlapping

--- a/charts/observability-dashboards/files/envoy-ai-gateway/actor-consumption.json
+++ b/charts/observability-dashboards/files/envoy-ai-gateway/actor-consumption.json
@@ -331,7 +331,7 @@
           "placement": "right",
           "showLegend": false,
           "calcs": [
-            "sum",
+            "mean",
             "max"
           ]
         },

--- a/charts/observability-dashboards/files/envoy-ai-gateway/actor-consumption.json
+++ b/charts/observability-dashboards/files/envoy-ai-gateway/actor-consumption.json
@@ -1,0 +1,476 @@
+{
+  "schemaVersion": 39,
+  "templating": {
+    "list": [
+      {
+        "type": "query",
+        "name": "actor",
+        "label": "Actor (user / repo)",
+        "skipUrlSync": false,
+        "query": "label_values({service_name=\"envoy-ai-gateway\"}, display_name)",
+        "datasource": {
+          "type": "loki",
+          "uid": "loki"
+        },
+        "current": {
+          "text": "All",
+          "value": "$__all",
+          "selected": true
+        },
+        "multi": false,
+        "allowCustomValue": true,
+        "refresh": 2,
+        "sort": 1,
+        "includeAll": true,
+        "allValue": ".+",
+        "auto": false,
+        "auto_min": "10s",
+        "auto_count": 30
+      },
+      {
+        "type": "query",
+        "name": "azp",
+        "label": "Client (azp)",
+        "skipUrlSync": false,
+        "query": "label_values({service_name=\"envoy-ai-gateway\"}, azp)",
+        "datasource": {
+          "type": "loki",
+          "uid": "loki"
+        },
+        "current": {
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ],
+          "selected": true
+        },
+        "multi": true,
+        "allowCustomValue": true,
+        "refresh": 2,
+        "sort": 1,
+        "includeAll": true,
+        "allValue": ".+",
+        "auto": false,
+        "auto_min": "10s",
+        "auto_count": 30
+      },
+      {
+        "type": "query",
+        "name": "model",
+        "label": "Model",
+        "skipUrlSync": false,
+        "query": "label_values({service_name=\"envoy-ai-gateway\"}, model)",
+        "datasource": {
+          "type": "loki",
+          "uid": "loki"
+        },
+        "current": {
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ],
+          "selected": true
+        },
+        "multi": true,
+        "allowCustomValue": true,
+        "refresh": 2,
+        "sort": 1,
+        "includeAll": true,
+        "allValue": ".+",
+        "auto": false,
+        "auto_min": "10s",
+        "auto_count": 30
+      }
+    ]
+  },
+  "annotations": {},
+  "uid": "envoy-ai-gateway-actor-consumption",
+  "title": "AI Gateway — actor consumption",
+  "description": "Per-actor consumption for the Envoy AI Gateway. The 'Actor' variable is the display_name label — a person's name for humans, the repository for CI (github-actions / lightbridge-code-intelligence) — so one picker covers 'user or actor (e.g. repository)'. Cost stat over the selected range ≈ the actor's monthly spend (default 30-day window); the daily-bars panel gives per-day, stacked by model. Cost = gen_ai.usage.custom_total_cost (micro-USD ÷ 1e6; ADR-0028/0051). ⚠️ LibreChat agent runs + RAG embeddings don't forward the end-user, so they land under azp=internal-key-librechat, not the human (docs/per-user-observability.md). GENERATED — source: tools/dashboards/envoy_ai_gateway/actor_consumption.py.",
+  "tags": [
+    "ai-gateway",
+    "cost",
+    "per-user",
+    "loki"
+  ],
+  "timezone": "browser",
+  "editable": true,
+  "graphTooltip": 1,
+  "time": {
+    "from": "now-30d",
+    "to": "now"
+  },
+  "fiscalYearStartMonth": 0,
+  "refresh": "5m",
+  "panels": [
+    {
+      "type": "row",
+      "collapsed": false,
+      "id": 0,
+      "panels": [],
+      "title": "Actor consumption",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      }
+    },
+    {
+      "type": "stat",
+      "targets": [
+        {
+          "expr": "((sum(sum_over_time({service_name=\"envoy-ai-gateway\", display_name=~\"$actor\", azp=~\"$azp\", model=~\"$model\"} | json gen_ai_usage_custom_total_cost=`[\"gen_ai.usage.custom_total_cost\"]` | unwrap gen_ai_usage_custom_total_cost | __error__=\"\" [$__range]))) / 1e6)",
+          "refId": "A",
+          "queryType": "range",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          }
+        }
+      ],
+      "title": "Cost — selected range (≈ per month)",
+      "transparent": false,
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 0,
+        "y": 1
+      },
+      "repeatDirection": "h",
+      "options": {
+        "graphMode": "area",
+        "colorMode": "value",
+        "justifyMode": "auto",
+        "textMode": "auto",
+        "wideLayout": true,
+        "showPercentChange": false,
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "values": false,
+          "fields": ""
+        },
+        "percentChangeColorMode": "standard",
+        "orientation": "horizontal"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "currencyUSD",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "value": null,
+                "color": "orange"
+              }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "stat",
+      "targets": [
+        {
+          "expr": "sum(sum_over_time({service_name=\"envoy-ai-gateway\", display_name=~\"$actor\", azp=~\"$azp\", model=~\"$model\"} | json gen_ai_usage_total_tokens=`[\"gen_ai.usage.total_tokens\"]` | unwrap gen_ai_usage_total_tokens | __error__=\"\" [$__range]))",
+          "refId": "A",
+          "queryType": "range",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          }
+        }
+      ],
+      "title": "Tokens — selected range",
+      "transparent": false,
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 8,
+        "y": 1
+      },
+      "repeatDirection": "h",
+      "options": {
+        "graphMode": "area",
+        "colorMode": "value",
+        "justifyMode": "auto",
+        "textMode": "auto",
+        "wideLayout": true,
+        "showPercentChange": false,
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "values": false,
+          "fields": ""
+        },
+        "percentChangeColorMode": "standard",
+        "orientation": "horizontal"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "value": null,
+                "color": "green"
+              }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "stat",
+      "targets": [
+        {
+          "expr": "sum(count_over_time({service_name=\"envoy-ai-gateway\", display_name=~\"$actor\", azp=~\"$azp\", model=~\"$model\"} [$__range]))",
+          "refId": "A",
+          "queryType": "range",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          }
+        }
+      ],
+      "title": "Requests — selected range",
+      "transparent": false,
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 16,
+        "y": 1
+      },
+      "repeatDirection": "h",
+      "options": {
+        "graphMode": "area",
+        "colorMode": "value",
+        "justifyMode": "auto",
+        "textMode": "auto",
+        "wideLayout": true,
+        "showPercentChange": false,
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "values": false,
+          "fields": ""
+        },
+        "percentChangeColorMode": "standard",
+        "orientation": "horizontal"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "value": null,
+                "color": "blue"
+              }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "((sum by (model) (sum_over_time({service_name=\"envoy-ai-gateway\", display_name=~\"$actor\", azp=~\"$azp\", model=~\"$model\"} | json gen_ai_usage_custom_total_cost=`[\"gen_ai.usage.custom_total_cost\"]` | unwrap gen_ai_usage_custom_total_cost | __error__=\"\" [1d]))) / 1e6)",
+          "refId": "A",
+          "legendFormat": "{{model}}",
+          "step": "1d",
+          "queryType": "range",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          }
+        }
+      ],
+      "title": "Cost per day, by model",
+      "transparent": false,
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 24,
+        "x": 0,
+        "y": 5
+      },
+      "repeatDirection": "h",
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": false,
+          "calcs": [
+            "sum",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "currencyUSD",
+          "custom": {
+            "drawStyle": "bars",
+            "lineWidth": 1.0,
+            "fillOpacity": 70.0,
+            "showPoints": "never",
+            "stacking": {
+              "mode": "normal"
+            }
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "piechart",
+      "targets": [
+        {
+          "expr": "((sum by (model) (sum_over_time({service_name=\"envoy-ai-gateway\", display_name=~\"$actor\", azp=~\"$azp\", model=~\"$model\"} | json gen_ai_usage_custom_total_cost=`[\"gen_ai.usage.custom_total_cost\"]` | unwrap gen_ai_usage_custom_total_cost | __error__=\"\" [$__range]))) / 1e6)",
+          "refId": "A",
+          "legendFormat": "{{model}}",
+          "queryType": "range",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          }
+        }
+      ],
+      "title": "Which models (cost share, selected range)",
+      "transparent": false,
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 12,
+        "x": 0,
+        "y": 16
+      },
+      "repeatDirection": "h",
+      "options": {
+        "pieType": "donut",
+        "tooltip": {
+          "mode": "single",
+          "sort": "asc"
+        },
+        "reduceOptions": {
+          "calcs": []
+        },
+        "legend": {
+          "values": [
+            "value",
+            "percent"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": false,
+          "calcs": []
+        },
+        "orientation": "auto"
+      }
+    },
+    {
+      "type": "bargauge",
+      "targets": [
+        {
+          "expr": "sort_desc(sum by (azp) (((sum_over_time({service_name=\"envoy-ai-gateway\", display_name=~\"$actor\", azp=~\"$azp\", model=~\"$model\"} | json gen_ai_usage_custom_total_cost=`[\"gen_ai.usage.custom_total_cost\"]` | unwrap gen_ai_usage_custom_total_cost | __error__=\"\" [$__range])) / 1e6)))",
+          "refId": "A",
+          "legendFormat": "{{azp}}",
+          "queryType": "range",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          }
+        }
+      ],
+      "title": "Cost by channel (azp, selected range)",
+      "transparent": false,
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 12,
+        "x": 12,
+        "y": 16
+      },
+      "repeatDirection": "h",
+      "options": {
+        "displayMode": "basic",
+        "valueMode": "color",
+        "namePlacement": "auto",
+        "showUnfilled": true,
+        "sizing": "auto",
+        "minVizWidth": 8,
+        "minVizHeight": 16,
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false,
+          "calcs": []
+        },
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "values": false,
+          "fields": ""
+        },
+        "maxVizHeight": 300,
+        "orientation": "horizontal"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "currencyUSD",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "value": null,
+                "color": "purple"
+              }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    }
+  ]
+}

--- a/charts/observability-dashboards/files/envoy-ai-gateway/cost-by-model.json
+++ b/charts/observability-dashboards/files/envoy-ai-gateway/cost-by-model.json
@@ -1,0 +1,451 @@
+{
+  "schemaVersion": 39,
+  "templating": {
+    "list": [
+      {
+        "type": "query",
+        "name": "azp",
+        "label": "Client (azp)",
+        "skipUrlSync": false,
+        "query": "label_values({service_name=\"envoy-ai-gateway\"}, azp)",
+        "datasource": {
+          "type": "loki",
+          "uid": "loki"
+        },
+        "current": {
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ],
+          "selected": true
+        },
+        "multi": true,
+        "allowCustomValue": true,
+        "refresh": 2,
+        "sort": 1,
+        "includeAll": true,
+        "allValue": ".+",
+        "auto": false,
+        "auto_min": "10s",
+        "auto_count": 30
+      },
+      {
+        "type": "query",
+        "name": "model",
+        "label": "Model",
+        "skipUrlSync": false,
+        "query": "label_values({service_name=\"envoy-ai-gateway\"}, model)",
+        "datasource": {
+          "type": "loki",
+          "uid": "loki"
+        },
+        "current": {
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ],
+          "selected": true
+        },
+        "multi": true,
+        "allowCustomValue": true,
+        "refresh": 2,
+        "sort": 1,
+        "includeAll": true,
+        "allValue": ".+",
+        "auto": false,
+        "auto_min": "10s",
+        "auto_count": 30
+      }
+    ]
+  },
+  "annotations": {},
+  "uid": "envoy-ai-gateway-cost-by-model",
+  "title": "AI Gateway — cost by model (monthly)",
+  "description": "Cost per model for the Envoy AI Gateway, daily granularity. The headline panel stacks one bar per day per model (resolution pinned to 1d). Default window is 30 days — set the range to a calendar month for monthly totals. Cost = gen_ai.usage.custom_total_cost (micro-USD ÷ 1e6; ADR-0028/0051). Spans all attributed traffic incl. service accounts. See docs/per-user-observability.md. GENERATED — source: tools/dashboards/envoy_ai_gateway/cost_by_model.py.",
+  "tags": [
+    "ai-gateway",
+    "cost",
+    "model",
+    "loki"
+  ],
+  "timezone": "browser",
+  "editable": true,
+  "graphTooltip": 1,
+  "time": {
+    "from": "now-30d",
+    "to": "now"
+  },
+  "fiscalYearStartMonth": 0,
+  "refresh": "5m",
+  "panels": [
+    {
+      "type": "row",
+      "collapsed": false,
+      "id": 0,
+      "panels": [],
+      "title": "Cost by model",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      }
+    },
+    {
+      "type": "stat",
+      "targets": [
+        {
+          "expr": "((sum(sum_over_time({service_name=\"envoy-ai-gateway\", azp=~\"$azp\", user_id=~\".+\", model=~\"$model\"} | json gen_ai_usage_custom_total_cost=`[\"gen_ai.usage.custom_total_cost\"]` | unwrap gen_ai_usage_custom_total_cost | __error__=\"\" [$__range]))) / 1e6)",
+          "refId": "A",
+          "queryType": "range",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          }
+        }
+      ],
+      "title": "Total cost (selected range)",
+      "transparent": false,
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 0,
+        "y": 1
+      },
+      "repeatDirection": "h",
+      "options": {
+        "graphMode": "area",
+        "colorMode": "value",
+        "justifyMode": "auto",
+        "textMode": "auto",
+        "wideLayout": true,
+        "showPercentChange": false,
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "values": false,
+          "fields": ""
+        },
+        "percentChangeColorMode": "standard",
+        "orientation": "horizontal"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "currencyUSD",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "value": null,
+                "color": "orange"
+              }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "stat",
+      "targets": [
+        {
+          "expr": "sum(sum_over_time({service_name=\"envoy-ai-gateway\", azp=~\"$azp\", user_id=~\".+\", model=~\"$model\"} | json gen_ai_usage_total_tokens=`[\"gen_ai.usage.total_tokens\"]` | unwrap gen_ai_usage_total_tokens | __error__=\"\" [$__range]))",
+          "refId": "A",
+          "queryType": "range",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          }
+        }
+      ],
+      "title": "Total tokens (selected range)",
+      "transparent": false,
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 8,
+        "y": 1
+      },
+      "repeatDirection": "h",
+      "options": {
+        "graphMode": "area",
+        "colorMode": "value",
+        "justifyMode": "auto",
+        "textMode": "auto",
+        "wideLayout": true,
+        "showPercentChange": false,
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "values": false,
+          "fields": ""
+        },
+        "percentChangeColorMode": "standard",
+        "orientation": "horizontal"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "value": null,
+                "color": "green"
+              }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "stat",
+      "targets": [
+        {
+          "expr": "sum(count_over_time({service_name=\"envoy-ai-gateway\", azp=~\"$azp\", user_id=~\".+\", model=~\"$model\"} [$__range]))",
+          "refId": "A",
+          "queryType": "range",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          }
+        }
+      ],
+      "title": "Total requests (selected range)",
+      "transparent": false,
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 16,
+        "y": 1
+      },
+      "repeatDirection": "h",
+      "options": {
+        "graphMode": "area",
+        "colorMode": "value",
+        "justifyMode": "auto",
+        "textMode": "auto",
+        "wideLayout": true,
+        "showPercentChange": false,
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "values": false,
+          "fields": ""
+        },
+        "percentChangeColorMode": "standard",
+        "orientation": "horizontal"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "value": null,
+                "color": "blue"
+              }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "((sum by (model) (sum_over_time({service_name=\"envoy-ai-gateway\", azp=~\"$azp\", user_id=~\".+\", model=~\"$model\"} | json gen_ai_usage_custom_total_cost=`[\"gen_ai.usage.custom_total_cost\"]` | unwrap gen_ai_usage_custom_total_cost | __error__=\"\" [1d]))) / 1e6)",
+          "refId": "A",
+          "legendFormat": "{{model}}",
+          "step": "1d",
+          "queryType": "range",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          }
+        }
+      ],
+      "title": "Cost per day, by model",
+      "transparent": false,
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 24,
+        "x": 0,
+        "y": 5
+      },
+      "repeatDirection": "h",
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": false,
+          "calcs": [
+            "sum",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "currencyUSD",
+          "custom": {
+            "drawStyle": "bars",
+            "lineWidth": 1.0,
+            "fillOpacity": 70.0,
+            "showPoints": "never",
+            "stacking": {
+              "mode": "normal"
+            }
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "bargauge",
+      "targets": [
+        {
+          "expr": "sort_desc(sum by (model) (((sum_over_time({service_name=\"envoy-ai-gateway\", azp=~\"$azp\", user_id=~\".+\", model=~\"$model\"} | json gen_ai_usage_custom_total_cost=`[\"gen_ai.usage.custom_total_cost\"]` | unwrap gen_ai_usage_custom_total_cost | __error__=\"\" [$__range])) / 1e6)))",
+          "refId": "A",
+          "legendFormat": "{{model}}",
+          "queryType": "range",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          }
+        }
+      ],
+      "title": "Cost by model — total (selected range)",
+      "transparent": false,
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 12,
+        "x": 0,
+        "y": 16
+      },
+      "repeatDirection": "h",
+      "options": {
+        "displayMode": "basic",
+        "valueMode": "color",
+        "namePlacement": "auto",
+        "showUnfilled": true,
+        "sizing": "auto",
+        "minVizWidth": 8,
+        "minVizHeight": 16,
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false,
+          "calcs": []
+        },
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "values": false,
+          "fields": ""
+        },
+        "maxVizHeight": 300,
+        "orientation": "horizontal"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "currencyUSD",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "value": null,
+                "color": "orange"
+              }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "piechart",
+      "targets": [
+        {
+          "expr": "((sum by (model) (sum_over_time({service_name=\"envoy-ai-gateway\", azp=~\"$azp\", user_id=~\".+\", model=~\"$model\"} | json gen_ai_usage_custom_total_cost=`[\"gen_ai.usage.custom_total_cost\"]` | unwrap gen_ai_usage_custom_total_cost | __error__=\"\" [$__range]))) / 1e6)",
+          "refId": "A",
+          "legendFormat": "{{model}}",
+          "queryType": "range",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          }
+        }
+      ],
+      "title": "Cost share by model (selected range)",
+      "transparent": false,
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 12,
+        "x": 12,
+        "y": 16
+      },
+      "repeatDirection": "h",
+      "options": {
+        "pieType": "donut",
+        "tooltip": {
+          "mode": "single",
+          "sort": "asc"
+        },
+        "reduceOptions": {
+          "calcs": []
+        },
+        "legend": {
+          "values": [
+            "value",
+            "percent"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": false,
+          "calcs": []
+        },
+        "orientation": "auto"
+      }
+    }
+  ]
+}

--- a/charts/observability-dashboards/files/envoy-ai-gateway/cost-by-model.json
+++ b/charts/observability-dashboards/files/envoy-ai-gateway/cost-by-model.json
@@ -306,7 +306,7 @@
           "placement": "right",
           "showLegend": false,
           "calcs": [
-            "sum",
+            "mean",
             "max"
           ]
         },

--- a/charts/observability-dashboards/files/envoy-ai-gateway/user-tokens-cost.json
+++ b/charts/observability-dashboards/files/envoy-ai-gateway/user-tokens-cost.json
@@ -1,0 +1,702 @@
+{
+  "schemaVersion": 39,
+  "templating": {
+    "list": [
+      {
+        "type": "query",
+        "name": "azp",
+        "label": "Client (azp)",
+        "skipUrlSync": false,
+        "query": "label_values({service_name=\"envoy-ai-gateway\"}, azp)",
+        "datasource": {
+          "type": "loki",
+          "uid": "loki"
+        },
+        "current": {
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ],
+          "selected": true
+        },
+        "multi": true,
+        "allowCustomValue": true,
+        "refresh": 2,
+        "sort": 1,
+        "includeAll": true,
+        "allValue": ".+",
+        "auto": false,
+        "auto_min": "10s",
+        "auto_count": 30
+      },
+      {
+        "type": "query",
+        "name": "model",
+        "label": "Model",
+        "skipUrlSync": false,
+        "query": "label_values({service_name=\"envoy-ai-gateway\"}, model)",
+        "datasource": {
+          "type": "loki",
+          "uid": "loki"
+        },
+        "current": {
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ],
+          "selected": true
+        },
+        "multi": true,
+        "allowCustomValue": true,
+        "refresh": 2,
+        "sort": 1,
+        "includeAll": true,
+        "allValue": ".+",
+        "auto": false,
+        "auto_min": "10s",
+        "auto_count": 30
+      }
+    ]
+  },
+  "annotations": {},
+  "uid": "envoy-ai-gateway-user-tokens-cost",
+  "title": "AI Gateway — users: tokens & cost",
+  "description": "Users x tokens x cost for the Envoy AI Gateway. The table gives one row per actor (display_name = a person for humans, the repository for CI) with requests / tokens / cost side by side over the selected range (default 30d ≈ monthly); per-day stacked panels add daily granularity, and the leaderboards rank by cost and by tokens. Cost = gen_ai.usage.custom_total_cost (micro-USD ÷ 1e6; ADR-0028/0051). Filters: azp, model. ⚠️ LibreChat agent runs + RAG embeddings fall back to azp=internal-key-librechat (not the human) — docs/per-user-observability.md. GENERATED — source: tools/dashboards/envoy_ai_gateway/user_tokens_cost.py.",
+  "tags": [
+    "ai-gateway",
+    "cost",
+    "tokens",
+    "per-user",
+    "loki"
+  ],
+  "timezone": "browser",
+  "editable": true,
+  "graphTooltip": 1,
+  "time": {
+    "from": "now-30d",
+    "to": "now"
+  },
+  "fiscalYearStartMonth": 0,
+  "refresh": "5m",
+  "panels": [
+    {
+      "type": "row",
+      "collapsed": false,
+      "id": 0,
+      "panels": [],
+      "title": "Users — tokens & cost",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      }
+    },
+    {
+      "type": "stat",
+      "targets": [
+        {
+          "expr": "((sum(sum_over_time({service_name=\"envoy-ai-gateway\", azp=~\"$azp\", user_id=~\".+\", model=~\"$model\"} | json gen_ai_usage_custom_total_cost=`[\"gen_ai.usage.custom_total_cost\"]` | unwrap gen_ai_usage_custom_total_cost | __error__=\"\" [$__range]))) / 1e6)",
+          "refId": "A",
+          "queryType": "range",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          }
+        }
+      ],
+      "title": "Total cost (range)",
+      "transparent": false,
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 1
+      },
+      "repeatDirection": "h",
+      "options": {
+        "graphMode": "area",
+        "colorMode": "value",
+        "justifyMode": "auto",
+        "textMode": "auto",
+        "wideLayout": true,
+        "showPercentChange": false,
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "values": false,
+          "fields": ""
+        },
+        "percentChangeColorMode": "standard",
+        "orientation": "horizontal"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "currencyUSD",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "value": null,
+                "color": "orange"
+              }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "stat",
+      "targets": [
+        {
+          "expr": "sum(sum_over_time({service_name=\"envoy-ai-gateway\", azp=~\"$azp\", user_id=~\".+\", model=~\"$model\"} | json gen_ai_usage_total_tokens=`[\"gen_ai.usage.total_tokens\"]` | unwrap gen_ai_usage_total_tokens | __error__=\"\" [$__range]))",
+          "refId": "A",
+          "queryType": "range",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          }
+        }
+      ],
+      "title": "Total tokens (range)",
+      "transparent": false,
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 1
+      },
+      "repeatDirection": "h",
+      "options": {
+        "graphMode": "area",
+        "colorMode": "value",
+        "justifyMode": "auto",
+        "textMode": "auto",
+        "wideLayout": true,
+        "showPercentChange": false,
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "values": false,
+          "fields": ""
+        },
+        "percentChangeColorMode": "standard",
+        "orientation": "horizontal"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "value": null,
+                "color": "green"
+              }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "stat",
+      "targets": [
+        {
+          "expr": "count(sum by (display_name) (count_over_time({service_name=\"envoy-ai-gateway\", azp=~\"$azp\", user_id=~\".+\", model=~\"$model\"} [$__range])))",
+          "refId": "A",
+          "queryType": "range",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          }
+        }
+      ],
+      "title": "Unique actors (range)",
+      "transparent": false,
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 12,
+        "y": 1
+      },
+      "repeatDirection": "h",
+      "options": {
+        "graphMode": "area",
+        "colorMode": "value",
+        "justifyMode": "auto",
+        "textMode": "auto",
+        "wideLayout": true,
+        "showPercentChange": false,
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "values": false,
+          "fields": ""
+        },
+        "percentChangeColorMode": "standard",
+        "orientation": "horizontal"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "value": null,
+                "color": "purple"
+              }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "stat",
+      "targets": [
+        {
+          "expr": "(sum(sum_over_time({service_name=\"envoy-ai-gateway\", azp=~\"$azp\", user_id=~\".+\", model=~\"$model\"} | json gen_ai_usage_custom_total_cost=`[\"gen_ai.usage.custom_total_cost\"]` | unwrap gen_ai_usage_custom_total_cost | __error__=\"\" [$__range])) / 1e6) / ((sum(sum_over_time({service_name=\"envoy-ai-gateway\", azp=~\"$azp\", user_id=~\".+\", model=~\"$model\"} | json gen_ai_usage_total_tokens=`[\"gen_ai.usage.total_tokens\"]` | unwrap gen_ai_usage_total_tokens | __error__=\"\" [$__range])) / 1000))",
+          "refId": "A",
+          "queryType": "range",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          }
+        }
+      ],
+      "title": "Blended cost / 1k tokens (range)",
+      "transparent": false,
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 18,
+        "y": 1
+      },
+      "repeatDirection": "h",
+      "options": {
+        "graphMode": "area",
+        "colorMode": "value",
+        "justifyMode": "auto",
+        "textMode": "auto",
+        "wideLayout": true,
+        "showPercentChange": false,
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "values": false,
+          "fields": ""
+        },
+        "percentChangeColorMode": "standard",
+        "orientation": "horizontal"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "currencyUSD",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "value": null,
+                "color": "blue"
+              }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "table",
+      "targets": [
+        {
+          "expr": "((sum by (display_name) (sum_over_time({service_name=\"envoy-ai-gateway\", azp=~\"$azp\", user_id=~\".+\", model=~\"$model\"} | json gen_ai_usage_custom_total_cost=`[\"gen_ai.usage.custom_total_cost\"]` | unwrap gen_ai_usage_custom_total_cost | __error__=\"\" [$__range]))) / 1e6)",
+          "refId": "A",
+          "legendFormat": "{{display_name}}",
+          "queryType": "range",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          }
+        },
+        {
+          "expr": "sum by (display_name) (sum_over_time({service_name=\"envoy-ai-gateway\", azp=~\"$azp\", user_id=~\".+\", model=~\"$model\"} | json gen_ai_usage_total_tokens=`[\"gen_ai.usage.total_tokens\"]` | unwrap gen_ai_usage_total_tokens | __error__=\"\" [$__range]))",
+          "refId": "B",
+          "legendFormat": "{{display_name}}",
+          "queryType": "range",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          }
+        },
+        {
+          "expr": "sum by (display_name) (count_over_time({service_name=\"envoy-ai-gateway\", azp=~\"$azp\", user_id=~\".+\", model=~\"$model\"} [$__range]))",
+          "refId": "C",
+          "legendFormat": "{{display_name}}",
+          "queryType": "range",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          }
+        }
+      ],
+      "title": "Per actor — requests · tokens · cost (selected range)",
+      "transparent": false,
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "gridPos": {
+        "h": 12,
+        "w": 24,
+        "x": 0,
+        "y": 5
+      },
+      "repeatDirection": "h",
+      "transformations": [
+        {
+          "id": "timeSeriesTable",
+          "options": {
+            "A": {
+              "stat": "lastNotNull"
+            },
+            "B": {
+              "stat": "lastNotNull"
+            },
+            "C": {
+              "stat": "lastNotNull"
+            }
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "renameByName": {
+              "display_name": "Actor",
+              "Trend #A": "Cost ($)",
+              "Trend #B": "Tokens",
+              "Trend #C": "Requests"
+            },
+            "excludeByName": {},
+            "indexByName": {}
+          }
+        },
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "field": "Cost ($)",
+                "desc": true
+              }
+            ]
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "auto",
+            "inspect": false,
+            "filterable": true
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Cost ($)"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "currencyUSD"
+              },
+              {
+                "id": "decimals",
+                "value": 2
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "((sum by (display_name) (sum_over_time({service_name=\"envoy-ai-gateway\", azp=~\"$azp\", user_id=~\".+\", model=~\"$model\"} | json gen_ai_usage_custom_total_cost=`[\"gen_ai.usage.custom_total_cost\"]` | unwrap gen_ai_usage_custom_total_cost | __error__=\"\" [1d]))) / 1e6)",
+          "refId": "A",
+          "legendFormat": "{{display_name}}",
+          "step": "1d",
+          "queryType": "range",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          }
+        }
+      ],
+      "title": "Cost per day, by actor",
+      "transparent": false,
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 0,
+        "y": 17
+      },
+      "repeatDirection": "h",
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": false,
+          "calcs": [
+            "sum"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "currencyUSD",
+          "custom": {
+            "drawStyle": "bars",
+            "lineWidth": 1.0,
+            "fillOpacity": 70.0,
+            "showPoints": "never",
+            "stacking": {
+              "mode": "normal"
+            }
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "sum by (display_name) (sum_over_time({service_name=\"envoy-ai-gateway\", azp=~\"$azp\", user_id=~\".+\", model=~\"$model\"} | json gen_ai_usage_total_tokens=`[\"gen_ai.usage.total_tokens\"]` | unwrap gen_ai_usage_total_tokens | __error__=\"\" [1d]))",
+          "refId": "A",
+          "legendFormat": "{{display_name}}",
+          "step": "1d",
+          "queryType": "range",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          }
+        }
+      ],
+      "title": "Tokens per day, by actor",
+      "transparent": false,
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 12,
+        "y": 17
+      },
+      "repeatDirection": "h",
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": false,
+          "calcs": [
+            "sum"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "bars",
+            "lineWidth": 1.0,
+            "fillOpacity": 70.0,
+            "showPoints": "never",
+            "stacking": {
+              "mode": "normal"
+            }
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "bargauge",
+      "targets": [
+        {
+          "expr": "topk(20, ((sum by (display_name) (sum_over_time({service_name=\"envoy-ai-gateway\", azp=~\"$azp\", user_id=~\".+\", model=~\"$model\"} | json gen_ai_usage_custom_total_cost=`[\"gen_ai.usage.custom_total_cost\"]` | unwrap gen_ai_usage_custom_total_cost | __error__=\"\" [$__range]))) / 1e6))",
+          "refId": "A",
+          "legendFormat": "{{display_name}}",
+          "queryType": "range",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          }
+        }
+      ],
+      "title": "Top actors by cost (selected range)",
+      "transparent": false,
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 0,
+        "y": 27
+      },
+      "repeatDirection": "h",
+      "options": {
+        "displayMode": "basic",
+        "valueMode": "color",
+        "namePlacement": "auto",
+        "showUnfilled": true,
+        "sizing": "auto",
+        "minVizWidth": 8,
+        "minVizHeight": 16,
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false,
+          "calcs": []
+        },
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "values": false,
+          "fields": ""
+        },
+        "maxVizHeight": 300,
+        "orientation": "horizontal"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "currencyUSD",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "value": null,
+                "color": "orange"
+              }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "bargauge",
+      "targets": [
+        {
+          "expr": "topk(20, sum by (display_name) (sum_over_time({service_name=\"envoy-ai-gateway\", azp=~\"$azp\", user_id=~\".+\", model=~\"$model\"} | json gen_ai_usage_total_tokens=`[\"gen_ai.usage.total_tokens\"]` | unwrap gen_ai_usage_total_tokens | __error__=\"\" [$__range])))",
+          "refId": "A",
+          "legendFormat": "{{display_name}}",
+          "queryType": "range",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          }
+        }
+      ],
+      "title": "Top actors by tokens (selected range)",
+      "transparent": false,
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 12,
+        "y": 27
+      },
+      "repeatDirection": "h",
+      "options": {
+        "displayMode": "basic",
+        "valueMode": "color",
+        "namePlacement": "auto",
+        "showUnfilled": true,
+        "sizing": "auto",
+        "minVizWidth": 8,
+        "minVizHeight": 16,
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false,
+          "calcs": []
+        },
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "values": false,
+          "fields": ""
+        },
+        "maxVizHeight": 300,
+        "orientation": "horizontal"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "value": null,
+                "color": "green"
+              }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    }
+  ]
+}

--- a/charts/observability-dashboards/files/envoy-ai-gateway/user-tokens-cost.json
+++ b/charts/observability-dashboards/files/envoy-ai-gateway/user-tokens-cost.json
@@ -395,6 +395,10 @@
           }
         },
         {
+          "id": "merge",
+          "options": {}
+        },
+        {
           "id": "organize",
           "options": {
             "renameByName": {
@@ -482,7 +486,8 @@
           "placement": "right",
           "showLegend": false,
           "calcs": [
-            "sum"
+            "mean",
+            "max"
           ]
         },
         "tooltip": {
@@ -540,7 +545,8 @@
           "placement": "right",
           "showLegend": false,
           "calcs": [
-            "sum"
+            "mean",
+            "max"
           ]
         },
         "tooltip": {

--- a/charts/observability-dashboards/values.yaml
+++ b/charts/observability-dashboards/values.yaml
@@ -62,6 +62,12 @@ dashboards:
     folderRef: ai-gateway
     file: files/envoy-ai-gateway/actor-consumption.json
     resyncPeriod: 5m
+  # User x tokens x cost: per-actor table (requests/tokens/cost) + per-day
+  # stacked breakdowns + cost/tokens leaderboards. Filters: azp, model.
+  - name: envoy-ai-gateway-user-tokens-cost
+    folderRef: ai-gateway
+    file: files/envoy-ai-gateway/user-tokens-cost.json
+    resyncPeriod: 5m
   # Alloy collector health (metrics/logs/traces pipelines, OTLP receiver,
   # clustering). Targets confirmed alloy_*/prometheus_remote_storage_*/
   # loki_write_*/otelcol_receiver_* series; datasource UID hardcoded to `mimir`.

--- a/charts/observability-dashboards/values.yaml
+++ b/charts/observability-dashboards/values.yaml
@@ -51,6 +51,17 @@ dashboards:
     folderRef: ai-gateway
     file: files/envoy-ai-gateway/per-user.json
     resyncPeriod: 5m
+  # Cost × model with daily granularity (stacked daily bars), default 30d window.
+  - name: envoy-ai-gateway-cost-by-model
+    folderRef: ai-gateway
+    file: files/envoy-ai-gateway/cost-by-model.json
+    resyncPeriod: 5m
+  # Per-actor (user OR repo via display_name) consumption: cost per month/day +
+  # which models + which channels. Input variables: actor / azp / model.
+  - name: envoy-ai-gateway-actor-consumption
+    folderRef: ai-gateway
+    file: files/envoy-ai-gateway/actor-consumption.json
+    resyncPeriod: 5m
   # Alloy collector health (metrics/logs/traces pipelines, OTLP receiver,
   # clustering). Targets confirmed alloy_*/prometheus_remote_storage_*/
   # loki_write_*/otelcol_receiver_* series; datasource UID hardcoded to `mimir`.

--- a/tools/dashboards/src/dashboards/envoy_ai_gateway/_shared.py
+++ b/tools/dashboards/src/dashboards/envoy_ai_gateway/_shared.py
@@ -140,6 +140,12 @@ def daily_bars_panel(
     """Stacked daily BARS timeseries — the canonical "X per day, stacked by
     series" cost viz. Pairs with an `expr` that uses a `[1d]` window and a
     `step="1d"` target (set by the caller) so each bar is exactly one day.
+
+    Legend calcs default to mean/max, NOT sum: with a relative range
+    (now-30d) Grafana evaluates the `[1d]` range-vector at the range start
+    too, so the leading bucket sums the 24h BEFORE the window — a legend
+    `sum` would overstate the range by up to a day. Authoritative totals
+    live in the stat / table / bargauge panels (which use `[$__range]`).
     """
     h, w, x, y = grid
     return (
@@ -157,7 +163,7 @@ def daily_bars_panel(
             cb.VizLegendOptions()
             .display_mode(cm.LegendDisplayMode.TABLE)
             .placement(cm.LegendPlacement.RIGHT)
-            .calcs(legend_calcs if legend_calcs is not None else ["sum"])
+            .calcs(legend_calcs if legend_calcs is not None else ["mean", "max"])
         )
         .tooltip(
             cb.VizTooltipOptions().mode(cm.TooltipDisplayMode.MULTI).sort(cm.SortOrder.DESCENDING)

--- a/tools/dashboards/src/dashboards/envoy_ai_gateway/_shared.py
+++ b/tools/dashboards/src/dashboards/envoy_ai_gateway/_shared.py
@@ -1,0 +1,265 @@
+"""Shared SDK panel/query helpers for the Envoy AI Gateway dashboards.
+
+`_common.py` is intentionally SDK-free (pure data). This module is the
+SDK-aware sibling: the query-builder gotchas the gateway dashboards all
+share (the µ$→USD divide, the `| json ["dotted.key"] | unwrap` form, the
+range-not-instant rule, daily-step buckets) live here ONCE so cost/actor
+dashboards stay consistent with each other.
+
+NOTE: `per_user.py` predates this module and keeps its own private copies of
+these helpers on purpose — refactoring it would change its generated JSON and
+trip the `dashboards check` drift guard. New dashboards import from here.
+"""
+
+from __future__ import annotations
+
+from grafana_foundation_sdk.builders import bargauge, loki, piechart, stat, timeseries
+from grafana_foundation_sdk.builders import common as cb
+from grafana_foundation_sdk.builders import dashboard as db
+from grafana_foundation_sdk.models import common as cm
+from grafana_foundation_sdk.models import dashboard as dm
+from grafana_foundation_sdk.models import piechart as pm
+
+from dashboards._common import GATEWAY_SERVICE_NAME, LOKI_UID
+
+LOKI_DS = dm.DataSourceRef(type_val="loki", uid=LOKI_UID)
+
+# Envoy's access-log format.json declares the GenAI usage fields with LITERAL
+# dots in the key name (`gen_ai.usage.total_tokens`), so the explicit
+# `| json <name>` path-lookup form must bracket+quote the dotted key
+# (`["dotted.key"]`) — a bare name doesn't match. See per_user._unwrap for the
+# full archaeology (ADR-0046).
+_JSON_PATHS = {
+    "gen_ai_usage_total_tokens": "gen_ai.usage.total_tokens",
+    "gen_ai_usage_custom_total_cost": "gen_ai.usage.custom_total_cost",
+}
+
+
+def unwrap(field: str) -> str:
+    """`| json <field> | unwrap <field> | __error__=""` — extract ONLY `field`.
+
+    Extracting one field (not a bare `| json`) keeps the per-line label set
+    down to the genuine stream labels, so `sum_over_time`'s implicit grouping
+    can't blow past Loki's 500-series cap. `__error__=""` drops samples that
+    fail the string→float conversion (absent fields arrive as "-").
+    """
+    path = _JSON_PATHS.get(field)
+    extract = f'{field}=`["{path}"]`' if path else field
+    return f'| json {extract} | unwrap {field} | __error__=""'
+
+
+def usd(expr: str) -> str:
+    """Convert a raw micro-USD LogQL aggregation to USD (pricing CEL emits µ$)."""
+    return f"(({expr}) / 1e6)"
+
+
+def selector(*matchers: str) -> str:
+    """`{service_name="envoy-ai-gateway", <extra matchers...>}`.
+
+    Pass extra label matchers as raw LogQL fragments, e.g.
+    `selector('display_name=~"$actor"', 'model=~"$model"')`.
+    """
+    parts = [f'service_name="{GATEWAY_SERVICE_NAME}"', *matchers]
+    return "{" + ", ".join(parts) + "}"
+
+
+def loki_target(
+    expr: str,
+    *,
+    legend: str = "",
+    ref_id: str = "A",
+    instant: bool = False,
+    step: str = "",
+) -> loki.Dataquery:
+    """A Loki query target. Range mode by default — the Loki Grafana plugin does
+    NOT substitute `$__range`/`$__interval` in instant queries (silent no-data).
+
+    `step="1d"` pins the query resolution so cost panels can't bucket finer than
+    a day (the "minimum granularity of days" contract).
+    """
+    q = (
+        loki.Dataquery()
+        .expr(expr)
+        .ref_id(ref_id)
+        .query_type("instant" if instant else "range")
+        .datasource(LOKI_DS)
+    )
+    if legend:
+        q = q.legend_format(legend)
+    if step:
+        q = q.step(step)
+    return q
+
+
+def single_color_thresholds(color: str) -> db.ThresholdsConfig:
+    return db.ThresholdsConfig().mode(dm.ThresholdsMode.ABSOLUTE).steps([dm.Threshold(color=color)])
+
+
+def stat_panel(
+    *,
+    title: str,
+    expr: str,
+    unit: str,
+    color: str,
+    grid: tuple[int, int, int, int],
+    step: str = "",
+) -> stat.Panel:
+    """Single-value stat with sparkline. `grid` is (h, w, x, y).
+
+    `[$__range]` + the default lastNotNull calc reads the per-range total at the
+    last evaluated point (a [1m]+sum form double-counts via overlapping
+    auto-step windows — see per_user._panel_user_total_cost).
+    """
+    h, w, x, y = grid
+    return (
+        stat.Panel()
+        .title(title)
+        .datasource(LOKI_DS)
+        .grid_pos(dm.GridPos(h=h, w=w, x=x, y=y))
+        .unit(unit)
+        .thresholds(single_color_thresholds(color))
+        .reduce_options(cb.ReduceDataOptions().calcs(["lastNotNull"]).fields("").values(False))
+        .orientation(cm.VizOrientation.HORIZONTAL)
+        .text_mode(cm.BigValueTextMode.AUTO)
+        .color_mode(cm.BigValueColorMode.VALUE)
+        .graph_mode(cm.BigValueGraphMode.AREA)
+        .justify_mode(cm.BigValueJustifyMode.AUTO)
+        .with_target(loki_target(expr, step=step))
+    )
+
+
+def daily_bars_panel(
+    *,
+    title: str,
+    expr: str,
+    legend: str,
+    unit: str,
+    grid: tuple[int, int, int, int],
+    legend_calcs: list[str] | None = None,
+) -> timeseries.Panel:
+    """Stacked daily BARS timeseries — the canonical "X per day, stacked by
+    series" cost viz. Pairs with an `expr` that uses a `[1d]` window and a
+    `step="1d"` target (set by the caller) so each bar is exactly one day.
+    """
+    h, w, x, y = grid
+    return (
+        timeseries.Panel()
+        .title(title)
+        .datasource(LOKI_DS)
+        .grid_pos(dm.GridPos(h=h, w=w, x=x, y=y))
+        .unit(unit)
+        .draw_style(cm.GraphDrawStyle.BARS)
+        .fill_opacity(70.0)
+        .line_width(1.0)
+        .show_points(cm.VisibilityMode.NEVER)
+        .stacking(cb.StackingConfig().mode(cm.StackingMode.NORMAL))
+        .legend(
+            cb.VizLegendOptions()
+            .display_mode(cm.LegendDisplayMode.TABLE)
+            .placement(cm.LegendPlacement.RIGHT)
+            .calcs(legend_calcs if legend_calcs is not None else ["sum"])
+        )
+        .tooltip(
+            cb.VizTooltipOptions().mode(cm.TooltipDisplayMode.MULTI).sort(cm.SortOrder.DESCENDING)
+        )
+        .with_target(loki_target(expr, legend=legend, step="1d"))
+    )
+
+
+def pie_panel(
+    *,
+    title: str,
+    expr: str,
+    legend_label: str,
+    grid: tuple[int, int, int, int],
+) -> piechart.Panel:
+    h, w, x, y = grid
+    return (
+        piechart.Panel()
+        .title(title)
+        .datasource(LOKI_DS)
+        .grid_pos(dm.GridPos(h=h, w=w, x=x, y=y))
+        .pie_type(pm.PieChartType.DONUT)
+        .legend(
+            piechart.PieChartLegendOptions()
+            .display_mode(cm.LegendDisplayMode.TABLE)
+            .placement(cm.LegendPlacement.RIGHT)
+            .values([pm.PieChartLegendValues.VALUE, pm.PieChartLegendValues.PERCENT])
+        )
+        .tooltip(cb.VizTooltipOptions().mode(cm.TooltipDisplayMode.SINGLE))
+        .with_target(loki_target(expr, legend=legend_label, instant=False))
+    )
+
+
+def bargauge_panel(
+    *,
+    title: str,
+    expr: str,
+    legend: str,
+    unit: str,
+    color: str,
+    grid: tuple[int, int, int, int],
+) -> bargauge.Panel:
+    """Horizontal bargauge — ranked totals (one bar per series). Range query so
+    `$__range` substitutes; the bar uses the series' last value."""
+    h, w, x, y = grid
+    return (
+        bargauge.Panel()
+        .title(title)
+        .datasource(LOKI_DS)
+        .grid_pos(dm.GridPos(h=h, w=w, x=x, y=y))
+        .unit(unit)
+        .orientation(cm.VizOrientation.HORIZONTAL)
+        .reduce_options(cb.ReduceDataOptions().calcs(["lastNotNull"]).fields("").values(False))
+        .display_mode(cm.BarGaugeDisplayMode.BASIC)
+        .thresholds(single_color_thresholds(color))
+        .with_target(loki_target(expr, legend=legend, instant=False))
+    )
+
+
+class _RowBuilder:
+    """Tiny adapter so a RowPanel can be passed to Dashboard.with_panel (the SDK
+    ships a RowPanel model but no row *builder*)."""
+
+    def __init__(self, row: dm.RowPanel) -> None:
+        self._row = row
+
+    def build(self) -> dm.RowPanel:
+        return self._row
+
+
+def row(title: str, *, y: int) -> _RowBuilder:
+    return _RowBuilder(dm.RowPanel(title=title, grid_pos=dm.GridPos(h=1, w=24, x=0, y=y)))
+
+
+def actor_var(*, name: str, label: str, definition: str) -> db.QueryVariable:
+    """Single-select query variable (for the actor picker — one user/repo at a
+    time). All-value `.+` so 'All' still renders a valid regex matcher."""
+    return (
+        db.QueryVariable(name)
+        .label(label)
+        .datasource(LOKI_DS)
+        .query(definition)
+        .refresh(dm.VariableRefresh.ON_TIME_RANGE_CHANGED)
+        .sort(dm.VariableSort.ALPHABETICAL_ASC)
+        .multi(False)
+        .include_all(True)
+        .all_value(".+")
+        .current(dm.VariableOption(selected=True, text="All", value="$__all"))
+    )
+
+
+def multi_var(*, name: str, label: str, definition: str) -> db.QueryVariable:
+    """Multi-select query variable (channel/model filters)."""
+    return (
+        db.QueryVariable(name)
+        .label(label)
+        .datasource(LOKI_DS)
+        .query(definition)
+        .refresh(dm.VariableRefresh.ON_TIME_RANGE_CHANGED)
+        .sort(dm.VariableSort.ALPHABETICAL_ASC)
+        .multi(True)
+        .include_all(True)
+        .all_value(".+")
+        .current(dm.VariableOption(selected=True, text=["All"], value=["$__all"]))
+    )

--- a/tools/dashboards/src/dashboards/envoy_ai_gateway/actor_consumption.py
+++ b/tools/dashboards/src/dashboards/envoy_ai_gateway/actor_consumption.py
@@ -1,0 +1,177 @@
+"""Envoy AI Gateway — actor consumption (GENERATED SOURCE).
+
+Pick ONE actor and see their spend per month / per day and across models. The
+actor selector is the `display_name` label, which is the unifying identity for
+both humans (e.g. "Ariel Kouebou") and CI repositories (e.g.
+"ADORSYS-GIS/keycloak-oid4vp-plugin", "vymalo/flutter-tools") — so "user or
+actor (e.g. repository)" is one picker. Optional Client (azp) / Model filters
+refine it further.
+
+The JSON file is regenerated from this module — do **not** hand-edit it.
+
+    uv run dashboards build
+
+Architecture decision: docs/adr/0008-python-dashboard-generation.md.
+Data path the dashboard consumes: docs/per-user-observability.md.
+"""
+
+from __future__ import annotations
+
+import json
+
+from grafana_foundation_sdk.builders import dashboard as db
+from grafana_foundation_sdk.cog.encoder import JSONEncoder
+from grafana_foundation_sdk.models import dashboard as dm
+
+from dashboards._common import (
+    GATEWAY_SERVICE_NAME,
+    LABEL_AZP,
+    LABEL_DISPLAY_NAME,
+    LABEL_MODEL,
+)
+from dashboards.envoy_ai_gateway import _shared as sh
+
+OUTPUT_PATH: str = "charts/observability-dashboards/files/envoy-ai-gateway/actor-consumption.json"
+
+# Scoped to the picked actor; azp/model further refine. display_name=~"$actor"
+# with $actor defaulting to ".+" (All) so the dashboard renders before a pick.
+_SELECTOR = sh.selector('display_name=~"$actor"', 'azp=~"$azp"', 'model=~"$model"')
+
+_COST = "gen_ai_usage_custom_total_cost"
+_TOKENS = "gen_ai_usage_total_tokens"
+
+_LEGEND_MODEL = "{{" + LABEL_MODEL + "}}"
+_LEGEND_AZP = "{{" + LABEL_AZP + "}}"
+
+
+def _panel_total_cost() -> object:
+    # With the default 30-day range this stat IS the actor's monthly cost.
+    return sh.stat_panel(
+        title="Cost — selected range (≈ per month)",
+        expr=sh.usd(f"sum(sum_over_time({_SELECTOR} {sh.unwrap(_COST)} [$__range]))"),
+        unit="currencyUSD",
+        color="orange",
+        grid=(4, 8, 0, 1),
+    )
+
+
+def _panel_total_tokens() -> object:
+    return sh.stat_panel(
+        title="Tokens — selected range",
+        expr=f"sum(sum_over_time({_SELECTOR} {sh.unwrap(_TOKENS)} [$__range]))",
+        unit="short",
+        color="green",
+        grid=(4, 8, 8, 1),
+    )
+
+
+def _panel_total_requests() -> object:
+    return sh.stat_panel(
+        title="Requests — selected range",
+        expr=f"sum(count_over_time({_SELECTOR} [$__range]))",
+        unit="short",
+        color="blue",
+        grid=(4, 8, 16, 1),
+    )
+
+
+def _panel_cost_per_day_by_model() -> object:
+    # Per-day AND which-models in one panel: daily bars stacked by model.
+    expr = sh.usd(f"sum by ({LABEL_MODEL}) (sum_over_time({_SELECTOR} {sh.unwrap(_COST)} [1d]))")
+    return sh.daily_bars_panel(
+        title="Cost per day, by model",
+        expr=expr,
+        legend=_LEGEND_MODEL,
+        unit="currencyUSD",
+        grid=(11, 24, 0, 5),
+        legend_calcs=["sum", "max"],
+    )
+
+
+def _panel_cost_by_model_pie() -> object:
+    expr = sh.usd(
+        f"sum by ({LABEL_MODEL}) (sum_over_time({_SELECTOR} {sh.unwrap(_COST)} [$__range]))"
+    )
+    return sh.pie_panel(
+        title="Which models (cost share, selected range)",
+        expr=expr,
+        legend_label=_LEGEND_MODEL,
+        grid=(11, 12, 0, 16),
+    )
+
+
+def _panel_cost_by_channel() -> object:
+    # An actor can spend across several channels (a human via opencode-cli AND
+    # lightbridge-api-key); break the actor's cost down by azp.
+    cost_sum = f"sum_over_time({_SELECTOR} {sh.unwrap(_COST)} [$__range])"
+    expr = f"sort_desc(sum by ({LABEL_AZP}) ({sh.usd(cost_sum)}))"
+    return sh.bargauge_panel(
+        title="Cost by channel (azp, selected range)",
+        expr=expr,
+        legend=_LEGEND_AZP,
+        unit="currencyUSD",
+        color="purple",
+        grid=(11, 12, 12, 16),
+    )
+
+
+_DESCRIPTION = (
+    "Per-actor consumption for the Envoy AI Gateway. The 'Actor' variable is the "
+    "display_name label — a person's name for humans, the repository for CI "
+    "(github-actions / lightbridge-code-intelligence) — so one picker covers "
+    "'user or actor (e.g. repository)'. Cost stat over the selected range ≈ the "
+    "actor's monthly spend (default 30-day window); the daily-bars panel gives "
+    "per-day, stacked by model. Cost = gen_ai.usage.custom_total_cost "
+    "(micro-USD ÷ 1e6; ADR-0028/0051). "
+    "⚠️ LibreChat agent runs + RAG embeddings don't forward the end-user, so they "
+    "land under azp=internal-key-librechat, not the human (docs/per-user-observability.md). "
+    "GENERATED — source: tools/dashboards/envoy_ai_gateway/actor_consumption.py."
+)
+
+
+def _dashboard() -> db.Dashboard:
+    return (
+        db.Dashboard("AI Gateway — actor consumption")
+        .uid("envoy-ai-gateway-actor-consumption")
+        .tags(["ai-gateway", "cost", "per-user", "loki"])
+        .description(_DESCRIPTION)
+        .timezone("browser")
+        .editable()
+        .tooltip(dm.DashboardCursorSync.CROSSHAIR)
+        .refresh("5m")
+        .time("now-30d", "now")
+        .with_variable(
+            sh.actor_var(
+                name="actor",
+                label="Actor (user / repo)",
+                definition=(
+                    f'label_values({{service_name="{GATEWAY_SERVICE_NAME}"}}, {LABEL_DISPLAY_NAME})'
+                ),
+            )
+        )
+        .with_variable(
+            sh.multi_var(
+                name="azp",
+                label="Client (azp)",
+                definition=f'label_values({{service_name="{GATEWAY_SERVICE_NAME}"}}, {LABEL_AZP})',
+            )
+        )
+        .with_variable(
+            sh.multi_var(
+                name="model",
+                label="Model",
+                definition=f'label_values({{service_name="{GATEWAY_SERVICE_NAME}"}}, {LABEL_MODEL})',
+            )
+        )
+        .with_panel(sh.row("Actor consumption", y=0))
+        .with_panel(_panel_total_cost())
+        .with_panel(_panel_total_tokens())
+        .with_panel(_panel_total_requests())
+        .with_panel(_panel_cost_per_day_by_model())
+        .with_panel(_panel_cost_by_model_pie())
+        .with_panel(_panel_cost_by_channel())
+    )
+
+
+def build() -> dict:
+    return json.loads(json.dumps(_dashboard().build(), cls=JSONEncoder))

--- a/tools/dashboards/src/dashboards/envoy_ai_gateway/actor_consumption.py
+++ b/tools/dashboards/src/dashboards/envoy_ai_gateway/actor_consumption.py
@@ -84,7 +84,6 @@ def _panel_cost_per_day_by_model() -> object:
         legend=_LEGEND_MODEL,
         unit="currencyUSD",
         grid=(11, 24, 0, 5),
-        legend_calcs=["sum", "max"],
     )
 
 

--- a/tools/dashboards/src/dashboards/envoy_ai_gateway/cost_by_model.py
+++ b/tools/dashboards/src/dashboards/envoy_ai_gateway/cost_by_model.py
@@ -1,0 +1,159 @@
+"""Envoy AI Gateway — cost by model, monthly (GENERATED SOURCE).
+
+Answers "what did each model cost this month?" with a minimum granularity of
+days: the headline panel is a stacked daily-bars timeseries, one series per
+model, defaulting to a 30-day window. Optional Client (azp) / Model filters.
+
+The JSON file is regenerated from this module — do **not** hand-edit it.
+
+    uv run dashboards build
+
+Architecture decision: docs/adr/0008-python-dashboard-generation.md.
+Data path the dashboard consumes: docs/per-user-observability.md.
+"""
+
+from __future__ import annotations
+
+import json
+
+from grafana_foundation_sdk.builders import dashboard as db
+from grafana_foundation_sdk.cog.encoder import JSONEncoder
+from grafana_foundation_sdk.models import dashboard as dm
+
+from dashboards._common import GATEWAY_SERVICE_NAME, LABEL_AZP, LABEL_MODEL
+from dashboards.envoy_ai_gateway import _shared as sh
+
+OUTPUT_PATH: str = "charts/observability-dashboards/files/envoy-ai-gateway/cost-by-model.json"
+
+# Spans ALL attributed traffic (humans + service accounts) regardless of the
+# filter variables' defaults — every gateway stream carries a user_id label
+# (a real sub or an "unstamped:*"/"missing:*" sentinel), so `user_id=~".+"`
+# matches everything while staying a valid selector.
+_SELECTOR = sh.selector('azp=~"$azp"', 'user_id=~".+"', 'model=~"$model"')
+
+_COST = "gen_ai_usage_custom_total_cost"
+_TOKENS = "gen_ai_usage_total_tokens"
+
+_LEGEND_MODEL = "{{" + LABEL_MODEL + "}}"
+
+
+def _panel_total_cost() -> object:
+    return sh.stat_panel(
+        title="Total cost (selected range)",
+        expr=sh.usd(f"sum(sum_over_time({_SELECTOR} {sh.unwrap(_COST)} [$__range]))"),
+        unit="currencyUSD",
+        color="orange",
+        grid=(4, 8, 0, 1),
+    )
+
+
+def _panel_total_tokens() -> object:
+    return sh.stat_panel(
+        title="Total tokens (selected range)",
+        expr=f"sum(sum_over_time({_SELECTOR} {sh.unwrap(_TOKENS)} [$__range]))",
+        unit="short",
+        color="green",
+        grid=(4, 8, 8, 1),
+    )
+
+
+def _panel_total_requests() -> object:
+    return sh.stat_panel(
+        title="Total requests (selected range)",
+        expr=f"sum(count_over_time({_SELECTOR} [$__range]))",
+        unit="short",
+        color="blue",
+        grid=(4, 8, 16, 1),
+    )
+
+
+def _panel_cost_per_day_by_model() -> object:
+    # [1d] window + step="1d" (set by daily_bars_panel) → one non-overlapping
+    # bar per calendar day, stacked by model. This is the "min granularity of
+    # days" contract: the resolution is pinned to a day and can't go finer.
+    expr = sh.usd(f"sum by ({LABEL_MODEL}) (sum_over_time({_SELECTOR} {sh.unwrap(_COST)} [1d]))")
+    return sh.daily_bars_panel(
+        title="Cost per day, by model",
+        expr=expr,
+        legend=_LEGEND_MODEL,
+        unit="currencyUSD",
+        grid=(11, 24, 0, 5),
+        legend_calcs=["sum", "max"],
+    )
+
+
+def _panel_cost_by_model_totals() -> object:
+    # sum_over_time can't take an inline by() (Loki) — group via the outer
+    # sum by; unwrap extracts only the cost field so cardinality stays bounded.
+    cost_sum = f"sum_over_time({_SELECTOR} {sh.unwrap(_COST)} [$__range])"
+    expr = f"sort_desc(sum by ({LABEL_MODEL}) ({sh.usd(cost_sum)}))"
+    return sh.bargauge_panel(
+        title="Cost by model — total (selected range)",
+        expr=expr,
+        legend=_LEGEND_MODEL,
+        unit="currencyUSD",
+        color="orange",
+        grid=(11, 12, 0, 16),
+    )
+
+
+def _panel_cost_by_model_pie() -> object:
+    expr = sh.usd(
+        f"sum by ({LABEL_MODEL}) (sum_over_time({_SELECTOR} {sh.unwrap(_COST)} [$__range]))"
+    )
+    return sh.pie_panel(
+        title="Cost share by model (selected range)",
+        expr=expr,
+        legend_label=_LEGEND_MODEL,
+        grid=(11, 12, 12, 16),
+    )
+
+
+_DESCRIPTION = (
+    "Cost per model for the Envoy AI Gateway, daily granularity. The headline "
+    "panel stacks one bar per day per model (resolution pinned to 1d). Default "
+    "window is 30 days — set the range to a calendar month for monthly totals. "
+    "Cost = gen_ai.usage.custom_total_cost (micro-USD ÷ 1e6; ADR-0028/0051). "
+    "Spans all attributed traffic incl. service accounts. "
+    "See docs/per-user-observability.md. "
+    "GENERATED — source: tools/dashboards/envoy_ai_gateway/cost_by_model.py."
+)
+
+
+def _dashboard() -> db.Dashboard:
+    return (
+        db.Dashboard("AI Gateway — cost by model (monthly)")
+        .uid("envoy-ai-gateway-cost-by-model")
+        .tags(["ai-gateway", "cost", "model", "loki"])
+        .description(_DESCRIPTION)
+        .timezone("browser")
+        .editable()
+        .tooltip(dm.DashboardCursorSync.CROSSHAIR)
+        .refresh("5m")
+        .time("now-30d", "now")
+        .with_variable(
+            sh.multi_var(
+                name="azp",
+                label="Client (azp)",
+                definition=f'label_values({{service_name="{GATEWAY_SERVICE_NAME}"}}, {LABEL_AZP})',
+            )
+        )
+        .with_variable(
+            sh.multi_var(
+                name="model",
+                label="Model",
+                definition=f'label_values({{service_name="{GATEWAY_SERVICE_NAME}"}}, {LABEL_MODEL})',
+            )
+        )
+        .with_panel(sh.row("Cost by model", y=0))
+        .with_panel(_panel_total_cost())
+        .with_panel(_panel_total_tokens())
+        .with_panel(_panel_total_requests())
+        .with_panel(_panel_cost_per_day_by_model())
+        .with_panel(_panel_cost_by_model_totals())
+        .with_panel(_panel_cost_by_model_pie())
+    )
+
+
+def build() -> dict:
+    return json.loads(json.dumps(_dashboard().build(), cls=JSONEncoder))

--- a/tools/dashboards/src/dashboards/envoy_ai_gateway/cost_by_model.py
+++ b/tools/dashboards/src/dashboards/envoy_ai_gateway/cost_by_model.py
@@ -78,7 +78,6 @@ def _panel_cost_per_day_by_model() -> object:
         legend=_LEGEND_MODEL,
         unit="currencyUSD",
         grid=(11, 24, 0, 5),
-        legend_calcs=["sum", "max"],
     )
 
 

--- a/tools/dashboards/src/dashboards/envoy_ai_gateway/user_tokens_cost.py
+++ b/tools/dashboards/src/dashboards/envoy_ai_gateway/user_tokens_cost.py
@@ -1,0 +1,278 @@
+"""Envoy AI Gateway — users: tokens & cost (GENERATED SOURCE).
+
+The user x tokens x cost cross: one table row per actor (display_name) with
+requests / tokens / cost side by side, plus per-day stacked breakdowns and
+ranked leaderboards. display_name is a person's name for humans and the
+repository for CI, so "user/actor" is one axis.
+
+The JSON file is regenerated from this module — do **not** hand-edit it.
+
+    uv run dashboards build
+
+Architecture decision: docs/adr/0008-python-dashboard-generation.md.
+Data path the dashboard consumes: docs/per-user-observability.md.
+"""
+
+from __future__ import annotations
+
+import json
+
+from grafana_foundation_sdk.builders import dashboard as db
+from grafana_foundation_sdk.builders import table
+from grafana_foundation_sdk.cog.encoder import JSONEncoder
+from grafana_foundation_sdk.models import dashboard as dm
+
+from dashboards._common import (
+    GATEWAY_SERVICE_NAME,
+    LABEL_AZP,
+    LABEL_DISPLAY_NAME,
+    LABEL_MODEL,
+)
+from dashboards.envoy_ai_gateway import _shared as sh
+
+OUTPUT_PATH: str = "charts/observability-dashboards/files/envoy-ai-gateway/user-tokens-cost.json"
+
+# All attributed traffic (humans + service accounts / repos), refined by the
+# azp / model filters. user_id=~".+" matches every gateway stream.
+_SELECTOR = sh.selector('azp=~"$azp"', 'user_id=~".+"', 'model=~"$model"')
+
+_COST = "gen_ai_usage_custom_total_cost"
+_TOKENS = "gen_ai_usage_total_tokens"
+
+_LEGEND_USER = "{{" + LABEL_DISPLAY_NAME + "}}"
+
+# Per-user range aggregations. The [$__range] window means the LAST evaluated
+# point of each series IS the per-range total (same trick as the stat panels);
+# timeSeriesTable's lastNotNull stat then reads exactly that total.
+_COST_BY_USER = sh.usd(
+    f"sum by ({LABEL_DISPLAY_NAME}) (sum_over_time({_SELECTOR} {sh.unwrap(_COST)} [$__range]))"
+)
+_TOKENS_BY_USER = (
+    f"sum by ({LABEL_DISPLAY_NAME}) (sum_over_time({_SELECTOR} {sh.unwrap(_TOKENS)} [$__range]))"
+)
+_REQS_BY_USER = f"sum by ({LABEL_DISPLAY_NAME}) (count_over_time({_SELECTOR} [$__range]))"
+
+
+# ---------------------------------------------------------------------------
+# Stats row
+# ---------------------------------------------------------------------------
+
+
+def _panel_total_cost() -> object:
+    return sh.stat_panel(
+        title="Total cost (range)",
+        expr=sh.usd(f"sum(sum_over_time({_SELECTOR} {sh.unwrap(_COST)} [$__range]))"),
+        unit="currencyUSD",
+        color="orange",
+        grid=(4, 6, 0, 1),
+    )
+
+
+def _panel_total_tokens() -> object:
+    return sh.stat_panel(
+        title="Total tokens (range)",
+        expr=f"sum(sum_over_time({_SELECTOR} {sh.unwrap(_TOKENS)} [$__range]))",
+        unit="short",
+        color="green",
+        grid=(4, 6, 6, 1),
+    )
+
+
+def _panel_unique_users() -> object:
+    return sh.stat_panel(
+        title="Unique actors (range)",
+        expr=f"count(sum by ({LABEL_DISPLAY_NAME}) (count_over_time({_SELECTOR} [$__range])))",
+        unit="short",
+        color="purple",
+        grid=(4, 6, 12, 1),
+    )
+
+
+def _panel_cost_per_1k_tokens() -> object:
+    # Blended efficiency: total USD / (total tokens / 1000). Arithmetic between
+    # two scalar LogQL aggregations is valid; both collapse via sum().
+    cost = f"sum(sum_over_time({_SELECTOR} {sh.unwrap(_COST)} [$__range])) / 1e6"
+    ktok = f"(sum(sum_over_time({_SELECTOR} {sh.unwrap(_TOKENS)} [$__range])) / 1000)"
+    return sh.stat_panel(
+        title="Blended cost / 1k tokens (range)",
+        expr=f"({cost}) / ({ktok})",
+        unit="currencyUSD",
+        color="blue",
+        grid=(4, 6, 18, 1),
+    )
+
+
+# ---------------------------------------------------------------------------
+# The user x tokens x cost table
+# ---------------------------------------------------------------------------
+
+
+def _panel_user_table() -> table.Panel:
+    # Three range queries (refIds A/B/C) grouped by display_name, merged into one
+    # row-per-user table by `timeSeriesTable` (reduces each series with
+    # lastNotNull → its per-range total). `organize` renames the auto "Trend #X"
+    # columns; `sortBy` ranks by cost. Cost column carries the USD unit override.
+    panel = (
+        table.Panel()
+        .title("Per actor — requests · tokens · cost (selected range)")
+        .datasource(sh.LOKI_DS)
+        .grid_pos(dm.GridPos(h=12, w=24, x=0, y=5))
+        .filterable(True)
+        .with_target(sh.loki_target(_COST_BY_USER, ref_id="A", legend=_LEGEND_USER))
+        .with_target(sh.loki_target(_TOKENS_BY_USER, ref_id="B", legend=_LEGEND_USER))
+        .with_target(sh.loki_target(_REQS_BY_USER, ref_id="C", legend=_LEGEND_USER))
+        .with_transformation(
+            dm.DataTransformerConfig(
+                id_val="timeSeriesTable",
+                options={
+                    "A": {"stat": "lastNotNull"},
+                    "B": {"stat": "lastNotNull"},
+                    "C": {"stat": "lastNotNull"},
+                },
+            )
+        )
+        .with_transformation(
+            dm.DataTransformerConfig(
+                id_val="organize",
+                options={
+                    "renameByName": {
+                        LABEL_DISPLAY_NAME: "Actor",
+                        "Trend #A": "Cost ($)",
+                        "Trend #B": "Tokens",
+                        "Trend #C": "Requests",
+                    },
+                    "excludeByName": {},
+                    "indexByName": {},
+                },
+            )
+        )
+        .with_transformation(
+            dm.DataTransformerConfig(
+                id_val="sortBy",
+                options={"fields": {}, "sort": [{"field": "Cost ($)", "desc": True}]},
+            )
+        )
+    )
+    # USD unit + 2 decimals on the cost column (others stay plain counts).
+    return panel.override_by_name(
+        "Cost ($)",
+        [
+            dm.DynamicConfigValue(id_val="unit", value="currencyUSD"),
+            dm.DynamicConfigValue(id_val="decimals", value=2),
+        ],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Per-day breakdowns (min granularity = days, like the sibling boards)
+# ---------------------------------------------------------------------------
+
+
+def _panel_cost_per_day_by_user() -> object:
+    expr = sh.usd(
+        f"sum by ({LABEL_DISPLAY_NAME}) (sum_over_time({_SELECTOR} {sh.unwrap(_COST)} [1d]))"
+    )
+    return sh.daily_bars_panel(
+        title="Cost per day, by actor",
+        expr=expr,
+        legend=_LEGEND_USER,
+        unit="currencyUSD",
+        grid=(10, 12, 0, 17),
+        legend_calcs=["sum"],
+    )
+
+
+def _panel_tokens_per_day_by_user() -> object:
+    expr = f"sum by ({LABEL_DISPLAY_NAME}) (sum_over_time({_SELECTOR} {sh.unwrap(_TOKENS)} [1d]))"
+    return sh.daily_bars_panel(
+        title="Tokens per day, by actor",
+        expr=expr,
+        legend=_LEGEND_USER,
+        unit="short",
+        grid=(10, 12, 12, 17),
+        legend_calcs=["sum"],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Leaderboards (dependable, regardless of the table transform)
+# ---------------------------------------------------------------------------
+
+
+def _panel_top_users_cost() -> object:
+    expr = f"topk(20, {_COST_BY_USER})"
+    return sh.bargauge_panel(
+        title="Top actors by cost (selected range)",
+        expr=expr,
+        legend=_LEGEND_USER,
+        unit="currencyUSD",
+        color="orange",
+        grid=(10, 12, 0, 27),
+    )
+
+
+def _panel_top_users_tokens() -> object:
+    expr = f"topk(20, {_TOKENS_BY_USER})"
+    return sh.bargauge_panel(
+        title="Top actors by tokens (selected range)",
+        expr=expr,
+        legend=_LEGEND_USER,
+        unit="short",
+        color="green",
+        grid=(10, 12, 12, 27),
+    )
+
+
+_DESCRIPTION = (
+    "Users x tokens x cost for the Envoy AI Gateway. The table gives one row per "
+    "actor (display_name = a person for humans, the repository for CI) with "
+    "requests / tokens / cost side by side over the selected range (default 30d ≈ "
+    "monthly); per-day stacked panels add daily granularity, and the leaderboards "
+    "rank by cost and by tokens. Cost = gen_ai.usage.custom_total_cost "
+    "(micro-USD ÷ 1e6; ADR-0028/0051). Filters: azp, model. "
+    "⚠️ LibreChat agent runs + RAG embeddings fall back to azp=internal-key-librechat "
+    "(not the human) — docs/per-user-observability.md. "
+    "GENERATED — source: tools/dashboards/envoy_ai_gateway/user_tokens_cost.py."
+)
+
+
+def _dashboard() -> db.Dashboard:
+    return (
+        db.Dashboard("AI Gateway — users: tokens & cost")
+        .uid("envoy-ai-gateway-user-tokens-cost")
+        .tags(["ai-gateway", "cost", "tokens", "per-user", "loki"])
+        .description(_DESCRIPTION)
+        .timezone("browser")
+        .editable()
+        .tooltip(dm.DashboardCursorSync.CROSSHAIR)
+        .refresh("5m")
+        .time("now-30d", "now")
+        .with_variable(
+            sh.multi_var(
+                name="azp",
+                label="Client (azp)",
+                definition=f'label_values({{service_name="{GATEWAY_SERVICE_NAME}"}}, {LABEL_AZP})',
+            )
+        )
+        .with_variable(
+            sh.multi_var(
+                name="model",
+                label="Model",
+                definition=f'label_values({{service_name="{GATEWAY_SERVICE_NAME}"}}, {LABEL_MODEL})',
+            )
+        )
+        .with_panel(sh.row("Users — tokens & cost", y=0))
+        .with_panel(_panel_total_cost())
+        .with_panel(_panel_total_tokens())
+        .with_panel(_panel_unique_users())
+        .with_panel(_panel_cost_per_1k_tokens())
+        .with_panel(_panel_user_table())
+        .with_panel(_panel_cost_per_day_by_user())
+        .with_panel(_panel_tokens_per_day_by_user())
+        .with_panel(_panel_top_users_cost())
+        .with_panel(_panel_top_users_tokens())
+    )
+
+
+def build() -> dict:
+    return json.loads(json.dumps(_dashboard().build(), cls=JSONEncoder))

--- a/tools/dashboards/src/dashboards/envoy_ai_gateway/user_tokens_cost.py
+++ b/tools/dashboards/src/dashboards/envoy_ai_gateway/user_tokens_cost.py
@@ -108,10 +108,18 @@ def _panel_cost_per_1k_tokens() -> object:
 
 
 def _panel_user_table() -> table.Panel:
-    # Three range queries (refIds A/B/C) grouped by display_name, merged into one
-    # row-per-user table by `timeSeriesTable` (reduces each series with
-    # lastNotNull → its per-range total). `organize` renames the auto "Trend #X"
-    # columns; `sortBy` ranks by cost. Cost column carries the USD unit override.
+    # Three range queries (refIds A/B/C) grouped by display_name. The transform
+    # chain is order-critical:
+    #   1. timeSeriesTable — reduce each series to its per-range total
+    #      (lastNotNull on the [$__range] running sum), one frame per refId with
+    #      columns [display_name, "Trend #A"|"#B"|"#C"].
+    #   2. merge — collapse the three frames into ONE row per display_name
+    #      (Grafana merges rows sharing identical values in shared fields, i.e.
+    #      display_name). WITHOUT this, the three frames stay separate and the
+    #      table can't show Cost/Tokens/Requests side by side or sort across
+    #      them (Grafana "Merge series/tables"; PR #485 review).
+    #   3. organize — rename the auto "Trend #X" columns + display_name.
+    #   4. sortBy — rank by cost. Cost column carries the USD unit override.
     panel = (
         table.Panel()
         .title("Per actor — requests · tokens · cost (selected range)")
@@ -131,6 +139,7 @@ def _panel_user_table() -> table.Panel:
                 },
             )
         )
+        .with_transformation(dm.DataTransformerConfig(id_val="merge", options={}))
         .with_transformation(
             dm.DataTransformerConfig(
                 id_val="organize",
@@ -178,7 +187,6 @@ def _panel_cost_per_day_by_user() -> object:
         legend=_LEGEND_USER,
         unit="currencyUSD",
         grid=(10, 12, 0, 17),
-        legend_calcs=["sum"],
     )
 
 
@@ -190,7 +198,6 @@ def _panel_tokens_per_day_by_user() -> object:
         legend=_LEGEND_USER,
         unit="short",
         grid=(10, 12, 12, 17),
-        legend_calcs=["sum"],
     )
 
 

--- a/tools/dashboards/src/dashboards/main.py
+++ b/tools/dashboards/src/dashboards/main.py
@@ -26,7 +26,11 @@ from types import ModuleType
 
 # Registry of every generated dashboard. Import-by-string so Python's
 # import-time errors don't blow up unrelated `--help`.
-_DASHBOARD_MODULES: tuple[str, ...] = ("dashboards.envoy_ai_gateway.per_user",)
+_DASHBOARD_MODULES: tuple[str, ...] = (
+    "dashboards.envoy_ai_gateway.per_user",
+    "dashboards.envoy_ai_gateway.cost_by_model",
+    "dashboards.envoy_ai_gateway.actor_consumption",
+)
 
 
 def _load_modules() -> list[ModuleType]:

--- a/tools/dashboards/src/dashboards/main.py
+++ b/tools/dashboards/src/dashboards/main.py
@@ -30,6 +30,7 @@ _DASHBOARD_MODULES: tuple[str, ...] = (
     "dashboards.envoy_ai_gateway.per_user",
     "dashboards.envoy_ai_gateway.cost_by_model",
     "dashboards.envoy_ai_gateway.actor_consumption",
+    "dashboards.envoy_ai_gateway.user_tokens_cost",
 )
 
 


### PR DESCRIPTION
## 1. Summary

This PR adds **three new generated Grafana dashboards** to the **AI Gateway** folder (ADR-0008 dashboards-as-code, Loki-backed):

- **`AI Gateway — cost by model (monthly)`** (`envoy-ai-gateway-cost-by-model`) — cost × model with a minimum granularity of days (stacked one-bar-per-day-per-model), per-model totals, share donut. Filters: `azp`, `model`.
- **`AI Gateway — actor consumption`** (`envoy-ai-gateway-actor-consumption`) — pick one **actor** (`display_name` = a person for humans, the **repository** for CI) → cost over range (≈ per month) + cost-per-day-by-model + which-models + cost-by-channel. Inputs: `actor`, `azp`, `model`.
- **`AI Gateway — users: tokens & cost`** (`envoy-ai-gateway-user-tokens-cost`) — the **user × tokens × cost** cross: a per-actor table (requests · tokens · cost) + per-day stacked cost/tokens + cost/tokens leaderboards + blended cost/1k-tokens. Filters: `azp`, `model`.

It solves:

- Maintainer request for per-month / per-day cost views by model and by user/actor, with model breakdowns. Extends the cost-attribution work from #484 (cost-by-channel on the per-user board).

---

## 2. Intent

The intent of this PR is:

> Give the team self-serve cost visibility — "what did each model cost this month, by day?", "what is this user/repo consuming?", and "users × tokens × cost in one table" — using the existing per-user attribution data path (ADR-0005/0011/0046), so cost questions don't need ad-hoc Loki queries. `display_name` is the unifying actor axis (human name OR CI repository), so a single picker covers "user or actor (e.g. repository)".

---

## 3. Scope

### In Scope

- Three new generator modules under `tools/dashboards/src/dashboards/envoy_ai_gateway/` + a shared SDK-helper module (`_shared.py`), registered in `main.py`.
- The three generated JSON dashboards + their `GrafanaDashboard` CR entries (`folderRef: ai-gateway`) in `charts/observability-dashboards/values.yaml`.
- Folder README updated with the sibling-dashboard table.

### Out of Scope

- `per_user.py` is intentionally **untouched** (keeps its own private helper copies) to avoid changing its generated JSON and tripping the drift guard.
- The Grafana/observability **resource bumps** and the **Alloy gh-runners log-drop** (the Hetzner Object Storage `SlowDown` mitigation) live in the private `ai-helm-values` repo — not this PR.
- No workload/templating/auth changes.

---

## 4. Verification

I verified this change by:

- [x] Running automated tests (generator drift guard + helm lint/template)
- [x] Running manual tests (executed the exact generated LogQL against live Loki)
- [x] Checking metrics (per-model / per-user cost values returned correctly)
- [ ] Testing error cases
- [ ] Testing permissions/security behavior
- [ ] Testing rollback or failure behavior, if relevant

Commands run:

```bash
cd tools/dashboards
uv run ruff format . && uv run ruff check src/dashboards/   # clean
uv run dashboards build                                      # regenerated 4 JSON
uv run dashboards check                                      # no drift
helm lint charts/observability-dashboards --strict           # 0 chart(s) failed
helm template x charts/observability-dashboards | grep GrafanaDashboard  # 3 new CRs in ai-gateway
```

Results:

```text
ruff: All checks passed!
dashboards check: ok — every dashboard matches its generator
helm lint: 1 chart(s) linted, 0 chart(s) failed
helm template: GrafanaDashboard CRs envoy-ai-gateway-{cost-by-model,actor-consumption,user-tokens-cost} render with folderRef "ai-gateway"
live Loki: the generated `sum by (model)(...)`/`sum by (display_name)(...)` cost+token queries return correct values
  (e.g. cost-by-model 3h: glm-5p1 $34.40, adorsys-reviewer-pro $4.71, qwen3p6-plus $2.32, … — 12 model series)
```

---

## 5. Screenshots / Evidence

- Generated dashboards: `charts/observability-dashboards/files/envoy-ai-gateway/{cost-by-model,actor-consumption,user-tokens-cost}.json`
- Live query parity proof: the exact generated LogQL (vars → `.+`) returned correct per-model/per-actor cost from Loki during development.
- ⚠️ Full **30-day** queries currently read historical chunks from Hetzner Object Storage while it sheds a `SlowDown` backlog (mitigated separately in `ai-helm-values`); **recent ranges render instantly, the monthly view warms up as the read path recovers**. Dashboards are correct; this is environmental latency, not a query defect.

---

## 6. Risk Assessment

Risk level:

* [x] Low

Potential risks:

* The `user-tokens-cost` table is the repo's first `timeSeriesTable`+`organize`+`sortBy` transform chain; it could not be rendered in the live Grafana UI yet (Loki historical reads timing out under the clearing `SlowDown`), so a column header *could* need a one-line `organize` rename.
* Monthly (30d) cost queries can be slow/empty until the Hetzner Object Storage read path recovers.

Mitigation:

* The same table also ships dependable bargauge leaderboards + daily stacked panels, so the data is available regardless of the table transform.
* Additive-only: new CRs in a new-ish folder; no existing dashboard or workload is modified. Rollback = revert this PR (operator prunes the 3 CRs).

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [x] Drafting documentation
* [x] Reviewing the diff

Human verification:

* [x] I understand every meaningful change in this PR
* [x] I checked generated code manually
* [x] I removed unsupported AI assumptions
* [x] I accept responsibility for this PR

---

## 8. Reviewer Focus

Please focus your review on:

* [x] Correctness
* [x] Product intent
* [x] Maintainability

Specifically: the `user-tokens-cost` table transform chain (column naming after `timeSeriesTable`→`organize`), and whether the default `now-30d` range + `1d` step is the granularity you want.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
