### PR TITLE
feat(alerting): add $30 free-tier budget warning (keep $50 critical)

### DIFF
--- a/charts/observability-dashboards/values.yaml
+++ b/charts/observability-dashboards/values.yaml
@@ -251,18 +251,42 @@ alerting:
           severity: warning
           summary: "AI Gateway 30-day spend exceeded $6000 (budget knob — set to your actual monthly budget; run-rate ~$5k)."
         # Per-actor: fires when a SINGLE person's own rolling 30d spend crosses
-        # their OWN plan's monthly cap (charts/ai-models/values.yaml
-        # rateLimitBudgeting.plans — free $50, pro $200; service/internal are
-        # uncapped by design and excluded, no budget to cross). Split into ONE
-        # RULE PER PLAN so the query VALUE is the dollar spend and the threshold
-        # is the plan's real dollar cap — this lets the alert message state the
-        # actual "$X spent of $Y budget" instead of an opaque bare percentage
-        # (PromQL has no per-series threshold, so a single unified rule could
-        # only compare a % and couldn't show dollars). `$values.B.Value` is the
-        # reduced dollar figure; `printf "%.2f"` formats it (Grafana annotation
-        # templates are Go text/template — printf is a builtin).
+        # their OWN plan's monthly cap. Free-tier budget is $30, alerted in TWO
+        # TIERS — a $30 WARNING (reached budget) and a $50 CRITICAL (well over);
+        # pro is $200. service/internal are uncapped by design and excluded.
+        # Split into ONE RULE PER (plan, tier) so the query VALUE is the dollar
+        # spend and the threshold is a real dollar figure — this lets the message
+        # state the actual "$X spent of $Y budget" instead of an opaque bare
+        # percentage (PromQL has no per-series threshold, so a single unified
+        # rule could only compare a % and couldn't show dollars). `$values.B.Value`
+        # is the reduced dollar figure; `printf "%.2f"` formats it (Grafana
+        # annotation templates are Go text/template — printf is a builtin).
+        - uid: cost-actor-budget-free-warn
+          title: AI Gateway — free-tier actor reached budget ($30)
+          datasourceUid: mimir
+          expr: >-
+            sum by (email, display_name)
+              (increase(loki_process_custom_gen_ai_usage_cost_micro_usd{billing_plan="free"}[30d])) / 1e6
+          fromSeconds: 2592000
+          op: gt
+          threshold: 30
+          for: 0m
+          severity: warning
+          summary: >-
+            ⚠️ {{ $labels.display_name }} ({{ $labels.email }}) has spent
+            ${{ printf "%.2f" $values.B.Value }} in the last 30 days —
+            reached their $30.00/month free-tier budget.
+          description: >-
+            Per-actor ROLLING 30-day spend (ADR-0058 precomputed Mimir metric)
+            reached the free-tier monthlyBudgetUsd cap of $30 (warning tier; the
+            $50 rule below escalates to critical). Value = dollars spent (trailing
+            30d). ⚠️ This is cumulative trailing-30d spend, NOT the same window the
+            rate limiter enforces against (ADR-0070's fixed 30-day epoch bucket in
+            redis, which resets on a schedule, not rolling) — someone can be over
+            budget here while their LIVE enforcement budget is well under cap.
+            Check the AI Gateway — rate-limit quota dashboard for the live state.
         - uid: cost-actor-budget-free
-          title: AI Gateway — free-tier actor over budget
+          title: AI Gateway — free-tier actor well over budget ($50)
           datasourceUid: mimir
           expr: >-
             sum by (email, display_name)
@@ -275,18 +299,18 @@ alerting:
           summary: >-
             🚨 {{ $labels.display_name }} ({{ $labels.email }}) has spent
             ${{ printf "%.2f" $values.B.Value }} in the last 30 days —
-            over their $50.00/month free-tier budget.
+            well over their $30.00/month free-tier budget.
           description: >-
             Per-actor ROLLING 30-day spend (ADR-0058 precomputed Mimir metric)
