### PR TITLE
fix(lightbridge): add helm.image-name to image-updater annotations

### DIFF
--- a/charts/lightbridge/templates/applications.yaml
+++ b/charts/lightbridge/templates/applications.yaml
@@ -91,16 +91,18 @@ metadata:
     argocd.argoproj.io/sync-wave: {{ .Values.app.syncWave | quote }}
     # Continuous delivery (ADR-0055): argocd-image-updater picks the newest
     # COSIGN-signed `sha-<gitsha>` build of each first-party image and git
-    # write-backs the tag into environments/prod/values/lightbridge-app.yaml on
-    # ai-helm-values `main` (api → global.authz.image.version, mcp →
-    # global.authz_mcp.image.version). Tag-only: the repositories are chart
-    # defaults, not in the values file. cosign identity = the lightbridge-authz
-    # CI workflow that signs the images. Until a signed build exists the updater
-    # finds no verifiable tag and safely leaves the pinned version untouched.
+    # write-backs the image into environments/prod/values/lightbridge-app.yaml on
+    # ai-helm-values `main` (api → global.authz.image.{repository,version}, mcp →
+    # global.authz_mcp.image.{repository,version}). BOTH image-name (repository)
+    # and image-tag (version) are required — the operator errors ("could not find
+    # an image-name") if only the tag param is given. cosign identity = the
+    # lightbridge-authz CI workflow that signs the images. Until a signed build
+    # exists the updater finds no verifiable tag and leaves the version untouched.
     argocd-image-updater.argoproj.io/image-list: api=ghcr.io/adorsys-gis/lightbridge-authz,mcp=ghcr.io/adorsys-gis/lightbridge-authz-mcp
     argocd-image-updater.argoproj.io/api.update-strategy: newest-build
     argocd-image-updater.argoproj.io/api.allow-tags: regexp:^sha-[0-9a-f]+$
     argocd-image-updater.argoproj.io/api.force-update: "true"
+    argocd-image-updater.argoproj.io/api.helm.image-name: global.authz.image.repository
     argocd-image-updater.argoproj.io/api.helm.image-tag: global.authz.image.version
     argocd-image-updater.argoproj.io/api.signature-type: cosign
     argocd-image-updater.argoproj.io/api.cosign.certificate-oidc-issuer: https://token.actions.githubusercontent.com
@@ -108,6 +110,7 @@ metadata:
     argocd-image-updater.argoproj.io/mcp.update-strategy: newest-build
     argocd-image-updater.argoproj.io/mcp.allow-tags: regexp:^sha-[0-9a-f]+$
     argocd-image-updater.argoproj.io/mcp.force-update: "true"
+    argocd-image-updater.argoproj.io/mcp.helm.image-name: global.authz_mcp.image.repository
     argocd-image-updater.argoproj.io/mcp.helm.image-tag: global.authz_mcp.image.version
     argocd-image-updater.argoproj.io/mcp.signature-type: cosign
     argocd-image-updater.argoproj.io/mcp.cosign.certificate-oidc-issuer: https://token.actions.githubusercontent.com


### PR DESCRIPTION
## Summary

Add `helm.image-name` (repository) to the `lightbridge-app` image-updater annotations for both api and mcp. Without it the operator errors and skips the write-back.

**Source of truth:** the operator log on the live cluster —
```
error: Could not update application spec: could not find an image-name for image adorsys-gis/lightbridge-authz  → images_updated=0 errors=1
```

## Root cause

The CRD-based image-updater's Helm write-back needs **both** `helm.image-name` and `helm.image-tag` parameters; #592 set only `image-tag` (on the mistaken assumption that the repository being a chart default made image-name unnecessary). The operator was otherwise fully working — CR active, cosign verify passes, `newest-build` selects `sha-fe33f3ee…` for api+mcp — it just couldn't commit without the name param. LCI (the working reference) sets both.

## Fix

- `api.helm.image-name: global.authz.image.repository`
- `mcp.helm.image-name: global.authz_mcp.image.repository`

The workload chart reads `global.authz.image.{repository,version}` and `global.authz_mcp.image.{repository,version}` (verified in the lightbridge-authz / lightbridge-mcp chart values), so these are the correct paths; the operator writes both back to `lightbridge-app.yaml`.

## Verification

- [x] `helm template charts/lightbridge` renders both `helm.image-name` + `helm.image-tag` for api and mcp.
- [x] Paths match the chart's actual image keys (`.repository` default = `ghcr.io/adorsys-gis/lightbridge-authz{,-mcp}`, same as the pinned repo).
- [ ] End-to-end: after this republishes + the orchestrator syncs, the operator's next cycle commits `sha-fe33f3ee…` to `ai-helm-values` (the write-back was one param away).

## Risk

- [x] Low — one annotation per image; the operator was already selecting the correct signed tag.

## AI Usage Declaration

AI was used for: diagnosing from the operator logs and adding the missing param. Human verification: confirmed the chart image-value paths and rendered the annotations.

## Reviewer Focus

- [x] The two `helm.image-name` paths matching `global.authz{,_mcp}.image.repository`.
