### PR TITLE
feat(ai-models): block GLM-5.2 on the external gateway host only

### DIFF
--- a/charts/ai-model/templates/aigatewayroute.yaml
+++ b/charts/ai-model/templates/aigatewayroute.yaml
@@ -1,6 +1,9 @@
 {{- /* Required-field guards */ -}}
 {{- if not .Values.modelName }}{{- fail "ai-model: .Values.modelName is required" -}}{{- end -}}
 {{- if not .Values.gatewayRef.name }}{{- fail "ai-model: .Values.gatewayRef.name is required" -}}{{- end -}}
+{{- if and .Values.disableExternal (not .Values.gatewayRef.internalSectionName) }}
+{{- fail (printf "Model '%s': disableExternal requires gatewayRef.internalSectionName to be set, else the route would have no parentRefs at all" .Values.modelName) -}}
+{{- end -}}
 {{- if not .Values.backendsInventory }}{{- fail "ai-model: .Values.backendsInventory is required (the parent's backends map, for resourceName lookup)" -}}{{- end -}}
 {{- $modelName := .Values.modelName -}}
 {{- /* Route-level request budget. The AIGatewayRoute CRD DEFAULTS
@@ -28,6 +31,7 @@ metadata:
   name: {{ $modelName }}
 spec:
   parentRefs:
+    {{- if not .Values.disableExternal }}
     - group: gateway.networking.k8s.io
       kind: Gateway
       name: {{ .Values.gatewayRef.name }}
@@ -37,6 +41,7 @@ spec:
       # listener is left to the http→https redirect + the ACME solver.
       sectionName: {{ . }}
       {{- end }}
+    {{- end }}
     {{- with .Values.gatewayRef.internalSectionName }}
     # Internal plane (ADR-0021): also attach to the api-internal listener so the
     # same model backends serve in-cluster callers. The per-host AuthConfig sets

--- a/charts/ai-model/values.yaml
+++ b/charts/ai-model/values.yaml
@@ -38,6 +38,13 @@ gatewayRef:
   # "api-https") so it's HTTPS-only. Empty = attach to all listeners.
   sectionName: ""
 
+# Optional: skip the external (api-https) parentRef entirely, so the model's
+# AIGatewayRoute attaches only to gatewayRef.internalSectionName. Use this to
+# block a model on the public host (api.ai.camer.digital) while keeping it
+# reachable for in-cluster callers (e.g. LibreChat) on the internal plane.
+# Requires gatewayRef.internalSectionName to be set — see aigatewayroute.yaml.
+disableExternal: false
+
 # Required: pricing strategy. Drives the cost CEL expression rendered by
 # AIGatewayRoute. See _helpers.tpl for the supported strategies
 # (weighted, tieredWeighted, flat).

--- a/charts/ai-models/templates/applicationset.yaml
+++ b/charts/ai-models/templates/applicationset.yaml
@@ -54,6 +54,7 @@ spec:
       "modelName" $modelName
       "kind" (default "text" $modelConfig.kind)
       "gatewayRef" $.Values.gatewayRef
+      "disableExternal" (default false $modelConfig.disableExternal)
       "pricing" $modelConfig.pricing
       "backends" $modelConfig.backends
       "rateLimitBudgeting" (default (dict) $modelConfig.rateLimitBudgeting)

--- a/charts/ai-models/values.yaml
+++ b/charts/ai-models/values.yaml
@@ -626,6 +626,9 @@ models:
 
   reviewer:
     kind: text
+    # Blocked on the external host (api.ai.camer.digital) — still reachable
+    # on the internal plane (LibreChat, in-cluster callers).
+    disableExternal: true
     # DeepInfra · zai-org/GLM-5.2 — 1,048,576-token context, 131k max output,
     # agentic thinking mode + function calling + vision. Repointed from GLM-5
     # (ADR-0075): GLM-5.2's DeepInfra price dropped to $0.93/$0.18/$3.00,
@@ -651,6 +654,9 @@ models:
 
   adorsys-planner:
     kind: text
+    # Blocked on the external host (api.ai.camer.digital) — still reachable
+    # on the internal plane (LibreChat, in-cluster callers).
+    disableExternal: true
     # DeepInfra · zai-org/GLM-5.2 — 1,048,576-token context, 131k max output.
     # Repointed from GLM-5 (ADR-0075); see `reviewer` above for the price note.
     info:
@@ -674,6 +680,9 @@ models:
 
   adorsys-planner-pro:
     kind: text
+    # Blocked on the external host (api.ai.camer.digital) — still reachable
+    # on the internal plane (LibreChat, in-cluster callers).
+    disableExternal: true
     # DeepInfra · zai-org/GLM-5.2 — 1,048,576-token context, 131k max output,
     # long-horizon agentic engineering (thinking + function calling + MCP).
     # Repointed from GLM-5.1 (ADR-0075) — now the same backing as
@@ -794,6 +803,9 @@ models:
     # GLM-5.1 on every axis with a far larger context ceiling — GLM-5/5.1 are
     # retired from the catalog.
     kind: text
+    # Blocked on the external host (api.ai.camer.digital) — still reachable
+    # on the internal plane (LibreChat, in-cluster callers).
+    disableExternal: true
     info:
       displayName: "GLM-5.2"
       contextLength: 1048576
@@ -1015,6 +1027,9 @@ models:
 
   adorsys-coder-pro:
     kind: text
+    # Blocked on the external host (api.ai.camer.digital) — still reachable
+    # on the internal plane (LibreChat, in-cluster callers).
+    disableExternal: true
     # Backing: DeepInfra · zai-org/GLM-5.2 — strong long-horizon coder.
     # Repointed from GLM-5.1 (ADR-0075); see `reviewer` above for the price note.
     info:
@@ -1061,6 +1076,9 @@ models:
 
   adorsys-reviewer-pro:
     kind: text
+    # Blocked on the external host (api.ai.camer.digital) — still reachable
+    # on the internal plane (LibreChat, in-cluster callers).
+    disableExternal: true
     # Backing: DeepInfra · zai-org/GLM-5.2 — thorough agentic reviewer.
     # Price corrected to DeepInfra's confirmed current rate (ADR-0075).
     info:


### PR DESCRIPTION
## 1. Summary

This PR changes:

- Adds a per-model `disableExternal` flag to the `ai-model` leaf chart (`charts/ai-model/templates/aigatewayroute.yaml`, `charts/ai-model/values.yaml`), which skips the `AIGatewayRoute`'s parentRef to the external `api-https` listener (`api.ai.camer.digital`) while keeping it attached to the internal `api-internal` listener.
- Threads the flag from the `ai-models` orchestrator through to each model child (`charts/ai-models/templates/applicationset.yaml`).
- Sets `disableExternal: true` on the 6 GLM-5.2-backed catalog entries in `charts/ai-models/values.yaml`: `glm-5p2`, `reviewer`, `adorsys-planner`, `adorsys-planner-pro`, `adorsys-coder-pro`, `adorsys-reviewer-pro`.
- Adds a Helm `fail` guard rejecting `disableExternal: true` when `gatewayRef.internalSectionName` isn't set, so a model can never render a route with zero parentRefs.

It solves:

- #593

---

## 2. Intent

> The maintainer asked to block GLM-5.2 on `api.ai.camer.digital` specifically, without removing it from the catalog entirely. Today the only per-model toggle is `enabled: false`, which is all-or-nothing across both the external and internal gateway planes — there was no way to pull a model off the public API surface while keeping it reachable for first-party in-cluster callers (e.g. LibreChat). This adds that host-scoped toggle at the `AIGatewayRoute` parentRef level, the layer where the external (`api-https`) vs internal (`api-internal`) Gateway listeners are already split (ADR-0021).

---

## 3. Scope

### In Scope

- The new `disableExternal` field on the `ai-model` leaf chart + the guard.
- Wiring it through the `ai-models` orchestrator's `ApplicationSet`.
- Applying it to the 6 GLM-5.2-backed catalog entries.

### Out of Scope

- An AuthConfig/Authorino CEL-based blocking approach (rejected — would need editing the private `ai-helm-values` AuthConfig content per ADR-0056, more moving parts for the same result).
- Explicitly blocking the vanity redirect host `api.ai.kivoyo.com` — it 307-redirects to `api.ai.camer.digital`, so it's covered transitively once that host's route is gone.
- Removing the retired `glm-5`/`glm-5p1` catalog ids — unrelated, already handled by ADR-0075.

---

## 4. Verification

I verified this change by:

- [x] Running manual tests
- [x] Checking logs

Commands run:

```bash
helm dep build charts/ai-model/ && helm dep build charts/ai-models/

# 1. disableExternal=true + internalSectionName set -> only internal parentRef
helm template x charts/ai-model --set modelName=glm-5p2 \
  --set gatewayRef.name=core-gateway --set gatewayRef.namespace=envoy-gateway-system \
  --set gatewayRef.sectionName=api-https --set gatewayRef.internalSectionName=api-internal \
  --set disableExternal=true [...backend/pricing set flags...] | grep -A 20 parentRefs

# 2. guard: disableExternal=true with NO internalSectionName -> must fail
helm template x charts/ai-model --set modelName=glm-5p2 \
  --set gatewayRef.sectionName=api-https --set disableExternal=true [...] 2>&1 | tail -5

# 3. unmodified model -> both parentRefs still render
helm template x charts/ai-model --set modelName=some-other-model \
  --set gatewayRef.internalSectionName=api-internal [...] | grep -A 15 parentRefs

# 4. CI-equivalent lint/render
helm lint charts/ai-model --strict -f charts/ai-model/ci/lint-values.yaml
helm template x charts/ai-model -f charts/ai-model/ci/lint-values.yaml --dry-run
helm lint charts/ai-models

# 5. orchestrator threading
helm template x charts/ai-models --dry-run | grep -B2 -A2 disableExternal
```

Results:

```text
1. parentRefs rendered ONLY the api-internal entry (sectionName: api-internal),
   the api-https entry was correctly omitted.

2. Error: execution error at (ai-model/templates/aigatewayroute.yaml:5:4):
   Model 'glm-5p2': disableExternal requires gatewayRef.internalSectionName
   to be set, else the route would have no parentRefs at all
   (guard fired as intended)

3. parentRefs rendered BOTH api-https and api-internal entries unchanged
   (no regression for models without the flag).

4. charts/ai-model:  helm lint --strict -> 0 chart(s) failed
                      helm template --dry-run -> OK
   charts/ai-models: helm lint -> 0 chart(s) failed

5. All 6 GLM-5.2 catalog entries (glm-5p2, reviewer, adorsys-planner,
   adorsys-planner-pro, adorsys-coder-pro, adorsys-reviewer-pro) rendered
   `disableExternal: true` in their child valuesYaml; every other model
   rendered `disableExternal: false`.
```

---

## 5. Screenshots / Evidence

Not applicable — this is a Helm chart routing change with no UI surface; verified entirely via `helm template`/`helm lint` output above (this is not deployed by this PR; ArgoCD reconciles on merge to `main` per ADR-0055 continuous delivery).

---

## 6. Risk Assessment

Risk level:

* [x] Low

Potential risks:

* If `disableExternal: true` were set without `gatewayRef.internalSectionName` configured, the `AIGatewayRoute` would have zero `parentRefs` (an invalid/inert route).
* Since `charts/apps`/`ai-models` deploys are continuous (merge to `main` = live deploy, ADR-0055), this PR merging immediately blocks the 6 GLM-5.2-backed models on the public API.

Mitigation:

* Added a Helm `fail` guard that hard-stops the render if `disableExternal: true` is set without `internalSectionName` — verified in testing above.
* The 6 models remain fully served on the internal plane (LibreChat, in-cluster callers) — this is the explicitly requested scope, not a full model removal.

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [x] Reviewing the diff

Human verification:

* [x] I understand every meaningful change in this PR
* [x] I checked generated code manually
* [x] I removed unsupported AI assumptions
* [x] I accept responsibility for this PR

---

## 8. Reviewer Focus

Please focus your review on:

* [x] Correctness
* [x] Architecture
* [x] Product intent
