### PR TITLE
feat(lightbridge-ci): deploy restate-worker + a2a control-plane roles (RFC-0005/0006, ADR-0074)

### DIFF
--- a/charts/apps/values.yaml
+++ b/charts/apps/values.yaml
@@ -531,10 +531,12 @@ applications:
       # declares, which otherwise show a permanent cosmetic OutOfSync + selfHeal churn.
       # ServerSideDiff ignores those server-owned fields so the app reads Synced.
       argocd.argoproj.io/compare-options: ServerSideDiff=true
-      # Images aliased: cp/disp/recon (control-plane, role-selected), web, runner (the one-shot
+      # Images aliased: cp/disp/recon/rw/a2a (control-plane, role-selected), web, runner (the one-shot
       # agent-runner/indexer image the dispatcher launches), and review (the slimmer review-only Job
       # image — no Python/Graphify — picked for review tasks; ADR-0004 per-kind images, #207).
-      argocd-image-updater.argoproj.io/image-list: cp=ghcr.io/vymalo/lightbridge-control-plane,disp=ghcr.io/vymalo/lightbridge-control-plane,recon=ghcr.io/vymalo/lightbridge-control-plane,web=ghcr.io/vymalo/lightbridge-web,runner=ghcr.io/vymalo/lightbridge-agent-runner,review=ghcr.io/vymalo/lightbridge-agent-review
+      # `rw` = restate-worker (RFC-0005/ADR-0074), `a2a` = the A2A surface (RFC-0006) — both the SAME
+      # control-plane image, kept in lockstep so the new roles never lag the control-plane on a build.
+      argocd-image-updater.argoproj.io/image-list: cp=ghcr.io/vymalo/lightbridge-control-plane,disp=ghcr.io/vymalo/lightbridge-control-plane,recon=ghcr.io/vymalo/lightbridge-control-plane,rw=ghcr.io/vymalo/lightbridge-control-plane,a2a=ghcr.io/vymalo/lightbridge-control-plane,web=ghcr.io/vymalo/lightbridge-web,runner=ghcr.io/vymalo/lightbridge-agent-runner,review=ghcr.io/vymalo/lightbridge-agent-review
       # ── control-plane ──
       argocd-image-updater.argoproj.io/cp.update-strategy: newest-build
       argocd-image-updater.argoproj.io/cp.allow-tags: regexp:^sha-[0-9a-f]+$
@@ -565,6 +567,26 @@ applications:
       argocd-image-updater.argoproj.io/recon.signature-type: cosign
       argocd-image-updater.argoproj.io/recon.cosign.certificate-oidc-issuer: https://token.actions.githubusercontent.com
       argocd-image-updater.argoproj.io/recon.cosign.certificate-identity-regexp: ^https://github\.com/vymalo/lightbridge-code-intelligence/\.github/workflows/build-images\.yml@.*$
+      # ── restate-worker (SAME image as control-plane, role-selected; RFC-0005/ADR-0074) — keeps its
+      #    tag in lockstep so the Restate SDK worker never lags the control-plane on a build. ──
+      argocd-image-updater.argoproj.io/rw.update-strategy: newest-build
+      argocd-image-updater.argoproj.io/rw.allow-tags: regexp:^sha-[0-9a-f]+$
+      argocd-image-updater.argoproj.io/rw.force-update: "true"
+      argocd-image-updater.argoproj.io/rw.helm.image-name: lci.controllers.restate-worker.containers.main.image.repository
+      argocd-image-updater.argoproj.io/rw.helm.image-tag: lci.controllers.restate-worker.containers.main.image.tag
+      argocd-image-updater.argoproj.io/rw.signature-type: cosign
+      argocd-image-updater.argoproj.io/rw.cosign.certificate-oidc-issuer: https://token.actions.githubusercontent.com
+      argocd-image-updater.argoproj.io/rw.cosign.certificate-identity-regexp: ^https://github\.com/vymalo/lightbridge-code-intelligence/\.github/workflows/build-images\.yml@.*$
+      # ── a2a (SAME image as control-plane, role-selected; RFC-0006) — keeps its tag in lockstep so
+      #    the A2A surface never lags the control-plane on a build. ──
+      argocd-image-updater.argoproj.io/a2a.update-strategy: newest-build
+      argocd-image-updater.argoproj.io/a2a.allow-tags: regexp:^sha-[0-9a-f]+$
+      argocd-image-updater.argoproj.io/a2a.force-update: "true"
+      argocd-image-updater.argoproj.io/a2a.helm.image-name: lci.controllers.a2a.containers.main.image.repository
+      argocd-image-updater.argoproj.io/a2a.helm.image-tag: lci.controllers.a2a.containers.main.image.tag
+      argocd-image-updater.argoproj.io/a2a.signature-type: cosign
+      argocd-image-updater.argoproj.io/a2a.cosign.certificate-oidc-issuer: https://token.actions.githubusercontent.com
+      argocd-image-updater.argoproj.io/a2a.cosign.certificate-identity-regexp: ^https://github\.com/vymalo/lightbridge-code-intelligence/\.github/workflows/build-images\.yml@.*$
       # ── web ──
       argocd-image-updater.argoproj.io/web.update-strategy: newest-build
       argocd-image-updater.argoproj.io/web.allow-tags: regexp:^sha-[0-9a-f]+$

