### PR TITLE
feat: GHCR pull-secret wiring for going-private images (image-updater + kubelet)

### DIFF
--- a/charts/apps/values.yaml
+++ b/charts/apps/values.yaml
@@ -541,6 +541,10 @@ applications:
       argocd-image-updater.argoproj.io/cp.update-strategy: newest-build
       argocd-image-updater.argoproj.io/cp.allow-tags: regexp:^sha-[0-9a-f]+$
       argocd-image-updater.argoproj.io/cp.force-update: "true"
+      # GHCR read cred so tag detection survives ghcr.io/vymalo/* going private. The
+      # #621 secret's dockerconfigjson is keyed on the ghcr.io host, so it authenticates
+      # the vymalo org too — one secret for both orgs. Applied to every alias below.
+      argocd-image-updater.argoproj.io/cp.pull-secret: pullsecret:argocd/adorsys-gis-ghcr-pull
       argocd-image-updater.argoproj.io/cp.helm.image-name: lci.controllers.control-plane.containers.main.image.repository
       argocd-image-updater.argoproj.io/cp.helm.image-tag: lci.controllers.control-plane.containers.main.image.tag
       argocd-image-updater.argoproj.io/cp.signature-type: cosign
@@ -551,6 +555,7 @@ applications:
       argocd-image-updater.argoproj.io/disp.update-strategy: newest-build
       argocd-image-updater.argoproj.io/disp.allow-tags: regexp:^sha-[0-9a-f]+$
       argocd-image-updater.argoproj.io/disp.force-update: "true"
+      argocd-image-updater.argoproj.io/disp.pull-secret: pullsecret:argocd/adorsys-gis-ghcr-pull
       argocd-image-updater.argoproj.io/disp.helm.image-name: lci.controllers.dispatcher.containers.main.image.repository
       argocd-image-updater.argoproj.io/disp.helm.image-tag: lci.controllers.dispatcher.containers.main.image.tag
       argocd-image-updater.argoproj.io/disp.signature-type: cosign
@@ -562,6 +567,7 @@ applications:
       argocd-image-updater.argoproj.io/recon.update-strategy: newest-build
       argocd-image-updater.argoproj.io/recon.allow-tags: regexp:^sha-[0-9a-f]+$
       argocd-image-updater.argoproj.io/recon.force-update: "true"
+      argocd-image-updater.argoproj.io/recon.pull-secret: pullsecret:argocd/adorsys-gis-ghcr-pull
       argocd-image-updater.argoproj.io/recon.helm.image-name: lci.controllers.reconciler.containers.main.image.repository
       argocd-image-updater.argoproj.io/recon.helm.image-tag: lci.controllers.reconciler.containers.main.image.tag
       argocd-image-updater.argoproj.io/recon.signature-type: cosign
@@ -572,6 +578,7 @@ applications:
       argocd-image-updater.argoproj.io/rw.update-strategy: newest-build
       argocd-image-updater.argoproj.io/rw.allow-tags: regexp:^sha-[0-9a-f]+$
       argocd-image-updater.argoproj.io/rw.force-update: "true"
+      argocd-image-updater.argoproj.io/rw.pull-secret: pullsecret:argocd/adorsys-gis-ghcr-pull
       argocd-image-updater.argoproj.io/rw.helm.image-name: lci.controllers.restate-worker.containers.main.image.repository
       argocd-image-updater.argoproj.io/rw.helm.image-tag: lci.controllers.restate-worker.containers.main.image.tag
       argocd-image-updater.argoproj.io/rw.signature-type: cosign
@@ -582,6 +589,7 @@ applications:
       argocd-image-updater.argoproj.io/a2a.update-strategy: newest-build
       argocd-image-updater.argoproj.io/a2a.allow-tags: regexp:^sha-[0-9a-f]+$
       argocd-image-updater.argoproj.io/a2a.force-update: "true"
+      argocd-image-updater.argoproj.io/a2a.pull-secret: pullsecret:argocd/adorsys-gis-ghcr-pull
       argocd-image-updater.argoproj.io/a2a.helm.image-name: lci.controllers.a2a.containers.main.image.repository
       argocd-image-updater.argoproj.io/a2a.helm.image-tag: lci.controllers.a2a.containers.main.image.tag
       argocd-image-updater.argoproj.io/a2a.signature-type: cosign
@@ -591,6 +599,7 @@ applications:
       argocd-image-updater.argoproj.io/web.update-strategy: newest-build
       argocd-image-updater.argoproj.io/web.allow-tags: regexp:^sha-[0-9a-f]+$
       argocd-image-updater.argoproj.io/web.force-update: "true"
