### PR TITLE
feat(lci): wire the review-only runner image (image-updater review alias, #207)

### DIFF
--- a/charts/apps/values.yaml
+++ b/charts/apps/values.yaml
@@ -467,9 +467,10 @@ applications:
       # declares, which otherwise show a permanent cosmetic OutOfSync + selfHeal churn.
       # ServerSideDiff ignores those server-owned fields so the app reads Synced.
       argocd.argoproj.io/compare-options: ServerSideDiff=true
-      # Images aliased: cp/disp/poll (control-plane, role-selected), web, and runner
-      # (the one-shot agent-runner image the dispatcher launches per task).
-      argocd-image-updater.argoproj.io/image-list: cp=ghcr.io/vymalo/lightbridge-control-plane,disp=ghcr.io/vymalo/lightbridge-control-plane,poll=ghcr.io/vymalo/lightbridge-control-plane,web=ghcr.io/vymalo/lightbridge-web,runner=ghcr.io/vymalo/lightbridge-agent-runner
+      # Images aliased: cp/disp/poll (control-plane, role-selected), web, runner (the one-shot
+      # agent-runner/indexer image the dispatcher launches), and review (the slimmer review-only Job
+      # image — no Python/Graphify — picked for review tasks; ADR-0004 per-kind images, #207).
+      argocd-image-updater.argoproj.io/image-list: cp=ghcr.io/vymalo/lightbridge-control-plane,disp=ghcr.io/vymalo/lightbridge-control-plane,poll=ghcr.io/vymalo/lightbridge-control-plane,web=ghcr.io/vymalo/lightbridge-web,runner=ghcr.io/vymalo/lightbridge-agent-runner,review=ghcr.io/vymalo/lightbridge-agent-review
       # ── control-plane ──
       argocd-image-updater.argoproj.io/cp.update-strategy: newest-build
       argocd-image-updater.argoproj.io/cp.allow-tags: regexp:^sha-[0-9a-f]+$
@@ -521,6 +522,16 @@ applications:
       argocd-image-updater.argoproj.io/runner.signature-type: cosign
       argocd-image-updater.argoproj.io/runner.cosign.certificate-oidc-issuer: https://token.actions.githubusercontent.com
       argocd-image-updater.argoproj.io/runner.cosign.certificate-identity-regexp: ^https://github\.com/vymalo/lightbridge-code-intelligence/\.github/workflows/build-images\.yml@.*$
+      # ── review (the review-only Job image — drops Python/Graphify, ~44% smaller; #207). The
+      #    dispatcher's image_for() picks it for review tasks (control_plane env AGENT_REVIEW_RUNNER_IMAGE;
+      #    falls back to AGENT_RUNNER_IMAGE when unset). Same cosign identity / build workflow as runner. ──
+      argocd-image-updater.argoproj.io/review.update-strategy: newest-build
+      argocd-image-updater.argoproj.io/review.allow-tags: regexp:^sha-[0-9a-f]+$
+      argocd-image-updater.argoproj.io/review.force-update: "true"
+      argocd-image-updater.argoproj.io/review.helm.image-spec: lci.controllers.dispatcher.containers.main.env.AGENT_REVIEW_RUNNER_IMAGE
+      argocd-image-updater.argoproj.io/review.signature-type: cosign
+      argocd-image-updater.argoproj.io/review.cosign.certificate-oidc-issuer: https://token.actions.githubusercontent.com
+      argocd-image-updater.argoproj.io/review.cosign.certificate-identity-regexp: ^https://github\.com/vymalo/lightbridge-code-intelligence/\.github/workflows/build-images\.yml@.*$
       # ── git write-back → ai-helm-values main (PRIVATE; the org-wide adorsys-gis
       # GitHub App commits, and ArgoCD reads Source B via the same repo-creds —
       # exactly like converse-ui). Unprotected branch → the bot can direct-commit. ──

--- a/charts/lightbridge-code-intelligence/values.yaml
+++ b/charts/lightbridge-code-intelligence/values.yaml
@@ -520,8 +520,13 @@ lci:
             AGENT_SERVICE_ACCOUNT: "lightbridge-agent"
             # image-updater-managed (charts/apps `runner` alias via helm.image-spec): prod pins this
             # to a sha- tag in ai-helm-values and bumps it per signed build. `:latest` is only the
-            # defaults-render fallback.
+            # defaults-render fallback. Used for index tasks (and as the fallback for review).
             AGENT_RUNNER_IMAGE: "ghcr.io/vymalo/lightbridge-agent-runner:latest"
+            # The slimmer review-only Job image (no Python/Graphify; #207). The control plane's
+            # image_for() picks it for REVIEW tasks and falls back to AGENT_RUNNER_IMAGE when unset, so a
+            # cluster that hasn't seeded it keeps working on the combined image. image-updater-managed
+            # (charts/apps `review` alias via helm.image-spec) → pinned to a sha- tag in ai-helm-values.
+            AGENT_REVIEW_RUNNER_IMAGE: "ghcr.io/vymalo/lightbridge-agent-review:latest"
             # Secret (agents ns) whose ca.crt the runner mounts to trust the HTTPS gateway.
             AGENT_CA_SECRET: "lightbridge-agent-ca"
             # FQDN, not the bare Service name: the runner Jobs run in the lightbridge-agents


### PR DESCRIPTION
## What

Wires the **review-only runner image** into the deploy, completing the per-kind image split from [lightbridge-ci #207](https://github.com/vymalo/lightbridge-code-intelligence/pull/207).

#207 split the agent runner into a full **indexer** image and a slimmer **review-only** image (drops Python/Graphify, ~44% smaller / 117→66 MB), and the control plane already selects per task kind via `image_for()` — it reads `AGENT_REVIEW_RUNNER_IMAGE` for review tasks and falls back to `AGENT_RUNNER_IMAGE` when unset. Only the deploy wiring was missing:

- **`charts/apps`** — add a cosign-pinned image-updater **`review`** alias for `ghcr.io/vymalo/lightbridge-agent-review`, with `helm.image-spec` writing the full ref into the dispatcher's `AGENT_REVIEW_RUNNER_IMAGE` env. Mirrors the existing `runner` alias exactly.
- **`charts/lightbridge-code-intelligence`** — add `AGENT_REVIEW_RUNNER_IMAGE` to the dispatcher env (default `:latest`; image-updater pins a `sha-` tag in ai-helm-values per signed build).

## Effect

Review tasks launch the slim image; index tasks keep the full one. **Safe fallback:** until ai-helm-values seeds the tag, `image_for()` falls back to `AGENT_RUNNER_IMAGE`, so nothing breaks — this PR alone only makes the slim image *available* to select.

## Source of truth

- [lightbridge-ci #207](https://github.com/vymalo/lightbridge-code-intelligence/pull/207) (per-kind runner/review image split + `image_for`); mirrors the existing `runner` image-updater alias in this repo.

## Verification

- [x] `helm template charts/lightbridge-code-intelligence` → dispatcher carries **both** `AGENT_RUNNER_IMAGE` and `AGENT_REVIEW_RUNNER_IMAGE` (confirmed in render output).
- [x] `helm lint charts/lightbridge-code-intelligence` and `helm lint charts/apps` → both `1 chart(s) linted, 0 chart(s) failed`.
- [x] `charts/apps/values.yaml` parses (YAML load clean).

## Follow-up

[ai-helm-values#14](https://github.com/ADORSYS-GIS/ai-helm-values/pull/14) seeds `AGENT_REVIEW_RUNNER_IMAGE: ghcr.io/vymalo/lightbridge-agent-review:sha-<gitsha>` on the dispatcher (image-updater then owns it).

## AI Usage Declaration

AI (Claude Code) was used for: generating the image-updater alias + dispatcher env wiring, drafting this description, and running the `helm template`/`helm lint` verification.

- [x] I understand every change in this PR
- [x] I checked the generated manifests manually
- [x] I accept responsibility for this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
