### PR TITLE
feat(model-serving-qwen25-3b-awq): add vllm chart for Qwen2.5-3B-Inst…

### DIFF
--- a/charts/ai-models/values.yaml
+++ b/charts/ai-models/values.yaml
@@ -159,6 +159,18 @@ backendDefaults:
     securityType: APIKey
     tlsHostname: qwen3-4b--poc.ssegning.com
 
+  # Self-hosted Qwen2.5-3B-AWQ on the home GPU — vLLM via KServe's
+  # huggingfaceserver, same pattern as vllmLocal but a distinct edge FQDN.
+  # AWQ 4-bit quantized; prefix is /openai/v1 (KServe OpenAI-compatible route).
+  vllmLocalAwq: &vllmLocalAwqBackend
+    schema: OpenAI
+    prefix: "/openai/v1"
+    fqdn:
+      hostname: qwen25-3b-awq--poc.ssegning.com
+      port: 443
+    securityType: APIKey
+    tlsHostname: qwen25-3b-awq--poc.ssegning.com
+
 modelDefaults:
   backendRefs:
     fwPrimary: &fwBackendPrimary
@@ -331,6 +343,19 @@ backends:
       key: ai/camer/digital/prod/env
       property: vllm_local_api_key
 
+  # Self-hosted Qwen2.5-3B-AWQ on the home GPU — vLLM via KServe's
+  # huggingfaceserver (AWQ 4-bit quantized). Same API key as the other local
+  # vLLM models. Distinct edge host MUST match charts/model-serving-qwen25-3b-awq
+  # ingress host. DISABLED until cutover (one GPU → one model).
+  vllm-local-awq-01:
+    <<: *vllmLocalAwqBackend
+    resourceName: vllm-local-awq-01-svc
+    secretRef:
+      name: vllm-local-awq-api-key
+    externalSecret:
+      key: ai/camer/digital/prod/env
+      property: vllm_local_api_key
+
 # Models — each entry becomes one child Application using the `ai-model`
 # leaf chart. Setting `enabled: false` on a model skips its Application
 # (the AppSet controller will delete a previously-generated child).
@@ -421,7 +446,7 @@ models:
   # 12GB A2000 (vs the 16k wall on qwen3-4b). Served by llama-server (prefix /v1),
   # served-model-name = --alias `qwen3-5-4b`.
   qwen3-5-4b-local:
-    enabled: true                    # CUTOVER 2026-06-08: arch load-gate PASSED (llama.cpp loads the Qwen3.5 GGUF) — live
+    enabled: false                   # DISABLED — swapped by qwen2.5-3b-awq-local (one GPU). Re-enable to roll back.
     kind: text
     minBackends: 1                   # single self-hosted backend by design (one GPU)
     timeout:
@@ -443,6 +468,44 @@ models:
         ref: llama-local-01
         priority: 0
         modelNameOverride: "qwen3-5-4b"   # = llama-server --alias
+
+  # Self-hosted Qwen2.5-3B-AWQ on the home GPU — vLLM via KServe's
+  # huggingfaceserver (AWQ 4-bit quantized). Qwen2.5 is a non-thinking causal LM
+  # with 32K native context; AWQ INT4 fits the full window in 12GB A2000 VRAM.
+  # DISABLED by default (staged) — one GPU, one model. Enable + disable another
+  # self-hosted model at cutover.
+  #
+  # Model card (Qwen/Qwen2.5-3B-Instruct-AWQ · Apache-2.0):
+  #   3.0B params, 36 layers, GQA 16 Q / 2 KV, 32,768 native context,
+  #   AWQ 4-bit quantization. Supports tool/function calling via hermes
+  #   parser. Non-thinking (no reasoning mode).
+  #   https://huggingface.co/Qwen/Qwen2.5-3B-Instruct-AWQ
+  #
+  # Cost (ADR-0028: cost-recovery for owned-hardware): same rate as the other
+  # self-hosted models — the hardware cost is identical.
+  qwen2.5-3b-awq-local:
+    enabled: true                    # CUTOVER — live on the home GPU.
+    kind: text
+    minBackends: 1
+    timeout:
+      requestTimeout: 600s
+      connectionIdleTimeout: 1h
+    info:
+      displayName: "Qwen2.5-3B-AWQ (self-hosted)"
+      contextLength: 32768           # full native context fits with AWQ INT4
+      maxOutputTokens: 8192
+      supportedParameters: *spStandard   # Qwen2.5 is non-thinking → standard params
+    pricing:
+      strategy: weighted
+      standard:
+        inputPer1M: 0.15
+        cachedInputPer1M: 0.03
+        outputPer1M: 1.00
+    backends:
+      vllm-local-awq-01:
+        ref: vllm-local-awq-01
+        priority: 0
+        modelNameOverride: "qwen2.5-3b-awq"
 
   deepseek-v4-flash:
     kind: text

