### PR TITLE
fix(dashboards): make SCHEMA_VERSION real, correct 42→39 (PR #494 P2)

### DIFF
--- a/tools/dashboards/src/dashboards/_common.py
+++ b/tools/dashboards/src/dashboards/_common.py
@@ -115,11 +115,16 @@ DEFAULT_REFRESH_INTERVALS: tuple[str, ...] = (
 
 
 # ---------------------------------------------------------------------------
-# Grafana dashboard schema version. Tracks the cluster's Grafana.
-# Today: Grafana 12 → schemaVersion 42 (audit task #15).
-# Bump when grafana is bumped; ADR-0008.
+# Grafana dashboard schema version, pinned on every generated dashboard by the
+# orchestrator (`main._emit`) so the emitted JSON is decoupled from whatever the
+# grafana-foundation-sdk happens to default to (its builder exposes no fluent
+# `.schema_version()` setter, so the orchestrator stamps it post-build). 39 is
+# the SDK's current target and what the in-cluster Grafana (12.x) migrates
+# upward on import — so pinning 39 keeps today's output byte-identical while
+# making the value explicit. Bump deliberately alongside an SDK/Grafana upgrade;
+# ADR-0008.
 # ---------------------------------------------------------------------------
-SCHEMA_VERSION = 42
+SCHEMA_VERSION = 39
 
 
 # ---------------------------------------------------------------------------

--- a/tools/dashboards/src/dashboards/main.py
+++ b/tools/dashboards/src/dashboards/main.py
@@ -24,6 +24,8 @@ import tempfile
 from pathlib import Path
 from types import ModuleType
 
+from dashboards._common import SCHEMA_VERSION
+
 # Registry of every generated dashboard. Import-by-string so Python's
 # import-time errors don't blow up unrelated `--help`.
 _DASHBOARD_MODULES: tuple[str, ...] = (
@@ -59,6 +61,11 @@ def _repo_root() -> Path:
 
 def _emit(mod: ModuleType, target_dir: Path) -> Path:
     dashboard = mod.build()  # type: ignore[attr-defined]
+    # Pin the schema version explicitly. The grafana-foundation-sdk builder has
+    # no fluent `.schema_version()` setter, so we stamp it here — one place,
+    # every generated dashboard — instead of relying on the SDK's internal
+    # default. See `_common.SCHEMA_VERSION`.
+    dashboard["schemaVersion"] = SCHEMA_VERSION
     out_path = target_dir / mod.OUTPUT_PATH  # type: ignore[attr-defined]
     out_path.parent.mkdir(parents=True, exist_ok=True)
     out_path.write_text(


### PR DESCRIPTION
## 1. Summary

This PR changes:

- Corrects `_common.SCHEMA_VERSION` from the wrong/misleading `42` to `39` — the value the grafana-foundation-sdk actually targets and that every generated dashboard already emits.
- Makes the previously-**dead** constant real: the orchestrator `main._emit` now imports it and stamps `dashboard["schemaVersion"] = SCHEMA_VERSION` once, covering every generated dashboard from a single DRY choke point.
- Rewrites the constant's now-accurate comment (the old one claimed "Grafana 12 → schemaVersion 42", which never shipped).

It solves:

- Non-blocking **P2** flagged by `lightbridge-assistant` on #494 (ADR-0060 scoreboard), deferred there to keep that PR scoped. Source of truth: https://github.com/ADORSYS-GIS/ai-helm/pull/494

---

## 2. Intent

The intent of this PR is:

> `SCHEMA_VERSION` was dead code — nothing referenced it, so the SDK emitted its own model default (`schemaVersion: 39`) on every dashboard, and the constant's `42` was both unused and wrong vs reality. Rather than delete it, wire it through so the schema version is pinned **explicitly** and decoupled from whatever the SDK happens to default to internally (a future SDK bump won't silently change emitted dashboards). The author's original intent — "pin the schema version" — is honoured, just actually realised.

---

## 3. Scope

### In Scope

- `tools/dashboards/src/dashboards/_common.py` — constant value `42`→`39` + corrected comment.
- `tools/dashboards/src/dashboards/main.py` — import the constant; stamp `schemaVersion` centrally in `_emit`.

### Out of Scope

- The 2 `collectors/` dashboards (alloy, tempo) — not in the generator registry (hand/imported JSON), so the constant correctly governs only the 5 SDK-generated dashboards.
- Any actual Grafana/SDK version upgrade — value stays at the current `39`.

---

## 4. Verification

I verified this change by:

- [x] Running automated tests
- [ ] Running manual tests
- [ ] Checking logs
- [ ] Checking metrics
- [ ] Testing error cases
- [ ] Testing permissions/security behavior
- [ ] Testing rollback or failure behavior, if relevant

Commands run:

```bash
cd tools/dashboards
uv run dashboards build
uv run dashboards check
uv run ruff format .
uv run ruff check .
git status --short   # confirm no JSON drift
```

Results:

```text
build  → wrote all 5 envoy-ai-gateway dashboards
check  → ok — every dashboard matches its generator   (zero drift: 39 == 39)
format → 10 files left unchanged
lint   → All checks passed!
status → only the two .py files changed; no regenerated JSON
```

The JSON is byte-identical because the SDK default and the committed files were already `39`; this PR makes that value explicit and owned, not implicit.

---

## 5. Screenshots / Evidence

* Logs: `uv run dashboards check` → "ok — every dashboard matches its generator" (see §4).

---

## 6. Risk Assessment

Risk level:

* [x] Low
* [ ] Medium
* [ ] High

Potential risks:

* None functional — emitted dashboard JSON is unchanged (verified via `dashboards check`).

Mitigation:

* `dashboards-drift` CI guard would catch any unexpected JSON change; none occurred.

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [x] Refactoring
* [ ] Generating tests
* [ ] Drafting documentation
* [x] Reviewing the diff
* [ ] Not used

Human verification:

* [x] I understand every meaningful change in this PR
* [x] I checked generated code manually
* [ ] I checked generated tests manually
* [x] I removed unsupported AI assumptions
* [x] I accept responsibility for this PR

---

## 8. Reviewer Focus

Please focus your review on:

* [x] Correctness
* [ ] Architecture
* [ ] Security
* [ ] Performance
* [ ] Tests
* [x] Maintainability
* [ ] Product intent
* [ ] Edge cases
