### PR TITLE
feat(lci): fast-tier lean prompt + per-tier tool allowlist (ADR-0062)

### DIFF
--- a/charts/lightbridge-code-intelligence/templates/config.yaml
+++ b/charts/lightbridge-code-intelligence/templates/config.yaml
@@ -89,7 +89,24 @@ data:
 {{- $tv := index $cfg.model $tier }}
 {{- if and $tv $tv.model }}
 {{- $t := dict "base_url" "{env:LLM_BASE_URL}" "api_key" "{env:LLM_API_KEY}" "model" $tv.model }}
-{{- if ne (toString $cfg.reviewSystemPrompt) "" }}{{- $_ := set $t "system_prompt_file" "/etc/lightbridge/review-system.md" }}{{- end }}
+{{- /* Per-tier system prompt (lightbridge-ci ADR-0062): the FAST tier may use its own lean prompt
+       (config.reviewSystemPromptFast → review-system-fast.md) that tells the model it has no retrieval,
+       to review the diff directly and `finish` with a verdict — stops it burning turns calling tools it
+       can't use, and improves severity calibration. When reviewSystemPromptFast is empty the fast tier
+       falls back to the shared review-system.md; the DEEP tier always uses the shared prompt. */}}
+{{- $promptFile := "" }}
+{{- if and (eq $tier "fast") (ne (toString $cfg.reviewSystemPromptFast) "") }}
+{{- $promptFile = "/etc/lightbridge/review-system-fast.md" }}
+{{- else if ne (toString $cfg.reviewSystemPrompt) "" }}
+{{- $promptFile = "/etc/lightbridge/review-system.md" }}
+{{- end }}
+{{- if ne $promptFile "" }}{{- $_ := set $t "system_prompt_file" $promptFile }}{{- end }}
+{{- /* Per-tier tool allowlist (lightbridge-ci ADR-0062): the exact tools this tier offers the model,
+       e.g. ["add_review_comment","finish","abort"] for a diff-only fast pass. A list → truthy only when
+       non-empty; unset → the runner's built-in per-tier default. The runner validates every name and
+       fails closed on an unknown one. REQUIRES a runner image carrying review.<tier>.tools
+       (lightbridge-ci #237) before this is set, else deny_unknown_fields fails every Job. */}}
+{{- if $tv.tools }}{{- $_ := set $t "tools" $tv.tools }}{{- end }}
 {{- if $tv.maxDiffChars }}{{- $_ := set $t "max_diff_chars" $tv.maxDiffChars }}{{- end }}
 {{- if $tv.temperature }}{{- $_ := set $t "temperature" $tv.temperature }}{{- end }}
 {{- if $tv.topP }}{{- $_ := set $t "top_p" $tv.topP }}{{- end }}
@@ -133,5 +150,11 @@ data:
 {{- if ne (toString $cfg.reviewSystemPrompt) "" }}
   review-system.md: |
 {{ $cfg.reviewSystemPrompt | indent 4 }}
+{{- end }}
+{{- /* The FAST tier's lean prompt (lightbridge-ci ADR-0062), mounted as a second file the fast tier
+       points at via review.fast.system_prompt_file. Empty → the fast tier reuses review-system.md. */}}
+{{- if ne (toString $cfg.reviewSystemPromptFast) "" }}
+  review-system-fast.md: |
+{{ $cfg.reviewSystemPromptFast | indent 4 }}
 {{- end }}
 {{- end }}

--- a/charts/lightbridge-code-intelligence/values.yaml
+++ b/charts/lightbridge-code-intelligence/values.yaml
@@ -99,6 +99,15 @@ config:
   # add_review_comment / add_comment / finish) is appended by the runner and is not part of this text.
   reviewSystemPrompt: ""
 
+  # The FAST tier's own lean system prompt (lightbridge-ci ADR-0062) → mounted as review-system-fast.md
+  # and pointed at by review.fast.system_prompt_file. Tell the fast model it has NO retrieval/read_file,
+  # to review the diff directly, record findings with add_review_comment, and ALWAYS `finish` with a
+  # verdict (even if clean) — and to raise only what's provable from the diff (phrase the unverifiable as
+  # a question, not a P0/P1). This stops the fast pass burning turns on tools it can't call and fixes the
+  # over-confident severities seen when it reused the deep prompt. Empty → the fast tier reuses
+  # reviewSystemPrompt. Set per-env in ai-helm-values.
+  reviewSystemPromptFast: ""
+
   # Review LLM generation params → the model's `options` in opencode.json. Empty → model/provider
   # default. (max_diff_chars caps the diff pasted into the prompt.) maxTurns is operator-tuned per-env
   # → ai-helm-values; the rest stay empty (provider defaults) until an env needs them.
