### PR TITLE
feat(lci): maxCoverageBounces knob → review.max_coverage_bounces (ADR-0069)

### DIFF
--- a/charts/lightbridge-code-intelligence/templates/config.yaml
+++ b/charts/lightbridge-code-intelligence/templates/config.yaml
@@ -74,6 +74,10 @@ data:
 {{- if ne (toString $cfg.model.maxFilesRead) "" }}{{- $_ := set $rev "max_files_read" $cfg.model.maxFilesRead }}{{- end }}
 {{- if ne (toString $cfg.model.maxSearches) "" }}{{- $_ := set $rev "max_searches" $cfg.model.maxSearches }}{{- end }}
 {{- if ne (toString $cfg.model.maxBatches) "" }}{{- $_ := set $rev "max_batches" $cfg.model.maxBatches }}{{- end }}
+{{- /* Coverage-gate bounce cap (lightbridge-ci ADR-0069). 0 is MEANINGFUL (disables the bounce;
+       the coverage disclosure still applies) and 1 = legacy bounce-once; the runner does not clamp it.
+       ⚠️ REQUIRES a runner image carrying review.max_coverage_bounces before it's set. */}}
+{{- if ne (toString $cfg.model.maxCoverageBounces) "" }}{{- $_ := set $rev "max_coverage_bounces" $cfg.model.maxCoverageBounces }}{{- end }}
 {{- /* SSE streaming toggle (#206) → agent.json review.stream. A bool; empty → omitted (runner default
        off). Needs a runner image carrying the review.stream field (lightbridge-ci #211) before it's set
        to true, else deny_unknown_fields fails the Job. */}}
@@ -127,6 +131,10 @@ data:
 {{- if $tv.maxFilesRead }}{{- $_ := set $t "max_files_read" $tv.maxFilesRead }}{{- end }}
 {{- if $tv.maxSearches }}{{- $_ := set $t "max_searches" $tv.maxSearches }}{{- end }}
 {{- if $tv.maxBatches }}{{- $_ := set $t "max_batches" $tv.maxBatches }}{{- end }}
+{{- /* Coverage-gate bounce cap (ADR-0069): NOT a truthiness guard — 0 (disable) must render, and
+       only nil/"" skip. kindIs "invalid" catches the unset-key nil the truthiness comment above warns
+       about. */}}
+{{- if and (not (kindIs "invalid" $tv.maxCoverageBounces)) (ne (toString $tv.maxCoverageBounces) "") }}{{- $_ := set $t "max_coverage_bounces" $tv.maxCoverageBounces }}{{- end }}
 {{- if $tv.contextWindow }}{{- $_ := set $t "context_window" $tv.contextWindow }}{{- end }}
 {{- if $tv.requestTimeoutSecs }}{{- $_ := set $t "request_timeout_secs" $tv.requestTimeoutSecs }}{{- end }}
 {{- if $tv.stream }}{{- $_ := set $t "stream" $tv.stream }}{{- end }}

--- a/charts/lightbridge-code-intelligence/values.yaml
+++ b/charts/lightbridge-code-intelligence/values.yaml
@@ -127,6 +127,13 @@ config:
     maxFilesRead: ""    # → review.max_files_read   (cumulative read_file cap)
     maxSearches: ""     # → review.max_searches     (cumulative vector+graph search cap)
     maxBatches: ""      # → review.max_batches      (cumulative investigation-round cap)
+    # Coverage-gate bounce cap (lightbridge-ci ADR-0069) → agent.json `review.max_coverage_bounces`.
+    # How many times an early `finish` with changed files never opened/commented is bounced back before
+    # it goes through (with a coverage disclosure on the posted summary). Empty → the runner's built-in
+    # default (3). `0` DISABLES the bounce entirely (disclosure still applies), `1` = the legacy
+    # bounce-once — 0 is meaningful, so the runner does NOT clamp this one. ⚠️ REQUIRES a runner image
+    # carrying `review.max_coverage_bounces` before it's set, else deny_unknown_fields fails every Job.
+    maxCoverageBounces: ""
     # NB: there is no `fallbackModel` knob — the review failover model was removed (lightbridge-ci
     # ADR-0053 / #208), replaced by a single model + retry/backoff + circuit breaker. (Any ADR-NNNN
     # below refers to the lightbridge-ci repo's ADRs, not this chart's own ADR index.)
@@ -148,7 +155,8 @@ config:
     # Two-tier review (lightbridge-ci ADR-0062) → agent.json `review.fast` / `review.deep`. Each is a
     # COMPLETE, independent per-tier config: it shares the gateway (env) + system prompt, and carries its
     # OWN model + the same generation/budget knobs as above (model, extra, maxTurns, stream,
-    # requestTimeoutSecs, contextWindow, maxTokens, temperature, topP, maxDiffChars, max* read budgets).
+    # requestTimeoutSecs, contextWindow, maxTokens, temperature, topP, maxDiffChars, max* read budgets,
+    # maxCoverageBounces).
     # `fast`  = the automatic `pull_request opened` pass (cheap model; the runner enforces a single
     #           diff-only turn with no retrieval regardless of maxTurns — SAST is the backbone).
     # `deep`  = the `@mention` run (strong model, long requestTimeoutSecs; full retrieval + multi-turn).


### PR DESCRIPTION
## Summary

Maps a new knob for the lightbridge-code-intelligence chart: `config.model.maxCoverageBounces` (flat) and `config.model.<tier>.maxCoverageBounces` (per-tier) → `agent.json` `review[.fast|.deep].max_coverage_bounces` — the coverage-gate bounce cap introduced runner-side by lightbridge-ci ADR-0069 (vymalo/lightbridge-code-intelligence#279).

Source of truth: vymalo/lightbridge-code-intelligence#279 (ADR-0069) — incident run `bac4b5d8` on vymalo/vymalo-shop#422, where a weak model gamed the bounce-once coverage gate.

## Intent

Make the gate's strictness operator-tunable per tier: empty → runner default (3 bounces), `1` → the legacy bounce-once behaviour, `0` → bounce disabled entirely (the coverage disclosure on the posted summary still applies).

## Details / Reviewer focus

- The **per-tier** mapping deliberately deviates from the surrounding truthiness guards: truthiness skips `0`, but `0` is a meaningful setting for this knob, so it uses `kindIs "invalid"` (nil-aware) + `toString ≠ ""` instead. A template comment documents why.
- The **flat** mapping follows the existing `ne (toString …) ""` pattern (the key is declared `""` in the chart's values.yaml, so nil never reaches `toString`).
- Deploy order (the usual three-repo law): this PR is safe to merge now — nothing renders until the value is set in ai-helm-values, and setting it **requires a runner image carrying `review.max_coverage_bounces`** (deny_unknown_fields), noted in both comment blocks.

## Verification

```bash
helm template lci charts/lightbridge-code-intelligence -f <prod values> -s templates/config.yaml
```

- Knob **unset** (current prod values): rendered output **byte-identical** to main (`diff` clean, 0 occurrences of `max_coverage_bounces`).
- Synthetic values (flat `2`, `fast.maxCoverageBounces: 0`, `deep.maxCoverageBounces: 5`): decoded agent.json shows `flat: 2, fast: 0, deep: 5` — the `0` renders (the truthiness-guard pitfall this PR explicitly avoids).

## AI Usage Declaration

AI was used for: generating the template mapping and values documentation, and running the render verifications above. Human verification and accountability: owner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
