### PR TITLE
fix(alerting): actor budget alert — show dollars, not an opaque percentage

### DIFF
--- a/charts/observability-dashboards/values.yaml
+++ b/charts/observability-dashboards/values.yaml
@@ -250,45 +250,64 @@ alerting:
           for: 1h
           severity: warning
           summary: "AI Gateway 30-day spend exceeded $6000 (budget knob — set to your actual monthly budget; run-rate ~$5k)."
-        # Per-actor: fires when a SINGLE person/actor's own rolling 30d spend
-        # reaches their OWN plan's monthly cap (charts/ai-models/values.yaml
+        # Per-actor: fires when a SINGLE person's own rolling 30d spend crosses
+        # their OWN plan's monthly cap (charts/ai-models/values.yaml
         # rateLimitBudgeting.plans — free $50, pro $200; service/internal are
-        # uncapped by design and deliberately excluded, no budget to cross).
-        # Each plan's fraction-of-cap is computed separately (PromQL has no
-        # per-series threshold, so the % conversion happens IN the query) then
-        # unioned with `or` — disjoint billing_plan label values, no collision.
-        # `gt 100` is the practical `>= 100%` (spend is a continuous $ value,
-        # same "exceeded" convention the two org-wide rules above use).
-        - uid: cost-actor-budget-crossed
-          title: AI Gateway — actor hit their monthly budget
+        # uncapped by design and excluded, no budget to cross). Split into ONE
+        # RULE PER PLAN so the query VALUE is the dollar spend and the threshold
+        # is the plan's real dollar cap — this lets the alert message state the
+        # actual "$X spent of $Y budget" instead of an opaque bare percentage
+        # (PromQL has no per-series threshold, so a single unified rule could
+        # only compare a % and couldn't show dollars). `$values.B.Value` is the
+        # reduced dollar figure; `printf "%.2f"` formats it (Grafana annotation
+        # templates are Go text/template — printf is a builtin).
+        - uid: cost-actor-budget-free
+          title: AI Gateway — free-tier actor over budget
           datasourceUid: mimir
           expr: >-
-            (sum by (email, display_name, billing_plan)
-              (increase(loki_process_custom_gen_ai_usage_cost_micro_usd{billing_plan="free"}[30d]))
-              / 1e6 / 50 * 100)
-            or
-            (sum by (email, display_name, billing_plan)
-              (increase(loki_process_custom_gen_ai_usage_cost_micro_usd{billing_plan="pro"}[30d]))
-              / 1e6 / 200 * 100)
+            sum by (email, display_name)
+              (increase(loki_process_custom_gen_ai_usage_cost_micro_usd{billing_plan="free"}[30d])) / 1e6
           fromSeconds: 2592000
           op: gt
-          threshold: 100
+          threshold: 50
           for: 0m
           severity: critical
           summary: >-
-            🚨 {{ $labels.display_name }} ({{ $labels.email }}, {{ $labels.billing_plan }} plan)
-            is at {{ $values.B.Value }}% of their monthly budget over the last 30d.
+            🚨 {{ $labels.display_name }} ({{ $labels.email }}) has spent
+            ${{ printf "%.2f" $values.B.Value }} in the last 30 days —
+            over their $50.00/month free-tier budget.
           description: >-
             Per-actor ROLLING 30-day spend (ADR-0058 precomputed Mimir metric)
-            crossed 100% of their own plan's monthlyBudgetUsd cap (free=$50,
-            pro=$200; see AI Gateway — actor consumption / chats-by-user
-            dashboards for detail). ⚠️ This is cumulative trailing-30d spend,
-            NOT the same window the rate limiter enforces against (ADR-0070's
-            fixed 30-day epoch bucket in redis, which resets on a schedule,
-            not on a rolling basis) — a person can show >100% here while their
-            LIVE enforcement budget is well under cap. Check the
+            exceeded the free-tier monthlyBudgetUsd cap of $50. Value = dollars
+            spent (trailing 30d). See the AI Gateway — actor consumption /
+            chats-by-user dashboards for the breakdown. ⚠️ This is cumulative
+            trailing-30d spend, NOT the same window the rate limiter enforces
+            against (ADR-0070's fixed 30-day epoch bucket in redis, which resets
+            on a schedule, not rolling) — someone can be over $50 here while
+            their LIVE enforcement budget is well under cap. Check the
             AI Gateway — rate-limit quota dashboard for their actual current
             enforcement state before assuming they're blocked.
