### PR TITLE
[DO NOT MERGE until EG≥1.8.2] feat(ratelimit): shared cross-model monthly budget (#532)

### DIFF
--- a/charts/ai-model/templates/backendtrafficpolicy.yaml
+++ b/charts/ai-model/templates/backendtrafficpolicy.yaml
@@ -7,18 +7,23 @@ bucket is exhausted):
   1. burst requests/min — keyed on x-account-id + x-billing-plan (per user per model).
   2. burst tokens/min   — keyed on x-account-id + x-billing-plan, cost = the llm_total_token
                           response metadata (TotalToken) the AIGatewayRoute emits.
-  3. monthly budget     — keyed on (x-account-id, x-billing-plan) ONLY — no
-                          model selector — so the budget is a SINGLE shared
-                          counter across ALL models (ADR-0035). micro-USD,
-                          cost = llm_custom_total_cost response metadata.
-                          Emitted ONLY for plans that carry a budget →
-                          service/internal stay uncapped.
+  3. monthly budget     — micro-USD, cost = llm_custom_total_cost. Emitted ONLY
+                          for plans that carry a budget → service/internal stay
+                          uncapped. ⚠️ CAVEAT: because this BTP targets the
+                          per-model HTTPRoute, Envoy Gateway namespaces the
+                          counter PER ROUTE — so despite the model-agnostic
+                          descriptor this budget is enforced PER MODEL, not shared
+                          (a heavy user held ~29 separate counters, #532). The
+                          shared fix moves this rule to the gateway-wide BTP with
+                          `shared: true` (charts/core-gateway); when
+                          `.Values.sharedBudget.enabled` this per-model rule is
+                          DROPPED and the policy instead merges
+                          (`mergeType: StrategicMerge`) with that gateway budget.
 
 x-billing-plan (stamped by the AuthConfig from Keycloak's billing_plan claim (from group attribute)) selects the plan.
 
-Budget per plan = global plan default (.Values.plans.<plan>.monthlyBudgetUsd) — no per-model overrides for shared budget
-else the global plan default (.Values.plans.<plan>.monthlyBudgetUsd). Burst
-(rules 1+2) remains per-model; comes from .Values.plans.<plan>.burst.
+Budget per plan = global plan default (.Values.plans.<plan>.monthlyBudgetUsd).
+Burst (rules 1+2) is always per-model; comes from .Values.plans.<plan>.burst.
 
 ⚠️ Every clientSelectors header spells out `invert: false` explicitly, even
 though it's the zero value. The BackendTrafficPolicy CRD schema declares
@@ -31,6 +36,13 @@ makes the rendered manifest match what the API server actually stores.
 {{- $modelName := .Values.modelName -}}
 {{- $plans := .Values.plans -}}
 {{- $costKey := "llm_custom_total_cost" -}}
+{{- /* Shared-budget cutover (#532): when enabled, the monthly-budget rule below
+       is DROPPED (it moves to the gateway-wide BTP with `shared: true`) and this
+       per-model policy MERGES with that gateway policy instead of overriding it,
+       so it keeps its per-model burst + timeout while inheriting the one shared
+       budget counter. Requires Envoy Gateway ≥ v1.8.2 (see core-gateway BTP).
+       Defaults off → unchanged per-model behaviour. */ -}}
+{{- $sharedBudget := (.Values.sharedBudget | default dict).enabled -}}
 ---
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: BackendTrafficPolicy
@@ -41,6 +53,18 @@ spec:
     - group: gateway.networking.k8s.io
       kind: HTTPRoute
       name: {{ $modelName }}
+  {{- if $sharedBudget }}
+  # Merge with the gateway-wide BTP (which carries the shared budget) rather than
+  # fully overriding it (EG default). Without this the route would drop the
+  # gateway's shared-budget rule. StrategicMerge combines the rate-limit rule
+  # lists (gateway budget + this policy's burst).
+  mergeType: StrategicMerge
+  # Merging also inherits the gateway policy's retry (numRetries: 1). Model routes
+  # deliberately DON'T retry LLM calls (amplifies load on stressed backends, and
+  # risks double-charging a partial generation) — so neutralise it back to 0.
+  retry:
+    numRetries: 0
+  {{- end }}
   {{- /*
   Per-model upstream timeout.
   */ -}}
@@ -108,8 +132,9 @@ spec:
                 namespace: io.envoy.ai_gateway
                 key: llm_total_token
         {{- end }}
-        {{- /* ── 3. monthly budget (SHARED across all models per user, micro-USD) ── */}}
+        {{- /* ── 3. monthly budget (per-model unless sharedBudget.enabled → moved to gateway BTP) ── */}}
         {{- $budgetUsd := $planCfg.monthlyBudgetUsd }}
+        {{- if not $sharedBudget }}
         {{- with $budgetUsd }}
         {{- $limit := mulf . 1000000 | int64 }}
         - clientSelectors:
@@ -122,7 +147,7 @@ spec:
                   type: Exact
                   value: {{ $planName | quote }}
           limit:
-            requests: {{ $limit }} # {{ $planName }} monthly budget ${{ . }} — shared across ALL models
+            requests: {{ $limit }} # {{ $planName }} monthly budget ${{ . }} — PER MODEL (see caveat; shared version is the gateway BTP)
             unit: Month
           cost:
             request:
@@ -133,5 +158,6 @@ spec:
               metadata:
                 namespace: io.envoy.ai_gateway
                 key: {{ $costKey }}
+        {{- end }}
         {{- end }}
         {{- end }}

--- a/charts/ai-model/values.yaml
+++ b/charts/ai-model/values.yaml
@@ -73,3 +73,11 @@ plans: {}
 #     monthlyBudgetUsd: 30
 #   pro:
 #     monthlyBudgetUsd: 200
+
+# Shared cross-model monthly budget cutover (#532). When enabled, this per-model
+# BTP drops its monthly-budget rule and merges (StrategicMerge) with the
+# gateway-wide BTP that carries ONE `shared: true` budget counter across all
+# models. Keep FALSE until Envoy Gateway ≥ v1.8.2 (bug #9244), then flip this and
+# core-gateway `backendTrafficPolicy.monthlyBudget.enabled` together.
+sharedBudget:
+  enabled: false

--- a/charts/ai-models/templates/applicationset.yaml
+++ b/charts/ai-models/templates/applicationset.yaml
@@ -61,6 +61,7 @@ spec:
       "backendsInventory" $.Values.backends
       "minBackends" (default 2 $modelConfig.minBackends)
       "timeout" (default (dict) $modelConfig.timeout)
+      "sharedBudget" (default (dict) $.Values.sharedBudget)
 }}
 {{ $childValues | toYaml | indent 14 }}
 {{- end }}

