### PR TITLE
docs(authz): correct LibreChat email + cardinality wording (ADR-0068 review)

### DIFF
--- a/charts/observability-dashboards/files/envoy-ai-gateway/jwt-tokens.json
+++ b/charts/observability-dashboards/files/envoy-ai-gateway/jwt-tokens.json
@@ -65,7 +65,7 @@
   "annotations": {},
   "uid": "envoy-ai-gateway-jwt-tokens",
   "title": "AI Gateway — JWT tokens x consumption",
-  "description": "Per-JWT (the oidc_jti access-token id) consumption — cost / tokens / requests — and last usages, with the email taken from the JWT claim ONLY (the Loki `email` label, not the Keycloak directory). Known service callers (GitHub CI, LCI, LibreChat) show a structured synthetic identity (<resource>@<service> / <kind>:<id>, ADR-0068); genuine gaps show their `missing:*`/`unstamped:*` sentinel. Loki-backed because oidc_jti is an access-log body field, never a Mimir label (per-token cardinality, ADR-0064). Cost ÷1e6 for USD. Filters: email, model. GENERATED — source: tools/dashboards/envoy_ai_gateway/jwt_tokens.py.",
+  "description": "Per-JWT (the oidc_jti access-token id) consumption — cost / tokens / requests — and last usages, with the email taken from the JWT claim ONLY (the Loki `email` label, not the Keycloak directory). GitHub CI and LCI show a synthetic <resource>@<service> email; LibreChat keeps its real forwarded email; all three get a synthetic <kind>:<id> jti (ADR-0068). Genuine gaps show their `missing:*`/`unstamped:*` sentinel. Loki-backed because oidc_jti is an access-log body field, never a Mimir label (per-token cardinality, ADR-0064). Cost ÷1e6 for USD. Filters: email, model. GENERATED — source: tools/dashboards/envoy_ai_gateway/jwt_tokens.py.",
   "tags": [
     "ai-gateway",
     "per-user",

--- a/docs/architecture/08-observability.md
+++ b/docs/architecture/08-observability.md
@@ -152,10 +152,10 @@ behind it.
 the JWT id `oidc_jti` (an access-log **body** field — deliberately never a Mimir
 label, ADR-0064) × the JWT-derived `email` label: per-token cost/tokens/requests,
 a cost-per-JWT timeseries, and a last-usages logs panel. Email comes from the JWT
-claim **only** (the `email` label, not the Keycloak datasource); known service
-callers (GitHub CI, LCI, LibreChat) show a structured synthetic identity
-(`<resource>@<service>` / `<kind>:<id>`, ADR-0068), genuine gaps their
-`missing:*`/`unstamped:*` sentinel. ⚠️ LogQL trap: extract `oidc_jti` in the
+claim **only** (the `email` label, not the Keycloak datasource); GitHub CI and
+LCI show a synthetic `<resource>@<service>` email, LibreChat keeps its real
+forwarded email, and all three get a synthetic `<kind>:<id>` jti (ADR-0068);
+genuine gaps show their `missing:*`/`unstamped:*` sentinel. ⚠️ LogQL trap: extract `oidc_jti` in the
 *same* `| json` the outer `sum by` groups on, or it collapses to `-`. Full guide:
 [`jwt-token-observability.md`](../jwt-token-observability.md).
 

--- a/docs/per-user-observability.md
+++ b/docs/per-user-observability.md
@@ -163,7 +163,7 @@ body and is queried with `| json | <field>=~"..."`.
 | `user_id` | `user_id` ← `x-oidc-user-id` (JWT `sub`) | One value per registered user | Primary attribution dimension; required for per-user dashboards |
 | `azp` | `azp` ← `x-oidc-azp` (JWT `azp`) | One value per Keycloak client (~10–20) | Lets dashboards split human vs SA traffic and pivot by app |
 | `model` | `gen_ai.request.model` ← `x-ai-eg-model` | One value per catalog model (~10–20) | Backs the dashboard's model variable + per-model splits without a body parse (ADR-0046) |
-| `email` | `oidc_email` ← `x-oidc-email` (JWT `email`) | 1:1 with user_id — adds no stream cardinality | Unique human-readable user identity; PII (stored in label index) |
+| `email` | `oidc_email` ← `x-oidc-email` (JWT `email`) | ≤ user_id granularity — adds no stream cardinality | Unique human-readable user identity; PII (stored in label index). Humans: 1:1 with user_id. Synthetic service emails (ADR-0068, e.g. `<repo>@gh-runners`) are **coarser** than user_id (one email per repo, while user_id = the GitHub `sub` carries repo+ref) — functionally determined by it, so no new streams. |
 | `display_name` | `oidc_name` ← `x-oidc-name` (JWT `name`, e.g. "Kunga Derick") | 1:1 with user_id | Human-readable label for bar charts; first name extracted at query time via `label_replace` |
 | `billing_plan` | `billing_plan` ← `x-billing-plan` | 4 distinct values (free/pro/service/internal) | Very cheap; enables tier segmentation in dashboards |
 

--- a/tools/dashboards/src/dashboards/envoy_ai_gateway/jwt_tokens.py
+++ b/tools/dashboards/src/dashboards/envoy_ai_gateway/jwt_tokens.py
@@ -3,10 +3,11 @@
 Per **JWT** (the `oidc_jti` access-token id) consumption — cost / tokens /
 requests — and last usages, alongside the **email from the JWT claim only**
 (the Loki `email` label Alloy promotes from `oidc_email`), NOT the Keycloak
-directory. Known non-human callers (GitHub CI, LCI, LibreChat) carry a
-structured synthetic identity Authorino builds from the request — `email =
-<resource>@<service>`, `jti = <kind>:<id>` (ADR-0068) — while genuine gaps still
-show their honest `missing:*` / `unstamped:*` sentinel: the "from the JWT only" view.
+directory. Known non-human callers get an identity Authorino builds from the
+request (ADR-0068): GitHub CI and LCI get a synthetic `email = <resource>@<service>`;
+LibreChat keeps its **real** forwarded user email — and all three get a synthetic
+`jti = <kind>:<id>`. Genuine gaps still show their honest `missing:*` /
+`unstamped:*` sentinel: the "from the JWT only" view.
 
 Why Loki (not Mimir): the JWT id `oidc_jti` is an access-log **body** field —
 it is deliberately NOT promoted to a Mimir metric label (per-token cardinality;
@@ -291,10 +292,10 @@ def _multi_var(*, name: str, label: str, definition: str) -> db.QueryVariable:
 _DESCRIPTION = (
     "Per-JWT (the oidc_jti access-token id) consumption — cost / tokens / requests "
     "— and last usages, with the email taken from the JWT claim ONLY (the Loki "
-    "`email` label, not the Keycloak directory). Known service callers (GitHub CI, "
-    "LCI, LibreChat) show a structured synthetic identity (<resource>@<service> / "
-    "<kind>:<id>, ADR-0068); genuine gaps show their `missing:*`/`unstamped:*` "
-    "sentinel. Loki-backed because oidc_jti is an "
+    "`email` label, not the Keycloak directory). GitHub CI and LCI show a synthetic "
+    "<resource>@<service> email; LibreChat keeps its real forwarded email; all three "
+    "get a synthetic <kind>:<id> jti (ADR-0068). Genuine gaps show their "
+    "`missing:*`/`unstamped:*` sentinel. Loki-backed because oidc_jti is an "
     "access-log body field, never a Mimir label (per-token cardinality, ADR-0064). "
     "Cost ÷1e6 for USD. Filters: email, model. "
     "GENERATED — source: tools/dashboards/envoy_ai_gateway/jwt_tokens.py."


### PR DESCRIPTION
## 1. Summary
Doc/description corrections addressing the `lightbridge-assistant` P2 review findings on #512 (ADR-0068).

- **LibreChat email mislabel** (`jwt_tokens.py` docstring + `_DESCRIPTION`; `docs/architecture/08-observability.md`): the prose implied all three known callers show a synthetic `<resource>@<service>` email. Per ADR-0068, only **GitHub CI + LCI** get a synthetic email; **LibreChat keeps its real forwarded user email** — only the jti is synthetic. Split the two axes (`arc42.md` already had it right). Regenerated `jwt-tokens.json` (drift green).
- **email cardinality wording** (`docs/per-user-observability.md`): clarified the "1:1 with user_id" budget note to "≤ user_id granularity" and spelled out that synthetic service emails are *coarser* than `user_id` → no new streams.

**Source of truth:** review findings on https://github.com/ADORSYS-GIS/ai-helm/pull/512 ; design in ADR-0068.

## 2. Intent
> Keep the ADR-0068 docs factually precise about which identity axis is synthetic per caller, and correct the cardinality note the bot flagged (while rebutting its "multiplicative streams" rationale — a synthetic email is functionally determined by the finer `user_id`).

## 4. Verification
- [x] Running automated tests

```bash
cd tools/dashboards && uv run dashboards build && uv run dashboards check
```
```text
wrote charts/observability-dashboards/files/envoy-ai-gateway/jwt-tokens.json
ok — every dashboard matches its generator
```

## 6. Risk Assessment
Risk level: **Low** — docs + a dashboard description string only.

## 7. AI Usage Declaration
AI used for: drafting documentation, reviewing the diff. I understand every change and accept responsibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