+        - uid: cost-actor-budget-pro
+          title: AI Gateway — pro actor over budget
+          datasourceUid: mimir
+          expr: >-
+            sum by (email, display_name)
+              (increase(loki_process_custom_gen_ai_usage_cost_micro_usd{billing_plan="pro"}[30d])) / 1e6
+          fromSeconds: 2592000
+          op: gt
+          threshold: 200
+          for: 0m
+          severity: critical
+          summary: >-
+            🚨 {{ $labels.display_name }} ({{ $labels.email }}) has spent
+            ${{ printf "%.2f" $values.B.Value }} in the last 30 days —
+            over their $200.00/month pro budget.
+          description: >-
+            Per-actor ROLLING 30-day spend (ADR-0058 precomputed Mimir metric)
+            exceeded the pro monthlyBudgetUsd cap of $200. Value = dollars spent
+            (trailing 30d). Same rolling-vs-enforcement caveat as the free-tier
+            rule above — check the AI Gateway — rate-limit quota dashboard for
+            the live enforcement state.
 
     - name: stack-health
       folderRef: collectors


### PR DESCRIPTION
## 1. Summary

The per-actor budget alert fired with an opaque bare percentage — *"is at 100.70582571744009% of their monthly budget"* — which doesn't say what the budget is or how much was actually spent. This makes the message show **dollars**.

Source of truth: maintainer feedback on the fired alert ("the alert is not clear… how much is the budget? what's the current consumption?").

## 2. Intent

> Split the single percentage rule into one rule per plan (free / pro) so the alert value is the **dollar spend** and the threshold is the plan's real dollar cap. The message then states "$X spent of $Y/month budget" instead of a raw percentage.

Before:
```
🚨 Christian Defometio (…, free plan) is at 199.40930032852785% of their monthly budget over the last 30d.
```
After:
```
🚨 Christian Defometio (christian.defometio@adorsys.com) has spent $101.75 in the last 30 days — over their $50.00/month free-tier budget.
```

## 3. Scope

### In Scope
- Replace `cost-actor-budget-crossed` (one % rule) with `cost-actor-budget-free` ($50 cap) + `cost-actor-budget-pro` ($200 cap) in `charts/observability-dashboards/values.yaml` (`ai-gateway-cost` group).
- Dollar figure via `printf "%.2f"`; rolling-vs-enforcement caveat retained.

### Out of Scope
- No change to what triggers the alert (still: rolling-30d spend over the plan cap) or its Discord routing.

## 4. Verification

I verified this change by:

- [x] Running automated tests
- [x] Checking metrics

Commands run:
```bash
helm lint charts/observability-dashboards --strict   # 0 failed
helm template x charts/observability-dashboards --dry-run   # both rules render; params [50] / [200]; printf preserved

# Live Mimir — the dollar query returns the expected amounts:
#   Christian Defometio  free  $101.75  (203.5% of $50)
#   Victoire J. M. Wandjeu free $92.20  (184.4%)
#   ... (matches the fired-alert percentages)
```

Results:
```text
1 chart(s) linted, 0 chart(s) failed
Rendered: cost-actor-budget-free (threshold 50) + cost-actor-budget-pro (threshold 200), $-formatted summaries.
```

Not verified pre-merge: the `printf` rendering in a live-fired alert (Go text/template builtin; the prior rule's `{{ $values.B.Value }}` already rendered, so the templating path works). Worst case it shows the raw value — cosmetic, not harmful.

## 5. Screenshots / Evidence
* The before/after message text above; live Mimir dollar figures in Verification.

## 6. Risk Assessment
Risk level:
* [x] Low (alert message + threshold shape only; same trigger semantics, same Discord route)

## 7. AI Usage Declaration
AI was used for:
* [x] Understanding existing code
* [x] Generating code
* [x] Checking metrics

Human verification:
* [ ] I understand every meaningful change in this PR
* [ ] I accept responsibility for this PR

## 8. Reviewer Focus
* [x] Correctness
* [x] Product intent

🤖 Generated with [Claude Code](https://claude.com/claude-code)