--- a/charts/ai-models/values.yaml
+++ b/charts/ai-models/values.yaml
@@ -54,6 +54,15 @@ argocd:
 #                             x-org-id). OMITTED for a plan ⇒ uncapped budget.
 # x-billing-plan (set by the AuthConfig from the Keycloak `billing_plan` claim,
 # or "internal" on the internal plane) selects which plan's rules apply.
+# Shared cross-model monthly-budget cutover (#532). Single lever propagated to
+# every per-model ai-model child. When true: each model's BTP drops its per-model
+# budget rule and merges with the gateway-wide BTP's ONE `shared: true` counter
+# per (user, plan). ⚠️ Keep false until Envoy Gateway ≥ v1.8.2 (bug #9244), and
+# flip core-gateway `backendTrafficPolicy.monthlyBudget.enabled` in the SAME
+# rollout so there is never a window with neither budget active.
+sharedBudget:
+  enabled: false
+
 rateLimitBudgeting:
   plans:
     free:

--- a/charts/core-gateway/templates/backendtrafficpolicy.yaml
+++ b/charts/core-gateway/templates/backendtrafficpolicy.yaml
@@ -41,6 +41,55 @@ spec:
     http:
       requestTimeout: {{ . | quote }}
   {{- end }}
+  {{- /* ── Shared cross-model monthly budget (#532) ──────────────────────────
+     ONE gateway-scoped, `shared: true` counter per (x-account-id, x-billing-plan)
+     that spans EVERY model route — the fix for budgets being enforced per-model
+     (a heavy user held ~29 separate per-model counters, so the real cap was
+     $30 × models). Lives on THIS gateway-wide policy because `shared: true` keys
+     the bucket by policy name, so it only collapses to one bucket when the rule
+     is on a single policy (not the 28 per-model BTPs). The per-model BTPs merge
+     with this one via `mergeType: StrategicMerge` (charts/ai-model) to keep their
+     per-model burst + timeout while inheriting this shared budget.
+
+     ⚠️ REQUIRES Envoy Gateway ≥ v1.8.2. On v1.8.1 (bug envoyproxy/gateway#9244) a
+     rule that is BOTH `shared: true` AND cost-bearing drops the per-request cost
+     → the counter ticks +1/req instead of +micro-USD → budget effectively
+     UNLIMITED (worse than per-model). `monthlyBudget.enabled` defaults false;
+     flip it (and ai-model `sharedBudget.enabled`) TOGETHER only after the upgrade.
+  */ -}}
+  {{- with $btp.monthlyBudget }}
+  {{- if .enabled }}
+  rateLimit:
+    type: Global
+    global:
+      rules:
+        {{- range $planName, $usd := .plans }}
+        - clientSelectors:
+            - headers:
+                - invert: false
+                  name: x-account-id
+                  type: Distinct
+                - invert: false
+                  name: x-billing-plan
+                  type: Exact
+                  value: {{ $planName | quote }}
+          limit:
+            requests: {{ mulf $usd 1000000.0 | int64 }} # {{ $planName }} shared monthly budget ${{ $usd }} across ALL models
+            unit: Month
+          # The lever (#9244): keyed by policy, shared across every route/model.
+          shared: true
+          cost:
+            request:
+              from: Number
+              number: 0
+            response:
+              from: Metadata
+              metadata:
+                namespace: io.envoy.ai_gateway
+                key: llm_custom_total_cost
+        {{- end }}
+  {{- end }}
+  {{- end }}
   connection:
     bufferLimit: {{ $btp.bufferLimit | default "100Mi" | quote }}
   retry:

