### PR TITLE
fix(ai-model): spell out invert:false to fix perpetual BackendTrafficPolicy OutOfSync

### DIFF
--- a/charts/ai-model/templates/backendtrafficpolicy.yaml
+++ b/charts/ai-model/templates/backendtrafficpolicy.yaml
@@ -19,6 +19,14 @@ x-billing-plan (stamped by the AuthConfig from Keycloak's billing_plan claim (fr
 Budget per plan = global plan default (.Values.plans.<plan>.monthlyBudgetUsd) — no per-model overrides for shared budget
 else the global plan default (.Values.plans.<plan>.monthlyBudgetUsd). Burst
 (rules 1+2) remains per-model; comes from .Values.plans.<plan>.burst.
+
+⚠️ Every clientSelectors header spells out `invert: false` explicitly, even
+though it's the zero value. The BackendTrafficPolicy CRD schema declares
+`default: false` for this field, so the k8s API server stamps it onto the
+LIVE object on every apply regardless of what we send — omitting it here
+made ArgoCD's diff perpetually see "live has extra fields" and every model
+Application showed a permanent, cosmetic OutOfSync. Spelling it out here
+makes the rendered manifest match what the API server actually stores.
 */ -}}
 {{- $modelName := .Values.modelName -}}
 {{- $plans := .Values.plans -}}
@@ -53,12 +61,15 @@ spec:
         {{- with $burst.requestsPerMin }}
         - clientSelectors:
             - headers:
-                - name: x-account-id
+                - invert: false
+                  name: x-account-id
                   type: Distinct
-                - name: x-billing-plan
+                - invert: false
+                  name: x-billing-plan
                   type: Exact
                   value: {{ $planName | quote }}
-                - name: x-ai-eg-model
+                - invert: false
+                  name: x-ai-eg-model
                   type: Exact
                   value: {{ $modelName | quote }}
           limit:
@@ -73,12 +84,15 @@ spec:
         {{- with $burst.tokensPerMin }}
         - clientSelectors:
             - headers:
-                - name: x-account-id
+                - invert: false
+                  name: x-account-id
                   type: Distinct
-                - name: x-billing-plan
+                - invert: false
+                  name: x-billing-plan
                   type: Exact
                   value: {{ $planName | quote }}
-                - name: x-ai-eg-model
+                - invert: false
+                  name: x-ai-eg-model
                   type: Exact
                   value: {{ $modelName | quote }}
           limit:
@@ -100,9 +114,11 @@ spec:
         {{- $limit := mulf . 1000000 | int64 }}
         - clientSelectors:
             - headers:
-                - name: x-account-id
+                - invert: false
+                  name: x-account-id
                   type: Distinct
-                - name: x-billing-plan
+                - invert: false
+                  name: x-billing-plan
                   type: Exact
                   value: {{ $planName | quote }}
           limit:


### PR DESCRIPTION
## Summary

Fixes a pre-existing, repo-wide ArgoCD sync-status bug: every `charts/ai-models` child Application (all ~24 models) permanently shows `OutOfSync` in ArgoCD despite being Healthy and functionally correct.

Source of truth: this session's live investigation on the `admin@homeos`/Hetzner clusters (kubectl + a direct helm-render-vs-live-object diff), prompted by a follow-up question after merging [PR #558](https://github.com/ADORSYS-GIS/ai-helm/pull/558).

## Intent

Stop every model's ArgoCD sync badge from lying — a permanent OutOfSync makes it impossible to tell "this is the known cosmetic noise" from "this model actually has a bad deploy" at a glance, and it was masking real signal during today's merge/verify loop.

## Scope

- `charts/ai-model/templates/backendtrafficpolicy.yaml` — every `clientSelectors[].headers[]` entry now spells out `invert: false` explicitly, plus a comment explaining why.

## Root cause (confirmed, not hypothesis)

The `BackendTrafficPolicy` CRD's OpenAPI schema declares `default: false` for `spec.rateLimit.global.rules[].clientSelectors[].headers[].invert`. The Kubernetes API server stamps that default onto the **live** object on every apply. Our template never set `invert`, so the **desired** manifest ArgoCD renders always omitted it — ArgoCD's diff sees "live has extra fields" on every one of the ~9 rate-limit rules per model, forever.

Ruled out:
- **Not a status-subresource issue.** Both `AIGatewayRoute` (Synced) and `BackendTrafficPolicy` (OutOfSync) properly register a `status` subresource (`{"status":{}}` on both CRDs) — that wasn't the differentiator.
- **Not a missing ArgoCD `ignoreDifferences` config.** `argocd-cm` has no `resource.customizations` at all repo-wide; this is a chart problem, not an ArgoCD config gap, so no ArgoCD-side config change is needed.

## Verification

- [x] Extracted the exact synced Helm values ArgoCD used for a live model (`models-glm-5p2`, via `kubectl get application -o json` -> `status.operationState.operation.sync.source.helm.values`)
- [x] Rendered the chart locally with those exact values, both before and after the fix
- [x] **Before the fix:** confirmed textually the rendered manifest omits `invert` while the live object has `invert: false` on every header
- [x] **After the fix:** programmatically diffed the rendered `spec.rateLimit` against the live cluster object's `spec.rateLimit` (normalized JSON comparison) — **zero differences, byte-for-byte identical**
- [x] `helm lint --strict` clean on `charts/ai-model` (via its `ci/lint-values.yaml` fixture, per this repo's render-only-leaf convention) and `charts/ai-models`
- [x] `helm template --dry-run` clean on both
- [x] Repo-wide grep: `clientSelectors` only appears in this one template — no other chart needs the same fix

## Risk Assessment

Low. Merge = live deploy (ADR-0055): every model's `BackendTrafficPolicy` gets a no-op re-apply (the live object's actual behavior is unchanged — `invert: false` was already the effective value via CRD defaulting; this only changes what the chart *declares*, not what Envoy enforces). Expected outcome after this deploys and every model app syncs: `OutOfSync` -> `Synced` across the fleet, with zero functional change to rate limiting.

## AI Usage Declaration

- AI (Claude Fable 5 via Claude Code) diagnosed the root cause via live cluster investigation, wrote and verified the fix (including the live-vs-desired diff proof above), and ran all render/lint checks.
- [x] A human (@stephane-segning) asked the follow-up question that triggered this investigation, reviewed the root-cause finding, and owns the merge decision.
- [x] I can explain every line of this change.

## Reviewer Focus

- Confirm the field-ordering choice (`invert` first, matching the live/API-server-defaulted ordering) is fine stylistically — it has no functional effect since YAML/JSON diffing here is structural, not textual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)