### PR TITLE
feat(keycloak-baseline): add lightbridge context scope + mapper

### DIFF
--- a/charts/keycloak-baseline/Chart.yaml
+++ b/charts/keycloak-baseline/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: keycloak-baseline
 description: Reusable Keycloak baseline configuration for enterprise AI services
 type: application
-version: 0.4.0
+version: 0.5.0
 appVersion: "1.0.0"
 
 keywords:

--- a/charts/keycloak-baseline/docs/lightbridge-spi-token-exchange.md
+++ b/charts/keycloak-baseline/docs/lightbridge-spi-token-exchange.md
@@ -1,0 +1,87 @@
+# Lightbridge context-resolution SPI — realm wiring runbook
+
+The Keycloak SPI (`adorsys-gis/lightbridge-keycloak-spi`) seals `account_id` /
+`project_id` into issued JWTs on a **`project_id` token exchange**. Two of the
+three moving parts are GitOps:
+
+| Part | Where | State |
+| --- | --- | --- |
+| OPA server (`/idp/v1/resolve-context`) | `ai-helm-values` → `lightbridge-app.yaml` (`opa.enabled: true`) | GitOps |
+| SPI provider config + truststore | `home-os` → `keycloak-ha` (`LIGHTBRIDGE_*` env) | GitOps |
+| Realm: `lightbridge` scope + Standard Token Exchange | **this chart** + **manual** | see below |
+
+> ⚠️ The `camer-digital` realm is **not currently reconciled** by this chart
+> (no running `keycloak-config-cli` CronJob / `KeycloakRealmImport`). The
+> `lightbridge` client scope + mapper added here are the declarative source of
+> truth, but until config-sync is wired they must be applied to the live realm
+> manually. Standard Token Exchange is a per-client capability this chart's realm
+> template can't yet express, so it is manual either way.
+
+## What the SPI needs in the realm
+
+1. The **`lightbridge` client scope** carrying the `lightbridge-context-mapper`
+   protocol mapper (defined in `values.yaml` → `clientScopes.lightbridge`).
+2. That scope as a **default scope** on the client that performs the exchange
+   (`self-service-mcp-api`).
+3. **Standard Token Exchange enabled** on that client.
+
+The SPI provider itself is global (installed via the jars in `keycloak-ha`); no
+realm setting selects it — it engages automatically when a `project_id` form
+param is present on a standard token exchange.
+
+## Manual apply (kcadm, against the live realm)
+
+```sh
+kcadm.sh config credentials --server https://auth.verif.fyi \
+  --realm master --user "$KC_ADMIN" --password "$KC_ADMIN_PW"
+
+REALM=camer-digital
+
+# 1. Create the lightbridge client scope
+SCOPE_ID=$(kcadm.sh create client-scopes -r "$REALM" -i \
+  -s name=lightbridge \
+  -s protocol=openid-connect \
+  -s 'attributes."include.in.token.scope"=true' \
+  -s 'attributes."display.on.consent.screen"=false')
+
+# 2. Add the Lightbridge Context Mapper to the scope
+kcadm.sh create "client-scopes/$SCOPE_ID/protocol-mappers/models" -r "$REALM" \
+  -s name=lightbridge_context \
+  -s protocol=openid-connect \
+  -s protocolMapper=lightbridge-context-mapper \
+  -s 'config."access.token.claim"=true' \
+  -s 'config."id.token.claim"=true' \
+  -s 'config."userinfo.token.claim"=true' \
+  -s 'config."introspection.token.claim"=true'
+
+# 3. Attach the scope as a default scope on the exchanging client
+CID=$(kcadm.sh get clients -r "$REALM" -q clientId=self-service-mcp-api --fields id --format csv --noquotes)
+kcadm.sh update "clients/$CID/default-client-scopes/$SCOPE_ID" -r "$REALM"
+
+# 4. Enable Standard Token Exchange on the client (KC 26.2+ capability)
+kcadm.sh update "clients/$CID" -r "$REALM" \
+  -s 'attributes."standard.token.exchange.enabled"=true'
+```
+
+> Admin-console equivalent for step 4: **Clients → self-service-mcp-api →
+> Settings → Capability config → Standard Token Exchange → On**. Confirm the
+> exact attribute key in your 26.6 console if the kcadm form is rejected.
+
+## Verify end-to-end
+
+```sh
+# Get a user access token (subject_token) for self-service-mcp-api, then exchange
+# WITH a project_id the user is a member of. Do NOT pass audience=<same client>
+# (Keycloak rejects a self-audience with "Requested audience not available").
+curl -s https://auth.verif.fyi/realms/camer-digital/protocol/openid-connect/token \
+  -d grant_type=urn:ietf:params:oauth:grant-type:token-exchange \
+  -d client_id=self-service-mcp-api -d client_secret="$CLIENT_SECRET" \
+  -d subject_token="$USER_TOKEN" \
+  -d subject_token_type=urn:ietf:params:oauth:token-type:access_token \
+  -d project_id="$PROJECT_ID" | jq -r .access_token \
+  | cut -d. -f2 | base64 -d 2>/dev/null | jq '{account_id, project_id}'
+```
+
+Expected: the exchanged token carries `account_id` + `project_id`. Without the
+`project_id` param the claims are absent (the provider only engages on it). An
+unknown project / non-member subject → the exchange fails closed (no token).