--- a/charts/core-gateway/values.yaml
+++ b/charts/core-gateway/values.yaml
@@ -203,6 +203,20 @@ clientTrafficPolicy:
 backendTrafficPolicy:
   bufferLimit: 100Mi
 
+  # ── Shared cross-model monthly budget (#532) ──────────────────────────────
+  # One SHARED micro-USD budget per (user, plan) across ALL model routes, instead
+  # of the per-model counters that let a heavy user spend cap × N-models. Rendered
+  # as a `shared: true` cost rule on the gateway-wide BTP (see the template).
+  # ⚠️ enabled MUST stay false until Envoy Gateway is ≥ v1.8.2 (bug #9244 breaks
+  # shared+cost on 1.8.1). Flip this AND ai-model `sharedBudget.enabled` together.
+  # `plans` values (USD) must match what the per-model path used (ai-models
+  # rateLimitBudgeting.plans.<plan>.monthlyBudgetUsd) at cutover.
+  monthlyBudget:
+    enabled: false
+    plans:
+      free: 30
+      pro: 200
+
   # Whole-request ceiling for routes this gateway-wide policy governs (the
   # non-model routes — model routes are governed by their own per-model BTP in
   # charts/ai-model, which replaces this one). ADR-0034.


### PR DESCRIPTION
## Problem (confirmed live)
The monthly budget is enforced **per model**, not shared. Each model's route-scoped `BackendTrafficPolicy` gets its own Envoy Gateway counter — the Redis keys carry `…/converse/<model>/…` — so a user's real cap is **$budget × models-used**. Scanning the free-plan budget keys, one account (`a8b16bd6…`) held **29 separate counters**.

## Fix (flag-gated, default OFF)
Move the monthly-budget rule onto the **gateway-wide BTP** as a single **`shared: true`** counter per `(x-account-id, x-billing-plan)` that spans all model routes. Per-model BTPs **merge** with it (`mergeType: StrategicMerge`) to keep per-model burst + timeout, with the inherited gateway retry neutralised (`numRetries: 0` — model routes must not retry LLM calls).

- **core-gateway** BTP + values: `backendTrafficPolicy.monthlyBudget` → shared+cost budget rules (`free: 30`, `pro: 200`).
- **ai-model** BTP: drops its per-model budget rule and adds `mergeType`/`retry:0` when `sharedBudget.enabled`.
- **ai-models**: one `sharedBudget.enabled` lever threaded to every model child.

Renders verified both ways (OFF = byte-identical current behaviour; ON = budget gone from per-model BTP, shared rules on gateway BTP, `mergeType`+`retry:0` present). All 3 charts lint clean.

## ⚠️ DO NOT MERGE until Envoy Gateway ≥ v1.8.2
Deployed EG is **v1.8.1**, which has [#9244](https://github.com/envoyproxy/gateway/issues/9244): a rule that is both `shared: true` **and** cost-bearing has its per-request cost dropped → the shared counter ticks **+1/req instead of +micro-USD** → budget effectively **unlimited**. Fixed in **v1.8.2** ([PR #9245](https://github.com/envoyproxy/gateway/pull/9245)).

## Cutover checklist (after EG ≥ 1.8.2)
1. Confirm EG controller image ≥ `v1.8.2`.
2. Flip **both** flags in the same rollout (never a window with neither budget active):
   - `ai-models` `sharedBudget.enabled: true`
   - `core-gateway` `backendTrafficPolicy.monthlyBudget.enabled: true`
3. Verify rendered xDS: the shared budget rule lands on the per-route ratelimit filter config with `hits_addend` (the #9245 fix), and the Redis counter for a test user increments by the micro-USD cost — not +1/req.
4. Remove the now-unused per-model `monthlyBudgetUsd` from `ai-models` (follow-up cleanup); keep `plans.*.burst`.

Interim mitigation in the meantime: [#598](https://github.com/ADORSYS-GIS/ai-helm/pull/598) lowered the per-model free cap 50→30.

🤖 Generated with [Claude Code](https://claude.com/claude-code)