### PR TITLE
feat(lci): map the ADR-0042 read-budget knobs (maxBatchSize etc.) to agent.json

### DIFF
--- a/charts/lightbridge-code-intelligence/templates/config.yaml
+++ b/charts/lightbridge-code-intelligence/templates/config.yaml
@@ -56,6 +56,13 @@ data:
 {{- if ne (toString $cfg.model.maxTokens) "" }}{{- $_ := set $rev "max_tokens" $cfg.model.maxTokens }}{{- end }}
 {{- if ne (toString $cfg.model.maxTurns) "" }}{{- $_ := set $rev "max_turns" $cfg.model.maxTurns }}{{- end }}
 {{- if ne (toString $cfg.model.contextWindow) "" }}{{- $_ := set $rev "context_window" $cfg.model.contextWindow }}{{- end }}
+{{- /* Risk-first read budgets (lightbridge-ci ADR-0042): max read-only tool calls run concurrently per
+       turn (max_batch_size), and the cumulative caps before the loop winds down. Empty → the runner's
+       built-in defaults (batch 8, files 30, searches 15, batches 6). The runner clamps each to ≥1. */}}
+{{- if ne (toString $cfg.model.maxBatchSize) "" }}{{- $_ := set $rev "max_batch_size" $cfg.model.maxBatchSize }}{{- end }}
+{{- if ne (toString $cfg.model.maxFilesRead) "" }}{{- $_ := set $rev "max_files_read" $cfg.model.maxFilesRead }}{{- end }}
+{{- if ne (toString $cfg.model.maxSearches) "" }}{{- $_ := set $rev "max_searches" $cfg.model.maxSearches }}{{- end }}
+{{- if ne (toString $cfg.model.maxBatches) "" }}{{- $_ := set $rev "max_batches" $cfg.model.maxBatches }}{{- end }}
 {{- /* SSE streaming toggle (#206) → agent.json review.stream. A bool; empty → omitted (runner default
        off). Needs a runner image carrying the review.stream field (lightbridge-ci #211) before it's set
        to true, else deny_unknown_fields fails the Job. */}}

--- a/charts/lightbridge-code-intelligence/values.yaml
+++ b/charts/lightbridge-code-intelligence/values.yaml
@@ -110,6 +110,14 @@ config:
     # Max agent turns per review (ADR-0037 loop). Empty → the runner's built-in default (40).
     # → agent.json `review.max_turns`.
     maxTurns: ""
+    # Risk-first read budgets (lightbridge-ci ADR-0042) → agent.json `review.*`. Empty → the runner's
+    # built-in defaults. maxBatchSize = max read-only tool calls run CONCURRENTLY per turn (default 8);
+    # the other three are cumulative caps before the loop winds down (default files 30 / searches 15 /
+    # batches 6). The runner clamps each to ≥1. Set per-env in ai-helm-values.
+    maxBatchSize: ""    # → review.max_batch_size (concurrent read-only tool calls per turn)
+    maxFilesRead: ""    # → review.max_files_read   (cumulative read_file cap)
+    maxSearches: ""     # → review.max_searches     (cumulative vector+graph search cap)
+    maxBatches: ""      # → review.max_batches      (cumulative investigation-round cap)
     # NB: there is no `fallbackModel` knob — the review failover model was removed (lightbridge-ci
     # ADR-0053 / #208), replaced by a single model + retry/backoff + circuit breaker. (Any ADR-NNNN
     # below refers to the lightbridge-ci repo's ADRs, not this chart's own ADR index.)


### PR DESCRIPTION
## What

Maps the **ADR-0042 risk-first read budgets** (lightbridge-ci) to `agent.json review.*` so an operator can tune them per-env from ai-helm-values **with no runner rebuild**. The runner already supports these fields — only the chart mapping was missing (same gap `stream`/`extra` had):

| value | → agent.json | meaning | default |
|---|---|---|---|
| `config.model.maxBatchSize` | `review.max_batch_size` | read-only tool calls run **concurrently** per turn | 8 |
| `config.model.maxFilesRead` | `review.max_files_read` | cumulative `read_file` cap | 30 |
| `config.model.maxSearches` | `review.max_searches` | cumulative vector+graph search cap | 15 |
| `config.model.maxBatches` | `review.max_batches` | cumulative investigation-round cap | 6 |

## Why

The motivating ask: bump the tool batch size from its default to 10. It was unsettable from YAML because the chart didn't map it (and the `LLM_MAX_BATCH_SIZE` env isn't injectable — the Job env is a fixed list in `k8s.rs`). This adds all four ADR-0042 knobs together since they're a coherent set and were all unmapped.

## Safety

Each knob is scalar + empty-guarded → omitted from `agent.json` when unset, so the chart is inert until an env sets a value. `deny_unknown_fields`-safe: these are long-standing ADR-0042 fields, present in the live review image (`sha-049597e`).

## Source of truth

- lightbridge-ci ADR-0042 (risk-first parallel batching + cumulative read budgets); the runner's `ReviewFile`/`ReviewConfig` already carry `max_batch_size` / `max_files_read` / `max_searches` / `max_batches`.

## Verification

- [x] `helm template` unset → **0** occurrences of any of the four keys (all omitted).
- [x] `helm template --set config.model.maxBatchSize=10` → `agent.json` review block has `"max_batch_size": 10`, the other three still omitted.
- [x] `helm lint` → `0 chart(s) failed`.

## AI Usage Declaration

AI (Claude Code) was used for: adding the four template mappings + values defaults, rendering verification, and drafting this description.

- [x] I understand every change in this PR
- [x] I checked the rendered `agent.json` manually
- [x] I accept responsibility for this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
