### PR TITLE
fix(same-origin-proxy): Caddy global options block (Caddyfile parse error)

### DIFF
--- a/charts/same-origin-proxy/templates/configmap.yaml
+++ b/charts/same-origin-proxy/templates/configmap.yaml
@@ -1,8 +1,14 @@
 {{- /*
-Caddyfile: one `handle <path>` block per route. `rewrite * <upstream.path>`
-forces that path to the one upstream resource, so a route can never be abused as
-an open proxy regardless of the request URL. TLS to the upstream is handled by
-Caddy (Go TLS); admin/auto_https off since Traefik terminates TLS at the ingress.
+Caddyfile: a leading GLOBAL OPTIONS block `{ admin off; auto_https off;
+persist_config off }` (these are global directives — they are NOT valid inside a
+site block, or Caddy aborts with "unrecognized directive: admin"), then a `:PORT`
+site block with one `handle <path>` per route. `rewrite * <upstream.path>` forces
+that path to the one upstream resource, so a route can never be abused as an open
+proxy regardless of the request URL. TLS to the upstream is handled by Caddy (Go
+TLS); auto_https off since Traefik terminates TLS at the ingress.
+⚠️ helm/lint/trivy do NOT validate Caddyfile syntax — only the running pod does.
+Validate changes: render this ConfigMap's Caddyfile and
+`docker run --rm -v <file>:/c/Caddyfile caddy:2-alpine caddy validate --config /c/Caddyfile --adapter caddyfile`.
 */}}
 apiVersion: v1
 kind: ConfigMap
@@ -12,10 +18,12 @@ metadata:
     app: {{ .Values.name }}
 data:
   Caddyfile: |-
-    :{{ .Values.port }} {
+    {
       admin off
       auto_https off
       persist_config off
+    }
+    :{{ .Values.port }} {
     {{- range .Values.routes }}
     {{- $scheme := .upstream.scheme | default "https" }}
       handle {{ .path }} {


### PR DESCRIPTION
## 1. Summary

This PR changes:

- Moves Caddy's global options (`admin off` / `auto_https off` / `persist_config off`) into a leading **global options block** `{ }`, out of the `:8080` site block.

It solves:

- **Second live regression on the #501 deploy** (found after the cap fix #502 let Caddy exec): the pod crashed with `adapting config: /etc/caddy/Caddyfile:2: unrecognized directive: admin`. Those are Caddy **global** directives — invalid inside a site block. The sibling MCP Caddyfile (ADR-0040) puts them in a leading `{ }` block; this matches it.
- Source of truth: the live pod logs on #501 — https://github.com/ADORSYS-GIS/ai-helm/pull/501

---

## 2. Intent

> Make the Caddyfile actually parse. helm/lint/trivy don't validate Caddyfile syntax (it's an opaque ConfigMap string), so this slipped through to runtime. Both the full (ci-values) and empty-routes renders now pass `caddy validate` ("Valid configuration"); a template comment documents how to validate going forward.

---

## 3. Scope

### In Scope
- Caddyfile structure fix (global block) + a validate-it note in the template comment.

### Out of Scope
- No change to routing, caps, netpol, or values-repo config.

---

## 4. Verification

I verified this change by:

- [x] Running automated tests
- [x] Checking logs

Commands run:

```bash
# render both shapes and validate with the real Caddy
helm template x charts/same-origin-proxy -f charts/same-origin-proxy/ci/lint-values.yaml --show-only templates/configmap.yaml   # full
helm template x charts/same-origin-proxy --show-only templates/configmap.yaml                                                   # empty-routes default
docker run --rm -v <file>:/c/Caddyfile caddy:2-alpine caddy validate --config /c/Caddyfile --adapter caddyfile
```

Results:

```text
Both renders → "Valid configuration".
(Prior live state: cap fix #502 let Caddy exec; it then failed on the global-directive-in-site-block error — now fixed.)
I will confirm pod Running + the feed HTTP 200 (atom) post-merge.
```

---

## 5. Screenshots / Evidence
* Live pod logs on #501; `charts/same-origin-proxy/templates/configmap.yaml`

---

## 6. Risk Assessment

Risk level:
* [x] Low

Potential risks:
* None beyond the one-file Caddyfile structure change; validated with the real Caddy binary.

Mitigation:
* `caddy validate` on both render shapes; template now documents the validation step.

---

## 7. AI Usage Declaration

AI was used for:
* [x] Understanding existing code
* [x] Generating code
* [x] Reviewing the diff

Human verification:
* [x] I understand every meaningful change in this PR
* [x] I checked generated code manually
* [x] I accept responsibility for this PR

---

## 8. Reviewer Focus
* [x] Correctness
