### PR TITLE
feat(ratelimit): enable shared cross-model monthly budget — cutover (#532)

### DIFF
--- a/charts/ai-models/values.yaml
+++ b/charts/ai-models/values.yaml
@@ -60,8 +60,10 @@ argocd:
 # per (user, plan). ⚠️ Keep false until Envoy Gateway ≥ v1.8.2 (bug #9244), and
 # flip core-gateway `backendTrafficPolicy.monthlyBudget.enabled` in the SAME
 # rollout so there is never a window with neither budget active.
+# CUTOVER 2026-07-08: enabled — EG is live on v1.8.2 (#9244 fixed), paired with
+# core-gateway monthlyBudget.enabled: true.
 sharedBudget:
-  enabled: false
+  enabled: true
 
 rateLimitBudgeting:
   plans:

--- a/charts/core-gateway/values.yaml
+++ b/charts/core-gateway/values.yaml
@@ -211,8 +211,10 @@ backendTrafficPolicy:
   # shared+cost on 1.8.1). Flip this AND ai-model `sharedBudget.enabled` together.
   # `plans` values (USD) must match what the per-model path used (ai-models
   # rateLimitBudgeting.plans.<plan>.monthlyBudgetUsd) at cutover.
+  # CUTOVER 2026-07-08: enabled — EG live on v1.8.2 (#9244 fixed), paired with
+  # ai-models sharedBudget.enabled: true.
   monthlyBudget:
-    enabled: false
+    enabled: true
     plans:
       free: 30
       pro: 200


### PR DESCRIPTION
## What
Flips both cutover flags to **activate** the shared cross-model budget built in #606. **EG is verified live on `v1.8.2`** (`envoy-gateway` image), so the #9244 shared+cost bug is fixed and this is safe.

- `ai-models` `sharedBudget.enabled: true` → threaded to every model child → each per-model BTP drops its budget rule and merges (`StrategicMerge`, `retry: 0`) with the gateway BTP.
- `core-gateway` `backendTrafficPolicy.monthlyBudget.enabled: true` → gateway-wide `shared: true` budget rule per (user, plan).

Result: **one** micro-USD budget counter per `(x-account-id, x-billing-plan)` across all models — the per-model `cap × N` leak is closed. Renders + lints verified.

## Why merging #606 alone did nothing
#606 shipped with both flags defaulting **false** (a safe no-op, so it couldn't activate the shared budget on v1.8.1). This PR is the actual cutover.

## ⚠️ Testing note — the counter key changed
Your earlier test inflated a **per-model** key (`…/converse/<model>/…`). After cutover the shared counter has a **different key** (keyed by the gateway policy, no `/converse/<model>/`). So:
1. Send a real request as the test account → find the NEW shared key: `redis-cli --scan --pattern '*rule-*match-0*<account-sub>*'` (it won't contain `/converse/<model>/`).
2. Inflate **that** key past the limit.
3. Hit **any** model with the same account → expect **429**.

Also: existing per-model spend does **not** carry over — users get a fresh shared budget at cutover (stale per-model keys expire on their own TTL).

## After ArgoCD syncs — verify
- `core-gateway` BTP shows the `rateLimit` block with `shared: true`; each model BTP shows `mergeType: StrategicMerge` and no `unit: Month` rule.
- Send a request as a test user, watch the shared Redis counter increment by the **micro-USD cost** (not +1/req) — confirms the #9244 fix is active.
- No mass 429s on normal traffic.

Follow-up (separate): remove the now-unused per-model `monthlyBudgetUsd` from `ai-models` (harmless while `sharedBudget.enabled` gates it off).

🤖 Generated with [Claude Code](https://claude.com/claude-code)