### PR TITLE
feat(converse-ui): float chart from converse-frontends OCI registry

### DIFF
--- a/charts/apps/values.yaml
+++ b/charts/apps/values.yaml
@@ -59,9 +59,11 @@ argocd:
   # per-env values, and the `environments/` overlays live in the PRIVATE
   # `ai-helm-values` repo (argocd-image-updater write-back). A merge to main is a
   # live deploy. Rollback = `git revert` in ai-helm-values and/or pin an app's
-  # chartVersionRange. External NON-OCI sources (converse-frontends,
-  # lightbridge-repo-auth, the upstream Lightbridge chart, etc.) pin their own
-  # SHAs/versions. Runbook: docs/continuous-delivery.md.
+  # chartVersionRange. converse-ui now floats from converse-frontends' OWN OCI
+  # namespace (oci://ghcr.io/adorsys-gis/converse-frontends/charts, not this
+  # chartRegistry). External NON-OCI sources (lightbridge-repo-auth, the upstream
+  # Lightbridge chart, etc.) pin their own SHAs/versions. Runbook:
+  # docs/continuous-delivery.md.
   # ── Continuous-delivery knobs (ADR-0055) ────────────────────────────────
   # Charts are published to OCI on merge to main and consumed by any app entry
   # that sets `chart: <name>`. Such an app floats on `chartVersionRange` (a
@@ -711,7 +713,10 @@ applications:
 
   # --- Converse UI --- (ADR-0055 continuous-delivery pilot: image write-back)
   # Multi-source (the lightbridge pattern, writing to ai-helm-values):
-  #   Source A — the external converse-frontends chart (unchanged pin).
+  #   Source A — the converse-frontend chart, now floated from OCI (converse-frontends
+  #     publishes it to oci://ghcr.io/adorsys-gis/converse-frontends/charts on merge
+  #     to main; a merge that republishes the chart auto-floats this app on the next
+  #     reconcile). Its OWN GHCR namespace, not adorsys-gis/charts.
   #   Source B — a $values ref to ai-helm-values, where argocd-image-updater commits
   #     the newest sha-<gitsha> build. Strategy: newest-build + allow-tags ^sha-…,
   #     UNSIGNED (converse-frontends images are not cosign-signed — no .sig tags).
@@ -735,12 +740,12 @@ applications:
       argocd-image-updater.argoproj.io/write-back-target: helmvalues:/environments/prod/values/converse-ui.yaml
       argocd-image-updater.argoproj.io/git-credentials: secret:argocd/github-app-creds--adorsys-gis
     sources:
-      # Source A — the external converse-frontends chart (unchanged pin).
-      - repoURL: https://github.com/ADORSYS-GIS/converse-frontends
-        # Pinned to a commit for a reproducible release (was HEAD). External repo —
-        # bump this SHA deliberately when you want a newer converse-ui, then re-release.
-        targetRevision: 500dba11e91d1385135802db5898c961debfe6e2
-        path: charts/converse-frontend
+      # Source A — the converse-frontend chart from OCI (ADR-0055 float): full chart
+      # path in repoURL + chart "." + a semver range, exactly like core-gateway.
+      # Published by converse-frontends' publish-charts-oci.yml (converse-frontends#100).
+      - repoURL: oci://ghcr.io/adorsys-gis/converse-frontends/charts/converse-frontend
+        chart: "."
+        targetRevision: ">=0.0.0"
         helm:
           releaseName: converse-ui
           # image.{repository,tag,pullPolicy} come from Source B's $values file
@@ -781,7 +786,8 @@ applications:
     # registry on a floating semver range (Source A = argocd.chartRegistry @
     # chartVersionRange), with per-env values from ai-helm-values via $values
     # (Source B). No image write-back here (the backup image is static) — this
-    # validates the `chart:` OCI path that converse-ui's external chart couldn't.
+    # was the first `chart:` OCI-float pilot (converse-ui has since joined it,
+    # floating from converse-frontends' own OCI namespace).
     # Once live, a merge that republishes charts/mongodb-backup auto-floats this
     # app to the new version on the next reconcile (no release/repoint needed).
     chart: mongodb-backup


