### PR TITLE
feat(lightbridge): argocd-image-updater + cosign git write-back for api/mcp

### DIFF
--- a/charts/lightbridge/templates/applications.yaml
+++ b/charts/lightbridge/templates/applications.yaml
@@ -89,6 +89,34 @@ metadata:
     - resources-finalizer.argocd.argoproj.io
   annotations:
     argocd.argoproj.io/sync-wave: {{ .Values.app.syncWave | quote }}
+    # Continuous delivery (ADR-0055): argocd-image-updater picks the newest
+    # COSIGN-signed `sha-<gitsha>` build of each first-party image and git
+    # write-backs the tag into environments/prod/values/lightbridge-app.yaml on
+    # ai-helm-values `main` (api → global.authz.image.version, mcp →
+    # global.authz_mcp.image.version). Tag-only: the repositories are chart
+    # defaults, not in the values file. cosign identity = the lightbridge-authz
+    # CI workflow that signs the images. Until a signed build exists the updater
+    # finds no verifiable tag and safely leaves the pinned version untouched.
+    argocd-image-updater.argoproj.io/image-list: api=ghcr.io/adorsys-gis/lightbridge-authz,mcp=ghcr.io/adorsys-gis/lightbridge-authz-mcp
+    argocd-image-updater.argoproj.io/api.update-strategy: newest-build
+    argocd-image-updater.argoproj.io/api.allow-tags: regexp:^sha-[0-9a-f]+$
+    argocd-image-updater.argoproj.io/api.force-update: "true"
+    argocd-image-updater.argoproj.io/api.helm.image-tag: global.authz.image.version
+    argocd-image-updater.argoproj.io/api.signature-type: cosign
+    argocd-image-updater.argoproj.io/api.cosign.certificate-oidc-issuer: https://token.actions.githubusercontent.com
+    argocd-image-updater.argoproj.io/api.cosign.certificate-identity-regexp: ^https://github\.com/ADORSYS-GIS/lightbridge-authz/\.github/workflows/ci\.yml@.*$
+    argocd-image-updater.argoproj.io/mcp.update-strategy: newest-build
+    argocd-image-updater.argoproj.io/mcp.allow-tags: regexp:^sha-[0-9a-f]+$
+    argocd-image-updater.argoproj.io/mcp.force-update: "true"
+    argocd-image-updater.argoproj.io/mcp.helm.image-tag: global.authz_mcp.image.version
+    argocd-image-updater.argoproj.io/mcp.signature-type: cosign
+    argocd-image-updater.argoproj.io/mcp.cosign.certificate-oidc-issuer: https://token.actions.githubusercontent.com
+    argocd-image-updater.argoproj.io/mcp.cosign.certificate-identity-regexp: ^https://github\.com/ADORSYS-GIS/lightbridge-authz/\.github/workflows/ci\.yml@.*$
+    argocd-image-updater.argoproj.io/write-back-method: git
+    argocd-image-updater.argoproj.io/git-branch: main
+    argocd-image-updater.argoproj.io/git-repository: https://github.com/adorsys-gis/ai-helm-values.git
+    argocd-image-updater.argoproj.io/write-back-target: helmvalues:/environments/prod/values/lightbridge-app.yaml
+    argocd-image-updater.argoproj.io/git-credentials: secret:argocd/github-app-creds--adorsys-gis
   labels:
     {{- include "common.labels.standard" . | nindent 4 }}
 spec:


### PR DESCRIPTION
## Summary

Wire **argocd-image-updater + cosign-verified git write-back** onto the `lightbridge-app` child Application, so the `lightbridge-authz` (api) and `-mcp` (mcp) images continuously deliver — the newest signed `sha-<gitsha>` build is committed into `ai-helm-values` and ArgoCD syncs it. This is Part B of the "wire image-updater for lightbridge-backend" work; Part A (cosign signing) is `ADORSYS-GIS/lightbridge-authz#75`.

**Source of truth:** [ADR-0055](docs/adr/0055-oci-charts-and-image-updater-writeback-to-values-repo.md) (OCI charts + image-updater write-back to `ai-helm-values`) — this applies its established `lightbridge-code-intelligence` pattern to the lightbridge backend.

## Intent

`lightbridge-backend` is an App-of-Apps, so the annotations belong on the **child** `lightbridge-app` Application (which owns the api+mcp workload values via the `$values` ref), not the orchestrator entry in `charts/apps/values.yaml`. This adds them to the child in `charts/lightbridge/templates/applications.yaml`.

## Scope

`charts/lightbridge/templates/applications.yaml` — image-updater annotations on the `lightbridge-app` child:
- `image-list: api=ghcr.io/adorsys-gis/lightbridge-authz,mcp=ghcr.io/adorsys-gis/lightbridge-authz-mcp`
- per image: `newest-build`, `allow-tags: regexp:^sha-[0-9a-f]+$`, `force-update`, `signature-type: cosign` + the lightbridge-authz CI cosign identity (`^https://github\.com/ADORSYS-GIS/lightbridge-authz/\.github/workflows/ci\.yml@.*$`, issuer `token.actions.githubusercontent.com`).
- `helm.image-tag` → `global.authz.image.version` (api) / `global.authz_mcp.image.version` (mcp) — **tag-only**; the repositories are chart defaults, and those two fields already exist in the values file.
- git write-back → `helmvalues:/environments/prod/values/lightbridge-app.yaml` on `ai-helm-values` `main`, creds `secret:argocd/github-app-creds--adorsys-gis` (same as LCI/converse-ui).

No `Chart.yaml` bump (ADR-0055: OCI version derived at publish). No `ai-helm-values` change — the write-back target file + `global.authz{,_mcp}.image.version` fields already exist.

## Verification

- [x] `helm template charts/lightbridge` renders the `lightbridge-app` child with all annotations, no template errors.
- [x] `helm.image-tag` paths match the existing keys in `ai-helm-values/environments/prod/values/lightbridge-app.yaml` (`global.authz.image.version`, `global.authz_mcp.image.version`, currently `sha-…`).
- [x] cosign identity regexp matches what lightbridge-authz#75 signs with.

## Screenshots / Evidence

Rendered annotation block (from `helm template`) — see the `argocd-image-updater.argoproj.io/*` keys on the `lightbridge-app` Application.

## Risk Assessment

- [x] Low

Annotations only — no workload/spec change. **Safe if merged before Part A lands:** with `signature-type: cosign` and no signed tag yet, the updater finds no verifiable candidate and leaves the pinned `version` untouched (no accidental deploy). It begins updating only once a signed `sha-` build exists.

## AI Usage Declaration

AI was used for:
- [x] Understanding existing code
- [x] Generating the chart change

Human verification:
- [x] I understand every meaningful change in this PR
- [x] I checked the rendered template manually
- [x] I accept responsibility for this PR

## Reviewer Focus

- [x] Annotations on the **child** `lightbridge-app` (correct target for the App-of-Apps), tag-only `helm.image-tag` paths, and the cosign identity matching lightbridge-authz#75.
- [x] Merge ordering: fine either way, but image-updater only acts once signed images exist.