--- a/charts/apps/values.yaml
+++ b/charts/apps/values.yaml
@@ -795,7 +795,7 @@ applications:
   # ai-models qwen3-5-4b-local/qwen3-4b-local enabled flags, then cut a release +
   # repoint root. Rollback = the inverse.
   - name: model-serving-qwen3-5
-    enabled: true                    # CUTOVER 2026-06-08: arch load-gate passed — live
+    enabled: false                   # DISABLED — swapped by model-serving-qwen25-3b-awq (one GPU). Re-enable to roll back.
     finalizers:
       - resources-finalizer.argocd.argoproj.io
     homeCluster: true
@@ -806,6 +806,37 @@ applications:
       targetRevision: ">=0.0.0"
       helm:
         releaseName: model-serving-qwen3-5
+        valuesObject: { }
+    destination:
+      namespace: converse-poc
+    syncPolicy:
+      syncOptions:
+        - CreateNamespace=true
+        - ServerSideApply=true
+      automated:
+        prune: true
+        selfHeal: true
+
+  # Self-hosted Qwen2.5-3B-AWQ (AWQ INT4, vLLM) on the home GPU — a smaller
+  # quantized model for fast, memory-efficient inference (full 32K context on the
+  # 12GB A2000). charts/model-serving-qwen25-3b-awq renders the weights PVC + AWQ
+  # seed Job + vLLM StatefulSet (model + Caddy auth-proxy) + Service + Ingress.
+  # Federated as the `vllm-local-awq-01` backend / `qwen2.5-3b-awq-local` model
+  # in charts/ai-models.
+  #
+  # DISABLED (staged) — one GPU, one model. Cutover = set this enabled:true +
+  # disable another self-hosted model app + flip the ai-models enabled flags.
+  - name: model-serving-qwen25-3b-awq
+    enabled: true                    # CUTOVER — live on the home GPU.
+    finalizers:
+      - resources-finalizer.argocd.argoproj.io
+    homeCluster: true
+    source:
+      repoURL: oci://ghcr.io/adorsys-gis/charts/model-serving-qwen25-3b-awq
+      chart: "."
+      targetRevision: ">=0.0.0"
+      helm:
+        releaseName: model-serving-qwen25-3b-awq
         valuesObject: { }
     destination:
       namespace: converse-poc

--- a/charts/model-serving-qwen25-3b-awq/Chart.lock
+++ b/charts/model-serving-qwen25-3b-awq/Chart.lock
@@ -1,0 +1,9 @@
+dependencies:
+- name: bjw-template
+  repository: file://../bjw-template
+  version: 4.6.2
+- name: common
+  repository: file://../common
+  version: 2.31.4
+digest: sha256:f83ef50208431185744bdd1666ba5723816bbdbaaa4f75f27e524b291cb1bfce
+generated: "2026-07-02T08:11:18.402496608+01:00"

