### PR TITLE
fix(lightbridge-code-intelligence): use RollingUpdate instead of Recreate

### DIFF
--- a/charts/lightbridge-code-intelligence/values.yaml
+++ b/charts/lightbridge-code-intelligence/values.yaml
@@ -259,10 +259,14 @@ lci:
     # (validates Keycloak-issued JWTs; ADR-0014).
     control-plane:
       type: deployment
-      # Single replica until delivery-id dedupe is durable: the control plane currently keeps
-      # its X-GitHub-Delivery dedupe set in process memory, so two replicas behind the Service
-      # could each accept the same delivery and (once task creation is wired) double-process it.
-      # Move dedupe to Postgres before scaling out.
+      # RollingUpdate (not the bjw-template default of Recreate): avoids a zero-pod gap on every
+      # rollout. This briefly overlaps old+new pods during the rollout window, which *could* double
+      # process one in-flight webhook delivery until dedupe moves to Postgres (accepted trade-off —
+      # a Recreate gap was judged worse). Single replica until then: the control plane currently keeps
+      # its X-GitHub-Delivery dedupe set in process memory, so steady-state concurrent replicas behind
+      # the Service could each accept the same delivery and (once task creation is wired) double-process
+      # it. Move dedupe to Postgres before scaling out.
+      strategy: RollingUpdate
       replicas: 1
       annotations:
         argocd.argoproj.io/sync-wave: "2"
@@ -377,6 +381,9 @@ lci:
     # Next.js web console: Keycloak OIDC client (Authorization-Code + PKCE; ADR-0014).
     web:
       type: deployment
+      # RollingUpdate (not the bjw-template default of Recreate) — stateless Next.js console, no
+      # reason to drop to zero pods on a rollout.
+      strategy: RollingUpdate
       replicas: 2
       annotations:
         argocd.argoproj.io/sync-wave: "2"
@@ -545,6 +552,10 @@ lci:
     # (ADR-0004). No HTTP server beyond /metrics; runs under a dedicated SA with Job-CRUD RBAC there.
     dispatcher:
       type: deployment
+      # RollingUpdate (not the bjw-template default of Recreate) — the Postgres work queue is
+      # consumed via SKIP LOCKED, which is designed for concurrent consumers, so a brief old+new
+      # overlap during rollout is safe (no dedupe caveat like control-plane).
+      strategy: RollingUpdate
       replicas: 1
       annotations:
         argocd.argoproj.io/sync-wave: "2"
@@ -643,8 +654,12 @@ lci:
     # dispatcher (role-selected via CONTROL_PLANE_ROLE=reconciler; `poller` is the legacy alias the
     # binary still accepts). It holds the GitHub App key (to mint installation tokens); ONE replica so
     # egress isn't doubled (ADR-0002 keeps the credential off the multi-replica serve pods + dispatcher).
+    # RollingUpdate (not the bjw-template default of Recreate): avoids a zero-pod gap on every
+    # rollout, at the cost of a brief old+new pod overlap where GitHub egress could theoretically
+    # double up for a moment — same accepted trade-off as control-plane above.
     reconciler:
       type: deployment
+      strategy: RollingUpdate
       replicas: 1
       annotations:
         argocd.argoproj.io/sync-wave: "2"


### PR DESCRIPTION
## 1. Summary

This PR changes:

- Adds `strategy: RollingUpdate` to the four `lci.controllers` entries in `charts/lightbridge-code-intelligence/values.yaml` (`control-plane`, `web`, `dispatcher`, `reconciler`).

It solves:

- #560 — every rollout of these Deployments terminated the running pod before creating its replacement (bjw-template's Deployment default is `Recreate`, and none of these controllers overrode it), causing avoidable downtime on every deploy.

---

## 2. Intent

> The maintainer flagged live, during a Claude Code session, that the LCI deployment terminates a pod before creating a new one and doesn't want that. Root cause: the vendored `bjw-common` chart (`templates/lib/deployment/_valuesToObject.tpl`) defaults `Deployment.strategy` to `Recreate` unless a controller sets `strategy` explicitly — none of the four LCI controllers did. `web` and `dispatcher` have no reason to use Recreate (stateless console / Postgres `SKIP LOCKED` queue consumer, safe under concurrent pods). `control-plane` and `reconciler` are pinned to 1 replica specifically to avoid double-processing (in-memory webhook dedupe / single GitHub-egress owner) — switching them to RollingUpdate too was a deliberate maintainer choice (accept a brief old+new pod overlap during rollout in exchange for removing the deploy-time outage), documented inline.

---

## 3. Scope

### In Scope

- `strategy: RollingUpdate` on all 4 `lci.controllers` (control-plane, web, dispatcher, reconciler).
- Inline comments documenting the trade-off for the two single-replica controllers.

### Out of Scope

- Moving control-plane's webhook dedupe to Postgres (separate follow-up, referenced in the existing values.yaml comment).
- Scaling control-plane/reconciler beyond 1 replica.

---

## 4. Verification

I verified this change by:

- [x] Running manual tests
- [x] Checking logs

Commands run:

```bash
helm dep build charts/lightbridge-code-intelligence/
helm template lci charts/lightbridge-code-intelligence/ | awk '/^kind: Deployment/{d=1} d && /^  name:/{n=$0} /^  strategy:/{print n" -> "$0; getline; print "    "$0; d=0}'
helm lint charts/lightbridge-code-intelligence/
```

Results:

```text
  name: lightbridge-ci-reconciler ->   strategy:
        type: RollingUpdate
  name: lightbridge-ci-web ->   strategy:
        type: RollingUpdate
  name: lightbridge-ci-control-plane ->   strategy:
        type: RollingUpdate
  name: lightbridge-ci-dispatcher ->   strategy:
        type: RollingUpdate

1 chart(s) linted, 0 chart(s) failed
```

Post-merge follow-up: verify live on the Hetzner cluster via `kubectl -n apps get deploy lightbridge-ci-{control-plane,web,dispatcher,reconciler} -o jsonpath='{.spec.strategy}'`.

---

## 5. Screenshots / Evidence

* Logs: see Verification section output above.

---

## 6. Risk Assessment

Risk level:

* [x] Low

Potential risks:

* `control-plane`/`reconciler` (single-replica) briefly run old+new pods simultaneously during a rollout, which could in theory double-process one in-flight GitHub webhook delivery or duplicate one GitHub-egress action.

Mitigation:

* Accepted trade-off vs. the current Recreate full-outage gap on every rollout; the overlap window is short (only until the new pod passes readiness) and this was an explicit maintainer decision. Revisit once webhook dedupe moves to Postgres.

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [x] Drafting documentation

Human verification:

* [x] I understand every meaningful change in this PR
* [x] I checked generated code manually
* [x] I removed unsupported AI assumptions
* [x] I accept responsibility for this PR

---

## 8. Reviewer Focus

Please focus your review on:

* [x] Correctness
* [x] Product intent
EOF
' 2>&1