+      argocd-image-updater.argoproj.io/web.pull-secret: pullsecret:argocd/adorsys-gis-ghcr-pull
       argocd-image-updater.argoproj.io/web.helm.image-name: lci.controllers.web.containers.main.image.repository
       argocd-image-updater.argoproj.io/web.helm.image-tag: lci.controllers.web.containers.main.image.tag
       argocd-image-updater.argoproj.io/web.signature-type: cosign
@@ -605,6 +614,7 @@ applications:
       argocd-image-updater.argoproj.io/runner.update-strategy: newest-build
       argocd-image-updater.argoproj.io/runner.allow-tags: regexp:^sha-[0-9a-f]+$
       argocd-image-updater.argoproj.io/runner.force-update: "true"
+      argocd-image-updater.argoproj.io/runner.pull-secret: pullsecret:argocd/adorsys-gis-ghcr-pull
       argocd-image-updater.argoproj.io/runner.helm.image-spec: lci.controllers.dispatcher.containers.main.env.AGENT_RUNNER_IMAGE
       argocd-image-updater.argoproj.io/runner.signature-type: cosign
       argocd-image-updater.argoproj.io/runner.cosign.certificate-oidc-issuer: https://token.actions.githubusercontent.com
@@ -615,6 +625,7 @@ applications:
       argocd-image-updater.argoproj.io/review.update-strategy: newest-build
       argocd-image-updater.argoproj.io/review.allow-tags: regexp:^sha-[0-9a-f]+$
       argocd-image-updater.argoproj.io/review.force-update: "true"
+      argocd-image-updater.argoproj.io/review.pull-secret: pullsecret:argocd/adorsys-gis-ghcr-pull
       argocd-image-updater.argoproj.io/review.helm.image-spec: lci.controllers.dispatcher.containers.main.env.AGENT_REVIEW_RUNNER_IMAGE
       argocd-image-updater.argoproj.io/review.signature-type: cosign
       argocd-image-updater.argoproj.io/review.cosign.certificate-oidc-issuer: https://token.actions.githubusercontent.com
@@ -727,6 +738,10 @@ applications:
       argocd-image-updater.argoproj.io/frontend.update-strategy: newest-build
       argocd-image-updater.argoproj.io/frontend.allow-tags: regexp:^sha-[0-9a-f]+$
       argocd-image-updater.argoproj.io/frontend.force-update: "true"
+      # GHCR read cred (App-based, argocd ns) so tag detection keeps working once
+      # ghcr.io/adorsys-gis/converse-frontends goes private. Same secret as #621
+      # (dockerconfigjson keyed on the ghcr.io host → covers every org). No-op public.
+      argocd-image-updater.argoproj.io/frontend.pull-secret: pullsecret:argocd/adorsys-gis-ghcr-pull
       argocd-image-updater.argoproj.io/frontend.helm.image-name: conversefrontend.controllers.main.containers.frontend.image.repository
       argocd-image-updater.argoproj.io/frontend.helm.image-tag: conversefrontend.controllers.main.containers.frontend.image.tag
       argocd-image-updater.argoproj.io/write-back-method: git

--- a/charts/lightbridge-code-intelligence/templates/agents-rbac.yaml
+++ b/charts/lightbridge-code-intelligence/templates/agents-rbac.yaml
@@ -52,6 +52,16 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: {{ $wave }}
 automountServiceAccountToken: false
+{{- if .Values.agents.pullSecretName }}
+# Private-image cutover: the runner images (ghcr.io/vymalo/*) are now private. The agent Jobs the
+# dispatcher launches use THIS SA (k8s.rs sets pod.serviceAccountName), and the kubelet automatically
+# merges an SA's imagePullSecrets into every pod that uses it — so this one line gives every Job pod
+# pull credentials with no dispatcher/manifest change. The secret is materialised in this namespace by
+# the ExternalSecret in externalsecret.yaml. (Unaffected by automountServiceAccountToken: false, which
+# only governs the API-token mount.)
+imagePullSecrets:
+  - name: {{ .Values.agents.pullSecretName }}
+{{- end }}
 ---
 # Identity the dispatcher runs as (release namespace). bjw uses the `default` SA otherwise, which is
 # shared cluster-wide — too broad to grant Job CRUD to. The dispatcher controller selects this SA via

--- a/charts/lightbridge-code-intelligence/templates/externalsecret.yaml
+++ b/charts/lightbridge-code-intelligence/templates/externalsecret.yaml
@@ -158,5 +158,46 @@ spec:
       remoteRef:
         key: {{ $key }}
         property: {{ .Values.secrets.openaiKeyProperty }}
