### PR TITLE
chore(eg): bump Envoy Gateway v1.8.1 → v1.8.2 (#532)

### DIFF
--- a/charts/apps/values.yaml
+++ b/charts/apps/values.yaml
@@ -318,9 +318,14 @@ applications:
     valuesFromRepo: true
     source:
       repoURL: oci://docker.io/envoyproxy/gateway-helm
-      # v1.8.1 — the new minimum required by AIEG v1.0 (was v1.8.0). Patch bump
-      # over the audited v1.8.0; no CRD breaking changes (ADR-0069).
-      targetRevision: v1.8.1
+      # v1.8.2 — patch bump over v1.8.1 (still satisfies the AIEG v1.0 floor of
+      # ≥v1.8.1). Fixes envoyproxy/gateway#9244 (PR #9245): shared+cost global
+      # rate-limit rules dropped the per-request cost on 1.8.0/1.8.1 — required
+      # before enabling the shared cross-model monthly budget (#532). No CRD
+      # breaking changes; the only runtime note (#9332, shared rules → filter
+      # typedPerFilterConfig) affects EnvoyPatchPolicy/extension-server users
+      # only, which we don't use.
+      targetRevision: v1.8.2
       path: .
       helm:
         releaseName: eg


### PR DESCRIPTION
One-line `targetRevision` bump of the `aii-eg` app (`oci://docker.io/envoyproxy/gateway-helm`).

## Why
Fixes [envoyproxy/gateway#9244](https://github.com/envoyproxy/gateway/issues/9244) ([PR #9245](https://github.com/envoyproxy/gateway/pull/9245)): on 1.8.0/1.8.1 a global rate-limit rule that is both `shared: true` **and** cost-bearing drops the per-request cost (counter ticks +1/req instead of +micro-USD). This is a **hard prerequisite** for the shared cross-model monthly budget ([#606](https://github.com/ADORSYS-GIS/ai-helm/pull/606)).

## Safety
- v1.8.2 satisfies the AIEG v1.0 floor (≥ v1.8.1); v1.8.2 is published on the registry (verified).
- Patch release, no CRD breaking changes. The one runtime note ([#9332](https://github.com/envoyproxy/gateway/pull/9332): shared rules → `typedPerFilterConfig`) only affects EnvoyPatchPolicy / extension-server consumers — we use neither.
- Independent of #606: that PR stays flag-OFF, so **budgets don't change** when this merges — still per-model until the flags are flipped.

## Operational note (control-plane upgrade)
This restarts the `envoy-gateway` controller and may trigger a rolling data-plane (envoy proxy) update. Merge in a maintenance window and watch:
- `kubectl -n envoy-gateway-system rollout status deploy/envoy-gateway`
- gateway stays serving (proxies roll one at a time); AuthConfig/SecurityPolicy/BTP status stay `Ready/Accepted`.

## Sequence
1. Merge this → EG on v1.8.2 (no budget change).
2. Then #606: flip `sharedBudget.enabled` + `monthlyBudget.enabled` together; verify the Redis counter charges micro-USD, not +1/req.

🤖 Generated with [Claude Code](https://claude.com/claude-code)