### PR TITLE
fix(ai-models): lower free monthly budget 50→30 — stop overspend (#532)

### DIFF
--- a/charts/ai-models/values.yaml
+++ b/charts/ai-models/values.yaml
@@ -58,9 +58,10 @@ rateLimitBudgeting:
   plans:
     free:
       # Per-person monthly budget (ADR-0035: keyed on x-account-id, NOT a shared
-      # x-org-id bucket — colleagues no longer contend for one pool). Raised
-      # 30 → 50 to relax the free tier.
-      monthlyBudgetUsd: 50
+      # x-org-id bucket — colleagues no longer contend for one pool). Lowered
+      # 50 → 30 (2026-07-07) to stop the bleeding while we investigate users
+      # exceeding the intended cap (per-model-vs-shared counter + billing_plan).
+      monthlyBudgetUsd: 30
       burst:
         requestsPerMin: 200
         # Raised 200k → 1M (2026-06-12) to match the 1M context ceiling


### PR DESCRIPTION
Immediate cost-control: lower `free.monthlyBudgetUsd` **50 → 30** while we investigate users exceeding the intended cap. Pro ($200) unchanged.

⚠️ This alone may not fully "stop the bleeding" — it only helps if the limiter counter is (a) actually counting cost and (b) scoped as we expect. Under active investigation:
- **Per-model vs shared budget:** the Redis counter key includes `/converse/<model>/rule/…`, so Envoy Gateway may scope the budget per-route (per-model) despite removing the `x-ai-eg-model` descriptor — meaning a user's real cap is `$30 × N models`.
- **billing_plan attribution:** if heavy users are `pro`, their cap is $200, not $30/$50.

Follow-up findings will be posted on #532.

🤖 Generated with [Claude Code](https://claude.com/claude-code)