### PR TITLE
feat(lightbridge): image-updater pull-secret for private GHCR images

### DIFF
--- a/charts/lightbridge/templates/applications.yaml
+++ b/charts/lightbridge/templates/applications.yaml
@@ -102,6 +102,10 @@ metadata:
     argocd-image-updater.argoproj.io/api.update-strategy: newest-build
     argocd-image-updater.argoproj.io/api.allow-tags: regexp:^sha-[0-9a-f]+$
     argocd-image-updater.argoproj.io/api.force-update: "true"
+    # GHCR read cred (App-based, argocd ns) so tag detection keeps working once
+    # ghcr.io/adorsys-gis/lightbridge-authz goes private. Secret provisioned in
+    # home-os (serverless/k/lightbridge-authz). No-op while the image is public.
+    argocd-image-updater.argoproj.io/api.pull-secret: pullsecret:argocd/adorsys-gis-ghcr-pull
     argocd-image-updater.argoproj.io/api.helm.image-name: global.authz.image.repository
     argocd-image-updater.argoproj.io/api.helm.image-tag: global.authz.image.version
     argocd-image-updater.argoproj.io/api.signature-type: cosign
@@ -110,6 +114,7 @@ metadata:
     argocd-image-updater.argoproj.io/mcp.update-strategy: newest-build
     argocd-image-updater.argoproj.io/mcp.allow-tags: regexp:^sha-[0-9a-f]+$
     argocd-image-updater.argoproj.io/mcp.force-update: "true"
+    argocd-image-updater.argoproj.io/mcp.pull-secret: pullsecret:argocd/adorsys-gis-ghcr-pull
     argocd-image-updater.argoproj.io/mcp.helm.image-name: global.authz_mcp.image.repository
     argocd-image-updater.argoproj.io/mcp.helm.image-tag: global.authz_mcp.image.version
     argocd-image-updater.argoproj.io/mcp.signature-type: cosign


### PR DESCRIPTION
## Summary

Add `argocd-image-updater.argoproj.io/{api,mcp}.pull-secret` annotations to the `lightbridge-app` child so image-updater authenticates to GHCR when the `ghcr.io/adorsys-gis/lightbridge-authz{,-mcp}` images go private. Without a registry cred, image-updater's tag query returns `unauthorized` and digests silently stop promoting.

## Related

- Provisions against `pullsecret:argocd/adorsys-gis-ghcr-pull`, created App-based in home-os: WhyThatFunction/home-os#99
- Part of the GHCR private cutover (charts already on OCI: this chart's `app.chart` → `oci://ghcr.io/adorsys-gis/charts/lightbridge-authz-stack`).

Source of truth: WhyThatFunction/home-os#99

## Changes

- `charts/lightbridge/templates/applications.yaml` — `api.pull-secret` + `mcp.pull-secret` → `pullsecret:argocd/adorsys-gis-ghcr-pull`.

## Verification

- [x] `helm template` renders both `pull-secret` annotations on the `lightbridge-app` Application. No-op while the images are public.

## Sequencing

Merge home-os#99 first (so the secret exists), then this, then flip the image packages private in the GitHub UI.

## AI Usage Declaration

- [x] AI-assisted — Claude added the annotations mirroring the vymalo image-updater cred pattern; verified via `helm template`. Human owns merge + the visibility flip.

> Governance: https://adorsys-gis.github.io/ai-governance/

🤖 Generated with [Claude Code](https://claude.com/claude-code)
