### PR TITLE
feat(lci): map config.model.{extra,stream} → review.*; drop fallbackModel (ADR-0053)

### DIFF
--- a/charts/lightbridge-code-intelligence/templates/config.yaml
+++ b/charts/lightbridge-code-intelligence/templates/config.yaml
@@ -56,6 +56,10 @@ data:
 {{- if ne (toString $cfg.model.maxTokens) "" }}{{- $_ := set $rev "max_tokens" $cfg.model.maxTokens }}{{- end }}
 {{- if ne (toString $cfg.model.maxTurns) "" }}{{- $_ := set $rev "max_turns" $cfg.model.maxTurns }}{{- end }}
 {{- if ne (toString $cfg.model.contextWindow) "" }}{{- $_ := set $rev "context_window" $cfg.model.contextWindow }}{{- end }}
+{{- /* SSE streaming toggle (#206) → agent.json review.stream. A bool; empty → omitted (runner default
+       off). Needs a runner image carrying the review.stream field (lightbridge-ci #211) before it's set
+       to true, else deny_unknown_fields fails the Job. */}}
+{{- if ne (toString $cfg.model.stream) "" }}{{- $_ := set $rev "stream" $cfg.model.stream }}{{- end }}
 {{- /* Provider-specific passthrough generation params (ADR-0051 ext, #205) — an OBJECT, not a scalar,
        so it's truthiness-guarded (an empty map is falsy). Merged verbatim into the chat body by the
        runner (review.extra), e.g. a reasoning budget like {"thinking":{"type":"disabled"}} for GLM. */}}

--- a/charts/lightbridge-code-intelligence/templates/config.yaml
+++ b/charts/lightbridge-code-intelligence/templates/config.yaml
@@ -60,10 +60,12 @@ data:
        off). Needs a runner image carrying the review.stream field (lightbridge-ci #211) before it's set
        to true, else deny_unknown_fields fails the Job. */}}
 {{- if ne (toString $cfg.model.stream) "" }}{{- $_ := set $rev "stream" $cfg.model.stream }}{{- end }}
-{{- /* Provider-specific passthrough generation params (ADR-0051 ext, #205) — an OBJECT, not a scalar,
+{{- /* Provider-specific passthrough generation params (lightbridge-ci #205) — an OBJECT, not a scalar,
        so it's truthiness-guarded (an empty map is falsy). Merged verbatim into the chat body by the
        runner (review.extra), e.g. a reasoning budget like {"thinking":{"type":"disabled"}} for GLM. */}}
 {{- if $cfg.model.extra }}{{- $_ := set $rev "extra" $cfg.model.extra }}{{- end }}
+{{- /* NB: review.fallback_model is intentionally NOT mapped — the review failover model was removed
+       (lightbridge-ci ADR-0053 / #208); a single model + retry/backoff + circuit breaker replaces it. */}}
 {{- $_ := set $ag "review" $rev }}
 apiVersion: v1
 kind: ConfigMap

--- a/charts/lightbridge-code-intelligence/templates/config.yaml
+++ b/charts/lightbridge-code-intelligence/templates/config.yaml
@@ -55,8 +55,11 @@ data:
 {{- if ne (toString $cfg.model.topP) "" }}{{- $_ := set $rev "top_p" $cfg.model.topP }}{{- end }}
 {{- if ne (toString $cfg.model.maxTokens) "" }}{{- $_ := set $rev "max_tokens" $cfg.model.maxTokens }}{{- end }}
 {{- if ne (toString $cfg.model.maxTurns) "" }}{{- $_ := set $rev "max_turns" $cfg.model.maxTurns }}{{- end }}
-{{- if ne (toString $cfg.model.fallbackModel) "" }}{{- $_ := set $rev "fallback_model" $cfg.model.fallbackModel }}{{- end }}
 {{- if ne (toString $cfg.model.contextWindow) "" }}{{- $_ := set $rev "context_window" $cfg.model.contextWindow }}{{- end }}
+{{- /* Provider-specific passthrough generation params (ADR-0051 ext, #205) — an OBJECT, not a scalar,
+       so it's truthiness-guarded (an empty map is falsy). Merged verbatim into the chat body by the
+       runner (review.extra), e.g. a reasoning budget like {"thinking":{"type":"disabled"}} for GLM. */}}
+{{- if $cfg.model.extra }}{{- $_ := set $rev "extra" $cfg.model.extra }}{{- end }}
 {{- $_ := set $ag "review" $rev }}
 apiVersion: v1
 kind: ConfigMap

--- a/charts/lightbridge-code-intelligence/values.yaml
+++ b/charts/lightbridge-code-intelligence/values.yaml
@@ -110,7 +110,10 @@ config:
     # Max agent turns per review (ADR-0037 loop). Empty → the runner's built-in default (40).
     # → agent.json `review.max_turns`.
     maxTurns: ""