--- a/charts/lightbridge-code-intelligence/values.yaml
+++ b/charts/lightbridge-code-intelligence/values.yaml
@@ -746,6 +746,202 @@ lci:
             capabilities:
               drop: [ALL]
 
+    # ── restate-worker (RFC-0005 / ADR-0074) ──────────────────────────────────────────────────────
+    # The SAME control-plane image in the `restate-worker` role: it serves the Restate SDK endpoint
+    # (plain h2c on :9080) that the Restate server (StatefulSet `restate`, ns converse) discovers and
+    # invokes, plus the metrics-only listener on :9090 like the other headless roles. It serves the
+    # `PlatformEgress` virtual object — the RFC-0005 Phase-A egress pilot — whose per-key exclusivity
+    # makes ADR-0059's single-writer-per-installation egress invariant STRUCTURAL (no more replicas=1
+    # comment). Serving PlatformEgress needs a DB pool + a platform impl (the GitHub App key); absent
+    # either it degrades to Health-only.
+    #
+    # ⚠️ DEPLOYED-BUT-IDLE by design: egress.mode stays `drain` (the reconciler drain remains the sole
+    # egress path), so the object is registered/served but NEVER invoked until the pilot is activated.
+    # Two operator steps gate activation (NOT this chart): (1) register the endpoint with the Restate
+    # server — `restate deployments register
+    # http://lightbridge-ci-restate-worker.converse.svc.cluster.local:9080` (or via the operator);
+    # (2) flip egress.mode=restate on the producer. The idle worker is safe and changes nothing until
+    # then. `enabled: false` here → inert on chart defaults; ai-helm-values enables it and supplies the
+    # image tag + DATABASE_URL + RESTATE_INGRESS_URL per-env.
+    restate-worker:
+      enabled: false
+      type: deployment
+      # RollingUpdate: the worker is stateless (durable state lives in the Restate server + Postgres),
+      # so a brief old+new overlap on rollout is safe.
+      strategy: RollingUpdate
+      replicas: 1
+      annotations:
+        argocd.argoproj.io/sync-wave: "2"
+      containers:
+        main:
+          image:
+            repository: ghcr.io/vymalo/lightbridge-control-plane
+            # Default/fallback; the deployed tag is overridden at sync time by ai-helm-values via the
+            # image-updater `rw` alias (charts/apps/values.yaml), in lockstep with control-plane.
+            tag: "0.1.0"
+            pullPolicy: IfNotPresent
+          env:
+            CONTROL_PLANE_ROLE: "restate-worker"
+            RUST_LOG: "info"
+            # Metrics-only listener (like dispatcher/reconciler) — /metrics + /healthz on :9090.
+            METRICS_ADDR: "0.0.0.0:9090"
+            # The Restate SDK endpoint (h2c). The Restate server connects here to discover + invoke;
+            # 9080 is the SDK's conventional port. The restate-worker Service (below) exposes it.
+            RESTATE_WORKER_BIND: "0.0.0.0:9080"
+            # Where the Restate server's INGRESS is (the producer submits invocations here once the
+            # egress pilot is activated). Points at the Restate server Service in converse. Consumed by
+            # the egress path in `restate` mode only; harmless while egress.mode stays `drain`.
+            # DEPLOYMENT-SPECIFIC → ai-helm-values; empty here.
+            RESTATE_INGRESS_URL: ""
+            # Same CNPG queue the serve/dispatcher/reconciler roles use. DATABASE_URL `value` (cluster
+            # host/namespace/db) → ai-helm-values; `dependsOn` stays here.
+            DB_PASSWORD:
+              valueFrom:
+                secretKeyRef:
+                  name: lightbridge-codeintel-db-role
+                  key: password
+            DATABASE_URL:
+              dependsOn: DB_PASSWORD
+              value: ""
+            # A platform impl (GitHub App key) is required to SERVE PlatformEgress (it posts intents);
+            # the same secret the control-plane + reconciler use. Absent it the role degrades to
+            # Health-only. Single replica + `drain` mode preserve the ADR-0002/0059 egress-credential
+            # posture until the pilot flip.
+            GITHUB_APP_ID:
+              valueFrom:
+                secretKeyRef:
+                  name: '{{ .Release.Name }}-github'
+                  key: app-id
+            GITHUB_APP_PRIVATE_KEY:
+              valueFrom:
+                secretKeyRef:
+                  name: '{{ .Release.Name }}-github'
+                  key: app-private-key
+          probes:
+            liveness:
+              enabled: true
+              custom: true
+              spec:
+                httpGet:
+                  path: /healthz
+                  port: 9090
+                initialDelaySeconds: 5
+                periodSeconds: 15
+            readiness:
+              enabled: true
+              custom: true
+              spec:
+                httpGet:
+                  path: /healthz
+                  port: 9090
+                initialDelaySeconds: 5
+                periodSeconds: 10
+            startup:
+              enabled: false
+          resources:
+            requests: { cpu: 50m, memory: 64Mi }
+            limits: { cpu: 500m, memory: 256Mi }
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsUser: 1000
+            capabilities:
+              drop: [ALL]
+
+    # ── a2a (RFC-0006) ────────────────────────────────────────────────────────────────────────────
+    # The SAME control-plane image in the `a2a` role: an A2A (Agent2Agent, spec v1.0.1) server. It
+    # serves the PUBLIC agent card at /.well-known/agent-card.json (the spec requires it be public) and
+    # the OIDC-protected JSON-RPC + REST bindings (the `review` skill) on :8080, plus the metrics-only
+    # listener on :9090. It REQUIRES a DB pool (the task queue) and OIDC_ISSUER — there is NO anonymous
+    # access; the role fails readiness without them.
+    #
+    # ⚠️ INERT-BUT-SAFE until operator prerequisites exist (NOT this chart): (1) a Keycloak CLIENT for
+    # A2A callers + the `a2a:review` permission in the token claim (ADR-0023); (2) DNS for the Ingress
+    # host; (3) per-identity quota defaults (A2A_QUOTA_MAX / A2A_QUOTA_WINDOW_SECS — code defaults
+    # 20/hour). Until the Keycloak client exists callers cannot authenticate, so the surface is inert
+    # (only the public card is reachable). `enabled: false` here → inert on chart defaults;
+    # ai-helm-values enables it and supplies image tag + DATABASE_URL + OIDC_ISSUER/OIDC_AUDIENCE +
+    # A2A_BASE_URL + the Ingress per-env.
+    a2a:
+      enabled: false
+      type: deployment
+      strategy: RollingUpdate
+      # Stateless HTTP behind the Ingress; the per-identity deep-run quota is Postgres-backed
+      # (count_recent), so concurrent replicas enforce it consistently. Two for no-downtime rollouts.
+      replicas: 2
+      annotations:
+        argocd.argoproj.io/sync-wave: "2"
+      containers:
+        main:
+          image:
+            repository: ghcr.io/vymalo/lightbridge-control-plane
+            # Default/fallback; overridden at sync time by ai-helm-values via the image-updater `a2a`
+            # alias (charts/apps/values.yaml), in lockstep with control-plane.
+            tag: "0.1.0"
+            pullPolicy: IfNotPresent
+          env:
+            CONTROL_PLANE_ROLE: "a2a"
+            RUST_LOG: "info"
+            # The A2A HTTP surface (card + protected bindings). :8080 is the role default; the a2a
+            # Service + Ingress (below) route to it.
+            A2A_BIND: "0.0.0.0:8080"
+            # Metrics-only listener (like dispatcher/reconciler) — /metrics + /healthz on :9090.
+            METRICS_ADDR: "0.0.0.0:9090"
+            # Externally reachable base URL advertised in the card's supportedInterfaces — must equal
+            # the public Ingress host. DEPLOYMENT-SPECIFIC → ai-helm-values; empty here.
+            A2A_BASE_URL: ""
+            # Authorization (ADR-0023): the dotted token claim carrying the caller's permissions; the
+            # `review` skill requires `a2a:review`. Keep in sync with the control-plane PERMISSIONS_CLAIM.
+            PERMISSIONS_CLAIM: "permissions"
+            # OAuth2 resource server: validate Keycloak-issued JWTs (ADR-0014). REQUIRED — the role
+            # fails readiness without OIDC_ISSUER (no anonymous access). DEPLOYMENT-SPECIFIC →
+            # ai-helm-values; empty here. OIDC_AUDIENCE mirrors the control-plane (expected token `aud`).
+            OIDC_ISSUER: ""
+            OIDC_AUDIENCE: ""
+            # Same CNPG queue (the A2A `review` skill creates a deep task). DATABASE_URL `value` →
+            # ai-helm-values; `dependsOn` stays here.
+            DB_PASSWORD:
+              valueFrom:
+                secretKeyRef:
+                  name: lightbridge-codeintel-db-role
+                  key: password
+            DATABASE_URL:
+              dependsOn: DB_PASSWORD
+              value: ""
+          probes:
+            # Liveness = the process/metrics server (:9090 /healthz), like the other headless roles.
+            liveness:
+              enabled: true
+              custom: true
+              spec:
+                httpGet:
+                  path: /healthz
+                  port: 9090
+                initialDelaySeconds: 5
+                periodSeconds: 15
+            # Readiness = the PUBLIC agent card on the A2A surface (:8080), so the pod is only Ready once
+            # the real HTTP surface serves. The card is unauthenticated (spec), so it is a valid probe.
+            readiness:
+              enabled: true
+              custom: true
+              spec:
+                httpGet:
+                  path: /.well-known/agent-card.json
+                  port: 8080
+                initialDelaySeconds: 5
+                periodSeconds: 10
+            startup:
+              enabled: false
+          resources:
+            requests: { cpu: 50m, memory: 64Mi }
+            limits: { cpu: 500m, memory: 256Mi }
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsUser: 1000
+            capabilities:
+              drop: [ALL]
+
   service:
     control-plane:
       controller: control-plane
