### PR TITLE
feat(lci): render per-tier review config (review.fast / review.deep) — ADR-0062

### DIFF
--- a/charts/lightbridge-code-intelligence/templates/config.yaml
+++ b/charts/lightbridge-code-intelligence/templates/config.yaml
@@ -73,6 +73,39 @@ data:
 {{- if $cfg.model.extra }}{{- $_ := set $rev "extra" $cfg.model.extra }}{{- end }}
 {{- /* NB: review.fallback_model is intentionally NOT mapped — the review failover model was removed
        (lightbridge-ci ADR-0053 / #208); a single model + retry/backoff + circuit breaker replaces it. */}}
+{{- /* Two-tier review (lightbridge-ci ADR-0062) → agent.json review.fast / review.deep. Each tier is a
+       COMPLETE, independent block: it shares the gateway (env) + system prompt (mounted file), and carries
+       its OWN model + generation/budget knobs. Set per tier in ai-helm-values (config.model.fast.* /
+       config.model.deep.*); `fast` is the automatic PR-opened pass (cheap model, single diff-only turn —
+       the runner enforces 1 turn + no retrieval regardless of maxTurns), `deep` is the `@mention` run
+       (strong model, long timeout). When a tier is unset the runner falls back to the flat review.* above.
+       ⚠️ REQUIRES a runner image carrying review.fast/review.deep (lightbridge-ci #233) before these are
+       set, else deny_unknown_fields fails every Job (ship the runner first). */}}
+{{- /* Truthiness guards (NOT `ne (toString …) ""`): an unset key in a `{}` tier block is nil, and
+       `toString nil` is "<nil>" (≠ ""), which would emit a JSON `null` the runner rejects. Truthiness
+       skips nil / "" / 0 / false cleanly. The whole tier is gated on a non-empty `model` so the default
+       (empty `fast: {}` / `deep: {}`) emits nothing → the runner uses the flat review.* (back-compat). */}}
+{{- range $tier := list "fast" "deep" }}
+{{- $tv := index $cfg.model $tier }}
+{{- if and $tv $tv.model }}
+{{- $t := dict "base_url" "{env:LLM_BASE_URL}" "api_key" "{env:LLM_API_KEY}" "model" $tv.model }}
+{{- if ne (toString $cfg.reviewSystemPrompt) "" }}{{- $_ := set $t "system_prompt_file" "/etc/lightbridge/review-system.md" }}{{- end }}
+{{- if $tv.maxDiffChars }}{{- $_ := set $t "max_diff_chars" $tv.maxDiffChars }}{{- end }}
+{{- if $tv.temperature }}{{- $_ := set $t "temperature" $tv.temperature }}{{- end }}
+{{- if $tv.topP }}{{- $_ := set $t "top_p" $tv.topP }}{{- end }}
+{{- if $tv.maxTokens }}{{- $_ := set $t "max_tokens" $tv.maxTokens }}{{- end }}
+{{- if $tv.maxTurns }}{{- $_ := set $t "max_turns" $tv.maxTurns }}{{- end }}
+{{- if $tv.maxBatchSize }}{{- $_ := set $t "max_batch_size" $tv.maxBatchSize }}{{- end }}
+{{- if $tv.maxFilesRead }}{{- $_ := set $t "max_files_read" $tv.maxFilesRead }}{{- end }}
+{{- if $tv.maxSearches }}{{- $_ := set $t "max_searches" $tv.maxSearches }}{{- end }}
+{{- if $tv.maxBatches }}{{- $_ := set $t "max_batches" $tv.maxBatches }}{{- end }}
+{{- if $tv.contextWindow }}{{- $_ := set $t "context_window" $tv.contextWindow }}{{- end }}
+{{- if $tv.requestTimeoutSecs }}{{- $_ := set $t "request_timeout_secs" $tv.requestTimeoutSecs }}{{- end }}
+{{- if $tv.stream }}{{- $_ := set $t "stream" $tv.stream }}{{- end }}
+{{- if $tv.extra }}{{- $_ := set $t "extra" $tv.extra }}{{- end }}
+{{- $_ := set $rev $tier $t }}
+{{- end }}
+{{- end }}
 {{- $_ := set $ag "review" $rev }}
 {{- /* Deterministic SAST pass (lightbridge-ci ADR-0061) → agent.json `sast`. opengrep scans the PR's
        changed files in the runner; findings ride the EXISTING review buffer (no second poster) and the

--- a/charts/lightbridge-code-intelligence/values.yaml
+++ b/charts/lightbridge-code-intelligence/values.yaml
@@ -136,6 +136,20 @@ config:
     # and finalizes (never discards findings) if it still overruns.
     contextWindow: ""
 
+    # Two-tier review (lightbridge-ci ADR-0062) → agent.json `review.fast` / `review.deep`. Each is a
+    # COMPLETE, independent per-tier config: it shares the gateway (env) + system prompt, and carries its
+    # OWN model + the same generation/budget knobs as above (model, extra, maxTurns, stream,
+    # requestTimeoutSecs, contextWindow, maxTokens, temperature, topP, maxDiffChars, max* read budgets).
+    # `fast`  = the automatic `pull_request opened` pass (cheap model; the runner enforces a single
+    #           diff-only turn with no retrieval regardless of maxTurns — SAST is the backbone).
+    # `deep`  = the `@mention` run (strong model, long requestTimeoutSecs; full retrieval + multi-turn).
+    # Leave BOTH empty (the default) to keep the single flat `model.*` config for every review (legacy).
+    # Set them per-env in ai-helm-values. `model` is required within a tier block (an empty model
+    # disables that tier). ⚠️ REQUIRES a runner image carrying `review.fast`/`review.deep`
+    # (lightbridge-ci #233) before these are set, else deny_unknown_fields fails every Job.
+    fast: {}
+    deep: {}
+
   # Deterministic SAST pass (lightbridge-ci ADR-0061) → agent.json `sast`. opengrep scans the PR's
   # changed files in the runner; findings ride the EXISTING review buffer (the control plane scopes +
   # posts them in the one grouped review — NOT reviewdog, NOT a second poster), and the review agent is


### PR DESCRIPTION
Renders the new optional `config.model.fast.*` / `config.model.deep.*` into `agent.json` `review.fast` / `review.deep`, enabling lightbridge-ci two-tier review (#232/#233) to run a **fully-independent config per tier** — own model + generation/budget knobs, sharing the gateway env + system prompt.

## Behavior
- A tier block is emitted **only when its `model` is non-empty**. Default (empty `fast: {}` / `deep: {}`) → nothing emitted → existing installs keep the single flat `review.*` block (**back-compat**).
- Truthiness guards (not `ne (toString …) ""`) so an unset key in a `{}` tier block does not emit a JSON `null` the runner rejects.
- Adds `request_timeout_secs` mapping (deep wants a long timeout; was not previously mapped).

## Verified
`helm lint` clean. `helm template` with `config.model.fast/deep` set → clean complete per-tier blocks (no nulls); with neither set → flat block only, no `fast`/`deep`.

## ⚠️ Deploy order
Requires a runner image carrying `review.fast`/`review.deep` (lightbridge-ci #233) to roll **before** ai-helm-values sets these blocks — otherwise `deny_unknown_fields` fails every runner Job. This chart change is inert until ai-helm-values populates the blocks.

Refs: lightbridge-ci ADR-0062, #232 (tier plumbing + fast loop), #233 (per-tier config in the runner).

🤖 Generated with [Claude Code](https://claude.com/claude-code)