### PR TITLE
feat(apps): deploy single-node Restate durable-execution server (RFC-0005)

### DIFF
--- a/charts/apps/values.yaml
+++ b/charts/apps/values.yaml
@@ -471,6 +471,35 @@ applications:
     destination:
       namespace: converse
 
+  # --- Restate (durable execution) — RFC-0005 / ADR-0074 Phase-1 enabler ---
+  # Single-node Restate durable-execution server for the LCI control plane. The
+  # future `restate-worker` control-plane role (in the lightbridge-code-intelligence
+  # app, default wave 0) registers services with + is invoked by this server, so
+  # Restate is a storage-backend dependency that MUST be up first → sync-wave -2
+  # (storage tier per SYNC_WAVE_PATTERN.md — same wave as the observability storage
+  # backends mimir/loki/tempo). Upstream chart from the Restate OCI registry, pinned
+  # to 1.7.2 (external source form, like eg/aieg). Single node: replicaCount 1,
+  # RocksDB on a PVC, NO cluster/Raft, NO S3. Namespace `converse` (the LCI workload
+  # namespace, ADR-0017 home-remote default). Workload values (resources / rocksdb
+  # budget / PVC size) live in ai-helm-values (ADR-0056), read via the $values ref
+  # the template injects (ignoreMissingValueFiles → renders on chart defaults until
+  # the file lands). No image-updater (upstream image, version-pinned); serviceMonitor
+  # stays off to keep the blast radius to just this new StatefulSet.
+  - name: restate
+    finalizers:
+      - resources-finalizer.argocd.argoproj.io
+    additionalAnnotations:
+      argocd.argoproj.io/sync-wave: "-2"
+    valuesFromRepo: true
+    source:
+      repoURL: oci://ghcr.io/restatedev/restate-helm
+      targetRevision: 1.7.2
+      path: .
+      helm:
+        releaseName: restate
+    destination:
+      namespace: converse
+
   # --- Lightbridge Code Intelligence ---
   # The GitHub-App code-review / repo-Q&A system (repo:
   # vymalo/lightbridge-code-intelligence): Rust control plane + Next.js web console


### PR DESCRIPTION
## 1. Summary

This PR changes:

- Adds a new ArgoCD `Application` entry `restate` in `charts/apps/values.yaml` that deploys the **upstream Restate Helm chart** (`oci://ghcr.io/restatedev/restate-helm`, pinned **1.7.2**) as a **single-node StatefulSet** in the **`converse`** namespace.
- Wires it as a storage-backend at **sync-wave `-2`** so it comes up before its future consumer.
- Reads workload config from `ai-helm-values` via the `$values` ref (`valuesFromRepo: true`) — companion PR seeds that file.

It solves:

- RFC-0005 (durable orchestration on Restate) Phase-1 enabler — stand up the durable-execution server that the future `restate-worker` control-plane role will call into.
- Ticket: `vymalo/lightbridge-code-intelligence#296`
- ADR: `docs/adr/0074-restate-egress-pilot.md`

**Companion PR (values):** https://github.com/ADORSYS-GIS/ai-helm-values/pull/54 — seeds `environments/prod/values/restate.yaml`.

---

## 2. Intent

The intent of this PR is:

> Provision a single-node Restate durable-execution server the GitOps way, as an isolated new component, so RFC-0005 orchestration work has a backend to build against. Restate is a storage/backend dependency: it must be healthy before the control-plane role that registers services with it (and is invoked by it) starts, hence the negative sync wave. No application Rust code is touched — infra only.

Source of truth:
- RFC: https://github.com/vymalo/lightbridge-code-intelligence/blob/main/docs/rfc/0005-durable-orchestration-on-restate.md
- ADR: https://github.com/vymalo/lightbridge-code-intelligence/blob/main/docs/adr/0074-restate-egress-pilot.md
- Ticket: https://github.com/vymalo/lightbridge-code-intelligence/issues/296

---

## 3. Scope

### In Scope

- One new `applications[]` entry (`restate`) in `charts/apps/values.yaml`.
- Chart pinned to `1.7.2`; single node (`replicaCount 1`), RocksDB on a PVC, no cluster/Raft, no S3.
- `sync-wave: "-2"` (storage tier per `SYNC_WAVE_PATTERN.md`, same wave as the observability storage backends mimir/loki/tempo).

### Out of Scope

- The `restate-worker` control-plane role / any application code (separate follow-up).
- NetworkPolicy allowing `restate-worker → restate` ingress (ships with the consumer).
- ServiceMonitor / dashboards (kept off to limit blast radius).
- Multi-node / Raft / S3 snapshotting.