@@ -773,6 +969,22 @@ lci:
       ports:
         metrics:
           port: 9090
+    # SDK-endpoint Service for the restate-worker role (h2c :9080). The Restate server (ns converse)
+    # reaches the worker here to discover + invoke its services once the endpoint is registered.
+    # `enabled` tracks the controller (both flipped on in ai-helm-values).
+    restate-worker:
+      enabled: false
+      controller: restate-worker
+      ports:
+        http:
+          port: 9080
+    # A2A HTTP surface Service (:8080) — the Ingress routes to it. `enabled` tracks the controller.
+    a2a:
+      enabled: false
+      controller: a2a
+      ports:
+        http:
+          port: 8080
 
   # DEPLOYMENT-SPECIFIC: ingress is OFF by default — the ingress class, cert-manager cluster-issuer,
   # public hostnames, and TLS secrets are all env-specific, so the FULL ingress config (enabled: true +
@@ -782,6 +994,12 @@ lci:
     web:
       enabled: false
     control-plane:
+      enabled: false
+    # Public A2A surface (RFC-0006). OFF by default (host + issuer + TLS secret are env-specific); the
+    # FULL config (enabled + className + cert-manager annotation + host + tls) lives in ai-helm-values.
+    # ⚠️ This exposes a PUBLIC authenticated Ingress: the agent card is served unauthenticated (spec),
+    # every A2A binding behind it is OIDC-gated in-app (no anonymous access).
+    a2a:
       enabled: false
 
   # emptyDir scratch dirs for the read-only-rootfs containers (control-plane, web).