-    # Provider-specific passthrough generation params (ADR-0051 ext, #205) → agent.json `review.extra`,
+    # NB: there is no `fallbackModel` knob — the review failover model was removed (lightbridge-ci
+    # ADR-0053 / #208), replaced by a single model + retry/backoff + circuit breaker. (Any ADR-NNNN
+    # below refers to the lightbridge-ci repo's ADRs, not this chart's own ADR index.)
+    # Provider-specific passthrough generation params (lightbridge-ci #205) → agent.json `review.extra`,
     # merged verbatim into the chat request body. An OBJECT (not a scalar); empty `{}` → omitted. Use it
     # for knobs the typed fields don't cover — notably a reasoning budget to stop a reasoning model
     # over-thinking, e.g. for GLM: `extra: { thinking: { type: disabled } }`. Set per-env in ai-helm-values.

--- a/charts/lightbridge-code-intelligence/values.yaml
+++ b/charts/lightbridge-code-intelligence/values.yaml
@@ -110,10 +110,11 @@ config:
     # Max agent turns per review (ADR-0037 loop). Empty → the runner's built-in default (40).
     # → agent.json `review.max_turns`.
     maxTurns: ""
-    # Secondary review model to fail over to when the primary times out / errs out a turn (ADR-0039).
-    # Empty → single-model (no failover). → agent.json `review.fallback_model`. Set per-env in
-    # ai-helm-values to a DIFFERENT alias than the primary so a primary-path outage actually fails over.
-    fallbackModel: ""
+    # Provider-specific passthrough generation params (ADR-0051 ext, #205) → agent.json `review.extra`,
+    # merged verbatim into the chat request body. An OBJECT (not a scalar); empty `{}` → omitted. Use it
+    # for knobs the typed fields don't cover — notably a reasoning budget to stop a reasoning model
+    # over-thinking, e.g. for GLM: `extra: { thinking: { type: disabled } }`. Set per-env in ai-helm-values.
+    extra: {}
     # Model context window in tokens (ADR-0045). → agent.json `review.context_window`. Empty → no
     # budgeting (the agent sends the full history and would fail a 400 on overflow). Set per-env in
     # ai-helm-values to the serving model's real window so the agent winds down + trims before overflow

--- a/charts/lightbridge-code-intelligence/values.yaml
+++ b/charts/lightbridge-code-intelligence/values.yaml
@@ -115,6 +115,10 @@ config:
     # for knobs the typed fields don't cover — notably a reasoning budget to stop a reasoning model
     # over-thinking, e.g. for GLM: `extra: { thinking: { type: disabled } }`. Set per-env in ai-helm-values.
     extra: {}
+    # SSE streaming toggle (#206) → agent.json `review.stream`. Empty → off (runner default). Set `true`
+    # per-env to collect a streamed response under a per-chunk idle timeout (helps a heavy-reasoning
+    # model's long turns). REQUIRES a runner image with the `review.stream` field (lightbridge-ci #211).
+    stream: ""
     # Model context window in tokens (ADR-0045). → agent.json `review.context_window`. Empty → no
     # budgeting (the agent sends the full history and would fail a 400 on overflow). Set per-env in
     # ai-helm-values to the serving model's real window so the agent winds down + trims before overflow


### PR DESCRIPTION
## What

Two coupled chart changes to the `lightbridge-code-intelligence` agent config (`templates/config.yaml` + `values.yaml`):

1. **Map `config.model.extra` → `review.extra`** — the runner gained a free-form passthrough block (ADR-0051 ext / lightbridge-ci #205) that is merged verbatim into the chat request body, for provider-specific generation params the typed fields do not cover. The motivating use is a **reasoning budget** to stop a reasoning model over-thinking (GLM-5.1 dogfood: `extra: { thinking: { type: disabled } }`). It is an **object**, so it is truthiness-guarded — an empty `{}` is omitted from `agent.json`.
2. **Remove the dead `fallbackModel` → `review.fallback_model` mapping** + its `values.yaml` default — the review **failover model was removed** (ADR-0053, lightbridge-ci #208). The live runner image (`sha-0f91313`) still *parses-but-ignores* a stale `fallback_model`, and prod `ai-helm-values` drops `fallbackModel` in the same wave, so nothing emits it anymore.

## Why now

Wave 1 of finishing the ADR-0053 deploy tails + enabling the GLM-5.1 reasoning-budget dogfood. The live runner already supports `review.extra` (no rebuild needed); this PR is the missing chart mapping. Safe to merge ahead of the values change — the mapping emits nothing until an env actually sets `config.model.extra`.

## Verification

`helm template` with `config.model.extra.thinking.type=disabled`:
- `agent.json` review block carries `"extra":{"thinking":{"type":"disabled"}}`
- `fallback_model`: **0 occurrences** (was mapped before)
- with `extra` unset: `"extra"` **0 occurrences** (omitted, not `{}`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Verification

- [x] Ran `helm template` with `config.model.extra.thinking.type=disabled` → `agent.json` review block carries `"extra":{"thinking":{"type":"disabled"}}`; with `extra` unset the key is omitted.
- [x] `fallback_model`: **0 occurrences** after the change (was mapped before).
- [x] `helm lint charts/lightbridge-code-intelligence` → 0 failed.

## Source of truth

- ADR-0053 (review fallback removal) + #205 (`review.extra`) / #206 (`review.stream`) in `vymalo/lightbridge-code-intelligence`.

## AI Usage Declaration

AI (Claude Code) was used for: generating the Helm template/values changes, drafting this description, and verifying the render.

- [x] I understand every change in this PR
- [x] I checked the generated template + render output manually
- [x] I accept responsibility for this PR