+{{- if and .Values.agents.pullSecretName .Values.secrets.ghcrUsernameProperty .Values.secrets.ghcrTokenProperty }}
+---
+# GHCR pull secret in the AGENTS namespace (private-image cutover). The runner images
+# (ghcr.io/vymalo/*) are private, and the Jobs the dispatcher launches here get NO bjw
+# defaultPodOptions (they're built imperatively in the app repo's k8s.rs), so the pull credential must
+# live in THIS namespace and be attached to the agent SA (agents-rbac.yaml) — pull secrets are
+# namespace-scoped, so the `converse` copy the bjw controllers use can't serve these Jobs. Same
+# dockerconfigjson shape + same PAT the rest of the platform uses (github_username/github_token in the
+# remoteKey bucket, keyed on the ghcr.io HOST so it also covers the vymalo org). Gated on the two GHCR
+# property names being set, so a defaults-only render (helm lint) emits nothing.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: {{ .Values.agents.pullSecretName }}
+  namespace: {{ .Values.agents.namespace }}
+  annotations:
+    argocd.argoproj.io/sync-wave: {{ $wave }}
+spec:
+  refreshInterval: {{ $refresh }}
+  secretStoreRef:
+    name: {{ $store }}
+    kind: ClusterSecretStore
+  target:
+    name: {{ .Values.agents.pullSecretName }}
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      type: kubernetes.io/dockerconfigjson
+      data:
+        .dockerconfigjson: |-
+          {{ `{"auths":{"ghcr.io":{"username":"{{ .username }}","password":"{{ .token }}","auth":"{{ printf "%s:%s" .username .token | b64enc }}"}}}` }}
+  data:
+    - secretKey: username
+      remoteRef:
+        key: {{ $key }}
+        property: {{ .Values.secrets.ghcrUsernameProperty }}
+    - secretKey: token
+      remoteRef:
+        key: {{ $key }}
+        property: {{ .Values.secrets.ghcrTokenProperty }}
+{{- end }}
 {{- end }}
 {{- end }}{{/* if $store */}}

--- a/charts/lightbridge-code-intelligence/values.yaml
+++ b/charts/lightbridge-code-intelligence/values.yaml
@@ -37,12 +37,29 @@ secrets:
   # it's agents.llm.model (also env-owned).
   agentRunnerTokenProperty: ""
   openaiKeyProperty: ""
+  # GHCR pull credential for the agent Jobs' namespace (private-image cutover). The runner images
+  # (ghcr.io/vymalo/*) are private, so the Jobs the dispatcher launches into `agents.namespace` need
+  # imagePullSecrets — and, unlike the bjw controllers, they get NO defaultPodOptions (they're created
+  # imperatively by the Rust dispatcher, see k8s.rs). We materialise a dockerconfigjson in that
+  # namespace (externalsecret.yaml) and attach it to the agent SA (agents-rbac.yaml). The PAT lives in
+  # the SAME bucket as remoteKey (github_username/github_token @ ai/camer/digital/prod/env); both
+  # property names are empty in chart defaults (ADR-0057), so the pull-secret ExternalSecret renders
+  # ONLY once the env override sets them → a defaults-only lint render stays render-neutral.
+  ghcrUsernameProperty: ""
+  ghcrTokenProperty: ""
 
 # ── Agent execution (epic #5): per-task Jobs in an isolated namespace ─────────
 agents:
   enabled: true
   namespace: lightbridge-agents
   serviceAccount: lightbridge-agent
+  # Pull secret (dockerconfigjson) the agent Job pods use for the now-private ghcr.io/vymalo/* runner
+  # images. Materialised in `namespace` by the ExternalSecret in externalsecret.yaml and attached to
+  # `serviceAccount` (agents-rbac.yaml), so every Job pod inherits it with NO dispatcher change — the
+  # kubelet merges an SA's imagePullSecrets into each pod that uses it. One name drives both the secret
+  # and the SA reference. Reuses the org-wide ghcr.io credential (keyed on the HOST, so it also covers
+  # the vymalo org). Empty → no imagePullSecrets attached (public images / anonymous pull).
+  pullSecretName: lightbridge-repo-auth-ghcr
   # NOTE: unused/vestigial — bjw renders the dispatcher env against the sub-chart scope where
   # top-level `agents.*` isn't visible, so the LIVE runner image is the dispatcher's
   # AGENT_RUNNER_IMAGE env literal (controllers.dispatcher) below, NOT this. That env value IS

--- a/charts/lightbridge-code-intelligence/values.yaml
+++ b/charts/lightbridge-code-intelligence/values.yaml
@@ -271,6 +271,16 @@ lci:
       runAsNonRoot: true
       seccompProfile:
         type: RuntimeDefault
