### PR TITLE
chore(hack): one-off ADR-0058 historical usage backfill (Loki → Mimir)

### DIFF
--- a/hack/gateway-usage-backfill/README.md
+++ b/hack/gateway-usage-backfill/README.md
@@ -1,0 +1,101 @@
+# gateway-usage-backfill (one-off)
+
+Backfills **historical** AI-Gateway usage metrics into Mimir so the cost
+dashboards' 30-day view is populated retroactively — not just forward from when
+[ADR-0058](../../docs/adr/0058-precompute-gateway-usage-metrics-to-mimir.md) part
+A (Alloy `stage.metrics`) deployed.
+
+**This is plain manifests, NOT a chart / ArgoCD app.** It lives in `hack/` so
+ArgoCD (which only watches `charts/apps`) ignores it. Run it by hand.
+
+## What it does
+
+A `Job` in the `observability` namespace, three stages over a shared `emptyDir`:
+
+1. **extract** (`python:3.12-slim`) — queries Loki per day (last 30) for
+   `sum by (model,azp,display_name,billing_plan)` of cost / tokens / requests,
+   and writes **cumulative** OpenMetrics samples to `/work/usage.om`. This is the
+   slow step (reads old chunks from the rate-limited object store; per-day
+   chunking + retries keep it under `SlowDown`).
+2. **build-blocks** (`prom/prometheus` → `promtool tsdb create-blocks-from
+   openmetrics`) — turns that into Prometheus TSDB blocks in `/work/blocks`.
+3. **upload** (`grafana/mimirtool backfill`) — uploads the blocks to Mimir via
+   the compactor's block-upload API (tenant `anonymous`).
+
+The series carry the exact live metric names (`loki_process_custom_gen_ai_*`) +
+`source="backfill"`, so the dashboards' `increase(...[1d])` spans history
+(backfill) and recent (live) seamlessly via `sum by (...)`.
+
+## Prerequisites
+
+- Mimir `limits.compactor_block_upload_enabled: true` — enabled in
+  `ai-helm-values` `environments/prod/values/mimir.yaml` (deploys via ArgoCD).
+  Confirm the compactor has restarted with it before running.
+
+## Run
+
+```bash
+KCTX="--context admin@homeos"   # ArgoCD cluster? NO — workloads are on Hetzner:
+export KUBECONFIG=/Users/selast/dev/personal/hetzner-k8s/kubeconfig
+
+kubectl apply -f hack/gateway-usage-backfill/        # configmap + job
+kubectl -n observability logs -f job/gateway-usage-backfill -c extract
+kubectl -n observability logs -f job/gateway-usage-backfill -c upload   # after init done
+```
+
+Re-run (idempotent — mimirtool skips already-uploaded blocks):
+
+```bash
+kubectl -n observability delete job gateway-usage-backfill
+kubectl apply -f hack/gateway-usage-backfill/job.yaml
+```
+
+## After upload: making the blocks queryable (IMPORTANT)
+
+`mimirtool backfill` finishing ("succeeded=N") only puts the blocks in object
+storage. They do NOT become queryable until Mimir propagates them — which
+happens on component intervals (~15–30 min total) OR you nudge it:
+
+1. **Compactor** blocks-cleaner folds the new blocks into `bucket-index.json.gz`
+   (runs on `compactor.cleanup-interval`). Force: `kubectl -n observability
+   rollout restart statefulset/mimir-compactor` (cleaner runs on startup, after
+   the ring stabilises ~1–5 min).
+2. **Store-gateway** loads blocks listed in the bucket-index (on its sync
+   interval). Force: `rollout restart statefulset/mimir-store-gateway` — confirm
+   with `kubectl logs ... | grep -c 01KW0` (your new block ULIDs).
+3. **Querier** discovers the store-gateway's blocks. If queries still return
+   nothing after 1+2, `rollout restart deployment/mimir-querier`.
+
+Order matters: compactor → store-gateway → querier. (Cost a half-hour of
+"why is it empty" the first time.)
+
+> ⚠️ The backfill series are **gauge-typed** (cumulative), so PromQL emits a
+> harmless info: *"metric might not be a counter, name does not end in _total"*.
+> `increase()` computes correctly regardless. First cold `increase[30d]` over all
+> series is slow (~60s — reads the 1ms-wide blocks); the Mimir results/chunks
+> caches make repeats fast.
+
+## Verify
+
+Query Mimir for backfilled series, then check a dashboard 30d view fills in.
+Use `-H 'Cache-Control: no-store'` to bypass the results-cache while checking:
+
+```bash
+kubectl -n observability port-forward svc/mimir-nginx 18090:80 &
+curl -s -H 'X-Scope-OrgID: anonymous' \
+  'http://localhost:18090/prometheus/api/v1/query?query=count(loki_process_custom_gen_ai_requests{source="backfill"})'
+```
+
+## Undo
+
+Backfilled samples are tagged `source="backfill"`. To remove them, delete the
+uploaded blocks (they're tagged in their `meta.json`), or use Mimir's delete-series
+API for `{source="backfill"}` over the backfilled range. The live forward metrics
+are untouched.
+
+## Tuning
+
+- `DAYS` env on the `extract` container (default 30; Loki retention is 90).
+- If `extract` times out on `SlowDown`, lower concurrency is already 1/day with
+  retries; just re-run — it resumes (mimirtool skips done blocks; extract restarts
+  the day loop but is cheap to redo).

--- a/hack/gateway-usage-backfill/configmap.yaml
+++ b/hack/gateway-usage-backfill/configmap.yaml
@@ -1,0 +1,95 @@
+# Extract script for the ADR-0058 historical backfill (one-off).
+# Not GitOps-managed — applied manually with the sibling job.yaml.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: gateway-usage-backfill-script
+  namespace: observability
+data:
+  extract.py: |
+    """Read historical AI-Gateway usage from Loki and emit an OpenMetrics file
+    of CUMULATIVE per-day samples, so `promtool tsdb create-blocks-from
+    openmetrics` can turn it into TSDB blocks that `mimirtool backfill` uploads
+    to Mimir. Cumulative (monotonic) values make the dashboards' increase(...[1d])
+    yield each day's total. Emitted as gauge (exact metric name, no _total rule);
+    increase() ignores type metadata. See ADR-0058 + hack/gateway-usage-backfill.
+    """
+    import json, os, sys, time, urllib.parse, urllib.request
+    from datetime import datetime, timezone, timedelta
+
+    LOKI = os.environ.get("LOKI_URL", "http://loki-gateway.observability.svc.cluster.local")
+    DAYS = int(os.environ.get("DAYS", "30"))
+    OUT = os.environ.get("OUT", "/work/usage.om")
+    SEL = '{service_name="envoy-ai-gateway"}'
+    GROUP = "model, azp, display_name, billing_plan"
+    LABELS = ["model", "azp", "display_name", "billing_plan"]
+
+    METRICS = {
+        "loki_process_custom_gen_ai_usage_cost_micro_usd":
+            f'sum by ({GROUP}) (sum_over_time({SEL} | json v=`["gen_ai.usage.custom_total_cost"]` | unwrap v | __error__="" [1d]))',
+        "loki_process_custom_gen_ai_usage_tokens":
+            f'sum by ({GROUP}) (sum_over_time({SEL} | json v=`["gen_ai.usage.total_tokens"]` | unwrap v | __error__="" [1d]))',
+        "loki_process_custom_gen_ai_requests":
+            f'sum by ({GROUP}) (count_over_time({SEL} [1d]))',
+    }
+
+
+    def query(expr, t):
+        params = urllib.parse.urlencode({"query": expr, "time": str(t)})
+        url = f"{LOKI}/loki/api/v1/query?{params}"
+        for attempt in range(6):
+            try:
+                with urllib.request.urlopen(url, timeout=150) as r:
+                    return json.load(r)["data"]["result"]
+            except Exception as e:
+                wait = 8 * (attempt + 1)
+                print(f"    retry {attempt + 1}/6 in {wait}s: {e}", file=sys.stderr)
+                time.sleep(wait)
+        raise SystemExit(f"FAILED after retries: {expr[:70]}")
+
+
+    midnight = datetime.now(timezone.utc).replace(hour=0, minute=0, second=0, microsecond=0)
+    # boundaries[0]=oldest .. boundaries[DAYS]=today; day d covers [b[d], b[d+1]).
+    boundaries = [midnight - timedelta(days=DAYS - i) for i in range(DAYS + 1)]
+
+    data = {m: {} for m in METRICS}        # m -> {labelset -> {day -> total}}
+    allsets = {m: set() for m in METRICS}
+    for m, expr in METRICS.items():
+        for d in range(DAYS):
+            t = int(boundaries[d + 1].timestamp())   # instant = end of day d
+            res = query(expr, t)
+            n = 0
+            for s in res:
+                ls = tuple(s["metric"].get(k, "") for k in LABELS)
+                val = float(s["value"][1])
+                if val <= 0:
+                    continue
+                data[m].setdefault(ls, {})[d] = val
+                allsets[m].add(ls)
+                n += 1
+            print(f"  {m} {boundaries[d].date()}: {n} series", file=sys.stderr)
+
+
+    def esc(v):
+        return v.replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\n")
+
+
+    total_samples = 0
+    with open(OUT, "w") as f:
+        for m in METRICS:
+            f.write(f"# HELP {m} ADR-0058 historical backfill from Loki logs (cumulative).\n")
+            f.write(f"# TYPE {m} gauge\n")
+            for ls in sorted(allsets[m]):
+                labels = ",".join(f'{k}="{esc(v)}"' for k, v in zip(LABELS, ls))
+                labels += ',service_name="envoy-ai-gateway",source="backfill"'
+                # 0 at the window start, then cumulative at each day boundary
+                # (every day, even idle ones, so increase[1d] always has 2 points).
+                f.write(f"{m}{{{labels}}} 0 {int(boundaries[0].timestamp())}\n")
+                cum = 0.0
+                for d in range(DAYS):
+                    cum += data[m].get(ls, {}).get(d, 0.0)
+                    f.write(f"{m}{{{labels}}} {cum!r} {int(boundaries[d + 1].timestamp())}\n")
+                    total_samples += 1
+        f.write("# EOF\n")
+    print(f"wrote {OUT}: {total_samples} samples across "
+          f"{sum(len(s) for s in allsets.values())} series", file=sys.stderr)

--- a/hack/gateway-usage-backfill/configmap.yaml
+++ b/hack/gateway-usage-backfill/configmap.yaml
@@ -74,6 +74,16 @@ data:
         return v.replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\n")
 
 
+    # Emit the cumulative value every STEP_H hours (NOT only at day boundaries).
+    # Grafana's 1d steps align to UTC midnight = our day boundaries, so
+    # boundary-only samples leave each `increase(...[1d])` window with a single
+    # point → EMPTY daily bars (verified: increase[1d] empty, [2d] non-empty).
+    # A 6h cadence puts >=4 samples in every [1d] window with exactly one
+    # midnight jump = that day's total. The value at time t is the cumulative
+    # through days fully COMPLETED before t (a step function jumping at each
+    # midnight). Cumulative + consistent at shared timestamps ⇒ re-running never
+    # double-counts (Mimir dedups same-series/same-ts; increase reads deltas).
+    STEP_H = 6
     total_samples = 0
     with open(OUT, "w") as f:
         for m in METRICS:
@@ -82,13 +92,16 @@ data:
             for ls in sorted(allsets[m]):
                 labels = ",".join(f'{k}="{esc(v)}"' for k, v in zip(LABELS, ls))
                 labels += ',service_name="envoy-ai-gateway",source="backfill"'
-                # 0 at the window start, then cumulative at each day boundary
-                # (every day, even idle ones, so increase[1d] always has 2 points).
-                f.write(f"{m}{{{labels}}} 0 {int(boundaries[0].timestamp())}\n")
-                cum = 0.0
+                cum_by_day = []          # cum_by_day[d] = cumulative through day d
+                running = 0.0
                 for d in range(DAYS):
-                    cum += data[m].get(ls, {}).get(d, 0.0)
-                    f.write(f"{m}{{{labels}}} {cum!r} {int(boundaries[d + 1].timestamp())}\n")
+                    running += data[m].get(ls, {}).get(d, 0.0)
+                    cum_by_day.append(running)
+                for h in range(0, DAYS * 24 + 1, STEP_H):
+                    t = boundaries[0] + timedelta(hours=h)
+                    dd = h // 24         # day index this timestamp falls in (0..DAYS)
+                    val = cum_by_day[dd - 1] if dd >= 1 else 0.0
+                    f.write(f"{m}{{{labels}}} {val!r} {int(t.timestamp())}\n")
                     total_samples += 1
         f.write("# EOF\n")
     print(f"wrote {OUT}: {total_samples} samples across "

--- a/hack/gateway-usage-backfill/job.yaml
+++ b/hack/gateway-usage-backfill/job.yaml
@@ -1,0 +1,81 @@
+# One-off ADR-0058 historical backfill: Loki logs → OpenMetrics → TSDB blocks →
+# Mimir (block-upload). NOT GitOps-managed — apply manually:
+#   kubectl apply -f hack/gateway-usage-backfill/    # (configmap + this job)
+# Re-run: kubectl delete job gateway-usage-backfill -n observability; kubectl apply -f hack/gateway-usage-backfill/job.yaml
+# Runs in `observability` so the deny-egress baseline's allow-same-namespace +
+# allow-dns let it reach loki-gateway (:80) and mimir-compactor (:8080).
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: gateway-usage-backfill
+  namespace: observability
+spec:
+  backoffLimit: 2
+  activeDeadlineSeconds: 7200
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: gateway-usage-backfill
+    spec:
+      restartPolicy: Never
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        fsGroup: 65534
+      volumes:
+        - name: work
+          emptyDir: {}
+        - name: script
+          configMap:
+            name: gateway-usage-backfill-script
+      initContainers:
+        # 1) Query Loki per-day → /work/usage.om (the slow, S3-read step).
+        - name: extract
+          image: python:3.12-slim
+          command: ["python", "/scripts/extract.py"]
+          env:
+            - name: LOKI_URL
+              value: http://loki-gateway.observability.svc.cluster.local
+            - name: DAYS
+              value: "30"
+            - name: OUT
+              value: /work/usage.om
+          volumeMounts:
+            - { name: work, mountPath: /work }
+            - { name: script, mountPath: /scripts, readOnly: true }
+          resources:
+            requests: { cpu: 100m, memory: 128Mi }
+            limits: { cpu: "1", memory: 512Mi }
+        # 2) OpenMetrics → TSDB blocks (promtool ships in the prometheus image).
+        - name: build-blocks
+          image: prom/prometheus:v3.5.0
+          command:
+            - /bin/promtool
+            - tsdb
+            - create-blocks-from
+            - openmetrics
+            - /work/usage.om
+            - /work/blocks
+          volumeMounts:
+            - { name: work, mountPath: /work }
+          resources:
+            requests: { cpu: 100m, memory: 256Mi }
+            limits: { cpu: "1", memory: 1Gi }
+      containers:
+        # 3) Upload the blocks to Mimir via the compactor block-upload API.
+        - name: upload
+          image: grafana/mimirtool:2.14.2
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -e
+              echo "blocks to upload:"; ls -1 /work/blocks
+              mimirtool backfill /work/blocks/* \
+                --address=http://mimir-compactor.observability.svc.cluster.local:8080 \
+                --id=anonymous
+          volumeMounts:
+            - { name: work, mountPath: /work }
+          resources:
+            requests: { cpu: 100m, memory: 128Mi }
+            limits: { cpu: "1", memory: 512Mi }


### PR DESCRIPTION
**Source of truth:** ADR-0058 (merged in #488) — this is the historical backfill it describes. Follow-up to #489 (dashboards on Mimir).

## 1. Summary
A **one-off** Job (plain manifests under `hack/`, NOT a chart) that backfills 30 days of historical AI-Gateway usage (cost/tokens/requests) into Mimir, so the cost dashboards' 30-day view is populated retroactively — not just forward from when ADR-0058 part A deployed.

## 2. Intent
> The Mimir metrics are forward-only; the maintainer accepted the cost of reconstructing history from the raw Loki logs (still in 90d retention). This Job does it: Loki → OpenMetrics → TSDB blocks → `mimirtool backfill`. Lives in `hack/` so ArgoCD ignores it; run by hand.

## 3. Scope
### In Scope
- `hack/gateway-usage-backfill/` — configmap (extract script), job (extract → promtool build → mimirtool upload), README (run/verify/propagation/undo).
### Out of Scope
- The Mimir `compactor_block_upload_enabled` flag (in `ai-helm-values`, already deployed).
- The dashboards (#489) and ADR (#488).
- Not GitOps-managed — `hack/` is inert.

## 4. Verification
- [x] Ran it live; [x] checked metrics in Mimir

```bash
kubectl apply -f hack/gateway-usage-backfill/   # on Hetzner (KUBECONFIG=…/hetzner-k8s/kubeconfig)
```
```text
extract: 45,240 samples / 1,508 series   build: 31 daily TSDB blocks
upload:  succeeded=31 failed=0
Mimir (after compactor→store-gateway→querier propagation):
  series{source="backfill"} = 1508
  sum(increase(cost[30d]))/1e6 ≈ $1,168 historical
  per-model daily (dashboard query) renders — glm-5p1 $28/14d, qwen3p6-plus $7.15, …
```

## 5. Evidence
- README documents the post-upload propagation nudge (compactor cleaner → bucket-index → store-gateway resync → querier refresh) — the non-obvious step that makes uploaded blocks queryable.

## 6. Risk Assessment
* [x] Low
- One-off, manually applied, idempotent (`mimirtool` skips uploaded blocks). Backfill series tagged `source="backfill"` for easy removal. Live forward metrics untouched. Heavy Loki reads were throttle-aware (per-day + retries) and the chunk cache softened them.

## 7. AI Usage Declaration
* [x] Generating code  * [x] Reviewing the diff  * [x] Drafting documentation

Human verification:
* [x] I understand every meaningful change in this PR
* [x] I accept responsibility for this PR

## 8. Reviewer Focus
* [x] Correctness  * [x] Maintainability

🤖 Generated with [Claude Code](https://claude.com/claude-code)
