### PR TITLE
fix(lightbridge): pull upstream chart via OCI instead of retired gh-pages

### DIFF
--- a/charts/lightbridge/templates/applications.yaml
+++ b/charts/lightbridge/templates/applications.yaml
@@ -125,12 +125,14 @@ metadata:
 spec:
   project: {{ $a.project | quote }}
   sources:
-    # Source A — the upstream Lightbridge workload (Helm chart as an ArgoCD
-    # source). releaseName stays `lightbridge` so workload resource names
-    # don't churn vs the old flat app. Values live in ai-helm-values (ADR-0056),
-    # read via the $values ref (Source C) — not inline.
-    - repoURL: {{ .Values.app.chart.repoURL | quote }}
-      chart: {{ .Values.app.chart.name | quote }}
+    # Source A — the upstream Lightbridge workload (OCI Helm chart as an ArgoCD
+    # source; full chart path in repoURL + chart "." per ADR-0055, same as the
+    # secrets/db leaves but pinned via app.chart.targetRevision rather than
+    # floated). releaseName stays `lightbridge` so workload resource names don't
+    # churn vs the old flat app. Values live in ai-helm-values (ADR-0056), read
+    # via the $values ref (Source C) — not inline.
+    - repoURL: {{ printf "%s/%s" $a.chartRegistry .Values.app.chart.chartName | quote }}
+      chart: "."
       targetRevision: {{ .Values.app.chart.targetRevision | quote }}
       helm:
         releaseName: {{ .Values.app.releaseName | quote }}

--- a/charts/lightbridge/values.yaml
+++ b/charts/lightbridge/values.yaml
@@ -82,10 +82,15 @@ app:
   appName: lightbridge-app
   releaseName: lightbridge
   syncWave: "2"
-  # Upstream Lightbridge chart.
+  # Upstream Lightbridge umbrella chart, now pulled via OCI (ADR-0055) instead of
+  # the retired gh-pages Helm repo. Published by lightbridge-authz CI to
+  # <argocd.chartRegistry>/<chartName> = oci://ghcr.io/adorsys-gis/charts/lightbridge-authz-stack
+  # (renamed from `lightbridge` to avoid colliding with THIS orchestrator's own
+  # charts/lightbridge package). Pinned — NOT floated like the secrets/db leaves —
+  # so a lightbridge-authz chart release doesn't auto-deploy; the workload IMAGE
+  # still floats via argocd-image-updater (annotations below).
   chart:
-    repoURL: https://adorsys-gis.github.io/lightbridge-authz
-    name: lightbridge
+    chartName: lightbridge-authz-stack
     targetRevision: "0.8.1"
   # App-scoped deps (ingress Certificates) — kustomize overlay in this repo,
   # added as a second source (issuer patched per env). ADR-0018 pattern.


### PR DESCRIPTION
## Summary

The `lightbridge-app` child (Source A of the `charts/lightbridge` app-of-apps) pulled the upstream Lightbridge umbrella chart from `https://adorsys-gis.github.io/lightbridge-authz` — the **gh-pages Helm repo that lightbridge-authz has now decommissioned** in favour of GHCR/OCI. This repoints Source A at the OCI package.

## Intent / Source of Truth

lightbridge-authz moved chart publishing from gh-pages (chart-releaser) to GHCR/OCI under the `charts/` prefix. Upstream PRs:
- ADORSYS-GIS/lightbridge-authz#91 — OCI publishing
- ADORSYS-GIS/lightbridge-authz#92 — renames the umbrella `lightbridge` → `lightbridge-authz-stack` (avoids colliding with **this** repo's own `charts/lightbridge` orchestrator package)

Source of truth: ADORSYS-GIS/lightbridge-authz#92

## ⚠️ Merge order / dependency

This PR is **blocked on lightbridge-authz#92 being merged and its publish workflow pushing `charts/lightbridge-authz-stack:0.8.1` to GHCR.** Until that image exists, the `lightbridge-app` Application will report `ComparisonError` (chart not found). Also: the new `charts/lightbridge-authz-stack` package is created **private** by default — it must be made **public** (matching the sibling `charts/*`) so ArgoCD can pull it.

## Changes Made

- `charts/lightbridge/values.yaml` — replace `app.chart.{repoURL,name}` (gh-pages) with `app.chart.chartName: lightbridge-authz-stack`; keep `targetRevision: "0.8.1"`.
- `charts/lightbridge/templates/applications.yaml` — Source A now uses the ADR-0055 OCI form (`repoURL: <chartRegistry>/<chartName>`, `chart: "."`), same as the secrets/db leaves, but pinned via `app.chart.targetRevision` rather than floated on `chartVersionRange`.

## Verification

- [x] `helm template lightbridge charts/lightbridge` renders `lightbridge-app` Source A as the expected OCI reference; no gh-pages ref remains; release name unchanged (no resource churn).

Rendered Source A: `repoURL: "oci://ghcr.io/adorsys-gis/charts/lightbridge-authz-stack"`, `chart: "."`, `targetRevision: "0.8.1"`, `releaseName: "lightbridge"`. Sources B (deps overlay) and C (`$values` ref) unchanged. `grep -rn "adorsys-gis.github.io/lightbridge-authz" charts/` returns nothing.

## AI Usage Declaration

- [x] AI-assisted

AI (Claude) traced the gh-pages→OCI cutover, made the edit matching the repo's ADR-0055 OCI convention, and verified via `helm template`. A human owns intent, merge-ordering, and the package-visibility step.

> Governance: https://adorsys-gis.github.io/ai-governance/

🤖 Generated with [Claude Code](https://claude.com/claude-code)
