### PR TITLE
feat(core-gateway): log LCI review attribution headers for per-repo cost slicing

### DIFF
--- a/charts/core-gateway/templates/envoy-proxy.yaml
+++ b/charts/core-gateway/templates/envoy-proxy.yaml
@@ -132,6 +132,14 @@ spec:
               project_id: "%REQ(X-PROJECT-ID)%"
               account_id: "%REQ(X-ACCOUNT-ID)%"
               billing_plan: "%REQ(X-BILLING-PLAN)%"
+              # LightBridge Code Intelligence review attribution (lci epic #89). The agent-runner sends
+              # these on every review LLM + embeddings call; logging them lets Loki attribute the
+              # gateway's authoritative custom_total_cost per repo / PR / run — so the LCI cost
+              # dashboard can read real billed cost from eaig instead of an app-side token estimate that
+              # goes stale on every model churn. Empty for all non-LCI traffic (harmless).
+              code_intelligence_repo:    "%REQ(X-CODE-INTELLIGENCE-REPO)%"
+              code_intelligence_target:  "%REQ(X-CODE-INTELLIGENCE-TARGET)%"
+              code_intelligence_task_id: "%REQ(X-CODE-INTELLIGENCE-TASK-ID)%"
               # LibreChat Downstream Headers
               lc_user_id: "%REQ(X-USER-ID)%"
               lc_user_email: "%REQ(X-USER-EMAIL)%"


### PR DESCRIPTION
## Summary

Adds three LightBridge Code Intelligence attribution headers to the **core-gateway access-log format** (`charts/core-gateway/templates/envoy-proxy.yaml`) so the gateway's authoritative billed cost can be sliced **per repo / PR / run** in Loki:

- `code_intelligence_repo` ← `X-CODE-INTELLIGENCE-REPO`
- `code_intelligence_target` ← `X-CODE-INTELLIGENCE-TARGET` (e.g. `pull_request#422`)
- `code_intelligence_task_id` ← `X-CODE-INTELLIGENCE-TASK-ID`

## Intent

The agent-runner already sends these headers on every review LLM + embeddings call (epic #89), and the gateway already meters + prices each request (`llmRequestCosts` + the `custom_total_cost` CEL, emitted to Loki as `gen_ai.usage.custom_total_cost`). But the access-log format captured only the generic `project_id`/`account_id`/`api_key_id` headers, so gateway cost was sliceable by project — **not by repo/PR**.

This closes that gap so the LCI cost dashboard can read **authoritative billed cost from eaig** instead of an app-side token estimate. Concretely: the LCI cost dashboard prices from a hardcoded per-model map, which returns **$0** the moment the model churns to one it doesn't know — exactly what happened when both review tiers moved to `gemini-3p1-flash-lite` (missing from the map → every recent review estimates at $0). The gateway already prices gemini correctly; logging these headers lets the dashboard consume that.

Source of truth: LCI review-cost dashboard (`tools/dashboard-gen/lci_dashboards/review_cost.py`, whose own docstring notes "billed cost (visible on the AI-Gateway cost dashboards) is typically lower") + the runner's `attribution_headers()` (epic #89).

## Scope

- **In:** three JSON log fields in the `# LightBridge` block of the EnvoyProxy access-log format.
- **Out:** routing, policy, rate-limit, metering (all unchanged); the fields are empty for non-LCI traffic.

## Verification

```bash
helm template cg charts/core-gateway -s templates/envoy-proxy.yaml | grep code_intelligence
```

Result: the three fields render in the access-log JSON alongside the existing `gen_ai.usage.custom_total_cost`. Non-LCI requests simply log empty strings for them (Envoy `%REQ()%` of an absent header → empty). This is a shared-gateway change (all model traffic), but it only *adds log fields* — no request is routed, priced, or rate-limited differently.

## Risk Assessment

**Low.** Log-format-only, additive; empty for all non-LCI callers. Reverting is a plain revert. Rollout is an ArgoCD ConfigMap/EnvoyProxy sync (no image build).

## AI Usage Declaration

AI was used for: locating the metering path (runner headers → `llmRequestCosts`/CEL → access log → Alloy → Loki), drafting the change, and the render verification. Human verification and accountability: owner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