-            exceeded the free-tier monthlyBudgetUsd cap of $50. Value = dollars
-            spent (trailing 30d). See the AI Gateway — actor consumption /
-            chats-by-user dashboards for the breakdown. ⚠️ This is cumulative
-            trailing-30d spend, NOT the same window the rate limiter enforces
-            against (ADR-0070's fixed 30-day epoch bucket in redis, which resets
-            on a schedule, not rolling) — someone can be over $50 here while
-            their LIVE enforcement budget is well under cap. Check the
-            AI Gateway — rate-limit quota dashboard for their actual current
-            enforcement state before assuming they're blocked.
+            passed $50 — well over the free-tier monthlyBudgetUsd cap of $30
+            (critical escalation of the $30 warning above). Value = dollars spent
+            (trailing 30d). See the AI Gateway — actor consumption / chats-by-user
+            dashboards for the breakdown. ⚠️ This is cumulative trailing-30d spend,
+            NOT the same window the rate limiter enforces against (ADR-0070's fixed
+            30-day epoch bucket in redis, which resets on a schedule, not rolling)
+            — someone can be over here while their LIVE enforcement budget is well
+            under cap. Check the AI Gateway — rate-limit quota dashboard for their
+            actual current enforcement state before assuming they're blocked.
         - uid: cost-actor-budget-pro
           title: AI Gateway — pro actor over budget
           datasourceUid: mimir


### PR DESCRIPTION
## 1. Summary

Free-tier budget was reduced to **$30**. Adds a **$30 warning** tier and keeps the existing **$50 critical** alert as the escalation.

- New `cost-actor-budget-free-warn` — `severity: warning`, threshold $30, "⚠️ … reached their $30.00/month free-tier budget."
- Existing `cost-actor-budget-free` — kept, threshold $50, `severity: critical`, reworded to "🚨 … well over their $30.00/month free-tier budget" (so both messages reference the real $30 budget — no contradictory "$50 budget" vs "$30 budget" in Discord).
- `cost-actor-budget-pro` ($200) — unchanged.

Source of truth: maintainer request ("reduced the budget to $30 … add a second alert for when users reach $30, and keep the $50 alerts").

## 2. Intent

> Two-tier per-actor free-tier budget alerting: a $30 warning (reached budget) escalating to a $50 critical (well over), both stating the actual dollar spend against the real $30 budget.

## 3. Scope

### In Scope
- `charts/observability-dashboards/values.yaml` `ai-gateway-cost` group: add the $30 warning rule; reword the $50 rule to reference $30.

### Out of Scope
- The pro ($200) rule — untouched.
- The rate-limit *enforcement* config (`rateLimitBudgeting.plans`) — this PR is alerting only; the alert thresholds are independent hardcoded values.

## 4. Verification

- [x] Running automated tests

Commands run:
```bash
helm lint charts/observability-dashboards --strict     # 0 failed
helm template x charts/observability-dashboards --dry-run   # 3 rules render:
#   cost-actor-budget-free-warn  severity warning   params [30]
#   cost-actor-budget-free       severity critical  params [50]
#   cost-actor-budget-pro        severity critical  params [200]
```

Results:
```text
1 chart(s) linted, 0 chart(s) failed
```

Not verified pre-merge: live Discord delivery of the new warning (same rule shape + `printf` templating as the already-live $50/$200 rules, which render fine).

## 5. Screenshots / Evidence
* Rendered rule thresholds/severities above.

## 6. Risk Assessment
Risk level:
* [x] Low (one added alert rule + a message reword; same query, same Discord route)

## 7. AI Usage Declaration
AI was used for:
* [x] Understanding existing code
* [x] Generating code

Human verification:
* [ ] I understand every meaningful change in this PR
* [ ] I accept responsibility for this PR

## 8. Reviewer Focus
* [x] Correctness
* [x] Product intent — is the $50 reword ("well over their $30 budget") what you want, or should the $50 message keep its own "$50 budget" wording?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
