### PR TITLE
feat(imageupdater): activate ImageUpdater CR for lightbridge-app write-back

### DIFF
--- a/charts/imageupdater/values.yaml
+++ b/charts/imageupdater/values.yaml
@@ -27,3 +27,13 @@ imageUpdaters:
     applicationRefs:
       - namePattern: aii-converse-ui
         useAnnotations: true
+  # ADR-0055 continuous-delivery — lightbridge backend api/mcp image write-back
+  # to ai-helm-values (newest-build, COSIGN-signed; lightbridge-authz signs in
+  # its CI). The write-back annotations live on the `lightbridge-app` child
+  # Application emitted by the lightbridge orchestrator chart (charts/lightbridge),
+  # NOT a charts/apps entry — so the pattern is the bare child name, no `aii-`
+  # prefix (exact match).
+  - name: lightbridge-app
+    applicationRefs:
+      - namePattern: lightbridge-app
+        useAnnotations: true


### PR DESCRIPTION
## Summary
Add the `lightbridge-app` entry to `charts/imageupdater` so the CRD-based argocd-image-updater actually processes it. This is the missing third piece of the lightbridge continuous-delivery wiring.

**Source of truth:** [ADR-0055](docs/adr/0055-oci-charts-and-image-updater-writeback-to-values-repo.md) + the opt-in recipe documented in `charts/imageupdater/values.yaml`.

## Why
This deployment runs the **CRD-based** image-updater (home-os `charts/argocd-image-updater`): the controller only reconciles Applications named in an `ImageUpdater` CR (`applicationRefs`). ai-helm#592 added the write-back **annotations** to the `lightbridge-app` child Application, and lightbridge-authz#75 signs the images — but with **no CR referencing `lightbridge-app`**, the controller never had it in scope, so no write-back happened (verified: `ai-helm-values` still pinned the old sha after 45 min).

## Change
One entry in `charts/imageupdater/values.yaml` `imageUpdaters[]`:
```yaml
- name: lightbridge-app
  applicationRefs:
    - namePattern: lightbridge-app   # bare child-app name (orchestrator child, not a charts/apps app → no aii- prefix)
      useAnnotations: true
```

## Verification
- [x] `helm template charts/imageupdater` renders the `lightbridge-app` ImageUpdater CR with the exact-match `applicationRefs`.
- [x] Target child Application is named `lightbridge-app` (charts/lightbridge `app.appName`), in the `argocd` namespace the controller watches (`watch.namespaces: argocd-image-updater,argocd`).
- [x] Signatures verified present on the api/mcp images with the identity the annotations require (`…/lightbridge-authz/.github/workflows/ci.yml@…`).
- [ ] End-to-end write-back observable once this chart republishes + the `imageupdater` controlPlane app syncs.

## Risk
- [x] Low — one activation CR; no workload change. Until a signed `sha-` build is newest (already true: `sha-fe33f3ee…`) it simply picks that and write-backs once.

## AI Usage Declaration
AI was used for: diagnosing why the write-back stalled (read home-os + ai-helm deployment) and adding the CR. Human verification: confirmed the CRD-based activation model and rendered the CR.

## Reviewer Focus
- [x] The bare `namePattern` (no `aii-` prefix) matching the orchestrator child, and that the CR lands in the watched `argocd` namespace.