### PR TITLE
feat(lci): enable opengrep SAST by default → agent.json sast (lightbridge-ci ADR-0061)

### DIFF
--- a/charts/lightbridge-code-intelligence/templates/config.yaml
+++ b/charts/lightbridge-code-intelligence/templates/config.yaml
@@ -74,6 +74,20 @@ data:
 {{- /* NB: review.fallback_model is intentionally NOT mapped — the review failover model was removed
        (lightbridge-ci ADR-0053 / #208); a single model + retry/backoff + circuit breaker replaces it. */}}
 {{- $_ := set $ag "review" $rev }}
+{{- /* Deterministic SAST pass (lightbridge-ci ADR-0061) → agent.json `sast`. opengrep scans the PR's
+       changed files in the runner; findings ride the EXISTING review buffer (no second poster) and the
+       agent is made aware of them without gating. Default-ENABLED in this chart (config.sast.enabled).
+       ⚠️ Like review.stream, emitting this block REQUIRES a runner image that carries the `sast` field
+       AND the bundled opengrep binary + vendored rules (lightbridge-ci #223) — sent to an older runner,
+       deny_unknown_fields fails EVERY Job. (A missing opengrep binary is best-effort/non-fatal at run
+       time, but the FIELD must parse.) `enabled` is a bool; the other knobs empty → the runner defaults
+       (rules=/opt/opengrep-rules, min_severity=error, max_findings=25, timeout=300s). */}}
+{{- $sast := dict "enabled" $cfg.sast.enabled }}
+{{- if ne (toString $cfg.sast.rules) "" }}{{- $_ := set $sast "rules" $cfg.sast.rules }}{{- end }}
+{{- if ne (toString $cfg.sast.minSeverity) "" }}{{- $_ := set $sast "min_severity" $cfg.sast.minSeverity }}{{- end }}
+{{- if ne (toString $cfg.sast.maxFindings) "" }}{{- $_ := set $sast "max_findings" $cfg.sast.maxFindings }}{{- end }}
+{{- if ne (toString $cfg.sast.timeoutSecs) "" }}{{- $_ := set $sast "timeout_secs" $cfg.sast.timeoutSecs }}{{- end }}
+{{- $_ := set $ag "sast" $sast }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/lightbridge-code-intelligence/values.yaml
+++ b/charts/lightbridge-code-intelligence/values.yaml
@@ -136,6 +136,31 @@ config:
     # and finalizes (never discards findings) if it still overruns.
     contextWindow: ""
 
+  # Deterministic SAST pass (lightbridge-ci ADR-0061) → agent.json `sast`. opengrep scans the PR's
+  # changed files in the runner; findings ride the EXISTING review buffer (the control plane scopes +
+  # posts them in the one grouped review — NOT reviewdog, NOT a second poster), and the review agent is
+  # made AWARE of them (a prompt digest) without GATING them. Deterministic, token-free, opt-in upstream
+  # but ENABLED BY DEFAULT here.
+  #
+  # ⚠️ REQUIRES a runner image that carries the `sast` agent.json field + the bundled opengrep binary and
+  # vendored rules (lightbridge-ci #223). Emitted to an OLDER runner image, the `sast` block fails EVERY
+  # Job via deny_unknown_fields — verify AGENT_RUNNER_IMAGE + AGENT_REVIEW_RUNNER_IMAGE are ≥ that build
+  # before this lands. (At run time a missing opengrep binary is best-effort/non-fatal — the scan just
+  # no-ops — but the field itself must parse.)
+  sast:
+    enabled: true
+    # opengrep `--config` value. Empty → the runner default: the vendored /opt/opengrep-rules set baked
+    # into the image (hermetic, no registry fetch). Override per-env to narrow the rules to your stack.
+    rules: ""
+    # Minimum SARIF level to surface (error|warning|note). Empty → runner default (error — high-signal,
+    # mostly real security/correctness, so the first rollout doesn't flood PRs). Lower per-env to widen.
+    minSeverity: ""
+    # Cap on findings posted per review (excess logged, not silently dropped). Empty → runner default (25).
+    maxFindings: ""
+    # Wall-clock ceiling on one scan, seconds. Empty → runner default (300). On timeout the pass is
+    # abandoned (non-fatal).
+    timeoutSecs: ""
+
   # PR feedback the control plane applies (FILE-ONLY knobs — no env equivalent).
   review:
     reactions: true        # 👀 started → 🎉 done / 😕 errored on the PR description


### PR DESCRIPTION
## 1. Summary

This PR changes:

- Maps `config.sast.*` → `agent.json` `sast` in the `lightbridge-code-intelligence` chart (config.yaml).
- Adds the `config.sast` block to the chart `values.yaml`, **enabled by default** (`enabled: true`); rules/severity/cap/timeout left empty → the runner's built-in defaults.

It solves:

- Deploying the deterministic opengrep SAST pass: lightbridge-ci ADR-0061 (vymalo/lightbridge-code-intelligence#223, merged). This is the chart-side wiring + default-on switch.

---

## 2. Intent

> opengrep runs in the runner over the PR's changed files; its findings ride the **existing** review buffer (the control plane scopes + posts them in the one grouped review — **not** reviewdog, **not** a second poster), and the review agent is made *aware* of them via a prompt digest **without gating** them. A deterministic, token-free security signal alongside the LLM reviewer. The user asked for it on **by default in the chart**, not just per-env.

---

## 3. Scope

### In Scope

- The `config.sast` → `agent.json.sast` mapping + the chart default (`enabled: true`).

### Out of Scope

- The runner code / opengrep binary / vendored rules — they ship in the runner image (lightbridge-ci #223, already published + pinned).
- Per-env overrides in ai-helm-values (none needed: the chart default flows through; narrow `config.sast.rules`/`minSeverity` there if prod gets noisy).
- The separate **CI-native** opengrep effort (this repo's ADR-0065/0066) — a different surface.

---

## 4. Verification

I verified this change by:

- [x] Running automated tests (`helm template`)
- [ ] Running manual tests
- [ ] Checking logs
- [ ] Checking metrics
- [ ] Testing error cases
- [x] Testing rollback or failure behavior, if relevant (deny_unknown_fields ordering — see Risk)

Commands run:

```bash
helm dependency build
helm template lci . --set agents.enabled=true --show-only templates/config.yaml
```

Results:

```text
agent.json: {"embeddings":{...},"review":{...},"sast":{"enabled":true}}
```

The emitted `sast` block carries only `enabled` (other knobs empty → omitted → runner defaults), and parses cleanly under the runner's `deny_unknown_fields` (all `SastFile` fields are optional).

---

## 6. Risk Assessment

Risk level:

* [x] Low
* [ ] Medium
* [ ] High

Potential risks:

* **deny_unknown_fields ordering** — emitting `sast` to a runner image without the field fails EVERY Job (the documented review.stream/contextWindow footgun).
* First-run PR noise from the default ruleset.

Mitigation:

* **Gate already satisfied:** `AGENT_RUNNER_IMAGE` + `AGENT_REVIEW_RUNNER_IMAGE` are pinned to `sha-3f9c3e4` (the #223 merge) in ai-helm-values, which carries the `sast` field + the bundled opengrep binary/rules. At run time a missing binary is best-effort/non-fatal (the scan no-ops).
* Default `min_severity=error` + changed-files-only scope + `max_findings=25` keep noise down; narrow `config.sast.rules` per-env if needed.

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [x] Drafting documentation
* [x] Reviewing the diff

Human verification:

* [ ] I understand every meaningful change in this PR
* [ ] I checked generated code manually
* [ ] I accept responsibility for this PR

> AI (Claude) authored the mapping + values + this body. Human review pending — AI output is not truth.

---

## 8. Reviewer Focus

Please focus your review on:

* [x] Correctness (the template mapping + the bool render)
* [x] Architecture (default-on posture)
* [x] Product intent
* [x] Edge cases (the image-ordering gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
