### PR TITLE
docs(lightbridge-secrets): OPA_PASSWORD no longer unused once opa is re-enabled

### DIFF
--- a/charts/lightbridge-secrets/values.yaml
+++ b/charts/lightbridge-secrets/values.yaml
@@ -20,12 +20,13 @@ externalSecrets:
       - secretKey: secret-id
         key: ai/camer/digital/prod/env
         property: lightbridge_api_client_secret_id
-  # OPA basic-auth password the api + mcp containers require as the
-  # OPA_PASSWORD env (secretKeyRef name: opa-secret, key: OPA_PASSWORD). The
-  # upstream chart still exposes lightbridge's internal OPA listener on api/mcp,
-  # so the pods won't start without this secret — even though OPA was removed
-  # from the auth path (ADR-0021), so the value is functionally UNUSED (any
-  # value works). Populate `lightbridge_opa_password` with any string.
+  # OPA basic-auth password (secretKeyRef name: opa-secret, key: OPA_PASSWORD).
+  # Consumed by the api + mcp pods (their configs carry the OPA listener block)
+  # AND by the re-enabled opa component, which authenticates the Keycloak
+  # token-exchange SPI's /idp/v1/resolve-context call with it. NOTE: this is NO
+  # LONGER a throwaway value — the SPI presents `authorino:<this password>` as
+  # Basic auth to opa, so `lightbridge_opa_password` MUST match the password the
+  # Keycloak SPI is configured with, or context resolution 401s.
   opa-secret:
     data:
       - secretKey: OPA_PASSWORD


### PR DESCRIPTION
## 1. Summary
Correct the `lightbridge-secrets` comment for `opa-secret`/`OPA_PASSWORD`: it is **no longer** a throwaway value.

## 2. Intent
Paired with re-enabling opa in prod. **Source of truth:** https://github.com/ADORSYS-GIS/ai-helm-values/pull/55 (reverses the opa half of ADR-0021/0026). With opa back, the Keycloak token-exchange SPI Basic-auths to opa's `/idp/v1/resolve-context` with `authorino:<OPA_PASSWORD>`. The old comment ("functionally UNUSED — any value works") is now a **footgun**: rotating `lightbridge_opa_password` to a random string would 401 context resolution.

## 3. Scope
- `charts/lightbridge-secrets/values.yaml` — comment only. No template/ES data/behaviour change.

## 4. Verification
- Comment-only diff; `helm template` output byte-identical. Confirmed the `opa-secret` ExternalSecret `data`/`remoteRef` mapping is untouched:
  ```
  git diff --stat  → charts/lightbridge-secrets/values.yaml | 13 +++++-------
  ```
- The re-enabled opa consumer that makes this true is verified in #55 (subchart `helm template` exit 0 with `OPA_PASSWORD`←`opa-secret`).

## 5. Screenshots / Evidence
n/a — documentation comment.

## 6. Risk Assessment
None functional. Prevents a future outage from an ill-informed secret rotation.

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [ ] Generating code
* [ ] Refactoring
* [ ] Generating tests
* [x] Drafting documentation
* [x] Reviewing the diff
* [ ] Not used

Human verification:

* [x] I understand every meaningful change in this PR
* [x] I checked generated code manually
* [x] I removed unsupported AI assumptions
* [x] I accept responsibility for this PR

## 8. Reviewer Focus
- Wording accuracy: the SPI-must-match constraint (the same password must reach the Keycloak namespace, out of this repo).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