--- a/charts/model-serving-qwen25-3b-awq/Chart.yaml
+++ b/charts/model-serving-qwen25-3b-awq/Chart.yaml
@@ -1,0 +1,36 @@
+apiVersion: v2
+name: model-serving-qwen25-3b-awq
+description: |
+  Self-hosted LLM on the home GPU: Qwen2.5-3B-Instruct-AWQ served via vLLM
+  (kserve/huggingfaceserver) with a Caddy auth-proxy sidecar. AWQ 4-bit
+  quantized — fits a 32K context on the 12GB A2000. Weights are pre-seeded
+  into a PVC (no per-start HuggingFace download).
+
+  Deployed via homeCluster (ADR-0017 exception) and federated into the Hetzner
+  Envoy AI Gateway as an OpenAI backend. See ADR-0022 (federation) + ADR-0029
+  (serving mode) + ADR-0030 (one STS via bjw-template).
+type: application
+version: 0.1.0
+appVersion: "0.1.0"
+kubeVersion: ">=1.28.0-0"
+keywords:
+  - llm
+  - vllm
+  - qwen
+  - awq
+  - inference
+  - gpu
+maintainers:
+  - name: ai-helm
+
+dependencies:
+  - name: bjw-template
+    version: "4.6.2"
+    repository: "file://../bjw-template"
+    alias: modelServing
+  - name: common
+    version: '*'
+    repository: "file://../common"
+    tags:
+      - common
+      - bitnami-common

