### PR TITLE
chore(lci): finish poller→reconciler rename in the deployment (ADR-0058)

### DIFF
--- a/charts/apps/values.yaml
+++ b/charts/apps/values.yaml
@@ -497,10 +497,10 @@ applications:
       # declares, which otherwise show a permanent cosmetic OutOfSync + selfHeal churn.
       # ServerSideDiff ignores those server-owned fields so the app reads Synced.
       argocd.argoproj.io/compare-options: ServerSideDiff=true
-      # Images aliased: cp/disp/poll (control-plane, role-selected), web, runner (the one-shot
+      # Images aliased: cp/disp/recon (control-plane, role-selected), web, runner (the one-shot
       # agent-runner/indexer image the dispatcher launches), and review (the slimmer review-only Job
       # image — no Python/Graphify — picked for review tasks; ADR-0004 per-kind images, #207).
-      argocd-image-updater.argoproj.io/image-list: cp=ghcr.io/vymalo/lightbridge-control-plane,disp=ghcr.io/vymalo/lightbridge-control-plane,poll=ghcr.io/vymalo/lightbridge-control-plane,web=ghcr.io/vymalo/lightbridge-web,runner=ghcr.io/vymalo/lightbridge-agent-runner,review=ghcr.io/vymalo/lightbridge-agent-review
+      argocd-image-updater.argoproj.io/image-list: cp=ghcr.io/vymalo/lightbridge-control-plane,disp=ghcr.io/vymalo/lightbridge-control-plane,recon=ghcr.io/vymalo/lightbridge-control-plane,web=ghcr.io/vymalo/lightbridge-web,runner=ghcr.io/vymalo/lightbridge-agent-runner,review=ghcr.io/vymalo/lightbridge-agent-review
       # ── control-plane ──
       argocd-image-updater.argoproj.io/cp.update-strategy: newest-build
       argocd-image-updater.argoproj.io/cp.allow-tags: regexp:^sha-[0-9a-f]+$
@@ -520,16 +520,17 @@ applications:
       argocd-image-updater.argoproj.io/disp.signature-type: cosign
       argocd-image-updater.argoproj.io/disp.cosign.certificate-oidc-issuer: https://token.actions.githubusercontent.com
       argocd-image-updater.argoproj.io/disp.cosign.certificate-identity-regexp: ^https://github\.com/vymalo/lightbridge-code-intelligence/\.github/workflows/build-images\.yml@.*$
-      # ── poller (SAME image as control-plane, role-selected) — keeps its tag in lockstep so the
-      #    feedback reconcile loop never lags the control-plane on a build. ──
-      argocd-image-updater.argoproj.io/poll.update-strategy: newest-build
-      argocd-image-updater.argoproj.io/poll.allow-tags: regexp:^sha-[0-9a-f]+$
-      argocd-image-updater.argoproj.io/poll.force-update: "true"
-      argocd-image-updater.argoproj.io/poll.helm.image-name: lci.controllers.poller.containers.main.image.repository
-      argocd-image-updater.argoproj.io/poll.helm.image-tag: lci.controllers.poller.containers.main.image.tag
-      argocd-image-updater.argoproj.io/poll.signature-type: cosign
-      argocd-image-updater.argoproj.io/poll.cosign.certificate-oidc-issuer: https://token.actions.githubusercontent.com
-      argocd-image-updater.argoproj.io/poll.cosign.certificate-identity-regexp: ^https://github\.com/vymalo/lightbridge-code-intelligence/\.github/workflows/build-images\.yml@.*$
+      # ── reconciler (SAME image as control-plane, role-selected) — the single GitHub-egress drainer +
+      #    feedback poll; keeps its tag in lockstep so egress never lags the control-plane on a build.
+      #    (alias `recon`; was `poll` before the ADR-0058 rename.) ──
+      argocd-image-updater.argoproj.io/recon.update-strategy: newest-build
+      argocd-image-updater.argoproj.io/recon.allow-tags: regexp:^sha-[0-9a-f]+$
+      argocd-image-updater.argoproj.io/recon.force-update: "true"
+      argocd-image-updater.argoproj.io/recon.helm.image-name: lci.controllers.reconciler.containers.main.image.repository
+      argocd-image-updater.argoproj.io/recon.helm.image-tag: lci.controllers.reconciler.containers.main.image.tag
+      argocd-image-updater.argoproj.io/recon.signature-type: cosign
+      argocd-image-updater.argoproj.io/recon.cosign.certificate-oidc-issuer: https://token.actions.githubusercontent.com
+      argocd-image-updater.argoproj.io/recon.cosign.certificate-identity-regexp: ^https://github\.com/vymalo/lightbridge-code-intelligence/\.github/workflows/build-images\.yml@.*$
       # ── web ──
       argocd-image-updater.argoproj.io/web.update-strategy: newest-build
       argocd-image-updater.argoproj.io/web.allow-tags: regexp:^sha-[0-9a-f]+$

--- a/charts/lightbridge-code-intelligence/values.yaml
+++ b/charts/lightbridge-code-intelligence/values.yaml
@@ -637,12 +637,13 @@ lci:
             capabilities:
               drop: [ALL]
 
