### PR TITLE
fix(same-origin-proxy): add NET_BIND_SERVICE so Caddy execs under no_new_privs

### DIFF
--- a/charts/same-origin-proxy/values.yaml
+++ b/charts/same-origin-proxy/values.yaml
@@ -64,6 +64,15 @@ containerSecurityContext:
   capabilities:
     drop:
       - ALL
+    # The caddy:2-alpine binary carries the `cap_net_bind_service` file
+    # capability (setcap +ep). With drop:ALL + allowPrivilegeEscalation:false
+    # (no_new_privs) the kernel refuses to exec a setcap binary whose cap isn't
+    # in the bounding set → "exec /usr/bin/caddy: operation not permitted" /
+    # CrashLoopBackOff. Granting exactly NET_BIND_SERVICE (the one add the
+    # restricted PSS allows) puts it in the bounding set so the exec is permitted.
+    # We bind :8080 (unprivileged), so it's never actually used at runtime.
+    add:
+      - NET_BIND_SERVICE
 
 # Ingress (Traefik) namespace — for the in-chart CiliumNetworkPolicy ingress rule
 # (the observability ns is default-deny-ingress).


### PR DESCRIPTION
## 1. Summary

This PR changes:

- Adds `NET_BIND_SERVICE` to the `same-origin-proxy` Caddy container capabilities (kept `drop: [ALL]`).

It solves:

- **Live regression caught in post-merge verification of #501**: the Caddy pod was `CrashLoopBackOff` with `exec /usr/bin/caddy: operation not permitted`. The `caddy:2-alpine` binary carries the `cap_net_bind_service` file capability (`setcap +ep`); with `drop: [ALL]` + `allowPrivilegeEscalation: false` (`no_new_privs`), the kernel refuses to exec a setcap binary whose cap isn't in the bounding set. Granting exactly `NET_BIND_SERVICE` (the only add the restricted PSS permits) puts it in the bounding set so the exec is allowed. We bind `:8080` (unprivileged), so the cap is never used at runtime.
- Source of truth: the live failure (pod logs) on PR #501's deploy — https://github.com/ADORSYS-GIS/ai-helm/pull/501

---

## 2. Intent

The intent of this PR is:

> Make the merged `same-origin-proxy` actually run, without weakening its hardening. Keep `readOnlyRootFilesystem: true`, non-root, `allowPrivilegeEscalation: false`, and `drop: [ALL]`; add only the single capability the restricted Pod Security Standard allows, to resolve the setcap-binary exec under `no_new_privs`.

---

## 3. Scope

### In Scope

- One-line capability add in `charts/same-origin-proxy/values.yaml`.

### Out of Scope

- No change to routing, the in-chart netpol, or the values-repo config.

---

## 4. Verification

I verified this change by:

- [x] Running automated tests
- [x] Checking logs

Commands run:

```bash
# live failure
kubectl -n observability logs <pod>            # exec /usr/bin/caddy: operation not permitted
# fix
helm template x charts/same-origin-proxy -f charts/same-origin-proxy/ci/lint-values.yaml   # capabilities: add NET_BIND_SERVICE, drop ALL, readOnlyRootFilesystem true
trivy config charts/same-origin-proxy --severity HIGH,CRITICAL   # 0 failures
helm lint charts/same-origin-proxy --strict -f .../ci/lint-values.yaml
```

Results:

```text
Grafana root unaffected (HTTP 302 — path route did not shadow it); only the feed path 503'd due to the crashloop.
After fix: render shows drop:[ALL] + add:[NET_BIND_SERVICE], readOnlyRootFilesystem:true; Trivy HIGH/CRITICAL 0; lint OK.
I will confirm the pod Running + the feed loading same-origin post-merge.
```

---

## 5. Screenshots / Evidence

* PR #501 deploy (the crashloop) — `charts/same-origin-proxy`

---

## 6. Risk Assessment

Risk level:

* [x] Low

Potential risks:

* `NET_BIND_SERVICE` is granted but unused (we bind :8080) — minimal surface; it's the single PSS-restricted-permitted add.

Mitigation:

* All other hardening retained (read-only root, non-root, no-priv-escalation, drop ALL).

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [x] Reviewing the diff

Human verification:

* [x] I understand every meaningful change in this PR
* [x] I checked generated code manually
* [x] I accept responsibility for this PR

---

## 8. Reviewer Focus

Please focus your review on:

* [x] Correctness
* [x] Security