@@ -147,6 +156,15 @@ config:
     # Set them per-env in ai-helm-values. `model` is required within a tier block (an empty model
     # disables that tier). ⚠️ REQUIRES a runner image carrying `review.fast`/`review.deep`
     # (lightbridge-ci #233) before these are set, else deny_unknown_fields fails every Job.
+    #
+    # Per-tier TOOL ALLOWLIST (lightbridge-ci ADR-0062) → agent.json `review.<tier>.tools`: a list of the
+    # exact tool names that tier offers the model. Unset → the runner's built-in per-tier default (full
+    # surface for deep; the write/finish/abort set for fast). For a true diff-only fast pass set e.g.
+    #   fast: { model: "...", tools: ["add_review_comment", "finish", "abort"] }
+    # Valid names: lightbridge_vector_semantic_search, lightbridge_graph_find_symbol,
+    # lightbridge_graph_get_callers, read_file, add_review_comment, retract_finding, add_comment, finish,
+    # report_progress, abort. The runner validates every name and fails the review closed on an unknown
+    # one. ⚠️ REQUIRES a runner image carrying `review.<tier>.tools` before it's set.
     fast: {}
     deep: {}
 


### PR DESCRIPTION
## Summary

Renders two new `agent.json` knobs for the two-tier fast pass (lightbridge-ci ADR-0062):

- **`review.<tier>.tools`** — a per-tier tool allowlist from `config.model.<tier>.tools` (a list → truthy-guarded). Operators declare exactly which tools a tier offers (prod fast = `[add_review_comment, finish, abort]`); the runner validates names (closed enum) and **fails closed** on an unknown one.
- **`review.fast.system_prompt_file` → `review-system-fast.md`** when `config.reviewSystemPromptFast` is set (else fast reuses `review-system.md`). Mounts the lean fast prompt as a second ConfigMap file. Deep keeps the shared `reviewSystemPrompt`.

## Intent

Make the automatic fast review a true diff-only quick pass: a lean prompt (no retrieval) + an explicit per-tier tool set, so the model stops calling tools it can't use and stops over-rating unverifiable concerns. Companion to the runner change that consumes these fields.

## Source of truth

- lightbridge-ci ADR-0062 (two-tier review).
- Runner PR that adds `review.<tier>.tools`: https://github.com/vymalo/lightbridge-code-intelligence/pull/237
- Companion prod values: https://github.com/ADORSYS-GIS/ai-helm-values/pull/23

## Verification

- [x] Rendered the chart against the prod values and inspected `agent.json`.

Commands run:

```bash
helm template lci charts/lightbridge-code-intelligence \
  -f ../ai-helm-values/environments/prod/values/lightbridge-code-intelligence.yaml \
  --show-only templates/config.yaml
```

Result:

```text
review.fast → { model: adorsys-reviewer, system_prompt_file: /etc/lightbridge/review-system-fast.md,
                tools: [add_review_comment, finish, abort], max_turns: 5, request_timeout_secs: 600 }
review.deep → system_prompt_file: /etc/lightbridge/review-system.md (no tools)
ConfigMap data: agent.json, review-system.md, review-system-fast.md
```

Both knobs are opt-in (chart defaults empty → render-neutral for any env that doesn't set them).

## Risk

Medium. `deny_unknown_fields`: the chart must not emit `review.<tier>.tools` until the runner image carrying it is live. Deploy order: runner image (lightbridge-ci#237, live as `sha-3f5b95b`) → this chart → ai-helm-values#23 (already merged). Verified both runner images rolled to `sha-3f5b95b` before requesting this merge.

## AI Usage Declaration

AI was used for:

- [x] Generating code (chart template + values plumbing)
- [x] Drafting documentation (this description)
- [x] Reviewing the diff (rendered + verified the output)

Human verification:

- [x] I understand every meaningful change in this PR
- [x] I checked the rendered `agent.json` and confirmed the deploy ordering
- [x] I accept responsibility for this PR