-    # Review-feedback poller (ADR-0035): a single replica that periodically reads reactions on the
-    # comments we posted and reconciles them into review_feedback. SAME image as control-plane/
-    # dispatcher (role-selected via CONTROL_PLANE_ROLE). Unlike the dispatcher it holds the GitHub App
-    # key (to mint installation tokens for reading reactions); ONE replica so reactions aren't
-    # double-polled (ADR-0002 keeps the credential off the multi-replica serve pods + the dispatcher).
-    poller:
+    # Reconciler (ADR-0058/0059): a SINGLE replica that owns ALL GitHub egress — it drains the
+    # github_outbox and delivers reviews/replies/reactions/failure-notices, AND runs the feedback poll
+    # (reads reactions on our comments into review_feedback, ADR-0035). SAME image as control-plane/
+    # dispatcher (role-selected via CONTROL_PLANE_ROLE=reconciler; `poller` is the legacy alias the
+    # binary still accepts). It holds the GitHub App key (to mint installation tokens); ONE replica so
+    # egress isn't doubled (ADR-0002 keeps the credential off the multi-replica serve pods + dispatcher).
+    reconciler:
       type: deployment
       replicas: 1
       annotations:
@@ -652,14 +653,14 @@ lci:
           image:
             repository: ghcr.io/vymalo/lightbridge-control-plane
             # Default/fallback; the deployed tag is overridden at sync time by ai-helm-values via the
-            # image-updater `poll` alias (charts/apps/values.yaml), in lockstep with control-plane.
+            # image-updater `recon` alias (charts/apps/values.yaml), in lockstep with control-plane.
             tag: "0.1.0"
             pullPolicy: IfNotPresent
           env:
-            CONTROL_PLANE_ROLE: "poller"
+            CONTROL_PLANE_ROLE: "reconciler"
             RUST_LOG: "info"
             METRICS_ADDR: "0.0.0.0:9090"
-            # Optional cadence knobs; absent → run_poller defaults (300s interval / 14-day window).
+            # Optional cadence knobs; absent → run_reconciler defaults (300s interval / 14-day window).
             # DATABASE_URL `value` (cluster host/namespace/db) → ai-helm-values; `dependsOn` stays here.
             DB_PASSWORD:
               valueFrom:
@@ -669,8 +670,8 @@ lci:
             DATABASE_URL:
               dependsOn: DB_PASSWORD
               value: ""
-            # The poller mints installation tokens to read reactions, so it needs the GitHub App key
-            # (the dispatcher does not). Same secret the control-plane uses.
+            # The reconciler mints installation tokens (for GitHub egress + reading reactions), so it
+            # needs the GitHub App key (the dispatcher does not). Same secret the control-plane uses.
             GITHUB_APP_ID:
               valueFrom:
                 secretKeyRef:
@@ -731,7 +732,7 @@ lci:
         http:
           port: 7474
     # Metrics-only Service for the dispatcher role (METRICS_ADDR :9090). The serve role's /metrics is
-    # already on the control-plane Service (:8080); the dispatcher/poller have no Service otherwise, so
+    # already on the control-plane Service (:8080); the dispatcher/reconciler have no Service otherwise, so
     # this gives the ServiceMonitor (templates/servicemonitor.yaml) a stable Endpoints target. The
     # dispatcher pod declares no containerPort, but a Service routes by numeric targetPort regardless.
     dispatcher:


### PR DESCRIPTION
## Summary

Finish the **poller → reconciler** rename (ADR-0058) in the deployment. The role was renamed in code + docs (the reconciler owns all GitHub egress, ADR-0059), but the chart still shipped a `poller` controller.

- `charts/lightbridge-code-intelligence/values.yaml`: `controllers.poller` → `reconciler`; `CONTROL_PLANE_ROLE: reconciler`; comments updated (egress drainer + feedback poll).
- `charts/apps/values.yaml`: image-updater alias `poll` → `recon`, repointed to `lci.controllers.reconciler.*`; image-list updated.

## Intent

Make the deployment name match the code/ADR so "poller" stops appearing in prod. The binary already accepts `reconciler` (and still `poller` as a legacy alias), so no image change.

## Source of truth

- https://github.com/vymalo/lightbridge-code-intelligence/blob/main/docs/adr/0058-rename-poller-role-to-reconciler.md
- https://github.com/vymalo/lightbridge-code-intelligence/blob/main/docs/adr/0059-reconciler-owns-all-github-egress.md

## Verification

- [x] `helm template` against the prod values (with the paired ai-helm-values rename) renders **only** `lightbridge-ci-reconciler` (role `reconciler`); zero `poller` in the output.
- [x] No stray `poller`/`poll.` left in the chart (beyond the intentional "legacy alias" notes).

## Risk

Low/Medium — a single-replica controller **swap** (ArgoCD prunes `lightbridge-ci-poller`, creates `lightbridge-ci-reconciler`). Safe because the `github_outbox` is durable (egress just waits) and concurrent drainers use `FOR UPDATE SKIP LOCKED` (partition rows, no double-post). **Merge together with the paired ai-helm-values PR** so ArgoCD swaps in one reconcile (avoids a transient mixed render).

## AI Usage Declaration

AI was used for: making the rename across both files + the render verification. Human owns intent + the merge decision.

AI was used for:

- [x] Generating code (the chart + image-updater rename)
- [x] Reviewing the diff (render verification + no-stray-poller check)

Human verification:

- [x] I understand the swap mechanics and verified the render is clean
- [x] I accept responsibility for this PR