+    # GHCR pull secret so kubelet can pull the now-private ghcr.io/vymalo/* images.
+    # REUSE the org-wide ghcr.io dockerconfigjson already materialised in `converse`
+    # by the lightbridge-repo-auth chart (secret `lightbridge-repo-auth-ghcr`,
+    # github_username/github_token @ ssegning-aws) — it's keyed on the ghcr.io HOST
+    # so it covers the vymalo org too, exactly as the authz stack reuses it
+    # (ai-helm-values lightbridge-app.yaml). bjw-s resolves imagePullSecrets from
+    # defaultPodOptions/pod — NOT global.imagePullSecrets. Harmless while the images
+    # are public (a missing/anonymous pull still works).
+    imagePullSecrets:
+      - name: lightbridge-repo-auth-ghcr
 
   controllers:
     # Rust control plane: GitHub webhook trust boundary + OAuth2 resource server


### PR DESCRIPTION
## 1. Summary

This PR wires the credential paths in **ai-helm** for the private-package cutover (image side + kubelet pulls):

- image-updater `.pull-secret` annotations on converse-ui + the 8 vymalo LCI image aliases → `adorsys-gis-ghcr-pull` (host-keyed → covers both orgs).
- LCI bjw controllers (namespace `converse`) reuse the existing host-keyed `lightbridge-repo-auth-ghcr` via `lci.defaultPodOptions.imagePullSecrets`.
- LCI agent Jobs (namespace `lightbridge-agents`, imperatively created by the dispatcher — no bjw defaultPodOptions) get a namespace-local `dockerconfigjson` ExternalSecret attached to the agent SA (ADR-0057, env-owned property names).

It solves: #624

## 2. Intent

> Once the GHCR image packages flip private, image-updater tag-detection and kubelet pulls 401 unless credentialed. The admin PAT already reads both orgs; a `dockerconfigjson` is keyed on the `ghcr.io` host, so one existing secret covers everything. This is cred-first wiring — a no-op while the packages are public — so the later visibility flip is a non-event.

## 3. Scope

### In Scope
- image-updater pull-secret annotations (Plane C) for converse-ui + LCI.
- kubelet imagePullSecrets (Plane D) for LCI controllers (`converse`) + agent Jobs (`lightbridge-agents`).

### Out of Scope
- Flipping package/repo visibility (manual, after merge).
- ArgoCD OCI repo-creds + argocd-ns pull secret (home-os) and the values-repo overrides (ai-helm-values) — sibling PRs on #624.

## 4. Verification

I verified this change by:

- [x] Running manual tests (helm lint + template renders)
- [x] Testing error cases (defaults-only render stays render-neutral — the agents-ns ExternalSecret is gated on env-set properties)

Commands run:

```bash
helm lint charts/lightbridge-code-intelligence
helm template x charts/lightbridge-code-intelligence                 # defaults (lint parity)
helm template x charts/lightbridge-code-intelligence -f /tmp/lci-test.yaml   # with ghcr props set
helm template x charts/apps --dry-run
```

Results:

```text
1 chart(s) linted, 0 chart(s) failed
defaults render OK — agents-ns ExternalSecret absent (gated); SA + 5 controllers carry imagePullSecrets: lightbridge-repo-auth-ghcr
with props set: dockerconfigjson ExternalSecret renders in namespace lightbridge-agents
apps render OK — 9 .pull-secret annotations present
```

## 5. Screenshots / Evidence

N/A — YAML/Helm only; evidence is the render output above.

## 6. Risk Assessment

Risk level: Low

Potential risks:
* A missing/disabled pull secret ⇒ anonymous pull, which still works while images are public — so no runtime change until the flip. At flip, an unwired path ⇒ ImagePullBackOff; mitigated by reusing already-materialised host-keyed secrets and by the values-repo-first counterpart landing first.

## 7. AI Usage Declaration

AI (Claude) planned the credential-plane model and wired the pull-secret annotations + the LCI controller imagePullSecrets reuse. The human maintainer authored the ADR-0057 agent-Jobs pull-secret mechanism and owns intent + live verification.

- [x] I understood the intent
- [x] I checked the source of truth
- [ ] I reviewed all AI-generated text/code

## 8. Reviewer Focus

- That reusing `lightbridge-repo-auth-ghcr` (rather than a new secret) is the intended pattern — it matches the authz stack.
- ADR-0057 render-neutrality: confirm the agents-ns ExternalSecret only renders when the env sets `ghcrUsernameProperty`/`ghcrTokenProperty`.