---

## 4. Verification

I verified this change by:

- [ ] Running automated tests
- [x] Running manual tests
- [ ] Checking logs
- [ ] Checking metrics
- [ ] Testing error cases
- [ ] Testing permissions/security behavior
- [ ] Testing rollback or failure behavior, if relevant

> **Coverage note:** this is YAML infra (no application code), so the 80%-coverage rule is **N/A**. Verification is render/lint-based.

Commands run:

```bash
# 1. Render the upstream Restate chart with the companion values file
helm template restate oci://ghcr.io/restatedev/restate-helm --version 1.7.2 \
  -f environments/prod/values/restate.yaml -n converse

# 2. Render the apps umbrella chart (produces the ArgoCD Application CR)
helm dependency build charts/apps
helm template apps charts/apps

# 3. Lint
helm lint charts/apps
```

Results:

```text
# (1) workload renders cleanly — 4 objects, single node, correct resources/rocksdb/PVC
kind: ServiceAccount / kind: Service / kind: Service / kind: StatefulSet
replicas: 1
resources: limits{cpu:1, memory:4Gi} requests{cpu:500m, memory:4Gi}
RESTATE_ROCKSDB_TOTAL_MEMORY_SIZE = 3Gi
volumeClaimTemplates: storage 32Gi, no storageClassName (default provisioner)

# (2) the rendered Application CR
kind: Application  name: aii-restate
  annotations: argocd.argoproj.io/sync-wave: "-2"
  project: ai
  sources:
    - repoURL: oci://ghcr.io/restatedev/restate-helm  targetRevision: 1.7.2  path: .
      helm.valueFiles: [$values/environments/prod/values/restate.yaml]  ignoreMissingValueFiles: true
    - ref: values  repoURL: https://github.com/adorsys-gis/ai-helm-values  targetRevision: main
  destination: {name: home-remote, namespace: converse}

# (3) lint
1 chart(s) linted, 0 chart(s) failed   (only INFO: icon recommended)

# diff is purely additive
charts/apps/values.yaml | 29 +++++++++++++++++++++++++++++  (1 file, 29 insertions, 0 deletions)
```

`kubeconform`/`kubeval` are not installed on this machine → schema validation skipped (helm render + lint stand in). `argocd app diff` skipped: it would query the live cluster (not read-only-safe in this context); delivery is via ArgoCD on merge.

---

## 5. Screenshots / Evidence

- Rendered Application CR + workload manifests: see Verification block above.
- No `kubectl apply` / `helm install` was run — delivery is ArgoCD-on-merge only.

---

## 6. Risk Assessment

Risk level:

* [ ] Low
* [x] Medium
* [ ] High

Potential risks:

* This is a prod GitOps change: merge to `ai-helm` `main` republishes the umbrella and ArgoCD will create the new StatefulSet on `home-remote`.
* A wrong sync-wave or namespace could disturb ordering for existing `converse` apps.
* Default-StorageClass assumption for the PVC.

Mitigation:

* **Blast radius contained to one new StatefulSet:** the diff is purely additive (29 insertions, 0 deletions); no existing Application, values file, or namespace resource is mutated. `helm lint` passes; the full apps chart renders with no errors.
* Sync-wave `-2` is the documented storage tier and does not renumber any existing app (existing `converse` apps stay at their default wave 0).
* PVC uses the cluster default StorageClass (`storageClassName` null), consistent with prod `cluster.yaml` `storageClass: ""`.

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [ ] Refactoring
* [ ] Generating tests
* [ ] Drafting documentation
* [ ] Reviewing the diff
* [ ] Not used

Human verification:

* [ ] I understand every meaningful change in this PR
* [ ] I checked generated code manually
* [ ] I checked generated tests manually
* [ ] I removed unsupported AI assumptions
* [ ] I accept responsibility for this PR

---

## 8. Reviewer Focus

Please focus your review on:

* [x] Correctness
* [x] Architecture
* [ ] Security
* [ ] Performance
* [ ] Tests
* [x] Maintainability
* [x] Product intent
* [x] Edge cases

Specifically scrutinize:
- **Sync-wave ordering** vs existing `converse` apps — `-2` should precede the wave-0 `lightbridge-code-intelligence` consumer; confirm nothing else in `converse` needs to precede Restate.
- **Namespace** `converse` is the intended home for this pilot (vs a dedicated ns).
- **PVC StorageClass** — relying on the cluster default provisioner is correct for prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
