### PR TITLE
feat(dashboards): repoint AI Gateway cost boards to Mimir (ADR-0058 part B)

### DIFF
--- a/charts/observability-dashboards/files/envoy-ai-gateway/README.md
+++ b/charts/observability-dashboards/files/envoy-ai-gateway/README.md
@@ -67,22 +67,24 @@ in the UI, then port the change back into the generator module.
 
 ## Sibling dashboards in this folder
 
-The `AI Gateway` folder now holds three cost/usage dashboards. They share the
-same Loki data path (above) and the helpers in
-`tools/dashboards/src/dashboards/envoy_ai_gateway/_shared.py`. All are GENERATED
-— edit the `.py`, then `uv run dashboards build` (commit the JSON).
+The `AI Gateway` folder holds four dashboards. `per-user.json` is **Loki-backed**
+(raw log activity); the three **cost** boards read the **precomputed Mimir
+metrics** (ADR-0058) via PromQL — NOT Loki log-scans — so they're instant at any
+range and don't touch the rate-limited object store. The cost boards share the
+PromQL helpers in `tools/dashboards/src/dashboards/envoy_ai_gateway/_shared.py`.
+All are GENERATED — edit the `.py`, then `uv run dashboards build` (commit JSON).
 
-| File / UID | Source module | What it shows |
-|---|---|---|
-| `per-user.json` · `envoy-ai-gateway-per-user` | `per_user.py` | Real-time per-user activity (requests, tokens, latency, status, cost-by-channel). Default `now-1h`. |
-| `cost-by-model.json` · `envoy-ai-gateway-cost-by-model` | `cost_by_model.py` | **Cost × model, daily granularity** — stacked one-bar-per-day-per-model timeseries + per-model totals + share pie. Default `now-30d`; set the range to a month for monthly totals. Filters: `azp`, `model`. |
-| `actor-consumption.json` · `envoy-ai-gateway-actor-consumption` | `actor_consumption.py` | **Per-actor consumption** — pick one `actor` (the `display_name` label = a person's name for humans, the **repository** for CI), see cost over the range (≈ per month) + cost-per-day-by-model bars + which-models pie + cost-by-channel. Filters: `actor`, `azp`, `model`. |
-| `user-tokens-cost.json` · `envoy-ai-gateway-user-tokens-cost` | `user_tokens_cost.py` | **Users x tokens x cost** — one table row per actor (requests · tokens · cost, via the `timeSeriesTable`+`organize`+`sortBy` transform chain) + per-day stacked cost/tokens-by-actor bars + cost/tokens leaderboards + a blended cost/1k-tokens stat. Filters: `azp`, `model`. |
+| File / UID | Source module | Backend | What it shows |
+|---|---|---|---|
+| `per-user.json` · `envoy-ai-gateway-per-user` | `per_user.py` | Loki | Real-time per-user activity (requests, tokens, latency, status, cost-by-channel). Default `now-1h`. |
+| `cost-by-model.json` · `envoy-ai-gateway-cost-by-model` | `cost_by_model.py` | Mimir | **Cost × model, daily granularity** — stacked one-bar-per-day-per-model + per-model totals + share pie. Default `now-30d`. Filters: `azp`, `model`. |
+| `actor-consumption.json` · `envoy-ai-gateway-actor-consumption` | `actor_consumption.py` | Mimir | **Per-actor consumption** — pick one `actor` (`display_name` = a person for humans, the **repository** for CI), cost over range (≈ per month) + cost-per-day-by-model + which-models pie + cost-by-channel. Filters: `actor`, `azp`, `model`. |
+| `user-tokens-cost.json` · `envoy-ai-gateway-user-tokens-cost` | `user_tokens_cost.py` | Mimir | **Users x tokens x cost** — one table row per actor (requests · tokens · cost, via 3 instant table queries + `merge`+`organize`+`sortBy`) + per-day stacked cost/tokens bars + leaderboards + blended cost/1k-tokens. Filters: `azp`, `model`. |
 
-> **Daily granularity contract:** the cost-per-day panels pin the Loki query
-> `step` to `1d` with a `[1d]` window, so each bar is exactly one non-overlapping
-> calendar day — the resolution can't go finer (the "minimum granularity of
-> days" ask). ⚠️ A full 30-day cost query reads historical chunks from Hetzner
-> Object Storage; if that store is rate-limiting (`SlowDown`), the monthly view
-> can be slow or empty even though recent ranges are instant — see the Loki
-> read-path note in the cluster runbook.
+> **Data source (cost boards):** PromQL `increase()` over the Alloy-emitted
+> counters `loki_process_custom_gen_ai_{usage_cost_micro_usd,usage_tokens,requests}`
+> in Mimir (cost ÷1e6 for USD). **Daily granularity:** the per-day panels use a
+> `[1d]` window pinned to a 1d step (`interval`) — one bar per day, can't go
+> finer. ⚠️ **Forward-only history** — the metrics began at ADR-0058 part A, so
+> the 30d view fills in over ~30 days. The old Loki/`unwrap` path remains in
+> `per_user.py` for raw log inspection.

--- a/charts/observability-dashboards/files/envoy-ai-gateway/actor-consumption.json
+++ b/charts/observability-dashboards/files/envoy-ai-gateway/actor-consumption.json
@@ -7,10 +7,10 @@
         "name": "actor",
         "label": "Actor (user / repo)",
         "skipUrlSync": false,
-        "query": "label_values({service_name=\"envoy-ai-gateway\"}, display_name)",
+        "query": "label_values(loki_process_custom_gen_ai_requests, display_name)",
         "datasource": {
-          "type": "loki",
-          "uid": "loki"
+          "type": "prometheus",
+          "uid": "mimir"
         },
         "current": {
           "text": "All",
@@ -32,10 +32,10 @@
         "name": "azp",
         "label": "Client (azp)",
         "skipUrlSync": false,
-        "query": "label_values({service_name=\"envoy-ai-gateway\"}, azp)",
+        "query": "label_values(loki_process_custom_gen_ai_requests, azp)",
         "datasource": {
-          "type": "loki",
-          "uid": "loki"
+          "type": "prometheus",
+          "uid": "mimir"
         },
         "current": {
           "text": [
@@ -61,10 +61,10 @@
         "name": "model",
         "label": "Model",
         "skipUrlSync": false,
-        "query": "label_values({service_name=\"envoy-ai-gateway\"}, model)",
+        "query": "label_values(loki_process_custom_gen_ai_requests, model)",
         "datasource": {
-          "type": "loki",
-          "uid": "loki"
+          "type": "prometheus",
+          "uid": "mimir"
         },
         "current": {
           "text": [
@@ -90,22 +90,22 @@
   "annotations": {},
   "uid": "envoy-ai-gateway-actor-consumption",
   "title": "AI Gateway — actor consumption",
-  "description": "Per-actor consumption for the Envoy AI Gateway. The 'Actor' variable is the display_name label — a person's name for humans, the repository for CI (github-actions / lightbridge-code-intelligence) — so one picker covers 'user or actor (e.g. repository)'. Cost stat over the selected range ≈ the actor's monthly spend (default 30-day window); the daily-bars panel gives per-day, stacked by model. Cost = gen_ai.usage.custom_total_cost (micro-USD ÷ 1e6; ADR-0028/0051). ⚠️ LibreChat agent runs + RAG embeddings don't forward the end-user, so they land under azp=internal-key-librechat, not the human (docs/per-user-observability.md). GENERATED — source: tools/dashboards/envoy_ai_gateway/actor_consumption.py.",
+  "description": "Per-actor consumption for the Envoy AI Gateway, from the precomputed Mimir metrics (ADR-0058, PromQL increase()). The 'Actor' variable is the display_name label — a person's name for humans, the repository for CI — so one picker covers 'user or actor (e.g. repository)'. Cost over the selected range ≈ the actor's monthly spend (default 30d); the daily-bars panel gives per-day, stacked by model. Cost ÷1e6 for USD (ADR-0028/0051). ⚠️ LibreChat agent runs + RAG embeddings fall back to azp=internal-key-librechat, not the human. ⚠️ Forward-only history. GENERATED — source: tools/dashboards/envoy_ai_gateway/actor_consumption.py.",
   "tags": [
     "ai-gateway",
     "cost",
     "per-user",
-    "loki"
+    "mimir"
   ],
   "timezone": "browser",
   "editable": true,
   "graphTooltip": 1,
   "time": {
-    "from": "now-7d",
+    "from": "now-30d",
     "to": "now"
   },
   "fiscalYearStartMonth": 0,
-  "refresh": "",
+  "refresh": "5m",
   "panels": [
     {
       "type": "row",
@@ -124,20 +124,22 @@
       "type": "stat",
       "targets": [
         {
-          "expr": "((sum(sum_over_time({service_name=\"envoy-ai-gateway\", display_name=~\"$actor\", azp=~\"$azp\", model=~\"$model\"} | json gen_ai_usage_custom_total_cost=`[\"gen_ai.usage.custom_total_cost\"]` | unwrap gen_ai_usage_custom_total_cost | __error__=\"\" [$__range]))) / 1e6)",
+          "expr": "((sum(increase(loki_process_custom_gen_ai_usage_cost_micro_usd{service_name=\"envoy-ai-gateway\", display_name=~\"$actor\", azp=~\"$azp\", model=~\"$model\"}[$__range]))) / 1e6)",
           "refId": "A",
-          "queryType": "range",
+          "instant": true,
+          "range": false,
+          "format": "time_series",
           "datasource": {
-            "type": "loki",
-            "uid": "loki"
+            "type": "prometheus",
+            "uid": "mimir"
           }
         }
       ],
       "title": "Cost — selected range (≈ per month)",
       "transparent": false,
       "datasource": {
-        "type": "loki",
-        "uid": "loki"
+        "type": "prometheus",
+        "uid": "mimir"
       },
       "gridPos": {
         "h": 4,
@@ -183,20 +185,22 @@
       "type": "stat",
       "targets": [
         {
-          "expr": "sum(sum_over_time({service_name=\"envoy-ai-gateway\", display_name=~\"$actor\", azp=~\"$azp\", model=~\"$model\"} | json gen_ai_usage_total_tokens=`[\"gen_ai.usage.total_tokens\"]` | unwrap gen_ai_usage_total_tokens | __error__=\"\" [$__range]))",
+          "expr": "sum(increase(loki_process_custom_gen_ai_usage_tokens{service_name=\"envoy-ai-gateway\", display_name=~\"$actor\", azp=~\"$azp\", model=~\"$model\"}[$__range]))",
           "refId": "A",
-          "queryType": "range",
+          "instant": true,
+          "range": false,
+          "format": "time_series",
           "datasource": {
-            "type": "loki",
-            "uid": "loki"
+            "type": "prometheus",
+            "uid": "mimir"
           }
         }
       ],
       "title": "Tokens — selected range",
       "transparent": false,
       "datasource": {
-        "type": "loki",
-        "uid": "loki"
+        "type": "prometheus",
+        "uid": "mimir"
       },
       "gridPos": {
         "h": 4,
@@ -242,20 +246,22 @@
       "type": "stat",
       "targets": [
         {
-          "expr": "sum(count_over_time({service_name=\"envoy-ai-gateway\", display_name=~\"$actor\", azp=~\"$azp\", model=~\"$model\"} [$__range]))",
+          "expr": "sum(increase(loki_process_custom_gen_ai_requests{service_name=\"envoy-ai-gateway\", display_name=~\"$actor\", azp=~\"$azp\", model=~\"$model\"}[$__range]))",
           "refId": "A",
-          "queryType": "range",
+          "instant": true,
+          "range": false,
+          "format": "time_series",
           "datasource": {
-            "type": "loki",
-            "uid": "loki"
+            "type": "prometheus",
+            "uid": "mimir"
           }
         }
       ],
       "title": "Requests — selected range",
       "transparent": false,
       "datasource": {
-        "type": "loki",
-        "uid": "loki"
+        "type": "prometheus",
+        "uid": "mimir"
       },
       "gridPos": {
         "h": 4,
@@ -301,22 +307,24 @@
       "type": "timeseries",
       "targets": [
         {
-          "expr": "((sum by (model) (sum_over_time({service_name=\"envoy-ai-gateway\", display_name=~\"$actor\", azp=~\"$azp\", model=~\"$model\"} | json gen_ai_usage_custom_total_cost=`[\"gen_ai.usage.custom_total_cost\"]` | unwrap gen_ai_usage_custom_total_cost | __error__=\"\" [1d]))) / 1e6)",
+          "expr": "((sum by (model) (increase(loki_process_custom_gen_ai_usage_cost_micro_usd{service_name=\"envoy-ai-gateway\", display_name=~\"$actor\", azp=~\"$azp\", model=~\"$model\"}[1d]))) / 1e6)",
           "refId": "A",
+          "instant": false,
+          "range": true,
+          "format": "time_series",
           "legendFormat": "{{model}}",
-          "step": "1d",
-          "queryType": "range",
           "datasource": {
-            "type": "loki",
-            "uid": "loki"
-          }
+            "type": "prometheus",
+            "uid": "mimir"
+          },
+          "interval": "1d"
         }
       ],
       "title": "Cost per day, by model",
       "transparent": false,
       "datasource": {
-        "type": "loki",
-        "uid": "loki"
+        "type": "prometheus",
+        "uid": "mimir"
       },
       "gridPos": {
         "h": 11,
@@ -360,21 +368,23 @@
       "type": "piechart",
       "targets": [
         {
-          "expr": "((sum by (model) (sum_over_time({service_name=\"envoy-ai-gateway\", display_name=~\"$actor\", azp=~\"$azp\", model=~\"$model\"} | json gen_ai_usage_custom_total_cost=`[\"gen_ai.usage.custom_total_cost\"]` | unwrap gen_ai_usage_custom_total_cost | __error__=\"\" [$__range]))) / 1e6)",
+          "expr": "((sum by (model) (increase(loki_process_custom_gen_ai_usage_cost_micro_usd{service_name=\"envoy-ai-gateway\", display_name=~\"$actor\", azp=~\"$azp\", model=~\"$model\"}[$__range]))) / 1e6)",
           "refId": "A",
+          "instant": true,
+          "range": false,
+          "format": "time_series",
           "legendFormat": "{{model}}",
-          "queryType": "range",
           "datasource": {
-            "type": "loki",
-            "uid": "loki"
+            "type": "prometheus",
+            "uid": "mimir"
           }
         }
       ],
       "title": "Which models (cost share, selected range)",
       "transparent": false,
       "datasource": {
-        "type": "loki",
-        "uid": "loki"
+        "type": "prometheus",
+        "uid": "mimir"
       },
       "gridPos": {
         "h": 11,
@@ -409,21 +419,23 @@
       "type": "bargauge",
       "targets": [
         {
-          "expr": "sort_desc(sum by (azp) (((sum_over_time({service_name=\"envoy-ai-gateway\", display_name=~\"$actor\", azp=~\"$azp\", model=~\"$model\"} | json gen_ai_usage_custom_total_cost=`[\"gen_ai.usage.custom_total_cost\"]` | unwrap gen_ai_usage_custom_total_cost | __error__=\"\" [$__range])) / 1e6)))",
+          "expr": "topk(20, ((sum by (azp) (increase(loki_process_custom_gen_ai_usage_cost_micro_usd{service_name=\"envoy-ai-gateway\", display_name=~\"$actor\", azp=~\"$azp\", model=~\"$model\"}[$__range]))) / 1e6))",
           "refId": "A",
+          "instant": true,
+          "range": false,
+          "format": "time_series",
           "legendFormat": "{{azp}}",
-          "queryType": "range",
           "datasource": {
-            "type": "loki",
-            "uid": "loki"
+            "type": "prometheus",
+            "uid": "mimir"
           }
         }
       ],
       "title": "Cost by channel (azp, selected range)",
       "transparent": false,
       "datasource": {
-        "type": "loki",
-        "uid": "loki"
+        "type": "prometheus",
+        "uid": "mimir"
       },
       "gridPos": {
         "h": 11,

--- a/charts/observability-dashboards/files/envoy-ai-gateway/cost-by-model.json
+++ b/charts/observability-dashboards/files/envoy-ai-gateway/cost-by-model.json
@@ -7,10 +7,10 @@
         "name": "azp",
         "label": "Client (azp)",
         "skipUrlSync": false,
-        "query": "label_values({service_name=\"envoy-ai-gateway\"}, azp)",
+        "query": "label_values(loki_process_custom_gen_ai_requests, azp)",
         "datasource": {
-          "type": "loki",
-          "uid": "loki"
+          "type": "prometheus",
+          "uid": "mimir"
         },
         "current": {
           "text": [
@@ -36,10 +36,10 @@
         "name": "model",
         "label": "Model",
         "skipUrlSync": false,
-        "query": "label_values({service_name=\"envoy-ai-gateway\"}, model)",
+        "query": "label_values(loki_process_custom_gen_ai_requests, model)",
         "datasource": {
-          "type": "loki",
-          "uid": "loki"
+          "type": "prometheus",
+          "uid": "mimir"
         },
         "current": {
           "text": [
@@ -65,22 +65,22 @@
   "annotations": {},
   "uid": "envoy-ai-gateway-cost-by-model",
   "title": "AI Gateway — cost by model (monthly)",
-  "description": "Cost per model for the Envoy AI Gateway, daily granularity. The headline panel stacks one bar per day per model (resolution pinned to 1d). Default window is 30 days — set the range to a calendar month for monthly totals. Cost = gen_ai.usage.custom_total_cost (micro-USD ÷ 1e6; ADR-0028/0051). Spans all attributed traffic incl. service accounts. See docs/per-user-observability.md. GENERATED — source: tools/dashboards/envoy_ai_gateway/cost_by_model.py.",
+  "description": "Cost per model for the Envoy AI Gateway, daily granularity, from the precomputed Mimir metrics (ADR-0058) — PromQL increase() over the loki_process_custom_gen_ai_usage_cost_micro_usd counter (÷1e6 for USD; ADR-0028/0051), NOT a Loki log-scan. Default 30 days; set the range to a calendar month for monthly totals. Spans all attributed traffic incl. service accounts. ⚠️ Forward-only history (began at ADR-0058 part A). GENERATED — source: tools/dashboards/envoy_ai_gateway/cost_by_model.py.",
   "tags": [
     "ai-gateway",
     "cost",
     "model",
-    "loki"
+    "mimir"
   ],
   "timezone": "browser",
   "editable": true,
   "graphTooltip": 1,
   "time": {
-    "from": "now-7d",
+    "from": "now-30d",
     "to": "now"
   },
   "fiscalYearStartMonth": 0,
-  "refresh": "",
+  "refresh": "5m",
   "panels": [
     {
       "type": "row",
@@ -99,20 +99,22 @@
       "type": "stat",
       "targets": [
         {
-          "expr": "((sum(sum_over_time({service_name=\"envoy-ai-gateway\", azp=~\"$azp\", user_id=~\".+\", model=~\"$model\"} | json gen_ai_usage_custom_total_cost=`[\"gen_ai.usage.custom_total_cost\"]` | unwrap gen_ai_usage_custom_total_cost | __error__=\"\" [$__range]))) / 1e6)",
+          "expr": "((sum(increase(loki_process_custom_gen_ai_usage_cost_micro_usd{service_name=\"envoy-ai-gateway\", azp=~\"$azp\", model=~\"$model\"}[$__range]))) / 1e6)",
           "refId": "A",
-          "queryType": "range",
+          "instant": true,
+          "range": false,
+          "format": "time_series",
           "datasource": {
-            "type": "loki",
-            "uid": "loki"
+            "type": "prometheus",
+            "uid": "mimir"
           }
         }
       ],
       "title": "Total cost (selected range)",
       "transparent": false,
       "datasource": {
-        "type": "loki",
-        "uid": "loki"
+        "type": "prometheus",
+        "uid": "mimir"
       },
       "gridPos": {
         "h": 4,
@@ -158,20 +160,22 @@
       "type": "stat",
       "targets": [
         {
-          "expr": "sum(sum_over_time({service_name=\"envoy-ai-gateway\", azp=~\"$azp\", user_id=~\".+\", model=~\"$model\"} | json gen_ai_usage_total_tokens=`[\"gen_ai.usage.total_tokens\"]` | unwrap gen_ai_usage_total_tokens | __error__=\"\" [$__range]))",
+          "expr": "sum(increase(loki_process_custom_gen_ai_usage_tokens{service_name=\"envoy-ai-gateway\", azp=~\"$azp\", model=~\"$model\"}[$__range]))",
           "refId": "A",
-          "queryType": "range",
+          "instant": true,
+          "range": false,
+          "format": "time_series",
           "datasource": {
-            "type": "loki",
-            "uid": "loki"
+            "type": "prometheus",
+            "uid": "mimir"
           }
         }
       ],
       "title": "Total tokens (selected range)",
       "transparent": false,
       "datasource": {
-        "type": "loki",
-        "uid": "loki"
+        "type": "prometheus",
+        "uid": "mimir"
       },
       "gridPos": {
         "h": 4,
@@ -217,20 +221,22 @@
       "type": "stat",
       "targets": [
         {
-          "expr": "sum(count_over_time({service_name=\"envoy-ai-gateway\", azp=~\"$azp\", user_id=~\".+\", model=~\"$model\"} [$__range]))",
+          "expr": "sum(increase(loki_process_custom_gen_ai_requests{service_name=\"envoy-ai-gateway\", azp=~\"$azp\", model=~\"$model\"}[$__range]))",
           "refId": "A",
-          "queryType": "range",
+          "instant": true,
+          "range": false,
+          "format": "time_series",
           "datasource": {
-            "type": "loki",
-            "uid": "loki"
+            "type": "prometheus",
+            "uid": "mimir"
           }
         }
       ],
       "title": "Total requests (selected range)",
       "transparent": false,
       "datasource": {
-        "type": "loki",
-        "uid": "loki"
+        "type": "prometheus",
+        "uid": "mimir"
       },
       "gridPos": {
         "h": 4,
@@ -276,22 +282,24 @@
       "type": "timeseries",
       "targets": [
         {
-          "expr": "((sum by (model) (sum_over_time({service_name=\"envoy-ai-gateway\", azp=~\"$azp\", user_id=~\".+\", model=~\"$model\"} | json gen_ai_usage_custom_total_cost=`[\"gen_ai.usage.custom_total_cost\"]` | unwrap gen_ai_usage_custom_total_cost | __error__=\"\" [1d]))) / 1e6)",
+          "expr": "((sum by (model) (increase(loki_process_custom_gen_ai_usage_cost_micro_usd{service_name=\"envoy-ai-gateway\", azp=~\"$azp\", model=~\"$model\"}[1d]))) / 1e6)",
           "refId": "A",
+          "instant": false,
+          "range": true,
+          "format": "time_series",
           "legendFormat": "{{model}}",
-          "step": "1d",
-          "queryType": "range",
           "datasource": {
-            "type": "loki",
-            "uid": "loki"
-          }
+            "type": "prometheus",
+            "uid": "mimir"
+          },
+          "interval": "1d"
         }
       ],
       "title": "Cost per day, by model",
       "transparent": false,
       "datasource": {
-        "type": "loki",
-        "uid": "loki"
+        "type": "prometheus",
+        "uid": "mimir"
       },
       "gridPos": {
         "h": 11,
@@ -335,21 +343,23 @@
       "type": "bargauge",
       "targets": [
         {
-          "expr": "sort_desc(sum by (model) (((sum_over_time({service_name=\"envoy-ai-gateway\", azp=~\"$azp\", user_id=~\".+\", model=~\"$model\"} | json gen_ai_usage_custom_total_cost=`[\"gen_ai.usage.custom_total_cost\"]` | unwrap gen_ai_usage_custom_total_cost | __error__=\"\" [$__range])) / 1e6)))",
+          "expr": "topk(30, ((sum by (model) (increase(loki_process_custom_gen_ai_usage_cost_micro_usd{service_name=\"envoy-ai-gateway\", azp=~\"$azp\", model=~\"$model\"}[$__range]))) / 1e6))",
           "refId": "A",
+          "instant": true,
+          "range": false,
+          "format": "time_series",
           "legendFormat": "{{model}}",
-          "queryType": "range",
           "datasource": {
-            "type": "loki",
-            "uid": "loki"
+            "type": "prometheus",
+            "uid": "mimir"
           }
         }
       ],
       "title": "Cost by model — total (selected range)",
       "transparent": false,
       "datasource": {
-        "type": "loki",
-        "uid": "loki"
+        "type": "prometheus",
+        "uid": "mimir"
       },
       "gridPos": {
         "h": 11,
@@ -402,21 +412,23 @@
       "type": "piechart",
       "targets": [
         {
-          "expr": "((sum by (model) (sum_over_time({service_name=\"envoy-ai-gateway\", azp=~\"$azp\", user_id=~\".+\", model=~\"$model\"} | json gen_ai_usage_custom_total_cost=`[\"gen_ai.usage.custom_total_cost\"]` | unwrap gen_ai_usage_custom_total_cost | __error__=\"\" [$__range]))) / 1e6)",
+          "expr": "((sum by (model) (increase(loki_process_custom_gen_ai_usage_cost_micro_usd{service_name=\"envoy-ai-gateway\", azp=~\"$azp\", model=~\"$model\"}[$__range]))) / 1e6)",
           "refId": "A",
+          "instant": true,
+          "range": false,
+          "format": "time_series",
           "legendFormat": "{{model}}",
-          "queryType": "range",
           "datasource": {
-            "type": "loki",
-            "uid": "loki"
+            "type": "prometheus",
+            "uid": "mimir"
           }
         }
       ],
       "title": "Cost share by model (selected range)",
       "transparent": false,
       "datasource": {
-        "type": "loki",
-        "uid": "loki"
+        "type": "prometheus",
+        "uid": "mimir"
       },
       "gridPos": {
         "h": 11,

--- a/charts/observability-dashboards/files/envoy-ai-gateway/user-tokens-cost.json
+++ b/charts/observability-dashboards/files/envoy-ai-gateway/user-tokens-cost.json
@@ -7,10 +7,10 @@
         "name": "azp",
         "label": "Client (azp)",
         "skipUrlSync": false,
-        "query": "label_values({service_name=\"envoy-ai-gateway\"}, azp)",
+        "query": "label_values(loki_process_custom_gen_ai_requests, azp)",
         "datasource": {
-          "type": "loki",
-          "uid": "loki"
+          "type": "prometheus",
+          "uid": "mimir"
         },
         "current": {
           "text": [
@@ -36,10 +36,10 @@
         "name": "model",
         "label": "Model",
         "skipUrlSync": false,
-        "query": "label_values({service_name=\"envoy-ai-gateway\"}, model)",
+        "query": "label_values(loki_process_custom_gen_ai_requests, model)",
         "datasource": {
-          "type": "loki",
-          "uid": "loki"
+          "type": "prometheus",
+          "uid": "mimir"
         },
         "current": {
           "text": [
@@ -65,23 +65,23 @@
   "annotations": {},
   "uid": "envoy-ai-gateway-user-tokens-cost",
   "title": "AI Gateway — users: tokens & cost",
-  "description": "Users x tokens x cost for the Envoy AI Gateway. The table gives one row per actor (display_name = a person for humans, the repository for CI) with requests / tokens / cost side by side over the selected range (default 30d ≈ monthly); per-day stacked panels add daily granularity, and the leaderboards rank by cost and by tokens. Cost = gen_ai.usage.custom_total_cost (micro-USD ÷ 1e6; ADR-0028/0051). Filters: azp, model. ⚠️ LibreChat agent runs + RAG embeddings fall back to azp=internal-key-librechat (not the human) — docs/per-user-observability.md. GENERATED — source: tools/dashboards/envoy_ai_gateway/user_tokens_cost.py.",
+  "description": "Users x tokens x cost for the Envoy AI Gateway, from the precomputed Mimir metrics (ADR-0058, PromQL increase()). The table gives one row per actor (display_name = a person for humans, the repository for CI) with requests / tokens / cost side by side over the selected range (default 30d ≈ monthly); per-day stacked panels add daily granularity, leaderboards rank by cost and tokens. Cost ÷1e6 for USD (ADR-0028/0051). Filters: azp, model. ⚠️ Forward-only history; LibreChat agents/embeddings fall back to azp=internal-key-librechat. GENERATED — source: tools/dashboards/envoy_ai_gateway/user_tokens_cost.py.",
   "tags": [
     "ai-gateway",
     "cost",
     "tokens",
     "per-user",
-    "loki"
+    "mimir"
   ],
   "timezone": "browser",
   "editable": true,
   "graphTooltip": 1,
   "time": {
-    "from": "now-7d",
+    "from": "now-30d",
     "to": "now"
   },
   "fiscalYearStartMonth": 0,
-  "refresh": "",
+  "refresh": "5m",
   "panels": [
     {
       "type": "row",
@@ -100,20 +100,22 @@
       "type": "stat",
       "targets": [
         {
-          "expr": "((sum(sum_over_time({service_name=\"envoy-ai-gateway\", azp=~\"$azp\", user_id=~\".+\", model=~\"$model\"} | json gen_ai_usage_custom_total_cost=`[\"gen_ai.usage.custom_total_cost\"]` | unwrap gen_ai_usage_custom_total_cost | __error__=\"\" [$__range]))) / 1e6)",
+          "expr": "((sum(increase(loki_process_custom_gen_ai_usage_cost_micro_usd{service_name=\"envoy-ai-gateway\", azp=~\"$azp\", model=~\"$model\"}[$__range]))) / 1e6)",
           "refId": "A",
-          "queryType": "range",
+          "instant": true,
+          "range": false,
+          "format": "time_series",
           "datasource": {
-            "type": "loki",
-            "uid": "loki"
+            "type": "prometheus",
+            "uid": "mimir"
           }
         }
       ],
       "title": "Total cost (range)",
       "transparent": false,
       "datasource": {
-        "type": "loki",
-        "uid": "loki"
+        "type": "prometheus",
+        "uid": "mimir"
       },
       "gridPos": {
         "h": 4,
@@ -159,20 +161,22 @@
       "type": "stat",
       "targets": [
         {
-          "expr": "sum(sum_over_time({service_name=\"envoy-ai-gateway\", azp=~\"$azp\", user_id=~\".+\", model=~\"$model\"} | json gen_ai_usage_total_tokens=`[\"gen_ai.usage.total_tokens\"]` | unwrap gen_ai_usage_total_tokens | __error__=\"\" [$__range]))",
+          "expr": "sum(increase(loki_process_custom_gen_ai_usage_tokens{service_name=\"envoy-ai-gateway\", azp=~\"$azp\", model=~\"$model\"}[$__range]))",
           "refId": "A",
-          "queryType": "range",
+          "instant": true,
+          "range": false,
+          "format": "time_series",
           "datasource": {
-            "type": "loki",
-            "uid": "loki"
+            "type": "prometheus",
+            "uid": "mimir"
           }
         }
       ],
       "title": "Total tokens (range)",
       "transparent": false,
       "datasource": {
-        "type": "loki",
-        "uid": "loki"
+        "type": "prometheus",
+        "uid": "mimir"
       },
       "gridPos": {
         "h": 4,
@@ -218,20 +222,22 @@
       "type": "stat",
       "targets": [
         {
-          "expr": "count(sum by (display_name) (count_over_time({service_name=\"envoy-ai-gateway\", azp=~\"$azp\", user_id=~\".+\", model=~\"$model\"} [$__range])))",
+          "expr": "count(sum by (display_name) (increase(loki_process_custom_gen_ai_requests{service_name=\"envoy-ai-gateway\", azp=~\"$azp\", model=~\"$model\"}[$__range])))",
           "refId": "A",
-          "queryType": "range",
+          "instant": true,
+          "range": false,
+          "format": "time_series",
           "datasource": {
-            "type": "loki",
-            "uid": "loki"
+            "type": "prometheus",
+            "uid": "mimir"
           }
         }
       ],
       "title": "Unique actors (range)",
       "transparent": false,
       "datasource": {
-        "type": "loki",
-        "uid": "loki"
+        "type": "prometheus",
+        "uid": "mimir"
       },
       "gridPos": {
         "h": 4,
@@ -277,20 +283,22 @@
       "type": "stat",
       "targets": [
         {
-          "expr": "(sum(sum_over_time({service_name=\"envoy-ai-gateway\", azp=~\"$azp\", user_id=~\".+\", model=~\"$model\"} | json gen_ai_usage_custom_total_cost=`[\"gen_ai.usage.custom_total_cost\"]` | unwrap gen_ai_usage_custom_total_cost | __error__=\"\" [$__range])) / 1e6) / ((sum(sum_over_time({service_name=\"envoy-ai-gateway\", azp=~\"$azp\", user_id=~\".+\", model=~\"$model\"} | json gen_ai_usage_total_tokens=`[\"gen_ai.usage.total_tokens\"]` | unwrap gen_ai_usage_total_tokens | __error__=\"\" [$__range])) / 1000))",
+          "expr": "(sum(increase(loki_process_custom_gen_ai_usage_cost_micro_usd{service_name=\"envoy-ai-gateway\", azp=~\"$azp\", model=~\"$model\"}[$__range])) / 1e6) / ((sum(increase(loki_process_custom_gen_ai_usage_tokens{service_name=\"envoy-ai-gateway\", azp=~\"$azp\", model=~\"$model\"}[$__range])) / 1000))",
           "refId": "A",
-          "queryType": "range",
+          "instant": true,
+          "range": false,
+          "format": "time_series",
           "datasource": {
-            "type": "loki",
-            "uid": "loki"
+            "type": "prometheus",
+            "uid": "mimir"
           }
         }
       ],
       "title": "Blended cost / 1k tokens (range)",
       "transparent": false,
       "datasource": {
-        "type": "loki",
-        "uid": "loki"
+        "type": "prometheus",
+        "uid": "mimir"
       },
       "gridPos": {
         "h": 4,
@@ -336,41 +344,44 @@
       "type": "table",
       "targets": [
         {
-          "expr": "((sum by (display_name) (sum_over_time({service_name=\"envoy-ai-gateway\", azp=~\"$azp\", user_id=~\".+\", model=~\"$model\"} | json gen_ai_usage_custom_total_cost=`[\"gen_ai.usage.custom_total_cost\"]` | unwrap gen_ai_usage_custom_total_cost | __error__=\"\" [$__range]))) / 1e6)",
+          "expr": "((sum by (display_name) (increase(loki_process_custom_gen_ai_usage_cost_micro_usd{service_name=\"envoy-ai-gateway\", azp=~\"$azp\", model=~\"$model\"}[$__range]))) / 1e6)",
           "refId": "A",
-          "legendFormat": "{{display_name}}",
-          "queryType": "range",
+          "instant": true,
+          "range": false,
+          "format": "table",
           "datasource": {
-            "type": "loki",
-            "uid": "loki"
+            "type": "prometheus",
+            "uid": "mimir"
           }
         },
         {
-          "expr": "sum by (display_name) (sum_over_time({service_name=\"envoy-ai-gateway\", azp=~\"$azp\", user_id=~\".+\", model=~\"$model\"} | json gen_ai_usage_total_tokens=`[\"gen_ai.usage.total_tokens\"]` | unwrap gen_ai_usage_total_tokens | __error__=\"\" [$__range]))",
+          "expr": "sum by (display_name) (increase(loki_process_custom_gen_ai_usage_tokens{service_name=\"envoy-ai-gateway\", azp=~\"$azp\", model=~\"$model\"}[$__range]))",
           "refId": "B",
-          "legendFormat": "{{display_name}}",
-          "queryType": "range",
+          "instant": true,
+          "range": false,
+          "format": "table",
           "datasource": {
-            "type": "loki",
-            "uid": "loki"
+            "type": "prometheus",
+            "uid": "mimir"
           }
         },
         {
-          "expr": "sum by (display_name) (count_over_time({service_name=\"envoy-ai-gateway\", azp=~\"$azp\", user_id=~\".+\", model=~\"$model\"} [$__range]))",
+          "expr": "sum by (display_name) (increase(loki_process_custom_gen_ai_requests{service_name=\"envoy-ai-gateway\", azp=~\"$azp\", model=~\"$model\"}[$__range]))",
           "refId": "C",
-          "legendFormat": "{{display_name}}",
-          "queryType": "range",
+          "instant": true,
+          "range": false,
+          "format": "table",
           "datasource": {
-            "type": "loki",
-            "uid": "loki"
+            "type": "prometheus",
+            "uid": "mimir"
           }
         }
       ],
       "title": "Per actor — requests · tokens · cost (selected range)",
       "transparent": false,
       "datasource": {
-        "type": "loki",
-        "uid": "loki"
+        "type": "prometheus",
+        "uid": "mimir"
       },
       "gridPos": {
         "h": 12,
@@ -381,20 +392,6 @@
       "repeatDirection": "h",
       "transformations": [
         {
-          "id": "timeSeriesTable",
-          "options": {
-            "A": {
-              "stat": "lastNotNull"
-            },
-            "B": {
-              "stat": "lastNotNull"
-            },
-            "C": {
-              "stat": "lastNotNull"
-            }
-          }
-        },
-        {
           "id": "merge",
           "options": {}
         },
@@ -403,11 +400,13 @@
           "options": {
             "renameByName": {
               "display_name": "Actor",
-              "Trend #A": "Cost ($)",
-              "Trend #B": "Tokens",
-              "Trend #C": "Requests"
+              "Value #A": "Cost ($)",
+              "Value #B": "Tokens",
+              "Value #C": "Requests"
             },
-            "excludeByName": {},
+            "excludeByName": {
+              "Time": true
+            },
             "indexByName": {}
           }
         },
@@ -456,22 +455,24 @@
       "type": "timeseries",
       "targets": [
         {
-          "expr": "((sum by (display_name) (sum_over_time({service_name=\"envoy-ai-gateway\", azp=~\"$azp\", user_id=~\".+\", model=~\"$model\"} | json gen_ai_usage_custom_total_cost=`[\"gen_ai.usage.custom_total_cost\"]` | unwrap gen_ai_usage_custom_total_cost | __error__=\"\" [1d]))) / 1e6)",
+          "expr": "((sum by (display_name) (increase(loki_process_custom_gen_ai_usage_cost_micro_usd{service_name=\"envoy-ai-gateway\", azp=~\"$azp\", model=~\"$model\"}[1d]))) / 1e6)",
           "refId": "A",
+          "instant": false,
+          "range": true,
+          "format": "time_series",
           "legendFormat": "{{display_name}}",
-          "step": "1d",
-          "queryType": "range",
           "datasource": {
-            "type": "loki",
-            "uid": "loki"
-          }
+            "type": "prometheus",
+            "uid": "mimir"
+          },
+          "interval": "1d"
         }
       ],
       "title": "Cost per day, by actor",
       "transparent": false,
       "datasource": {
-        "type": "loki",
-        "uid": "loki"
+        "type": "prometheus",
+        "uid": "mimir"
       },
       "gridPos": {
         "h": 10,
@@ -515,22 +516,24 @@
       "type": "timeseries",
       "targets": [
         {
-          "expr": "sum by (display_name) (sum_over_time({service_name=\"envoy-ai-gateway\", azp=~\"$azp\", user_id=~\".+\", model=~\"$model\"} | json gen_ai_usage_total_tokens=`[\"gen_ai.usage.total_tokens\"]` | unwrap gen_ai_usage_total_tokens | __error__=\"\" [1d]))",
+          "expr": "sum by (display_name) (increase(loki_process_custom_gen_ai_usage_tokens{service_name=\"envoy-ai-gateway\", azp=~\"$azp\", model=~\"$model\"}[1d]))",
           "refId": "A",
+          "instant": false,
+          "range": true,
+          "format": "time_series",
           "legendFormat": "{{display_name}}",
-          "step": "1d",
-          "queryType": "range",
           "datasource": {
-            "type": "loki",
-            "uid": "loki"
-          }
+            "type": "prometheus",
+            "uid": "mimir"
+          },
+          "interval": "1d"
         }
       ],
       "title": "Tokens per day, by actor",
       "transparent": false,
       "datasource": {
-        "type": "loki",
-        "uid": "loki"
+        "type": "prometheus",
+        "uid": "mimir"
       },
       "gridPos": {
         "h": 10,
@@ -574,21 +577,23 @@
       "type": "bargauge",
       "targets": [
         {
-          "expr": "topk(20, ((sum by (display_name) (sum_over_time({service_name=\"envoy-ai-gateway\", azp=~\"$azp\", user_id=~\".+\", model=~\"$model\"} | json gen_ai_usage_custom_total_cost=`[\"gen_ai.usage.custom_total_cost\"]` | unwrap gen_ai_usage_custom_total_cost | __error__=\"\" [$__range]))) / 1e6))",
+          "expr": "topk(20, ((sum by (display_name) (increase(loki_process_custom_gen_ai_usage_cost_micro_usd{service_name=\"envoy-ai-gateway\", azp=~\"$azp\", model=~\"$model\"}[$__range]))) / 1e6))",
           "refId": "A",
+          "instant": true,
+          "range": false,
+          "format": "time_series",
           "legendFormat": "{{display_name}}",
-          "queryType": "range",
           "datasource": {
-            "type": "loki",
-            "uid": "loki"
+            "type": "prometheus",
+            "uid": "mimir"
           }
         }
       ],
       "title": "Top actors by cost (selected range)",
       "transparent": false,
       "datasource": {
-        "type": "loki",
-        "uid": "loki"
+        "type": "prometheus",
+        "uid": "mimir"
       },
       "gridPos": {
         "h": 10,
@@ -641,21 +646,23 @@
       "type": "bargauge",
       "targets": [
         {
-          "expr": "topk(20, sum by (display_name) (sum_over_time({service_name=\"envoy-ai-gateway\", azp=~\"$azp\", user_id=~\".+\", model=~\"$model\"} | json gen_ai_usage_total_tokens=`[\"gen_ai.usage.total_tokens\"]` | unwrap gen_ai_usage_total_tokens | __error__=\"\" [$__range])))",
+          "expr": "topk(20, sum by (display_name) (increase(loki_process_custom_gen_ai_usage_tokens{service_name=\"envoy-ai-gateway\", azp=~\"$azp\", model=~\"$model\"}[$__range])))",
           "refId": "A",
+          "instant": true,
+          "range": false,
+          "format": "time_series",
           "legendFormat": "{{display_name}}",
-          "queryType": "range",
           "datasource": {
-            "type": "loki",
-            "uid": "loki"
+            "type": "prometheus",
+            "uid": "mimir"
           }
         }
       ],
       "title": "Top actors by tokens (selected range)",
       "transparent": false,
       "datasource": {
-        "type": "loki",
-        "uid": "loki"
+        "type": "prometheus",
+        "uid": "mimir"
       },
       "gridPos": {
         "h": 10,

--- a/tools/dashboards/src/dashboards/_common.py
+++ b/tools/dashboards/src/dashboards/_common.py
@@ -40,6 +40,21 @@ GATEWAY_SERVICE_NAME = "envoy-ai-gateway"
 
 
 # ---------------------------------------------------------------------------
+# Precomputed AI Gateway usage METRICS in Mimir (ADR-0058). Emitted by Alloy
+# `loki.process` `stage.metrics` (default `loki_process_custom_` prefix) at
+# ingest and scraped to Mimir, so the cost dashboards read cheap PromQL
+# time-series instead of unwrap-scanning a month of Loki logs from the
+# rate-limited object store. All three carry the ADR-0046 attribution labels
+# (model / azp / display_name / user_id / email / billing_plan / service_name).
+# Counters → use PromQL `increase(...[window])`. Cost is micro-USD (÷1e6).
+# ---------------------------------------------------------------------------
+_METRIC_PREFIX = "loki_process_custom_"
+METRIC_COST_MICRO_USD = _METRIC_PREFIX + "gen_ai_usage_cost_micro_usd"
+METRIC_TOKENS = _METRIC_PREFIX + "gen_ai_usage_tokens"
+METRIC_REQUESTS = _METRIC_PREFIX + "gen_ai_requests"
+
+
+# ---------------------------------------------------------------------------
 # Service-account client IDs — keep in sync with
 # `charts/apps/values.yaml` `security-policies.authConfigs.main.serviceAccountClients`.
 # Used by dashboards that want to split human vs SA traffic.

--- a/tools/dashboards/src/dashboards/envoy_ai_gateway/_shared.py
+++ b/tools/dashboards/src/dashboards/envoy_ai_gateway/_shared.py
@@ -1,93 +1,65 @@
-"""Shared SDK panel/query helpers for the Envoy AI Gateway dashboards.
+"""Shared SDK panel/query helpers for the Envoy AI Gateway COST dashboards.
 
-`_common.py` is intentionally SDK-free (pure data). This module is the
-SDK-aware sibling: the query-builder gotchas the gateway dashboards all
-share (the µ$→USD divide, the `| json ["dotted.key"] | unwrap` form, the
-range-not-instant rule, daily-step buckets) live here ONCE so cost/actor
-dashboards stay consistent with each other.
+These dashboards read the **precomputed Mimir metrics** (ADR-0058) — Alloy
+`stage.metrics` counters (`loki_process_custom_gen_ai_*`) scraped to Mimir — via
+**PromQL**, NOT Loki log-scans. That's what makes a 30-day view instant on a
+rate-limited object store. Counters → `increase(metric[window])`; cost is
+micro-USD (÷1e6 via `usd()`).
 
-NOTE: `per_user.py` predates this module and keeps its own private copies of
-these helpers on purpose — refactoring it would change its generated JSON and
-trip the `dashboards check` drift guard. New dashboards import from here.
+`_common.py` stays SDK-free (pure data); this is its SDK-aware sibling.
+`per_user.py` is a separate, Loki-backed dashboard and keeps its own helpers.
 """
 
 from __future__ import annotations
 
-from grafana_foundation_sdk.builders import bargauge, loki, piechart, stat, timeseries
+from grafana_foundation_sdk.builders import bargauge, piechart, prometheus, stat, timeseries
 from grafana_foundation_sdk.builders import common as cb
 from grafana_foundation_sdk.builders import dashboard as db
 from grafana_foundation_sdk.models import common as cm
 from grafana_foundation_sdk.models import dashboard as dm
 from grafana_foundation_sdk.models import piechart as pm
 
-from dashboards._common import GATEWAY_SERVICE_NAME, LOKI_UID
+from dashboards._common import GATEWAY_SERVICE_NAME, MIMIR_UID
 
-LOKI_DS = dm.DataSourceRef(type_val="loki", uid=LOKI_UID)
-
-# Envoy's access-log format.json declares the GenAI usage fields with LITERAL
-# dots in the key name (`gen_ai.usage.total_tokens`), so the explicit
-# `| json <name>` path-lookup form must bracket+quote the dotted key
-# (`["dotted.key"]`) — a bare name doesn't match. See per_user._unwrap for the
-# full archaeology (ADR-0046).
-_JSON_PATHS = {
-    "gen_ai_usage_total_tokens": "gen_ai.usage.total_tokens",
-    "gen_ai_usage_custom_total_cost": "gen_ai.usage.custom_total_cost",
-}
-
-
-def unwrap(field: str) -> str:
-    """`| json <field> | unwrap <field> | __error__=""` — extract ONLY `field`.
-
-    Extracting one field (not a bare `| json`) keeps the per-line label set
-    down to the genuine stream labels, so `sum_over_time`'s implicit grouping
-    can't blow past Loki's 500-series cap. `__error__=""` drops samples that
-    fail the string→float conversion (absent fields arrive as "-").
-    """
-    path = _JSON_PATHS.get(field)
-    extract = f'{field}=`["{path}"]`' if path else field
-    return f'| json {extract} | unwrap {field} | __error__=""'
+# Mimir is a Prometheus-compatible datasource.
+MIMIR_DS = dm.DataSourceRef(type_val="prometheus", uid=MIMIR_UID)
 
 
 def usd(expr: str) -> str:
-    """Convert a raw micro-USD LogQL aggregation to USD (pricing CEL emits µ$)."""
+    """Convert a micro-USD PromQL expression to USD (the cost counter is µ$)."""
     return f"(({expr}) / 1e6)"
 
 
 def selector(*matchers: str) -> str:
-    """`{service_name="envoy-ai-gateway", <extra matchers...>}`.
-
-    Pass extra label matchers as raw LogQL fragments, e.g.
-    `selector('display_name=~"$actor"', 'model=~"$model"')`.
-    """
+    """`{service_name="envoy-ai-gateway", <extra PromQL label matchers...>}`."""
     parts = [f'service_name="{GATEWAY_SERVICE_NAME}"', *matchers]
     return "{" + ", ".join(parts) + "}"
 
 
-def loki_target(
+def prom_target(
     expr: str,
     *,
     legend: str = "",
     ref_id: str = "A",
-    instant: bool = False,
-    step: str = "",
-) -> loki.Dataquery:
-    """A Loki query target. Range mode by default — the Loki Grafana plugin does
-    NOT substitute `$__range`/`$__interval` in instant queries (silent no-data).
+    instant: bool = True,
+    fmt: str = "time_series",
+    interval: str = "",
+) -> prometheus.Dataquery:
+    """A Mimir/PromQL query target.
 
-    `step="1d"` pins the query resolution so cost panels can't bucket finer than
-    a day (the "minimum granularity of days" contract).
+    Totals/leaderboards/pies use `instant=True` (one value per series at the
+    range end — `$__range` substitutes in Prometheus instant queries, unlike
+    Loki). Daily-bar timeseries pass `instant=False` + `interval="1d"` so each
+    bar is one day. `fmt="table"` is used for the per-actor table.
     """
-    q = (
-        loki.Dataquery()
-        .expr(expr)
-        .ref_id(ref_id)
-        .query_type("instant" if instant else "range")
-        .datasource(LOKI_DS)
-    )
+    q = prometheus.Dataquery().expr(expr).ref_id(ref_id).datasource(MIMIR_DS)
+    q = q.instant() if instant else q.range()
+    if fmt:
+        q = q.format(fmt)
     if legend:
         q = q.legend_format(legend)
-    if step:
-        q = q.step(step)
+    if interval:
+        q = q.interval(interval)
     return q
 
 
@@ -102,19 +74,13 @@ def stat_panel(
     unit: str,
     color: str,
     grid: tuple[int, int, int, int],
-    step: str = "",
 ) -> stat.Panel:
-    """Single-value stat with sparkline. `grid` is (h, w, x, y).
-
-    `[$__range]` + the default lastNotNull calc reads the per-range total at the
-    last evaluated point (a [1m]+sum form double-counts via overlapping
-    auto-step windows — see per_user._panel_user_total_cost).
-    """
+    """Single-value stat. `grid` is (h, w, x, y). Instant `sum(increase(...[$__range]))`."""
     h, w, x, y = grid
     return (
         stat.Panel()
         .title(title)
-        .datasource(LOKI_DS)
+        .datasource(MIMIR_DS)
         .grid_pos(dm.GridPos(h=h, w=w, x=x, y=y))
         .unit(unit)
         .thresholds(single_color_thresholds(color))
@@ -124,7 +90,7 @@ def stat_panel(
         .color_mode(cm.BigValueColorMode.VALUE)
         .graph_mode(cm.BigValueGraphMode.AREA)
         .justify_mode(cm.BigValueJustifyMode.AUTO)
-        .with_target(loki_target(expr, step=step))
+        .with_target(prom_target(expr, instant=True))
     )
 
 
@@ -137,21 +103,19 @@ def daily_bars_panel(
     grid: tuple[int, int, int, int],
     legend_calcs: list[str] | None = None,
 ) -> timeseries.Panel:
-    """Stacked daily BARS timeseries — the canonical "X per day, stacked by
-    series" cost viz. Pairs with an `expr` that uses a `[1d]` window and a
-    `step="1d"` target (set by the caller) so each bar is exactly one day.
+    """Stacked daily BARS — pass an `increase(metric[1d])` expr; this pins the
+    step to 1d (`interval`) so each bar is one day.
 
-    Legend calcs default to mean/max, NOT sum: with a relative range
-    (now-30d) Grafana evaluates the `[1d]` range-vector at the range start
-    too, so the leading bucket sums the 24h BEFORE the window — a legend
-    `sum` would overstate the range by up to a day. Authoritative totals
-    live in the stat / table / bargauge panels (which use `[$__range]`).
+    Legend calcs default to mean/max, NOT sum: `increase` over a relative range
+    evaluates a leading partial/lookback bucket at the range start, so a legend
+    `sum` would mislead. Authoritative totals live in the stat/table/bargauge
+    panels (instant `increase[$__range]`).
     """
     h, w, x, y = grid
     return (
         timeseries.Panel()
         .title(title)
-        .datasource(LOKI_DS)
+        .datasource(MIMIR_DS)
         .grid_pos(dm.GridPos(h=h, w=w, x=x, y=y))
         .unit(unit)
         .draw_style(cm.GraphDrawStyle.BARS)
@@ -168,7 +132,7 @@ def daily_bars_panel(
         .tooltip(
             cb.VizTooltipOptions().mode(cm.TooltipDisplayMode.MULTI).sort(cm.SortOrder.DESCENDING)
         )
-        .with_target(loki_target(expr, legend=legend, step="1d"))
+        .with_target(prom_target(expr, legend=legend, instant=False, interval="1d"))
     )
 
 
@@ -183,7 +147,7 @@ def pie_panel(
     return (
         piechart.Panel()
         .title(title)
-        .datasource(LOKI_DS)
+        .datasource(MIMIR_DS)
         .grid_pos(dm.GridPos(h=h, w=w, x=x, y=y))
         .pie_type(pm.PieChartType.DONUT)
         .legend(
@@ -193,7 +157,7 @@ def pie_panel(
             .values([pm.PieChartLegendValues.VALUE, pm.PieChartLegendValues.PERCENT])
         )
         .tooltip(cb.VizTooltipOptions().mode(cm.TooltipDisplayMode.SINGLE))
-        .with_target(loki_target(expr, legend=legend_label, instant=False))
+        .with_target(prom_target(expr, legend=legend_label, instant=True))
     )
 
 
@@ -206,26 +170,24 @@ def bargauge_panel(
     color: str,
     grid: tuple[int, int, int, int],
 ) -> bargauge.Panel:
-    """Horizontal bargauge — ranked totals (one bar per series). Range query so
-    `$__range` substitutes; the bar uses the series' last value."""
+    """Horizontal bargauge — ranked totals (one bar per series), instant query."""
     h, w, x, y = grid
     return (
         bargauge.Panel()
         .title(title)
-        .datasource(LOKI_DS)
+        .datasource(MIMIR_DS)
         .grid_pos(dm.GridPos(h=h, w=w, x=x, y=y))
         .unit(unit)
         .orientation(cm.VizOrientation.HORIZONTAL)
         .reduce_options(cb.ReduceDataOptions().calcs(["lastNotNull"]).fields("").values(False))
         .display_mode(cm.BarGaugeDisplayMode.BASIC)
         .thresholds(single_color_thresholds(color))
-        .with_target(loki_target(expr, legend=legend, instant=False))
+        .with_target(prom_target(expr, legend=legend, instant=True))
     )
 
 
 class _RowBuilder:
-    """Tiny adapter so a RowPanel can be passed to Dashboard.with_panel (the SDK
-    ships a RowPanel model but no row *builder*)."""
+    """Tiny adapter so a RowPanel can be passed to Dashboard.with_panel."""
 
     def __init__(self, row: dm.RowPanel) -> None:
         self._row = row
@@ -239,12 +201,11 @@ def row(title: str, *, y: int) -> _RowBuilder:
 
 
 def actor_var(*, name: str, label: str, definition: str) -> db.QueryVariable:
-    """Single-select query variable (for the actor picker — one user/repo at a
-    time). All-value `.+` so 'All' still renders a valid regex matcher."""
+    """Single-select query variable (the actor picker — one user/repo at a time)."""
     return (
         db.QueryVariable(name)
         .label(label)
-        .datasource(LOKI_DS)
+        .datasource(MIMIR_DS)
         .query(definition)
         .refresh(dm.VariableRefresh.ON_TIME_RANGE_CHANGED)
         .sort(dm.VariableSort.ALPHABETICAL_ASC)
@@ -260,7 +221,7 @@ def multi_var(*, name: str, label: str, definition: str) -> db.QueryVariable:
     return (
         db.QueryVariable(name)
         .label(label)
-        .datasource(LOKI_DS)
+        .datasource(MIMIR_DS)
         .query(definition)
         .refresh(dm.VariableRefresh.ON_TIME_RANGE_CHANGED)
         .sort(dm.VariableSort.ALPHABETICAL_ASC)
@@ -269,3 +230,8 @@ def multi_var(*, name: str, label: str, definition: str) -> db.QueryVariable:
         .all_value(".+")
         .current(dm.VariableOption(selected=True, text=["All"], value=["$__all"]))
     )
+
+
+def label_values(metric: str, label: str) -> str:
+    """PromQL template-variable query: distinct values of `label` on `metric`."""
+    return f"label_values({metric}, {label})"

--- a/tools/dashboards/src/dashboards/envoy_ai_gateway/actor_consumption.py
+++ b/tools/dashboards/src/dashboards/envoy_ai_gateway/actor_consumption.py
@@ -1,18 +1,16 @@
 """Envoy AI Gateway — actor consumption (GENERATED SOURCE).
 
-Pick ONE actor and see their spend per month / per day and across models. The
-actor selector is the `display_name` label, which is the unifying identity for
-both humans (e.g. "Ariel Kouebou") and CI repositories (e.g.
-"ADORSYS-GIS/keycloak-oid4vp-plugin", "vymalo/flutter-tools") — so "user or
-actor (e.g. repository)" is one picker. Optional Client (azp) / Model filters
-refine it further.
+Pick ONE actor and see their spend per month / per day and across models, from
+the precomputed Mimir metrics (ADR-0058) via PromQL — instant at any range. The
+actor selector is the `display_name` label = a person's name for humans and the
+repository for CI, so "user or actor (e.g. repository)" is one picker. Optional
+Client (azp) / Model filters.
 
 The JSON file is regenerated from this module — do **not** hand-edit it.
 
     uv run dashboards build
 
-Architecture decision: docs/adr/0008-python-dashboard-generation.md.
-Data path the dashboard consumes: docs/per-user-observability.md.
+ADR: docs/adr/0058-precompute-gateway-usage-metrics-to-mimir.md (+ ADR-0008).
 """
 
 from __future__ import annotations
@@ -24,31 +22,27 @@ from grafana_foundation_sdk.cog.encoder import JSONEncoder
 from grafana_foundation_sdk.models import dashboard as dm
 
 from dashboards._common import (
-    GATEWAY_SERVICE_NAME,
     LABEL_AZP,
     LABEL_DISPLAY_NAME,
     LABEL_MODEL,
+    METRIC_COST_MICRO_USD,
+    METRIC_REQUESTS,
+    METRIC_TOKENS,
 )
 from dashboards.envoy_ai_gateway import _shared as sh
 
 OUTPUT_PATH: str = "charts/observability-dashboards/files/envoy-ai-gateway/actor-consumption.json"
 
-# Scoped to the picked actor; azp/model further refine. display_name=~"$actor"
-# with $actor defaulting to ".+" (All) so the dashboard renders before a pick.
-_SELECTOR = sh.selector('display_name=~"$actor"', 'azp=~"$azp"', 'model=~"$model"')
-
-_COST = "gen_ai_usage_custom_total_cost"
-_TOKENS = "gen_ai_usage_total_tokens"
+_SEL = sh.selector('display_name=~"$actor"', 'azp=~"$azp"', 'model=~"$model"')
 
 _LEGEND_MODEL = "{{" + LABEL_MODEL + "}}"
 _LEGEND_AZP = "{{" + LABEL_AZP + "}}"
 
 
 def _panel_total_cost() -> object:
-    # With the default 30-day range this stat IS the actor's monthly cost.
     return sh.stat_panel(
         title="Cost — selected range (≈ per month)",
-        expr=sh.usd(f"sum(sum_over_time({_SELECTOR} {sh.unwrap(_COST)} [$__range]))"),
+        expr=sh.usd(f"sum(increase({METRIC_COST_MICRO_USD}{_SEL}[$__range]))"),
         unit="currencyUSD",
         color="orange",
         grid=(4, 8, 0, 1),
@@ -58,7 +52,7 @@ def _panel_total_cost() -> object:
 def _panel_total_tokens() -> object:
     return sh.stat_panel(
         title="Tokens — selected range",
-        expr=f"sum(sum_over_time({_SELECTOR} {sh.unwrap(_TOKENS)} [$__range]))",
+        expr=f"sum(increase({METRIC_TOKENS}{_SEL}[$__range]))",
         unit="short",
         color="green",
         grid=(4, 8, 8, 1),
@@ -68,7 +62,7 @@ def _panel_total_tokens() -> object:
 def _panel_total_requests() -> object:
     return sh.stat_panel(
         title="Requests — selected range",
-        expr=f"sum(count_over_time({_SELECTOR} [$__range]))",
+        expr=f"sum(increase({METRIC_REQUESTS}{_SEL}[$__range]))",
         unit="short",
         color="blue",
         grid=(4, 8, 16, 1),
@@ -76,8 +70,7 @@ def _panel_total_requests() -> object:
 
 
 def _panel_cost_per_day_by_model() -> object:
-    # Per-day AND which-models in one panel: daily bars stacked by model.
-    expr = sh.usd(f"sum by ({LABEL_MODEL}) (sum_over_time({_SELECTOR} {sh.unwrap(_COST)} [1d]))")
+    expr = sh.usd(f"sum by ({LABEL_MODEL}) (increase({METRIC_COST_MICRO_USD}{_SEL}[1d]))")
     return sh.daily_bars_panel(
         title="Cost per day, by model",
         expr=expr,
@@ -88,9 +81,7 @@ def _panel_cost_per_day_by_model() -> object:
 
 
 def _panel_cost_by_model_pie() -> object:
-    expr = sh.usd(
-        f"sum by ({LABEL_MODEL}) (sum_over_time({_SELECTOR} {sh.unwrap(_COST)} [$__range]))"
-    )
+    expr = sh.usd(f"sum by ({LABEL_MODEL}) (increase({METRIC_COST_MICRO_USD}{_SEL}[$__range]))")
     return sh.pie_panel(
         title="Which models (cost share, selected range)",
         expr=expr,
@@ -100,13 +91,10 @@ def _panel_cost_by_model_pie() -> object:
 
 
 def _panel_cost_by_channel() -> object:
-    # An actor can spend across several channels (a human via opencode-cli AND
-    # lightbridge-api-key); break the actor's cost down by azp.
-    cost_sum = f"sum_over_time({_SELECTOR} {sh.unwrap(_COST)} [$__range])"
-    expr = f"sort_desc(sum by ({LABEL_AZP}) ({sh.usd(cost_sum)}))"
+    inner = f"sum by ({LABEL_AZP}) (increase({METRIC_COST_MICRO_USD}{_SEL}[$__range]))"
     return sh.bargauge_panel(
         title="Cost by channel (azp, selected range)",
-        expr=expr,
+        expr=f"topk(20, {sh.usd(inner)})",
         legend=_LEGEND_AZP,
         unit="currencyUSD",
         color="purple",
@@ -115,15 +103,14 @@ def _panel_cost_by_channel() -> object:
 
 
 _DESCRIPTION = (
-    "Per-actor consumption for the Envoy AI Gateway. The 'Actor' variable is the "
-    "display_name label — a person's name for humans, the repository for CI "
-    "(github-actions / lightbridge-code-intelligence) — so one picker covers "
-    "'user or actor (e.g. repository)'. Cost stat over the selected range ≈ the "
-    "actor's monthly spend (default 30-day window); the daily-bars panel gives "
-    "per-day, stacked by model. Cost = gen_ai.usage.custom_total_cost "
-    "(micro-USD ÷ 1e6; ADR-0028/0051). "
-    "⚠️ LibreChat agent runs + RAG embeddings don't forward the end-user, so they "
-    "land under azp=internal-key-librechat, not the human (docs/per-user-observability.md). "
+    "Per-actor consumption for the Envoy AI Gateway, from the precomputed Mimir "
+    "metrics (ADR-0058, PromQL increase()). The 'Actor' variable is the "
+    "display_name label — a person's name for humans, the repository for CI — so "
+    "one picker covers 'user or actor (e.g. repository)'. Cost over the selected "
+    "range ≈ the actor's monthly spend (default 30d); the daily-bars panel gives "
+    "per-day, stacked by model. Cost ÷1e6 for USD (ADR-0028/0051). ⚠️ LibreChat "
+    "agent runs + RAG embeddings fall back to azp=internal-key-librechat, not the "
+    "human. ⚠️ Forward-only history. "
     "GENERATED — source: tools/dashboards/envoy_ai_gateway/actor_consumption.py."
 )
 
@@ -132,37 +119,32 @@ def _dashboard() -> db.Dashboard:
     return (
         db.Dashboard("AI Gateway — actor consumption")
         .uid("envoy-ai-gateway-actor-consumption")
-        .tags(["ai-gateway", "cost", "per-user", "loki"])
+        .tags(["ai-gateway", "cost", "per-user", "mimir"])
         .description(_DESCRIPTION)
         .timezone("browser")
         .editable()
         .tooltip(dm.DashboardCursorSync.CROSSHAIR)
-        # Auto-refresh OFF + 7d default — see cost_by_model for the rationale
-        # (cold 30d log-scans on the rate-limited store self-DoS Loki). Expand
-        # the range manually; Phase 2 (Mimir recording rules) restores fast 30d.
-        .refresh("")
-        .time("now-7d", "now")
+        .refresh("5m")
+        .time("now-30d", "now")
         .with_variable(
             sh.actor_var(
                 name="actor",
                 label="Actor (user / repo)",
-                definition=(
-                    f'label_values({{service_name="{GATEWAY_SERVICE_NAME}"}}, {LABEL_DISPLAY_NAME})'
-                ),
+                definition=sh.label_values(METRIC_REQUESTS, LABEL_DISPLAY_NAME),
             )
         )
         .with_variable(
             sh.multi_var(
                 name="azp",
                 label="Client (azp)",
-                definition=f'label_values({{service_name="{GATEWAY_SERVICE_NAME}"}}, {LABEL_AZP})',
+                definition=sh.label_values(METRIC_REQUESTS, LABEL_AZP),
             )
         )
         .with_variable(
             sh.multi_var(
                 name="model",
                 label="Model",
-                definition=f'label_values({{service_name="{GATEWAY_SERVICE_NAME}"}}, {LABEL_MODEL})',
+                definition=sh.label_values(METRIC_REQUESTS, LABEL_MODEL),
             )
         )
         .with_panel(sh.row("Actor consumption", y=0))

--- a/tools/dashboards/src/dashboards/envoy_ai_gateway/cost_by_model.py
+++ b/tools/dashboards/src/dashboards/envoy_ai_gateway/cost_by_model.py
@@ -1,15 +1,18 @@
 """Envoy AI Gateway — cost by model, monthly (GENERATED SOURCE).
 
-Answers "what did each model cost this month?" with a minimum granularity of
-days: the headline panel is a stacked daily-bars timeseries, one series per
-model, defaulting to a 30-day window. Optional Client (azp) / Model filters.
+Cost x model with a minimum granularity of days. Reads the precomputed Mimir
+metrics (ADR-0058) via PromQL — NOT Loki log-scans — so a 30-day view is instant
+on the rate-limited object store. The headline panel stacks one bar per day per
+model. Optional Client (azp) / Model filters.
+
+⚠️ Metrics are forward-only (they began when ADR-0058 part A deployed); the 30d
+view fills in over ~30 days.
 
 The JSON file is regenerated from this module — do **not** hand-edit it.
 
     uv run dashboards build
 
-Architecture decision: docs/adr/0008-python-dashboard-generation.md.
-Data path the dashboard consumes: docs/per-user-observability.md.
+ADR: docs/adr/0058-precompute-gateway-usage-metrics-to-mimir.md (+ ADR-0008).
 """
 
 from __future__ import annotations
@@ -20,19 +23,20 @@ from grafana_foundation_sdk.builders import dashboard as db
 from grafana_foundation_sdk.cog.encoder import JSONEncoder
 from grafana_foundation_sdk.models import dashboard as dm
 
-from dashboards._common import GATEWAY_SERVICE_NAME, LABEL_AZP, LABEL_MODEL
+from dashboards._common import (
+    LABEL_AZP,
+    LABEL_MODEL,
+    METRIC_COST_MICRO_USD,
+    METRIC_REQUESTS,
+    METRIC_TOKENS,
+)
 from dashboards.envoy_ai_gateway import _shared as sh
 
 OUTPUT_PATH: str = "charts/observability-dashboards/files/envoy-ai-gateway/cost-by-model.json"
 
-# Spans ALL attributed traffic (humans + service accounts) regardless of the
-# filter variables' defaults — every gateway stream carries a user_id label
-# (a real sub or an "unstamped:*"/"missing:*" sentinel), so `user_id=~".+"`
-# matches everything while staying a valid selector.
-_SELECTOR = sh.selector('azp=~"$azp"', 'user_id=~".+"', 'model=~"$model"')
-
-_COST = "gen_ai_usage_custom_total_cost"
-_TOKENS = "gen_ai_usage_total_tokens"
+# Spans all attributed gateway traffic (the metrics exist only for gateway
+# requests); azp/model filters refine it.
+_SEL = sh.selector('azp=~"$azp"', 'model=~"$model"')
 
 _LEGEND_MODEL = "{{" + LABEL_MODEL + "}}"
 
@@ -40,7 +44,7 @@ _LEGEND_MODEL = "{{" + LABEL_MODEL + "}}"
 def _panel_total_cost() -> object:
     return sh.stat_panel(
         title="Total cost (selected range)",
-        expr=sh.usd(f"sum(sum_over_time({_SELECTOR} {sh.unwrap(_COST)} [$__range]))"),
+        expr=sh.usd(f"sum(increase({METRIC_COST_MICRO_USD}{_SEL}[$__range]))"),
         unit="currencyUSD",
         color="orange",
         grid=(4, 8, 0, 1),
@@ -50,7 +54,7 @@ def _panel_total_cost() -> object:
 def _panel_total_tokens() -> object:
     return sh.stat_panel(
         title="Total tokens (selected range)",
-        expr=f"sum(sum_over_time({_SELECTOR} {sh.unwrap(_TOKENS)} [$__range]))",
+        expr=f"sum(increase({METRIC_TOKENS}{_SEL}[$__range]))",
         unit="short",
         color="green",
         grid=(4, 8, 8, 1),
@@ -60,7 +64,7 @@ def _panel_total_tokens() -> object:
 def _panel_total_requests() -> object:
     return sh.stat_panel(
         title="Total requests (selected range)",
-        expr=f"sum(count_over_time({_SELECTOR} [$__range]))",
+        expr=f"sum(increase({METRIC_REQUESTS}{_SEL}[$__range]))",
         unit="short",
         color="blue",
         grid=(4, 8, 16, 1),
@@ -68,10 +72,9 @@ def _panel_total_requests() -> object:
 
 
 def _panel_cost_per_day_by_model() -> object:
-    # [1d] window + step="1d" (set by daily_bars_panel) → one non-overlapping
-    # bar per calendar day, stacked by model. This is the "min granularity of
-    # days" contract: the resolution is pinned to a day and can't go finer.
-    expr = sh.usd(f"sum by ({LABEL_MODEL}) (sum_over_time({_SELECTOR} {sh.unwrap(_COST)} [1d]))")
+    # increase(...[1d]) at step 1d (set by daily_bars_panel) → one bar per day,
+    # stacked by model. The "minimum granularity of days" contract.
+    expr = sh.usd(f"sum by ({LABEL_MODEL}) (increase({METRIC_COST_MICRO_USD}{_SEL}[1d]))")
     return sh.daily_bars_panel(
         title="Cost per day, by model",
         expr=expr,
@@ -82,13 +85,10 @@ def _panel_cost_per_day_by_model() -> object:
 
 
 def _panel_cost_by_model_totals() -> object:
-    # sum_over_time can't take an inline by() (Loki) — group via the outer
-    # sum by; unwrap extracts only the cost field so cardinality stays bounded.
-    cost_sum = f"sum_over_time({_SELECTOR} {sh.unwrap(_COST)} [$__range])"
-    expr = f"sort_desc(sum by ({LABEL_MODEL}) ({sh.usd(cost_sum)}))"
+    inner = f"sum by ({LABEL_MODEL}) (increase({METRIC_COST_MICRO_USD}{_SEL}[$__range]))"
     return sh.bargauge_panel(
         title="Cost by model — total (selected range)",
-        expr=expr,
+        expr=f"topk(30, {sh.usd(inner)})",
         legend=_LEGEND_MODEL,
         unit="currencyUSD",
         color="orange",
@@ -97,9 +97,7 @@ def _panel_cost_by_model_totals() -> object:
 
 
 def _panel_cost_by_model_pie() -> object:
-    expr = sh.usd(
-        f"sum by ({LABEL_MODEL}) (sum_over_time({_SELECTOR} {sh.unwrap(_COST)} [$__range]))"
-    )
+    expr = sh.usd(f"sum by ({LABEL_MODEL}) (increase({METRIC_COST_MICRO_USD}{_SEL}[$__range]))")
     return sh.pie_panel(
         title="Cost share by model (selected range)",
         expr=expr,
@@ -109,12 +107,12 @@ def _panel_cost_by_model_pie() -> object:
 
 
 _DESCRIPTION = (
-    "Cost per model for the Envoy AI Gateway, daily granularity. The headline "
-    "panel stacks one bar per day per model (resolution pinned to 1d). Default "
-    "window is 30 days — set the range to a calendar month for monthly totals. "
-    "Cost = gen_ai.usage.custom_total_cost (micro-USD ÷ 1e6; ADR-0028/0051). "
-    "Spans all attributed traffic incl. service accounts. "
-    "See docs/per-user-observability.md. "
+    "Cost per model for the Envoy AI Gateway, daily granularity, from the "
+    "precomputed Mimir metrics (ADR-0058) — PromQL increase() over the "
+    "loki_process_custom_gen_ai_usage_cost_micro_usd counter (÷1e6 for USD; "
+    "ADR-0028/0051), NOT a Loki log-scan. Default 30 days; set the range to a "
+    "calendar month for monthly totals. Spans all attributed traffic incl. "
+    "service accounts. ⚠️ Forward-only history (began at ADR-0058 part A). "
     "GENERATED — source: tools/dashboards/envoy_ai_gateway/cost_by_model.py."
 )
 
@@ -123,30 +121,25 @@ def _dashboard() -> db.Dashboard:
     return (
         db.Dashboard("AI Gateway — cost by model (monthly)")
         .uid("envoy-ai-gateway-cost-by-model")
-        .tags(["ai-gateway", "cost", "model", "loki"])
+        .tags(["ai-gateway", "cost", "model", "mimir"])
         .description(_DESCRIPTION)
         .timezone("browser")
         .editable()
         .tooltip(dm.DashboardCursorSync.CROSSHAIR)
-        # Auto-refresh OFF + 7d default: a cold 30d log-scan over the
-        # rate-limited object store can't return within Grafana's timeout, and a
-        # 30d + 5m-refresh board saturated Loki (self-DoS → "No data"). 7d loads
-        # off the warm chunk cache; expand the range manually for longer windows.
-        # Phase 2 (Mimir recording rules) restores a fast 30d default.
-        .refresh("")
-        .time("now-7d", "now")
+        .refresh("5m")
+        .time("now-30d", "now")
         .with_variable(
             sh.multi_var(
                 name="azp",
                 label="Client (azp)",
-                definition=f'label_values({{service_name="{GATEWAY_SERVICE_NAME}"}}, {LABEL_AZP})',
+                definition=sh.label_values(METRIC_REQUESTS, LABEL_AZP),
             )
         )
         .with_variable(
             sh.multi_var(
                 name="model",
                 label="Model",
-                definition=f'label_values({{service_name="{GATEWAY_SERVICE_NAME}"}}, {LABEL_MODEL})',
+                definition=sh.label_values(METRIC_REQUESTS, LABEL_MODEL),
             )
         )
         .with_panel(sh.row("Cost by model", y=0))

--- a/tools/dashboards/src/dashboards/envoy_ai_gateway/user_tokens_cost.py
+++ b/tools/dashboards/src/dashboards/envoy_ai_gateway/user_tokens_cost.py
@@ -2,15 +2,15 @@
 
 The user x tokens x cost cross: one table row per actor (display_name) with
 requests / tokens / cost side by side, plus per-day stacked breakdowns and
-ranked leaderboards. display_name is a person's name for humans and the
-repository for CI, so "user/actor" is one axis.
+ranked leaderboards. Reads the precomputed Mimir metrics (ADR-0058) via PromQL.
+display_name is a person for humans and the repository for CI, so "user/actor"
+is one axis.
 
 The JSON file is regenerated from this module — do **not** hand-edit it.
 
     uv run dashboards build
 
-Architecture decision: docs/adr/0008-python-dashboard-generation.md.
-Data path the dashboard consumes: docs/per-user-observability.md.
+ADR: docs/adr/0058-precompute-gateway-usage-metrics-to-mimir.md (+ ADR-0008).
 """
 
 from __future__ import annotations
@@ -23,34 +23,27 @@ from grafana_foundation_sdk.cog.encoder import JSONEncoder
 from grafana_foundation_sdk.models import dashboard as dm
 
 from dashboards._common import (
-    GATEWAY_SERVICE_NAME,
     LABEL_AZP,
     LABEL_DISPLAY_NAME,
     LABEL_MODEL,
+    METRIC_COST_MICRO_USD,
+    METRIC_REQUESTS,
+    METRIC_TOKENS,
 )
 from dashboards.envoy_ai_gateway import _shared as sh
 
 OUTPUT_PATH: str = "charts/observability-dashboards/files/envoy-ai-gateway/user-tokens-cost.json"
 
-# All attributed traffic (humans + service accounts / repos), refined by the
-# azp / model filters. user_id=~".+" matches every gateway stream.
-_SELECTOR = sh.selector('azp=~"$azp"', 'user_id=~".+"', 'model=~"$model"')
-
-_COST = "gen_ai_usage_custom_total_cost"
-_TOKENS = "gen_ai_usage_total_tokens"
+_SEL = sh.selector('azp=~"$azp"', 'model=~"$model"')
 
 _LEGEND_USER = "{{" + LABEL_DISPLAY_NAME + "}}"
 
-# Per-user range aggregations. The [$__range] window means the LAST evaluated
-# point of each series IS the per-range total (same trick as the stat panels);
-# timeSeriesTable's lastNotNull stat then reads exactly that total.
+# Per-actor range totals (instant PromQL — one value per display_name).
 _COST_BY_USER = sh.usd(
-    f"sum by ({LABEL_DISPLAY_NAME}) (sum_over_time({_SELECTOR} {sh.unwrap(_COST)} [$__range]))"
+    f"sum by ({LABEL_DISPLAY_NAME}) (increase({METRIC_COST_MICRO_USD}{_SEL}[$__range]))"
 )
-_TOKENS_BY_USER = (
-    f"sum by ({LABEL_DISPLAY_NAME}) (sum_over_time({_SELECTOR} {sh.unwrap(_TOKENS)} [$__range]))"
-)
-_REQS_BY_USER = f"sum by ({LABEL_DISPLAY_NAME}) (count_over_time({_SELECTOR} [$__range]))"
+_TOKENS_BY_USER = f"sum by ({LABEL_DISPLAY_NAME}) (increase({METRIC_TOKENS}{_SEL}[$__range]))"
+_REQS_BY_USER = f"sum by ({LABEL_DISPLAY_NAME}) (increase({METRIC_REQUESTS}{_SEL}[$__range]))"
 
 
 # ---------------------------------------------------------------------------
@@ -61,7 +54,7 @@ _REQS_BY_USER = f"sum by ({LABEL_DISPLAY_NAME}) (count_over_time({_SELECTOR} [$_
 def _panel_total_cost() -> object:
     return sh.stat_panel(
         title="Total cost (range)",
-        expr=sh.usd(f"sum(sum_over_time({_SELECTOR} {sh.unwrap(_COST)} [$__range]))"),
+        expr=sh.usd(f"sum(increase({METRIC_COST_MICRO_USD}{_SEL}[$__range]))"),
         unit="currencyUSD",
         color="orange",
         grid=(4, 6, 0, 1),
@@ -71,7 +64,7 @@ def _panel_total_cost() -> object:
 def _panel_total_tokens() -> object:
     return sh.stat_panel(
         title="Total tokens (range)",
-        expr=f"sum(sum_over_time({_SELECTOR} {sh.unwrap(_TOKENS)} [$__range]))",
+        expr=f"sum(increase({METRIC_TOKENS}{_SEL}[$__range]))",
         unit="short",
         color="green",
         grid=(4, 6, 6, 1),
@@ -81,7 +74,7 @@ def _panel_total_tokens() -> object:
 def _panel_unique_users() -> object:
     return sh.stat_panel(
         title="Unique actors (range)",
-        expr=f"count(sum by ({LABEL_DISPLAY_NAME}) (count_over_time({_SELECTOR} [$__range])))",
+        expr=f"count(sum by ({LABEL_DISPLAY_NAME}) (increase({METRIC_REQUESTS}{_SEL}[$__range])))",
         unit="short",
         color="purple",
         grid=(4, 6, 12, 1),
@@ -89,10 +82,8 @@ def _panel_unique_users() -> object:
 
 
 def _panel_cost_per_1k_tokens() -> object:
-    # Blended efficiency: total USD / (total tokens / 1000). Arithmetic between
-    # two scalar LogQL aggregations is valid; both collapse via sum().
-    cost = f"sum(sum_over_time({_SELECTOR} {sh.unwrap(_COST)} [$__range])) / 1e6"
-    ktok = f"(sum(sum_over_time({_SELECTOR} {sh.unwrap(_TOKENS)} [$__range])) / 1000)"
+    cost = f"sum(increase({METRIC_COST_MICRO_USD}{_SEL}[$__range])) / 1e6"
+    ktok = f"(sum(increase({METRIC_TOKENS}{_SEL}[$__range])) / 1000)"
     return sh.stat_panel(
         title="Blended cost / 1k tokens (range)",
         expr=f"({cost}) / ({ktok})",
@@ -108,37 +99,20 @@ def _panel_cost_per_1k_tokens() -> object:
 
 
 def _panel_user_table() -> table.Panel:
-    # Three range queries (refIds A/B/C) grouped by display_name. The transform
-    # chain is order-critical:
-    #   1. timeSeriesTable — reduce each series to its per-range total
-    #      (lastNotNull on the [$__range] running sum), one frame per refId with
-    #      columns [display_name, "Trend #A"|"#B"|"#C"].
-    #   2. merge — collapse the three frames into ONE row per display_name
-    #      (Grafana merges rows sharing identical values in shared fields, i.e.
-    #      display_name). WITHOUT this, the three frames stay separate and the
-    #      table can't show Cost/Tokens/Requests side by side or sort across
-    #      them (Grafana "Merge series/tables"; PR #485 review).
-    #   3. organize — rename the auto "Trend #X" columns + display_name.
-    #   4. sortBy — rank by cost. Cost column carries the USD unit override.
+    # Three instant table-format PromQL queries (A=cost, B=tokens, C=requests),
+    # each `sum by (display_name)`. Prometheus instant+table returns one row per
+    # series with a "Value #<refId>" column; `merge` collapses the three frames
+    # into one row per display_name, `organize` renames + drops Time, `sortBy`
+    # ranks by cost. Far simpler than the Loki timeSeriesTable path.
     panel = (
         table.Panel()
         .title("Per actor — requests · tokens · cost (selected range)")
-        .datasource(sh.LOKI_DS)
+        .datasource(sh.MIMIR_DS)
         .grid_pos(dm.GridPos(h=12, w=24, x=0, y=5))
         .filterable(True)
-        .with_target(sh.loki_target(_COST_BY_USER, ref_id="A", legend=_LEGEND_USER))
-        .with_target(sh.loki_target(_TOKENS_BY_USER, ref_id="B", legend=_LEGEND_USER))
-        .with_target(sh.loki_target(_REQS_BY_USER, ref_id="C", legend=_LEGEND_USER))
-        .with_transformation(
-            dm.DataTransformerConfig(
-                id_val="timeSeriesTable",
-                options={
-                    "A": {"stat": "lastNotNull"},
-                    "B": {"stat": "lastNotNull"},
-                    "C": {"stat": "lastNotNull"},
-                },
-            )
-        )
+        .with_target(sh.prom_target(_COST_BY_USER, ref_id="A", instant=True, fmt="table"))
+        .with_target(sh.prom_target(_TOKENS_BY_USER, ref_id="B", instant=True, fmt="table"))
+        .with_target(sh.prom_target(_REQS_BY_USER, ref_id="C", instant=True, fmt="table"))
         .with_transformation(dm.DataTransformerConfig(id_val="merge", options={}))
         .with_transformation(
             dm.DataTransformerConfig(
@@ -146,11 +120,11 @@ def _panel_user_table() -> table.Panel:
                 options={
                     "renameByName": {
                         LABEL_DISPLAY_NAME: "Actor",
-                        "Trend #A": "Cost ($)",
-                        "Trend #B": "Tokens",
-                        "Trend #C": "Requests",
+                        "Value #A": "Cost ($)",
+                        "Value #B": "Tokens",
+                        "Value #C": "Requests",
                     },
-                    "excludeByName": {},
+                    "excludeByName": {"Time": True},
                     "indexByName": {},
                 },
             )
@@ -162,7 +136,6 @@ def _panel_user_table() -> table.Panel:
             )
         )
     )
-    # USD unit + 2 decimals on the cost column (others stay plain counts).
     return panel.override_by_name(
         "Cost ($)",
         [
@@ -173,14 +146,12 @@ def _panel_user_table() -> table.Panel:
 
 
 # ---------------------------------------------------------------------------
-# Per-day breakdowns (min granularity = days, like the sibling boards)
+# Per-day breakdowns + leaderboards
 # ---------------------------------------------------------------------------
 
 
 def _panel_cost_per_day_by_user() -> object:
-    expr = sh.usd(
-        f"sum by ({LABEL_DISPLAY_NAME}) (sum_over_time({_SELECTOR} {sh.unwrap(_COST)} [1d]))"
-    )
+    expr = sh.usd(f"sum by ({LABEL_DISPLAY_NAME}) (increase({METRIC_COST_MICRO_USD}{_SEL}[1d]))")
     return sh.daily_bars_panel(
         title="Cost per day, by actor",
         expr=expr,
@@ -191,7 +162,7 @@ def _panel_cost_per_day_by_user() -> object:
 
 
 def _panel_tokens_per_day_by_user() -> object:
-    expr = f"sum by ({LABEL_DISPLAY_NAME}) (sum_over_time({_SELECTOR} {sh.unwrap(_TOKENS)} [1d]))"
+    expr = f"sum by ({LABEL_DISPLAY_NAME}) (increase({METRIC_TOKENS}{_SEL}[1d]))"
     return sh.daily_bars_panel(
         title="Tokens per day, by actor",
         expr=expr,
@@ -201,16 +172,10 @@ def _panel_tokens_per_day_by_user() -> object:
     )
 
 
-# ---------------------------------------------------------------------------
-# Leaderboards (dependable, regardless of the table transform)
-# ---------------------------------------------------------------------------
-
-
 def _panel_top_users_cost() -> object:
-    expr = f"topk(20, {_COST_BY_USER})"
     return sh.bargauge_panel(
         title="Top actors by cost (selected range)",
-        expr=expr,
+        expr=f"topk(20, {_COST_BY_USER})",
         legend=_LEGEND_USER,
         unit="currencyUSD",
         color="orange",
@@ -219,10 +184,9 @@ def _panel_top_users_cost() -> object:
 
 
 def _panel_top_users_tokens() -> object:
-    expr = f"topk(20, {_TOKENS_BY_USER})"
     return sh.bargauge_panel(
         title="Top actors by tokens (selected range)",
-        expr=expr,
+        expr=f"topk(20, {_TOKENS_BY_USER})",
         legend=_LEGEND_USER,
         unit="short",
         color="green",
@@ -231,14 +195,14 @@ def _panel_top_users_tokens() -> object:
 
 
 _DESCRIPTION = (
-    "Users x tokens x cost for the Envoy AI Gateway. The table gives one row per "
-    "actor (display_name = a person for humans, the repository for CI) with "
-    "requests / tokens / cost side by side over the selected range (default 30d ≈ "
-    "monthly); per-day stacked panels add daily granularity, and the leaderboards "
-    "rank by cost and by tokens. Cost = gen_ai.usage.custom_total_cost "
-    "(micro-USD ÷ 1e6; ADR-0028/0051). Filters: azp, model. "
-    "⚠️ LibreChat agent runs + RAG embeddings fall back to azp=internal-key-librechat "
-    "(not the human) — docs/per-user-observability.md. "
+    "Users x tokens x cost for the Envoy AI Gateway, from the precomputed Mimir "
+    "metrics (ADR-0058, PromQL increase()). The table gives one row per actor "
+    "(display_name = a person for humans, the repository for CI) with requests / "
+    "tokens / cost side by side over the selected range (default 30d ≈ monthly); "
+    "per-day stacked panels add daily granularity, leaderboards rank by cost and "
+    "tokens. Cost ÷1e6 for USD (ADR-0028/0051). Filters: azp, model. "
+    "⚠️ Forward-only history; LibreChat agents/embeddings fall back to "
+    "azp=internal-key-librechat. "
     "GENERATED — source: tools/dashboards/envoy_ai_gateway/user_tokens_cost.py."
 )
 
@@ -247,28 +211,25 @@ def _dashboard() -> db.Dashboard:
     return (
         db.Dashboard("AI Gateway — users: tokens & cost")
         .uid("envoy-ai-gateway-user-tokens-cost")
-        .tags(["ai-gateway", "cost", "tokens", "per-user", "loki"])
+        .tags(["ai-gateway", "cost", "tokens", "per-user", "mimir"])
         .description(_DESCRIPTION)
         .timezone("browser")
         .editable()
         .tooltip(dm.DashboardCursorSync.CROSSHAIR)
-        # Auto-refresh OFF + 7d default — see cost_by_model for the rationale
-        # (cold 30d log-scans on the rate-limited store self-DoS Loki). Expand
-        # the range manually; Phase 2 (Mimir recording rules) restores fast 30d.
-        .refresh("")
-        .time("now-7d", "now")
+        .refresh("5m")
+        .time("now-30d", "now")
         .with_variable(
             sh.multi_var(
                 name="azp",
                 label="Client (azp)",
-                definition=f'label_values({{service_name="{GATEWAY_SERVICE_NAME}"}}, {LABEL_AZP})',
+                definition=sh.label_values(METRIC_REQUESTS, LABEL_AZP),
             )
         )
         .with_variable(
             sh.multi_var(
                 name="model",
                 label="Model",
-                definition=f'label_values({{service_name="{GATEWAY_SERVICE_NAME}"}}, {LABEL_MODEL})',
+                definition=sh.label_values(METRIC_REQUESTS, LABEL_MODEL),
             )
         )
         .with_panel(sh.row("Users — tokens & cost", y=0))


### PR DESCRIPTION
**Source of truth:** ADR-0058 (merged in #488); implements Part B of that decision. Follow-up to #485 / #487.

## 1. Summary

**ADR-0058 Part B (the implementation).** Repoint the three AI Gateway **cost** dashboards from Loki log-scans to the **precomputed Mimir metrics** (PromQL `increase()` over `loki_process_custom_gen_ai_*`), and restore the `now-30d` default + auto-refresh.

> Part B's code was accidentally pushed to the ADR branch (#488) *after* that PR had already merged, so only the ADR reached `main`. This PR delivers the orphaned implementation commit.

It solves:
- "No data" on the cost dashboards (they were still querying the rate-limited Loki/S3 path). Now they read Mimir → instant at any range, zero object-store reads.

## 2. Intent
> Complete ADR-0058: dashboards read cheap precomputed metrics instead of scanning a month of logs. Part A (Alloy `stage.metrics` → Mimir) + Mimir caching already shipped via `ai-helm-values`; this repoints the dashboards.

## 3. Scope
### In Scope
- `_common.py` metric-name constants; `_shared.py` rewritten Loki→Mimir (PromQL helpers); the 3 cost modules + regenerated JSON; folder README.
### Out of Scope
- `per_user.py` (stays Loki-backed — raw log activity).
- Part A / Mimir caches (in `ai-helm-values`); the ADR (#488, merged).
- Phase 3 (gamified scoreboard — captured in the ADR).

## 4. Verification
- [x] Automated (drift guard + helm lint)
- [x] Metrics checked (exact PromQL run against live Mimir)

```bash
uv run dashboards check    # ok — no drift
helm lint charts/observability-dashboards --strict   # 0 failed
```
```text
generated JSON: datasource=prometheus for panels AND variables (all 3 boards)
live Mimir (6h): total $5.90; glm-5p1 $5.01; top actor Assah Bismark $2.31
```

## 5. Evidence
- The `user-tokens-cost` table is now 3 instant table-format PromQL queries + `merge`→`organize`→`sortBy` (the Loki `timeSeriesTable` path removed).

## 6. Risk Assessment
* [x] Low
- ⚠️ **Forward-only history**: metrics began at Part A, so the 30d view fills in over ~30 days — but boards now **load instantly** at any range instead of timing out.
- Rollback = revert (per-user board unaffected).

## 7. AI Usage Declaration
* [x] Understanding existing code
* [x] Generating code
* [x] Reviewing the diff

Human verification:
* [x] I understand every meaningful change in this PR
* [x] I accept responsibility for this PR

## 8. Reviewer Focus
* [x] Correctness
* [x] Product intent

🤖 Generated with [Claude Code](https://claude.com/claude-code)