### PR DESCRIPTION
## Summary

Adds two new control-plane **Deployments** to the `lightbridge-code-intelligence` chart — the
**same** control-plane image, role-selected — so the newly-merged `restate-worker` (RFC-0005 /
ADR-0074) and `a2a` (RFC-0006) roles finally have a Kubernetes home ("merged != live"). They mirror
the existing `serve`/`dispatcher`/`reconciler` shape exactly (bjw-s app-template, one image, different
`CONTROL_PLANE_ROLE`).

- **restate-worker**: serves the Restate SDK endpoint over **h2c on :9080** (new Service) + the
  metrics listener on :9090. Serves the `PlatformEgress` virtual object — the RFC-0005 Phase-A egress
  pilot. **Deployed-but-idle by design**: `egress.mode` stays `drain`, so the object is
  registered/served but **never invoked** until the pilot is activated.
- **a2a**: serves the **public** agent card (`/.well-known/agent-card.json`) + the OIDC-protected A2A
  JSON-RPC/REST bindings on **:8080** (new Service + a **public Ingress** `a2a.ai.camer.digital`, TLS
  via cert-manager). **No anonymous access** — every binding behind the card is OIDC-gated in-app.

Both controllers/Services are gated `enabled: false` in the chart (inert on defaults — a defaults-only
render emits neither, keeping CI lint/render clean); they are enabled + configured per-env in the
paired **ai-helm-PLACEHOLDER_VALUES** PR. `charts/apps` gains image-updater `rw`/`a2a` aliases so the two roles
track control-plane builds in lockstep (same cosign identity).

