### PR TITLE
fix(dashboards): tame AI Gateway cost boards (7d default + auto-refresh off) to stop Loki self-DoS

### DIFF
--- a/charts/observability-dashboards/files/envoy-ai-gateway/actor-consumption.json
+++ b/charts/observability-dashboards/files/envoy-ai-gateway/actor-consumption.json
@@ -101,11 +101,11 @@
   "editable": true,
   "graphTooltip": 1,
   "time": {
-    "from": "now-30d",
+    "from": "now-7d",
     "to": "now"
   },
   "fiscalYearStartMonth": 0,
-  "refresh": "5m",
+  "refresh": "",
   "panels": [
     {
       "type": "row",

--- a/charts/observability-dashboards/files/envoy-ai-gateway/cost-by-model.json
+++ b/charts/observability-dashboards/files/envoy-ai-gateway/cost-by-model.json
@@ -76,11 +76,11 @@
   "editable": true,
   "graphTooltip": 1,
   "time": {
-    "from": "now-30d",
+    "from": "now-7d",
     "to": "now"
   },
   "fiscalYearStartMonth": 0,
-  "refresh": "5m",
+  "refresh": "",
   "panels": [
     {
       "type": "row",

--- a/charts/observability-dashboards/files/envoy-ai-gateway/user-tokens-cost.json
+++ b/charts/observability-dashboards/files/envoy-ai-gateway/user-tokens-cost.json
@@ -77,11 +77,11 @@
   "editable": true,
   "graphTooltip": 1,
   "time": {
-    "from": "now-30d",
+    "from": "now-7d",
     "to": "now"
   },
   "fiscalYearStartMonth": 0,
-  "refresh": "5m",
+  "refresh": "",
   "panels": [
     {
       "type": "row",

--- a/tools/dashboards/src/dashboards/envoy_ai_gateway/actor_consumption.py
+++ b/tools/dashboards/src/dashboards/envoy_ai_gateway/actor_consumption.py
@@ -137,8 +137,11 @@ def _dashboard() -> db.Dashboard:
         .timezone("browser")
         .editable()
         .tooltip(dm.DashboardCursorSync.CROSSHAIR)
-        .refresh("5m")
-        .time("now-30d", "now")
+        # Auto-refresh OFF + 7d default — see cost_by_model for the rationale
+        # (cold 30d log-scans on the rate-limited store self-DoS Loki). Expand
+        # the range manually; Phase 2 (Mimir recording rules) restores fast 30d.
+        .refresh("")
+        .time("now-7d", "now")
         .with_variable(
             sh.actor_var(
                 name="actor",

--- a/tools/dashboards/src/dashboards/envoy_ai_gateway/cost_by_model.py
+++ b/tools/dashboards/src/dashboards/envoy_ai_gateway/cost_by_model.py
@@ -128,8 +128,13 @@ def _dashboard() -> db.Dashboard:
         .timezone("browser")
         .editable()
         .tooltip(dm.DashboardCursorSync.CROSSHAIR)
-        .refresh("5m")
-        .time("now-30d", "now")
+        # Auto-refresh OFF + 7d default: a cold 30d log-scan over the
+        # rate-limited object store can't return within Grafana's timeout, and a
+        # 30d + 5m-refresh board saturated Loki (self-DoS → "No data"). 7d loads
+        # off the warm chunk cache; expand the range manually for longer windows.
+        # Phase 2 (Mimir recording rules) restores a fast 30d default.
+        .refresh("")
+        .time("now-7d", "now")
         .with_variable(
             sh.multi_var(
                 name="azp",

--- a/tools/dashboards/src/dashboards/envoy_ai_gateway/user_tokens_cost.py
+++ b/tools/dashboards/src/dashboards/envoy_ai_gateway/user_tokens_cost.py
@@ -252,8 +252,11 @@ def _dashboard() -> db.Dashboard:
         .timezone("browser")
         .editable()
         .tooltip(dm.DashboardCursorSync.CROSSHAIR)
-        .refresh("5m")
-        .time("now-30d", "now")
+        # Auto-refresh OFF + 7d default — see cost_by_model for the rationale
+        # (cold 30d log-scans on the rate-limited store self-DoS Loki). Expand
+        # the range manually; Phase 2 (Mimir recording rules) restores fast 30d.
+        .refresh("")
+        .time("now-7d", "now")
         .with_variable(
             sh.multi_var(
                 name="azp",


### PR DESCRIPTION
## 1. Summary

This PR changes:

- Cost dashboards (`cost-by-model`, `actor-consumption`, `user-tokens-cost`): **auto-refresh `5m` → off**, **default range `now-30d` → `now-7d`**.

It solves:

- "No data" on the AI Gateway cost dashboards (reported after #485 deployed). Follow-up to the Loki cache enablement in `ai-helm-values` (Phase 1).

## 2. Intent

> Stop the cost boards from self-DoSing Loki. They defaulted to a 30-day range with 5-minute auto-refresh; on this cluster Loki reads chunks from Hetzner Object Storage, which rate-limits (`SlowDown`). A 30d `unwrap` query is a burst of thousands of `GetObject`s that can't return within Grafana's timeout, and the auto-refresh re-fired it continuously — saturating Loki so even small queries (and the per-user board) timed out → every panel "No data". A 7d default loads off the now-warm chunk cache; auto-refresh off stops the continuous re-fire. Manual range expansion still works (warms incrementally).

## 3. Scope

### In Scope
- `refresh` and default `time` on the three cost dashboards (generator + regenerated JSON).

### Out of Scope
- **Phase 1** — Loki `chunksCache` + `resultsCache` enablement (already merged to `ai-helm-values`).
- **Phase 2** — cost as Loki recording rules → Mimir (separate ADR); that restores a fast `now-30d` default by reading precomputed metrics instead of scanning a month of logs.
- Panel/query logic (unchanged from #485).

## 4. Verification

- [x] Running automated tests (drift guard + helm lint)
- [x] Checking metrics (confirmed live: short-range queries fast after cache; 30d log-scan times out — root cause)

Commands run:
```bash
cd tools/dashboards && uv run ruff check src/dashboards/ && uv run dashboards build && uv run dashboards check
helm lint charts/observability-dashboards --strict
```
Results:
```text
ruff: All checks passed!   dashboards check: ok — no drift   helm lint: 0 chart(s) failed
generated JSON: time=now-7d, refresh=""  (all 3 boards)
live Loki: 1h cost-by-model 0.1s (cache warm); 30d query_range still times out at 170s (→ Phase 2)
```

## 5. Screenshots / Evidence
- Loki was observed processing `length=720h` (30d) queries split into ~110×24h sub-queries with `SlowDown` still firing — the saturation this PR removes.

## 6. Risk Assessment
Risk level:
* [x] Low

Potential risks:
* 7d may undersell a "monthly" board until Phase 2 lands.

Mitigation:
* Range is user-adjustable; Phase 2 restores 30d. Additive, generated-JSON-only; rollback = revert.

## 7. AI Usage Declaration
AI was used for:
* [x] Understanding existing code
* [x] Generating code
* [x] Reviewing the diff

Human verification:
* [x] I understand every meaningful change in this PR
* [x] I checked generated code manually
* [x] I accept responsibility for this PR

## 8. Reviewer Focus
* [x] Correctness
* [x] Product intent

🤖 Generated with [Claude Code](https://claude.com/claude-code)