--- a/charts/model-serving-qwen25-3b-awq/README.md
+++ b/charts/model-serving-qwen25-3b-awq/README.md
@@ -1,0 +1,55 @@
+# model-serving-qwen25-3b-awq
+
+Self-hosted LLM on the **home GPU** (RTX A2000, 12 GB): **Qwen2.5-3B-Instruct-AWQ**
+(AWQ 4-bit quantized, 3.0B params) served via **vLLM** (`kserve/huggingfaceserver`)
+with a **Caddy auth-proxy sidecar**. A single **`bjw-template StatefulSet`**
+(always-on, `replicas: 1`) with **two containers in one pod** — the model + the
+proxy. Weights are fed from a **pre-seeded PVC** (local mount, no per-start
+HuggingFace download). AWQ INT4 fits the full 32K context in 12GB VRAM.
+
+- **Why:** [ADR-0022](../../docs/adr/0022-self-hosted-gpu-model-federated-into-gateway.md) (federation) + [ADR-0028](../../docs/adr/0028-owned-hardware-model-pricing.md) (pricing) + [ADR-0029](../../docs/adr/0029-self-hosted-model-plain-deployment.md) (serving mode) + [ADR-0030](../../docs/adr/0030-merge-model-and-proxy-into-one-statefulset-bjw.md) (one STS via bjw)
+- **How:** [`docs/self-hosted-model-serving.md`](../../docs/self-hosted-model-serving.md)
+
+## Unusual things about this chart
+
+- **Hybrid bjw chart** (like `charts/librechat-app`): the `bjw-template` subchart
+  (values under `modelServing:`) renders the **whole workload** — the StatefulSet,
+  the seed `Job` (a bjw `job` controller), the Service, and the Ingress. The chart's
+  own `templates/` render only the PVC, the ExternalSecrets, and the Caddyfile
+  ConfigMap.
+- **⚠️ Port layout:** the model server binds HTTP `:8080` **and** KServe gRPC `:8081`;
+  the Caddy sidecar is on **`:8090`** (a sidecar on 8081 crashes the model's gRPC).
+- **It targets the HOME cluster**, not `home-remote` — the GPU lives on the home
+  Talos cluster. The single sanctioned exception to ADR-0017 (`homeCluster: true`).
+- **The model image ignores `VLLM_API_KEY`**, so the **Caddy sidecar** enforces the
+  Bearer and is the only exposed port (`:8090`); the model's `:8080` is pod-local.
+- **The gateway side is elsewhere.** This chart only stands up the model + proxy.
+  It's federated into the Hetzner Envoy AI Gateway as an ordinary OpenAI backend
+  (`vllm-local-awq-01` + the `qwen2.5-3b-awq-local` model) in
+  `charts/ai-models/values.yaml`.
+
+## What it renders (in sync-wave order)
+
+| Wave | Resource | Rendered by | Purpose |
+|---|---|---|---|
+| -2 | `ExternalSecret vllm-local-api-key` + `hf-token` | own templates | the API key (Bearer the sidecar enforces) + the HF download token |
+| -1 | `PVC qwen2.5-3b-awq-models` | own template | the weights volume (Longhorn, **RWX**) |
+| 0 | `Job qwen2.5-3b-awq-seed` (ArgoCD Sync hook) | **bjw** (`controllers.seed`, `type: job`) | downloads weights into the PVC **once**; ArgoCD waits for it |
+| 1 | `StatefulSet qwen2.5-3b-awq` (containers `model` + `proxy`) + `Service qwen2.5-3b-awq:8090` + `Ingress` | **bjw** | the model + Caddy sidecar; the Service → the Ingress (className traefik, cert-manager annotation) |
+| — | `ConfigMap qwen2.5-3b-awq-caddy` | own template | the Caddyfile mounted into the proxy sidecar |
+
+## Key knobs (`values.yaml`)
+
+- `model.{name,hfRepo,storagePath}` — drives the own templates (PVC subPath etc.).
+  ⚠️ the bjw seed Job hardcodes the repo/path (it can't read parent values from the
+  subchart scope) — keep `modelServing.controllers.seed` in sync with these.
+- `modelServing.controllers.main.containers.model.args` — vLLM flags include
+  `--quantization=awq`, `--dtype=float16`, `--max-model-len=32768` (full native
+  context fits with AWQ INT4). ⚠️ model probes use bjw `custom: true` so they hit
+  `:8080` (not the Service port `:8090`).
+- `modelServing.ingress.main` — the public Ingress: `host`, `className: traefik`,
+  the `cert-manager.io/cluster-issuer` annotation, and `tls`. The host MUST match
+  `charts/ai-models` `vllmLocalAwq.hostname`.
+- `apiKey.externalSecret.{key,property}` — reuses the `vllm_local_api_key` property
+  from `ssegning-aws` (same key as the other self-hosted vLLM models).
+- `edgeAuth.proxyResponseTimeout` — the Caddy sidecar's upstream timeout (600s).

--- a/charts/model-serving-qwen25-3b-awq/templates/_helpers.tpl
+++ b/charts/model-serving-qwen25-3b-awq/templates/_helpers.tpl
@@ -1,0 +1,10 @@
+{{/*
+model-serving-qwen25-3b-awq helpers (used by the chart's OWN templates/ — the PVC,
+seed Job, ExternalSecrets. The workload's env/args live in the bjw-template
+values under `modelServing:`).
+*/}}
+
+{{/* The logical model name — the served model id + the StatefulSet/Service name. */}}
+{{- define "model-serving-qwen25-3b-awq.name" -}}
+{{- .Values.model.name | required "model.name is required" -}}
+{{- end -}}

--- a/charts/model-serving-qwen25-3b-awq/templates/configmap-caddy.yaml
+++ b/charts/model-serving-qwen25-3b-awq/templates/configmap-caddy.yaml
@@ -1,0 +1,29 @@
+{{- /*
+The Caddyfile for the auth-proxy sidecar. Listens on :8090, validates the Bearer,
+and reverse-proxies to the model over localhost:8080.
+*/ -}}
+{{- if .Values.edgeAuth.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "model-serving-qwen25-3b-awq.name" . }}-caddy
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "common.labels.standard" . | nindent 4 }}
+data:
+  Caddyfile: |
+    {
+      admin off
+      auto_https off
+    }
+    :8090 {
+      @unauthorized not header Authorization "Bearer {env.MODEL_API_KEY}"
+      respond @unauthorized 401
+      reverse_proxy http://localhost:8080 {
+        transport http {
+          dial_timeout 10s
+          response_header_timeout {{ .Values.edgeAuth.proxyResponseTimeout | default "600s" }}
+        }
+      }
+    }
+{{- end }}

