### PR TITLE
feat(lci): render knowledge_tools.mcp_servers into control-plane.json (ADR-0066)

### DIFF
--- a/charts/lightbridge-code-intelligence/templates/config.yaml
+++ b/charts/lightbridge-code-intelligence/templates/config.yaml
@@ -34,6 +34,17 @@ interprets `{{ }}`).
 {{- if ne (toString $cfg.embeddings.dimension) "" }}
 {{- $_ := set $cp "embeddings" (dict "dimension" $cfg.embeddings.dimension "allow_reindex_on_dim_change" $cfg.embeddings.allowReindexOnDimChange) }}
 {{- end }}
+{{- /* External-knowledge MCP servers (lightbridge-ci ADR-0066) → control-plane.json
+       knowledge_tools.mcp_servers. Each is an already-running REMOTE HTTP MCP server the control
+       plane discovers tools from + proxies calls to; the per-tier `review.<tier>.tools` regex
+       allowlist then picks which discovered tools each tier offers. Declare the servers here; the
+       tool selection lives in config.model.<tier>.tools. Empty → no servers → no external tools (a
+       safe degrade). ⚠️ The control-plane image must carry the `knowledge_tools` FileConfig field
+       (lightbridge-ci #255) before this is set — else deny_unknown_fields fails config load. The
+       runner validates each url is http(s):// (remote-transport-only, never a local stdio server). */}}
+{{- $mcps := list }}
+{{- range $s := $cfg.knowledgeTools.mcpServers }}{{- if and $s.name $s.url }}{{- $mcps = append $mcps (dict "name" $s.name "url" $s.url) }}{{- end }}{{- end }}
+{{- if $mcps }}{{- $_ := set $cp "knowledge_tools" (dict "mcp_servers" $mcps) }}{{- end }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/lightbridge-code-intelligence/values.yaml
+++ b/charts/lightbridge-code-intelligence/values.yaml
@@ -200,6 +200,16 @@ config:
     labelFindings: needs-review  # ≥1 finding of any severity
     labelError: bug        # ≥1 error-severity finding
 
+  # External-knowledge MCP servers (lightbridge-ci ADR-0066): already-running REMOTE HTTP MCP servers
+  # the control plane discovers tools from + proxies calls to. Declare the servers here; each entry is
+  # {name, url} (url must be http(s)://). The per-tier tool SELECTION (which discovered tools each tier
+  # offers) lives in config.model.<tier>.tools as `mcp__<server>__<tool>` regex selectors. Empty here →
+  # no external-knowledge tools. Names must not contain `__` (breaks the mcp__<name>__<tool> split).
+  knowledgeTools:
+    mcpServers: []
+    # - name: brave-search
+    #   url: http://brave-search.converse-mcp.svc.cluster.local:8080/mcp
+
   # Embedding-store safety (ADR-0018). The live `code_chunks.embedding` column is vector(4096), set by
   # migration 0005 to match qwen3-embedding-8b. Changing the embedding model's dimension is
   # DESTRUCTIVE: on a mismatch the control plane either wipes + re-migrates the column (only when


### PR DESCRIPTION
## Summary

This PR changes:

- `charts/lightbridge-code-intelligence/templates/config.yaml`: renders `config.knowledgeTools.mcpServers` (a list of `{name,url}`) into control-plane.json's `knowledge_tools.mcp_servers`.
- `charts/lightbridge-code-intelligence/values.yaml`: adds `config.knowledgeTools.mcpServers: []` default + docs.

It solves: chart support for declaring external-knowledge MCP servers so the control plane can discover their tools + proxy calls (the declaration layer for lightbridge-ci ADR-0066).

## Intent

The control-plane file config is already mounted + live (`CONTROL_PLANE_CONFIG=/etc/lightbridge/control-plane.json`, ConfigMap `lightbridge-ci-control-plane-config`). This adds the `knowledge_tools` block to it so an operator can declare MCP servers in values (ai-helm-values), without any deployment change. Tool SELECTION per tier stays separate (`config.model.<tier>.tools` regex).

## Source of truth

- lightbridge-ci ADR-0066: https://github.com/vymalo/lightbridge-code-intelligence/blob/main/docs/adr/0066-deep-tier-external-knowledge-tools.md
- Implementation ticket: vymalo/lightbridge-code-intelligence#255 (merged as PRs #261/#263)

## Scope

### In Scope
- Render `knowledge_tools.mcp_servers` from values; empty → block omitted (safe degrade).

### Out of Scope
- Declaring specific servers (that's ai-helm-values, follows in ADORSYS-GIS/ai-helm-values#35).
- Per-tier tool selection (`config.model.<tier>.tools`).

## Verification

- [x] Ran `helm template` locally

```bash
helm template t charts/lightbridge-code-intelligence            # default: no knowledge_tools block
helm template t charts/lightbridge-code-intelligence \
  --set config.knowledgeTools.mcpServers[0].name=brave-search \
  --set config.knowledgeTools.mcpServers[0].url=http://brave-search.converse-mcp.svc.cluster.local:8080/mcp
```

Result: default renders control-plane.json with no `knowledge_tools` key; with a server set, it renders `knowledge_tools.mcp_servers: [{name, url}]`. Both confirmed.

## Deploy ordering / Risk Assessment

Risk: **Low**. Requires a control-plane image carrying the `knowledge_tools` FileConfig field (lightbridge-ci #255) before ai-helm-values sets it, else `deny_unknown_fields` fails config load. The live control-plane image is already past that (`sha-7ff5fc6`), and the empty default omits the block entirely, so merging this chart change alone is a no-op until values declare servers.

## AI Usage Declaration

AI (Claude Code) was used to: understand the existing chart config templating, write the template + values change, and verify the `helm template` output. The change is a small, mechanical addition mirroring the existing `review`/`embeddings` rendering blocks. Human owner (@stephane-segning) reviews and accepts responsibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
