### PR TITLE
feat(ratelimit): set free monthly budget to $15 (#532)

### DIFF
--- a/charts/ai-models/values.yaml
+++ b/charts/ai-models/values.yaml
@@ -68,11 +68,11 @@ sharedBudget:
 rateLimitBudgeting:
   plans:
     free:
-      # Per-person monthly budget (ADR-0035: keyed on x-account-id, NOT a shared
-      # x-org-id bucket — colleagues no longer contend for one pool). Lowered
-      # 50 → 30 (2026-07-07) to stop the bleeding while we investigate users
-      # exceeding the intended cap (per-model-vs-shared counter + billing_plan).
-      monthlyBudgetUsd: 30
+      # Per-person monthly budget. DORMANT since the #532 shared-budget cutover
+      # (sharedBudget.enabled gates the per-model rule off) — the LIVE knob is
+      # core-gateway backendTrafficPolicy.monthlyBudget.plans. Kept in sync
+      # (15, 2026-07-08) so a rollback to per-model budgets keeps the same cap.
+      monthlyBudgetUsd: 15
       burst:
         requestsPerMin: 200
         # Raised 200k → 1M (2026-06-12) to match the 1M context ceiling

--- a/charts/core-gateway/values.yaml
+++ b/charts/core-gateway/values.yaml
@@ -216,7 +216,9 @@ backendTrafficPolicy:
   monthlyBudget:
     enabled: true
     plans:
-      free: 30
+      # 30 → 15 (2026-07-08): now that the budget is genuinely shared across all
+      # models (#532 cutover), the old per-model headroom rationale is gone.
+      free: 15
       pro: 200
 
   # Whole-request ceiling for routes this gateway-wide policy governs (the


### PR DESCRIPTION
Sets the **free** tier's shared monthly budget to **\$15** (was \$30), now that the budget is verified to be one shared counter across all models per user (#532 cutover).

- Live knob: `core-gateway` `backendTrafficPolicy.monthlyBudget.plans.free: 15` → renders `requests: 15000000` µ\$/Month, `shared: true`.
- Dormant per-model `ai-models` `monthlyBudgetUsd` kept in sync (rollback safety).
- Pro (\$200) unchanged.

Note: takes effect on the **current** month window immediately — users already past \$15 this window will start getting 429s on their next request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)