--- a/charts/keycloak-baseline/values.yaml
+++ b/charts/keycloak-baseline/values.yaml
@@ -109,6 +109,30 @@ keycloak-config:
             jsonType.label: "String"
             usermodel.clientRoleMapping.clientId: "converse"
 
+    # Lightbridge tenant-context scope. Carries the Lightbridge Context Mapper
+    # (SPI provider id `lightbridge-context-mapper`), which copies the account_id
+    # and project_id the token-exchange SPI sealed into user-session notes onto
+    # the issued token as claims. Attach as a default scope to whichever client
+    # performs the project_id token exchange (self-service-mcp-api below). The
+    # claim names (account_id, project_id) are fixed by the mapper — no claim.name.
+    lightbridge:
+      name: "lightbridge"
+      description: "Lightbridge tenant context (account_id, project_id)"
+      protocol: "openid-connect"
+      attributes:
+        include.in.token.scope: "true"
+        display.on.consent.screen: "false"
+      protocolMappers:
+        - name: lightbridge_context
+          protocol: "openid-connect"
+          protocolMapper: "lightbridge-context-mapper"
+          consentRequired: false
+          config:
+            access.token.claim: "true"
+            id.token.claim: "true"
+            userinfo.token.claim: "true"
+            introspection.token.claim: "true"
+
   # OIDC Clients
   clients:
     converse:
@@ -201,6 +225,10 @@ keycloak-config:
         - roles
         - basic
         - email
+        # Seals account_id/project_id into tokens this client exchanges (with a
+        # project_id form param). Standard Token Exchange must also be enabled on
+        # this client — not expressible in this template yet; see the runbook.
+        - lightbridge
       optionalClientScopes:
         - address
         - librechat


### PR DESCRIPTION
## Summary

Declarative realm wiring for the Lightbridge token-exchange SPI: a `lightbridge`
client scope + `lightbridge-context-mapper`, attached to `self-service-mcp-api`,
plus a runbook for the parts this template can't yet express.

**Source of truth:** https://github.com/adorsys-gis/lightbridge-keycloak-spi
(protocol-mapper provider id `lightbridge-context-mapper`; ADR-0008).

## Intent

Once the SPI seals `account_id`/`project_id` into user-session notes on a
`project_id` exchange, a protocol mapper must copy them onto the token. This
captures that mapper + scope in the baseline realm source of truth.

## Scope

- `charts/keycloak-baseline/values.yaml`:
  - New `clientScopes.lightbridge` with the `lightbridge-context-mapper`
    (include in access/id/userinfo/introspection tokens; claim names fixed by
    the mapper).
  - Add `lightbridge` to `self-service-mcp-api.defaultClientScopes`.
- `docs/lightbridge-spi-token-exchange.md`: runbook (kcadm) — enabling Standard
  Token Exchange on the client + manual apply.
- `Chart.yaml`: 0.4.0 → 0.5.0.

## Verification

- [x] `helm template` (exit 0): rendered realm ConfigMap contains the
  `lightbridge` scope with the mapper, and `self-service-mcp-api`
  `defaultClientScopes` includes `lightbridge`.

## Screenshots / Evidence

Rendered `camer-digital-realm.yaml` clientScopes + client as above.

## Risk Assessment

- [x] Low

Additive realm config. **Two caveats, both in the runbook:** (1) Standard Token
Exchange (a per-client capability) is not expressible in this realm template yet
— it must be enabled manually; (2) the `camer-digital` realm is not currently
reconciled by a running config-sync CronJob, so this is the declarative source
of truth that must be applied to the live realm (runbook included).

## AI Usage Declaration

AI was used for:
- [x] Reading the mapper provider, drafting the scope/mapper, and writing the runbook.

Human verification:
- [x] I understand every change in this PR
- [x] I reviewed the rendered realm
- [x] I accept responsibility for this PR

## Reviewer Focus

- Whether `self-service-mcp-api` is the right client to carry the scope (vs a
  dedicated exchange client), and when to wire config-sync so this reconciles.