**Companion PR (must land alongside):** ADORSYS-GIS/ai-helm-values#67 — enables + wires
both roles (image tag, DATABASE_URL, RESTATE_INGRESS_URL, OIDC, A2A_BASE_URL, the a2a Ingress).
**Merge THIS PR first** (it adds the controllers, inert), then the PLACEHOLDER_VALUES PR (enables + configures them).

## Intent

Deploy the two roles that exist in the control-plane binary on `main` but have no Deployment yet.

**Source of truth:** RFC-0005 (`docs/rfc/0005-durable-orchestration-on-restate.md`), RFC-0006
(`docs/rfc/0006-a2a-agent-surface.md`), ADR-0074 (restate egress pilot) in the
vymalo/lightbridge-code-intelligence repo; roles landed via
vymalo/lightbridge-code-intelligence#297 and #299.

## Scope

- `charts/lightbridge-code-intelligence/PLACEHOLDER_VALUES.yaml`
  - New `restate-worker` controller (deployment, `enabled: false`, `CONTROL_PLANE_ROLE=restate-worker`,
    `RESTATE_WORKER_BIND=0.0.0.0:9080`, `METRICS_ADDR=0.0.0.0:9090`, `RESTATE_INGRESS_URL` [env-owned],
    DATABASE_URL, GitHub App key for the platform impl; probes on :9090; read-only rootfs, non-root).
  - New `a2a` controller (deployment, `enabled: false`, `CONTROL_PLANE_ROLE=a2a`,
    `A2A_BIND=0.0.0.0:8080`, `METRICS_ADDR=0.0.0.0:9090`, `A2A_BASE_URL`/`OIDC_ISSUER`/`OIDC_AUDIENCE`
    [env-owned], DATABASE_URL, `PERMISSIONS_CLAIM=permissions`; liveness :9090, readiness on the public
    card :8080; read-only rootfs, non-root; replicas 2 — the per-identity quota is Postgres-backed).
  - New `restate-worker` (:9080) + `a2a` (:8080) Services (`enabled: false`); new `a2a` ingress key
    (`enabled: false`).
- `charts/apps/PLACEHOLDER_VALUES.yaml` — image-updater `rw` + `a2a` aliases (newest-build, cosign-gated, helm
  image-name/tag paths), added to the `image-list` and the alias blocks, mirroring `disp`/`recon`.

**Out of scope (flagged, not done here):** endpoint registration with the Restate server +
`egress.mode=restate` flip; a Keycloak client for A2A callers + the `a2a:review` scope; DNS for the
a2a host. See Risk.

## Verification

CI (ADORSYS Actions) is currently red org-wide (billing) — validated **locally**. Not applied
(`kubectl`/`helm install` never run; GitOps only).