### PR DESCRIPTION
## 1. Summary

This PR changes:

- Switches the `converse-ui` Application's Source A from a **git-SHA pin** (`github.com/ADORSYS-GIS/converse-frontends`, `path: charts/converse-frontend`, `targetRevision: <sha>`) to an **OCI float**: `oci://ghcr.io/adorsys-gis/converse-frontends/charts/converse-frontend`, `chart: "."`, `targetRevision: ">=0.0.0"` — the same shape as `core-gateway`.
- Updates the surrounding comments (converse-ui block, the `argocd.chartRegistry` note, and the stale mongodb-backup "converse-ui's external chart couldn't" line).

It solves:

- `ADORSYS-GIS/converse-frontends#99` — converse-frontends now publishes its chart to its own GHCR OCI namespace on merge to main, so converse-ui can float it (a republish auto-deploys on the next reconcile, no SHA repoint).

---

## 2. Intent

The intent of this PR is:

> Complete the ADR-0055 continuous-delivery model for converse-ui: the chart floats from OCI (like every migrated app) instead of a manually-bumped git SHA. Source B (`$values` image write-back) is untouched — image-updater keeps owning the tag in ai-helm-values. The chart lives in converse-frontends' **own** GHCR namespace (`.../converse-frontends/charts`, not `adorsys-gis/charts`) because that's what its repo-scoped `GITHUB_TOKEN` can publish to.

---

## 3. Scope

### In Scope

- The `converse-ui` Source A OCI swap + comment updates.

### Out of Scope

- The ArgoCD **repository credential** for the private chart — added in `WhyThatFunction/home-os#102` (must sync first).
- `ai-helm-values` — no change; `converse-ui.yaml` and the render-check yaml-validation path are unaffected.

---

## 4. Verification

I verified this change by:

- [x] Running manual tests

Commands run:

```bash
helm template apps charts/apps | grep -A20 'name: aii-converse-ui'
helm show chart oci://ghcr.io/adorsys-gis/converse-frontends/charts/converse-frontend   # (authenticated)
```

Results:

```text
aii-converse-ui renders with:
  Source A: repoURL oci://ghcr.io/adorsys-gis/converse-frontends/charts/converse-frontend,
            chart ".", targetRevision ">=0.0.0", releaseName converse-ui,
            valueFiles [$values/environments/prod/values/converse-ui.yaml], ignoreMissingValueFiles true
  Source B: ref values (ai-helm-values @ main)
helm show chart → converse-frontend 0.1.10
```

The Source A `repoURL` matches (modulo the `oci://` scheme) the `url` on the home-os repository credential, so ArgoCD authenticates the private pull.

---

## 5. Screenshots / Evidence

* Paired credential PR: `WhyThatFunction/home-os#102`
* Chart publisher: `ADORSYS-GIS/converse-frontends#100` (merged)

---

## 6. Risk Assessment

Risk level:

* [x] Medium

Potential risks:

* **Sequencing** — if this merges before `home-os#102` syncs the repo credential, converse-ui hits a `ComparisonError` (unauthorized OCI pull) and won't sync.
* A bad/broken chart republish would auto-float here (mitigated by the range + `git revert` in converse-frontends, and image-updater owning the tag separately).

Mitigation:

* **Do not merge until `home-os#102` is merged and the `converse-frontends-charts-oci` repo secret is present in the cluster's `argocd` namespace.**
* Rollback = revert this PR (returns converse-ui to the git-SHA source) or pin `targetRevision` to a known-good version.

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [x] Drafting documentation
* [x] Reviewing the diff

Human verification:

* [x] I understand every meaningful change in this PR
* [x] I checked generated code manually
* [x] I removed unsupported AI assumptions
* [x] I accept responsibility for this PR

AI (Claude Code) made the Source A swap mirroring the `core-gateway` OCI shape and verified the `charts/apps` render. The private-pull credential path and sequencing were human-confirmed.

---

## 8. Reviewer Focus

Please focus your review on:

* [x] Correctness
* [x] Security
* [x] Product intent