--- a/charts/model-serving-qwen25-3b-awq/templates/externalsecret-hf-token.yaml
+++ b/charts/model-serving-qwen25-3b-awq/templates/externalsecret-hf-token.yaml
@@ -1,0 +1,28 @@
+{{- /*
+Optional HuggingFace token for the seed Job — lifts the anonymous HF Hub rate
+limit. Only rendered when seedJob.hfToken.enabled (+ its externalSecret.enabled).
+*/ -}}
+{{- if and .Values.seedJob.enabled .Values.seedJob.hfToken.enabled .Values.seedJob.hfToken.externalSecret.enabled }}
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: {{ .Values.seedJob.hfToken.secretName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "common.labels.standard" . | nindent 4 }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "-2"
+spec:
+  refreshInterval: {{ .Values.seedJob.hfToken.externalSecret.refreshInterval | default "1h" }}
+  secretStoreRef:
+    name: {{ .Values.seedJob.hfToken.externalSecret.secretStore | default "ssegning-aws" }}
+    kind: ClusterSecretStore
+  target:
+    name: {{ .Values.seedJob.hfToken.secretName }}
+    creationPolicy: Owner
+  data:
+    - secretKey: {{ .Values.seedJob.hfToken.dataKey }}
+      remoteRef:
+        key: {{ required "seedJob.hfToken.externalSecret.key is required" .Values.seedJob.hfToken.externalSecret.key | quote }}
+        property: {{ required "seedJob.hfToken.externalSecret.property is required" .Values.seedJob.hfToken.externalSecret.property | quote }}
+{{- end }}

--- a/charts/model-serving-qwen25-3b-awq/templates/externalsecret.yaml
+++ b/charts/model-serving-qwen25-3b-awq/templates/externalsecret.yaml
@@ -1,0 +1,29 @@
+{{- /*
+The vLLM API key — the Bearer the Caddy sidecar enforces (the model image
+IGNORES VLLM_API_KEY). ESO pulls it from ssegning-aws into a Secret that both
+pod containers read. Reuses the same vllm_local_api_key property.
+*/ -}}
+{{- if and .Values.apiKey.enabled .Values.apiKey.externalSecret.enabled }}
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: {{ .Values.apiKey.secretName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "common.labels.standard" . | nindent 4 }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "-2"
+spec:
+  refreshInterval: {{ .Values.apiKey.externalSecret.refreshInterval | default "1h" }}
+  secretStoreRef:
+    name: {{ .Values.apiKey.externalSecret.secretStore | default "ssegning-aws" }}
+    kind: ClusterSecretStore
+  target:
+    name: {{ .Values.apiKey.secretName }}
+    creationPolicy: Owner
+  data:
+    - secretKey: {{ .Values.apiKey.dataKey }}
+      remoteRef:
+        key: {{ required "apiKey.externalSecret.key is required" .Values.apiKey.externalSecret.key | quote }}
+        property: {{ required "apiKey.externalSecret.property is required" .Values.apiKey.externalSecret.property | quote }}
+{{- end }}

--- a/charts/model-serving-qwen25-3b-awq/templates/pvc.yaml
+++ b/charts/model-serving-qwen25-3b-awq/templates/pvc.yaml
@@ -1,0 +1,25 @@
+{{- /*
+The weights volume. Pre-seeded once by the seed Job (the bjw `seed` controller),
+then mounted read-only by the model container. RWX so the seed Job and the model
+STS can mount concurrently. Wave -1: before the seed Job.
+*/ -}}
+{{- if .Values.pvc.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ .Values.pvc.name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "common.labels.standard" . | nindent 4 }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  accessModes:
+    - {{ .Values.pvc.accessMode | default "ReadWriteOnce" }}
+  {{- with .Values.pvc.storageClassName }}
+  storageClassName: {{ . }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.pvc.size | default "10Gi" }}
+{{- end }}

--- a/charts/model-serving-qwen25-3b-awq/values.yaml
+++ b/charts/model-serving-qwen25-3b-awq/values.yaml
@@ -1,0 +1,258 @@
+# charts/model-serving-qwen25-3b-awq — self-hosted Qwen2.5-3B-Instruct-AWQ on the home GPU.
+# See ADR-0022 (federation) + ADR-0028 (pricing) + ADR-0029 (serving mode) +
+# ADR-0030 (one StatefulSet via bjw-template) + docs/self-hosted-model-serving.md.
+#
+# Shape: a hybrid bjw-template chart (like charts/librechat-app).
+#   - The bjw-template subchart (values under `modelServing:`) renders the WHOLE
+#     workload: the model StatefulSet (model + Caddy proxy sidecar), the seed
+#     Job (a bjw `job` controller, ArgoCD Sync hook), the Service, and the
+#     Ingress.
+#   - The chart's own templates/ render only the resources bjw doesn't do
+#     natively: the weights PVC, the ExternalSecrets, and the Caddyfile ConfigMap.
+#
+# Sync-wave ordering (this Application's resources, on the HOME cluster):
+#   -2  ExternalSecret (vllm-local-api-key + hf-token)  — before any pod
+#   -1  PVC (qwen2.5-3b-awq-models, RWX)                 — weights volume
+#    0  seed Job (download-once into the PVC)             — ArgoCD Sync hook
+#    1  StatefulSet (model + proxy) + Service + Ingress   — mounts the PVC
+
+global:
+  labels:
+    app: model-serving-qwen25-3b-awq
+    team: adorsys-gis
+
+model:
+  name: qwen2.5-3b-awq
+  hfRepo: Qwen/Qwen2.5-3B-Instruct-AWQ
+  storagePath: Qwen2.5-3B-Instruct-AWQ
+
+pvc:
+  enabled: true
+  name: qwen2.5-3b-awq-models
+  storageClassName: longhorn
+  accessMode: ReadWriteMany
+  size: 10Gi
+
+seedJob:
+  enabled: true
+  hfToken:
+    enabled: true
+    secretName: hf-token
+    dataKey: token
+    externalSecret:
+      enabled: true
+      secretStore: ssegning-aws
+      refreshInterval: 1h
+      key: ai/camer/digital/prod/env
+      property: hf_token
+
+apiKey:
+  enabled: true
+  secretName: vllm-local-api-key
+  dataKey: api_key
+  externalSecret:
+    enabled: true
+    secretStore: ssegning-aws
+    refreshInterval: 1h
+    key: ai/camer/digital/prod/env
+    property: vllm_local_api_key
+
+edgeAuth:
+  enabled: true
+  proxyResponseTimeout: 600s
+
+modelServing:
+  global:
+    fullnameOverride: qwen2.5-3b-awq
+
+  defaultPodOptions:
+    runtimeClassName: nvidia
+    nodeSelector:
+      gpu-node: "true"
+
+  controllers:
+    main:
+      type: statefulset
+      replicas: 1
+      annotations:
+        argocd.argoproj.io/sync-wave: "1"
+      containers:
+        model:
+          image:
+            repository: kserve/huggingfaceserver
+            tag: v0.18.0-gpu
+            pullPolicy: IfNotPresent
+          args:
+            - --model_name=qwen2.5-3b-awq
+            - --model_dir=/mnt/models
+            - --backend=vllm
+            - --dtype=float16
+            - --quantization=awq
+            - --max-model-len=32768
+            - --max-num-seqs=4
+            - --gpu-memory-utilization=0.90
+            - --swap-space=1
+            - --enforce-eager
+            - --enable-auto-tool-choice
+            - --tool-call-parser=hermes
+            - '--kv-transfer-config={"kv_connector":"LMCacheConnectorV1","kv_role":"kv_both"}'
+          env:
+            LMCACHE_USE_EXPERIMENTAL: "True"
+            LMCACHE_LOCAL_CPU: "True"
+            LMCACHE_MAX_LOCAL_CPU_SIZE: "1"
+            VLLM_API_KEY:
+              secretKeyRef:
+                name: vllm-local-api-key
+                key: api_key
+          ports:
+            - name: http
+              containerPort: 8080
+            - name: grpc
+              containerPort: 8081
+          probes:
+            startup:
+              enabled: true
+              custom: true
+              spec:
+                httpGet: { path: /v2/health/ready, port: 8080 }
+                periodSeconds: 15
+                failureThreshold: 120
+                timeoutSeconds: 5
+            readiness:
+              enabled: true
+              custom: true
+              spec:
+                httpGet: { path: /v2/health/ready, port: 8080 }
+                periodSeconds: 15
+                timeoutSeconds: 10
+                failureThreshold: 3
+            liveness:
+              enabled: true
+              custom: true
+              spec:
+                tcpSocket: { port: 8080 }
+                periodSeconds: 30
+                timeoutSeconds: 10
+                failureThreshold: 6
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            capabilities:
+              drop:
+                - ALL
+          resources:
+            requests:
+              cpu: "1"
+              memory: 2Gi
+            limits:
+              cpu: "3"
+              memory: 6Gi
+
+        proxy:
+          image:
+            repository: caddy
+            tag: 2-alpine
+            pullPolicy: IfNotPresent
+          env:
+            MODEL_API_KEY:
+              secretKeyRef:
+                name: vllm-local-api-key
+                key: api_key
+          ports:
+            - name: edge
+              containerPort: 8090
+          probes:
+            readiness:
+              enabled: true
+              custom: true
+              spec:
+                tcpSocket: { port: 8090 }
+                periodSeconds: 10
+          resources:
+            requests: { cpu: 10m, memory: 32Mi }
+            limits:   { cpu: 200m, memory: 128Mi }
+
+    seed:
+      type: job
+      annotations:
+        argocd.argoproj.io/hook: Sync
+        argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+        argocd.argoproj.io/sync-wave: "0"
+      pod:
+        restartPolicy: OnFailure
+      job:
+        backoffLimit: 6
+        activeDeadlineSeconds: 3600
+      containers:
+        seed:
+          image:
+            repository: python
+            tag: "3.12-slim"
+            pullPolicy: IfNotPresent
+          command: ["/bin/sh", "-ec"]
+          args:
+            - |
+              MODEL_DIR="/models/Qwen2.5-3B-Instruct-AWQ"
+              mkdir -p "$MODEL_DIR"
+              echo "Seeding Qwen/Qwen2.5-3B-Instruct-AWQ -> $MODEL_DIR (skips files already present)"
+              pip install --no-cache-dir -q --root-user-action=ignore "huggingface_hub[hf_xet]>=1.0"
+              hf download Qwen/Qwen2.5-3B-Instruct-AWQ --local-dir "$MODEL_DIR"
+              echo "Seed complete."
+          env:
+            HF_TOKEN:
+              secretKeyRef:
+                name: hf-token
+                key: token
+          resources:
+            requests: { cpu: "1", memory: 1Gi }
+            limits:   { cpu: "2", memory: 4Gi }
+
+  service:
+    main:
+      controller: main
+      type: ClusterIP
+      ports:
+        edge:
+          port: 8090
+          targetPort: 8090
+
+  ingress:
+    main:
+      enabled: true
+      className: traefik
+      annotations:
+        cert-manager.io/cluster-issuer: cert-cloudflare
+      hosts:
+        - host: qwen25-3b-awq--poc.ssegning.com
+          paths:
+            - path: /
+              pathType: Prefix
+              service:
+                identifier: main
+                port: edge
+      tls:
+        - secretName: qwen25-3b-awq-edge-tls
+          hosts:
+            - qwen25-3b-awq--poc.ssegning.com
+
+  persistence:
+    model-store:
+      enabled: true
+      existingClaim: qwen2.5-3b-awq-models
+      advancedMounts:
+        main:
+          model:
+            - path: /mnt/models
+              subPath: Qwen2.5-3B-Instruct-AWQ
+              readOnly: true
+        seed:
+          seed:
+            - path: /models
+    caddyfile:
+      enabled: true
+      type: configMap
+      name: qwen2.5-3b-awq-caddy
+      advancedMounts:
+        main:
+          proxy:
+            - path: /etc/caddy


### PR DESCRIPTION
…ruct-AWQ

## 1. Summary

This PR changes:

- Add a new Helm Chart model-serving-qwen25-3b-awq serving Qwen2.5-3B-Instruct-AWQ via vLLM 
- Wires the new model into the gateway (charts/ai-models) and the app fleet (charts/apps)
- Disables model-serving-qwen3-5 and qwen3-5-4b-local

It solves:

- Ticket #554 : prod test deployemnt of Qwen2.5-3B-Instruct-AWQ

---

## 2. Intent

The intent of this PR is:

>  To deploy a smaller AWQ-4-bit-quantized model on the home GPU (RTX A2000, 12GB) and having it accessible through our gateway ; Building Experience in model deployement and serving 

---

## 3. Scope

### In Scope

- New chart charts/model-serving-qwen25-3b-awq/ (Chart.yaml, values.yaml, 5 templates, README.md, Chart.lock)
- charts/ai-models/values.yaml: vllmLocalAwq backend, qwen2.5-3b-awq-local model (enabled)
- charts/apps/values.yaml: model-serving-qwen25-3b-awq app entry (enabled, homeCluster: true)
- - Disable model-serving-qwen3-5 app + qwen3-5-4b-local model 

### Out of Scope

- AWS SM property changes (vllm_local_api_key + hf_token already exist)

---

## 4. Verification

I verified this change by:

- [x] Running automated tests
- [x] Running manual tests
- [ ] Checking logs
- [ ] Checking metrics
- [ ] Testing error cases
- [ ] Testing permissions/security behavior
- [ ] Testing rollback or failure behavior, if relevant

Commands run:

```bash
helm dep uild charts/model-serving-qwen25-3b-awq/
helm lint charts/model-serving-qwen25-3b-awq/
helm template test charts/model-serving-qwen25-3b-awq/ --dry-run
```

Results:

```text
                                                                                                                                       
     # All 3 charts: "1 chart(s) linted, 0 chart(s) failed"                                                                                     
     # model-serving renders: Caddyfile CM, PVC, ExternalSecrets, StatefulSet, Service, Ingress                          
     # ai-models renders: qwen2.5-3b-awq-local ApplicationSet element present                                                            
     # apps renders: aii-model-serving-qwen25-3b-awq Application present                                                                  
     # Cross-checks (Python YAML parse):                                                                                                      
     #   Chart name → OCI repoURL:     ✓                                                                                                           
     #   --model_name → modelNameOverride:  ✓                                                                                                        
     #   Ingress host → backend hostname + TLS:  ✓                                                                                 
     #   Model backend ref → backend map:  ✓                                                                                            
     #   PVC name → existingClaim:    ✓                                                                                                   
     #   storagePath → subPath:       ✓                                                                                                             
     #   apiKey secretRef → both containers:  ✓                                                                                                                         
     #   Seed job HF repo → model.hfRepo:  ✓                                                                                                                    
     #   Exactly one self-hosted model enabled:  ✓ 
```

---

## 5. Screenshots / Evidence

Add evidence here:

  N/A — Helm chart verification only. Live cluster verification pending post-deploy.
---

## 6. Risk Assessment

Risk level:

* [x] Low
* [ ] Medium
* [ ] High

Potential risks:

* The seed Job fails to dowload weights from hugggingFAce

Mitigation:

* the seed Job retries 6 times with a 1h deadline

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [x] Refactoring
* [ ] Generating tests
* [ ] Drafting documentation
* [ ] Reviewing the diff
* [ ] Not used

Human verification:

* [x] I understand every meaningful change in this PR
* [x] I checked generated code manually
* [ ] I checked generated tests manually
* [x] I removed unsupported AI assumptions
* [x] I accept responsibility for this PR

---

## 8. Reviewer Focus

Please focus your review on:

* [x] Correctness
* [x] Architecture
* [ ] Security
* [ ] Performance
* [ ] Tests
* [x] Maintainability
* [ ] Product intent
* [ ] Edge cases