```
$ helm lint charts/lightbridge-code-intelligence   -> 0 failed
$ helm lint charts/apps                             -> 0 failed

# chart rendered with the prod PLACEHOLDER_VALUES overlay -> both Deployments, both Services, the a2a Ingress:
$ helm template ci charts/lightbridge-code-intelligence -f <ai-helm-PLACEHOLDER_VALUES>/.../lightbridge-code-intelligence.yaml
kind: Deployment  name: lightbridge-ci-restate-worker
kind: Deployment  name: lightbridge-ci-a2a
kind: Service     name: lightbridge-ci-restate-worker   (port 9080)
kind: Service     name: lightbridge-ci-a2a              (port 8080)
kind: Ingress     name: lightbridge-ci-a2a              (host a2a.ai.camer.digital -> :8080, TLS a2a...-tls)

# rendered env (excerpts):
restate-worker: CONTROL_PLANE_ROLE=restate-worker  RESTATE_WORKER_BIND=0.0.0.0:9080
                RESTATE_INGRESS_URL=http://restate.converse.svc.cluster.local:8080  METRICS_ADDR=0.0.0.0:9090
a2a:            CONTROL_PLANE_ROLE=a2a  A2A_BIND=0.0.0.0:8080  A2A_BASE_URL=https://a2a.ai.camer.digital
                OIDC_ISSUER=https://auth.verif.fyi/realms/camer-digital  OIDC_AUDIENCE=code-intelligence

# defaults-only render (helm lint path) emits NEITHER new role (enabled:false) -> CI stays clean:
$ helm template ci charts/lightbridge-code-intelligence | grep -c 'restate-worker|lightbridge-ci-a2a'  -> 0

# charts/apps renders with the new aliases (16 rw/a2a annotation lines); whole render parses as valid YAML.
```

## Screenshots / Evidence

Render excerpts above. No UI surface in this repo.

## Risk Assessment

**Medium-High.** This introduces a new **public, authenticated Ingress** (a2a) and is prod GitOps that
auto-deploys on merge to the PLACEHOLDER_VALUES repo. Mitigations:

- **Inert-by-default.** Chart-side both roles are `enabled: false`; nothing deploys until the PLACEHOLDER_VALUES PR
  enables them. A defaults render emits neither.
- **OIDC-required, no anonymous access.** The a2a role fails readiness without `OIDC_ISSUER`; only the
  public agent card is reachable unauthenticated (A2A spec requires it). Until an operator creates the
  Keycloak client for A2A callers, **no one can authenticate** -> the surface is inert-but-safe.
- **restate-worker changes nothing until activated.** `egress.mode` stays `drain`; the reconciler drain
  remains the sole egress path. PlatformEgress is served/registered but never invoked.
- **No NetworkPolicy added, deliberately.** The `converse` namespace has **no** default-deny-egress
  baseline (verified: zero NetworkPolicies for any converse app; all CiliumNetworkPolicies in this repo
  are observability-namespace). restate-worker<->restate egress works without one; adding an egress policy
  would flip the pod to default-deny and **isolate** it. (This corrects the task's "converse is
  default-deny" premise.)
- Single-replica restate-worker holding the GitHub App key preserves the ADR-0002/0059 egress-credential
  posture until the pilot flip.

**Operator prerequisites before either role is functional (NOT in this PR):**
1. restate-worker: register the endpoint --
   `restate deployments register http://lightbridge-ci-restate-worker.converse.svc.cluster.local:9080`
   (admin API on `restate.converse.svc:9070`) -- then flip `egress.mode=restate` on the producer.
2. a2a: a Keycloak **client** for A2A callers emitting the `a2a:review` permission (ADR-0023) with
   `aud=code-intelligence`; **DNS** for `a2a.ai.camer.digital`; confirm per-identity quota defaults
   (`A2A_QUOTA_MAX`/`A2A_QUOTA_WINDOW_SECS`, code default 20/hour).

## AI Usage Declaration

- [x] Generating code
- [ ] I have reviewed and understand all AI-generated changes
- [ ] I have verified the changes work as intended
- [ ] I take full accountability for this contribution

AI (Claude Code) authored the chart/PLACEHOLDER_VALUES edits from the RFC/ADR contract and the existing
serve/dispatcher/reconciler pattern; a human owns review, verification, and merge (incl. the merge
order and the operator prerequisites above).

## Reviewer Focus

- Are the role env/ports right against the binary (`RESTATE_WORKER_BIND`, `A2A_BIND`,
  `RESTATE_INGRESS_URL`, `METRICS_ADDR`, `OIDC_ISSUER`/`OIDC_AUDIENCE`)?
- The `enabled: false`-in-chart + enable-in-PLACEHOLDER_VALUES split and the recommended **chart-first** merge order.
- The **no-NetworkPolicy** decision for converse (verify converse truly has no egress baseline).
- image-updater `rw`/`a2a` alias correctness (helm image-name/tag paths, cosign identity).
- Whether restate-worker should carry the GitHub App key now (needed to serve PlatformEgress, not just
  Health) vs. deferring it to the activation flip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
