### PR TITLE
feat(lci): A2A push notifier — controller + egress NetworkPolicy + push token secret (ADR-0079)

### DIFF
--- a/charts/apps/values.yaml
+++ b/charts/apps/values.yaml
@@ -539,7 +539,7 @@ applications:
       # image — no Python/Graphify — picked for review tasks; ADR-0004 per-kind images, #207).
       # `rw` = restate-worker (RFC-0005/ADR-0074), `a2a` = the A2A surface (RFC-0006) — both the SAME
       # control-plane image, kept in lockstep so the new roles never lag the control-plane on a build.
-      argocd-image-updater.argoproj.io/image-list: cp=ghcr.io/vymalo/lightbridge-control-plane,disp=ghcr.io/vymalo/lightbridge-control-plane,recon=ghcr.io/vymalo/lightbridge-control-plane,rw=ghcr.io/vymalo/lightbridge-control-plane,a2a=ghcr.io/vymalo/lightbridge-control-plane,web=ghcr.io/vymalo/lightbridge-web,runner=ghcr.io/vymalo/lightbridge-agent-runner,review=ghcr.io/vymalo/lightbridge-agent-review
+      argocd-image-updater.argoproj.io/image-list: cp=ghcr.io/vymalo/lightbridge-control-plane,disp=ghcr.io/vymalo/lightbridge-control-plane,recon=ghcr.io/vymalo/lightbridge-control-plane,rw=ghcr.io/vymalo/lightbridge-control-plane,a2a=ghcr.io/vymalo/lightbridge-control-plane,notifier=ghcr.io/vymalo/lightbridge-control-plane,web=ghcr.io/vymalo/lightbridge-web,runner=ghcr.io/vymalo/lightbridge-agent-runner,review=ghcr.io/vymalo/lightbridge-agent-review
       # ── control-plane ──
       argocd-image-updater.argoproj.io/cp.update-strategy: newest-build
       argocd-image-updater.argoproj.io/cp.allow-tags: regexp:^sha-[0-9a-f]+$
@@ -598,6 +598,17 @@ applications:
       argocd-image-updater.argoproj.io/a2a.signature-type: cosign
       argocd-image-updater.argoproj.io/a2a.cosign.certificate-oidc-issuer: https://token.actions.githubusercontent.com
       argocd-image-updater.argoproj.io/a2a.cosign.certificate-identity-regexp: ^https://github\.com/vymalo/lightbridge-code-intelligence/\.github/workflows/build-images\.yml@.*$
+      # ── notifier (SAME image as control-plane, role-selected; RFC-0006 Phase 3 / ADR-0079) — keeps its
+      #    tag in lockstep so the A2A push-notification worker never lags the control-plane on a build. ──
+      argocd-image-updater.argoproj.io/notifier.update-strategy: newest-build
+      argocd-image-updater.argoproj.io/notifier.allow-tags: regexp:^sha-[0-9a-f]+$
+      argocd-image-updater.argoproj.io/notifier.force-update: "true"
+      argocd-image-updater.argoproj.io/notifier.pull-secret: pullsecret:argocd/adorsys-gis-ghcr-pull
+      argocd-image-updater.argoproj.io/notifier.helm.image-name: lci.controllers.notifier.containers.main.image.repository
+      argocd-image-updater.argoproj.io/notifier.helm.image-tag: lci.controllers.notifier.containers.main.image.tag
+      argocd-image-updater.argoproj.io/notifier.signature-type: cosign
+      argocd-image-updater.argoproj.io/notifier.cosign.certificate-oidc-issuer: https://token.actions.githubusercontent.com
+      argocd-image-updater.argoproj.io/notifier.cosign.certificate-identity-regexp: ^https://github\.com/vymalo/lightbridge-code-intelligence/\.github/workflows/build-images\.yml@.*$
       # ── web ──
       argocd-image-updater.argoproj.io/web.update-strategy: newest-build
       argocd-image-updater.argoproj.io/web.allow-tags: regexp:^sha-[0-9a-f]+$

--- a/charts/lightbridge-code-intelligence/Chart.yaml
+++ b/charts/lightbridge-code-intelligence/Chart.yaml
@@ -12,7 +12,7 @@ description: |
   matching the librechat-app pattern; ExternalSecrets are chart templates resolving
   against the ssegning-aws ClusterSecretStore; ingress is Traefik + cert-home-cert-http.
 type: application
-version: 0.7.1
+version: 0.8.0
 appVersion: "0.7.0"
 dependencies:
   - name: bjw-template

--- a/charts/lightbridge-code-intelligence/templates/externalsecret.yaml
+++ b/charts/lightbridge-code-intelligence/templates/externalsecret.yaml
@@ -47,6 +47,34 @@ spec:
       remoteRef:
         key: {{ $codeintelKey }}
         property: {{ .Values.secrets.githubAppPrivateKeyProperty }}
+{{- if .Values.secrets.a2aPushTokenKeyProperty }}
+---
+# A2A push-notification token-signing key (RFC-0006 Phase 3, ADR-0079 §3). The `notifier` role uses
+# it to encrypt each push-config's webhook auth token at rest. Sourced from the dedicated codeintel
+# bucket (`$codeintelKey`), like the GitHub App creds. Gated on the property name being set, so a
+# defaults-only render — or an env that hasn't migrated the SM property yet — emits nothing instead of
+# a malformed ExternalSecret. The 32-byte VALUE is an operator prereq in the SM bucket, never here.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: {{ .Release.Name }}-a2a-push
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    argocd.argoproj.io/sync-wave: {{ $wave }}
+spec:
+  refreshInterval: {{ $refresh }}
+  secretStoreRef:
+    name: {{ $store }}
+    kind: ClusterSecretStore
+  target:
+    name: {{ .Release.Name }}-a2a-push
+    creationPolicy: Owner
+  data:
+    - secretKey: push-token-key
+      remoteRef:
+        key: {{ $codeintelKey }}
+        property: {{ .Values.secrets.a2aPushTokenKeyProperty }}
+{{- end }}
 {{- /* TRANSITIONAL: the `-auth` secret feeds the outgoing better-auth web image. The OIDC web
        image (ADR-0014) is a PUBLIC client (PKCE, no client secret); drop this once it's live. */}}
 ---

--- a/charts/lightbridge-code-intelligence/templates/servicemonitor.yaml
+++ b/charts/lightbridge-code-intelligence/templates/servicemonitor.yaml
@@ -47,4 +47,26 @@ spec:
     - port: metrics
       path: /metrics
       interval: {{ $interval }}
+{{- /* notifier (ADR-0079) → the notifier metrics Service (:9090, port name `metrics`) added in values.
+       Gated ALSO on the notifier Service being enabled so we never emit a ServiceMonitor whose
+       Endpoints target (the Service) doesn't exist — a defaults-only render has the Service off. */}}
+{{- if (index .Values "lci" "service" "notifier" "enabled") }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ $fullname }}-notifier
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    argocd.argoproj.io/sync-wave: {{ $wave }}
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: {{ $fullname }}
+      app.kubernetes.io/service: {{ $fullname }}-notifier
+  endpoints:
+    - port: metrics
+      path: /metrics
+      interval: {{ $interval }}
+{{- end }}
 {{- end }}

--- a/charts/lightbridge-code-intelligence/values.yaml
+++ b/charts/lightbridge-code-intelligence/values.yaml
@@ -47,6 +47,13 @@ secrets:
   # ONLY once the env override sets them → a defaults-only lint render stays render-neutral.
   ghcrUsernameProperty: ""
   ghcrTokenProperty: ""
+  # A2A push-notification token key (RFC-0006 Phase 3, ADR-0079 §3): a base64-encoded 32-byte key the
+  # `notifier` role uses to encrypt each push-config's webhook auth token at rest. Lives in the dedicated
+  # codeintel bucket ($codeintelKey), like the GitHub App creds. Empty in chart defaults (ADR-0057) → the
+  # `-a2a-push` ExternalSecret (externalsecret.yaml) renders ONLY once an env override sets this property,
+  # so a defaults-only lint render stays render-neutral. The 32-byte VALUE is an OPERATOR PREREQ in the SM
+  # bucket — never in this chart.
+  a2aPushTokenKeyProperty: ""
 
 # ── Agent execution (epic #5): per-task Jobs in an isolated namespace ─────────
 agents:
@@ -935,6 +942,21 @@ lci:
             DATABASE_URL:
               dependsOn: DB_PASSWORD
               value: ""
+            # Push-notification token-signing key (ADR-0079 §3) — SHARED with the notifier. The a2a role
+            # ENCRYPTS each push config's webhook auth token on create_push_config and DECRYPTS it for the
+            # get/list echo (services/control-plane/src/a2a/mod.rs → push_token_key_from_env()); the
+            # notifier DECRYPTS it at delivery. SAME `{{ .Release.Name }}-a2a-push` ExternalSecret both
+            # roles read. `optional: true` MATTERS: without the key the code degrades gracefully (tokened
+            # CreateTaskPushNotificationConfig is rejected, tokenless webhooks still work) — it does NOT
+            # crash. Since the a2a surface is LIVE (it also serves the `review` skill), a hard secretKeyRef
+            # to a not-yet-provisioned secret would take the WHOLE surface down; optional keeps it up and
+            # only the push-token feature degrades until the operator adds the SM property. base64 32-byte.
+            A2A_PUSH_TOKEN_KEY:
+              valueFrom:
+                secretKeyRef:
+                  name: '{{ .Release.Name }}-a2a-push'
+                  key: push-token-key
+                  optional: true
           probes:
             # Liveness = the process/metrics server (:9090 /healthz), like the other headless roles.
             liveness:
@@ -955,6 +977,100 @@ lci:
                 httpGet:
                   path: /.well-known/agent-card.json
                   port: 8080
+                initialDelaySeconds: 5
+                periodSeconds: 10
+            startup:
+              enabled: false
+          resources:
+            requests: { cpu: 50m, memory: 64Mi }
+            limits: { cpu: 500m, memory: 256Mi }
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsUser: 1000
+            capabilities:
+              drop: [ALL]
+
+    # ── notifier (RFC-0006 Phase 3 / ADR-0079) ────────────────────────────────────────────────────
+    # The SAME control-plane image in the `notifier` role: a HEADLESS worker (like dispatcher/
+    # reconciler) that drains the A2A push-notification outbox and delivers webhook POSTs to the URLs
+    # callers registered on their push configs. It runs NO HTTP surface beyond the metrics-only listener
+    # on :9090 (/metrics + /healthz) — NO Service, NO Ingress. It REQUIRES a DB pool (the push_configs
+    # store + the monotonic delivery cursor) and the token-signing key; absent either it degrades.
+    #
+    # SECURITY — push delivery is an SSRF surface (ADR-0079 §2), defended in depth:
+    #   (1) app-level: the SSRF URL validator rejects private/link-local/loopback/metadata targets;
+    #   (2) A2A_PUSH_DENIED_CIDRS: an explicit deny list (this cluster's pod + service CIDRs) the
+    #       notifier refuses to POST to — belt-and-suspenders over (1);
+    #   (3) network-level: the notifier NetworkPolicy (`networkpolicies.notifier` below) is the CNI
+    #       backstop — egress allowed ONLY to 443 on PUBLIC IPs, plus DNS (kube-dns) + Postgres (CNPG);
+    #       RFC1918 + the pod/service CIDRs + link-local/metadata + loopback are excluded at the CNI.
+    # `enabled: false` here → inert on chart defaults; ai-helm-values enables it and supplies the image
+    # tag + DATABASE_URL + A2A_PUSH_DENIED_CIDRS per-env, and turns on the NetworkPolicy.
+    notifier:
+      enabled: false
+      type: deployment
+      # RollingUpdate: the outbox is drained via a monotonic cursor and delivery is idempotent-safe, so a
+      # brief old+new overlap on rollout is acceptable (matches the other headless roles).
+      strategy: RollingUpdate
+      replicas: 1
+      annotations:
+        argocd.argoproj.io/sync-wave: "2"
+      containers:
+        main:
+          image:
+            repository: ghcr.io/vymalo/lightbridge-control-plane
+            # Default/fallback; the deployed tag is overridden at sync time by ai-helm-values via the
+            # image-updater `notifier` alias (charts/apps/values.yaml), in lockstep with control-plane.
+            tag: "0.1.0"
+            pullPolicy: IfNotPresent
+          env:
+            CONTROL_PLANE_ROLE: "notifier"
+            RUST_LOG: "info"
+            # Metrics-only listener (like dispatcher/reconciler) — /metrics + /healthz on :9090.
+            METRICS_ADDR: "0.0.0.0:9090"
+            # Same CNPG queue the serve/dispatcher/reconciler roles use. DATABASE_URL `value` (cluster
+            # host/namespace/db) → ai-helm-values; `dependsOn` stays here.
+            DB_PASSWORD:
+              valueFrom:
+                secretKeyRef:
+                  name: lightbridge-codeintel-db-role
+                  key: password
+            DATABASE_URL:
+              dependsOn: DB_PASSWORD
+              value: ""
+            # Token-signing key (ADR-0079 §3) — SHARED with the a2a role. The notifier DECRYPTS each push
+            # config's webhook auth token at delivery time (the a2a role encrypts it at CRUD). base64
+            # 32-byte key from the `{{ .Release.Name }}-a2a-push` ExternalSecret (externalsecret.yaml,
+            # codeintel bucket). `optional: true` → without it the role degrades gracefully (delivers
+            # tokenless webhooks; tokened ones can't be decrypted) rather than the pod failing to start.
+            A2A_PUSH_TOKEN_KEY:
+              valueFrom:
+                secretKeyRef:
+                  name: '{{ .Release.Name }}-a2a-push'
+                  key: push-token-key
+                  optional: true
+            # SSRF network deny list (ADR-0079 §2): comma-separated CIDRs the notifier refuses to POST to
+            # (this cluster's pod + service CIDRs). Belt-and-suspenders over the app-level SSRF validator
+            # (which already blocks 10.0.0.0/8) and the NetworkPolicy. DEPLOYMENT-SPECIFIC → ai-helm-values.
+            A2A_PUSH_DENIED_CIDRS: ""
+          probes:
+            liveness:
+              enabled: true
+              custom: true
+              spec:
+                httpGet:
+                  path: /healthz
+                  port: 9090
+                initialDelaySeconds: 5
+                periodSeconds: 15
+            readiness:
+              enabled: true
+              custom: true
+              spec:
+                httpGet:
+                  path: /healthz
+                  port: 9090
                 initialDelaySeconds: 5
                 periodSeconds: 10
             startup:
@@ -1012,6 +1128,16 @@ lci:
       ports:
         http:
           port: 8080
+    # Metrics-only Service for the notifier role (METRICS_ADDR :9090) — same pattern as the dispatcher
+    # Service above: the headless notifier has no other Service, so this gives its ServiceMonitor
+    # (templates/servicemonitor.yaml) a stable Endpoints target for its push-delivery metrics. `enabled`
+    # tracks the controller (both flipped on in ai-helm-values); OFF here so defaults stay render-neutral.
+    notifier:
+      enabled: false
+      controller: notifier
+      ports:
+        metrics:
+          port: 9090
 
   # DEPLOYMENT-SPECIFIC: ingress is OFF by default — the ingress class, cert-manager cluster-issuer,
   # public hostnames, and TLS secrets are all env-specific, so the FULL ingress config (enabled: true +
@@ -1028,6 +1154,79 @@ lci:
     # every A2A binding behind it is OIDC-gated in-app (no anonymous access).
     a2a:
       enabled: false
+
+  # NetworkPolicies (bjw-s `networkpolicies` — rendered by bjw-common as networking.k8s.io/v1
+  # NetworkPolicy; Cilium, this cluster's CNI, enforces plain k8s NetworkPolicies natively). OFF by
+  # default so a defaults-only render emits nothing; ai-helm-values opts each one in per-env.
+  networkpolicies:
+    # ── notifier egress lock-down (RFC-0006 Phase 3 / ADR-0079 §2) ────────────────────────────────
+    # The network-layer half of the push-delivery SSRF defence. The notifier makes ONLY outbound
+    # calls, so we constrain Egress and leave Ingress untouched (policyTypes: [Egress] → ingress stays
+    # default-allow, so kubelet probes on :9090 keep working). Selecting a pod for Egress under Cilium
+    # DENIES all egress not listed here, so DNS + Postgres MUST be allowed explicitly or the pod wedges.
+    #   • DNS      → kube-dns pods (ns kube-system), UDP+TCP 53. The pod resolves via the kube-dns
+    #                ClusterIP (10.43.0.10), which Cilium evaluates against the destination ENDPOINT
+    #                (the CoreDNS pod) — so a namespaceSelector on the pod, NOT an ipBlock on the
+    #                ClusterIP, is the correct match (the service CIDR is inside the ipBlock `except`).
+    #   • Postgres → the CNPG pods backing `lightbridge-main-db-rw` (matched by cnpg.io/cluster, so BOTH
+    #                instances are allowed and a primary→replica failover never wedges egress), TCP 5432.
+    #                Again a podSelector, not the -rw ClusterIP, because Cilium resolves the DNAT to the
+    #                backing pod's endpoint identity.
+    #   • Webhooks → 0.0.0.0/0 minus RFC1918 + link-local/metadata + loopback (which COVERS this
+    #                cluster's pod CIDR 10.42.0.0/16 + service CIDR 10.43.0.0/16, both inside 10.0.0.0/8),
+    #                TCP 443 only. This is the CNI backstop over the app-level SSRF validator + the
+    #                A2A_PUSH_DENIED_CIDRS deny list.
+    # ⚠️ REVIEW: validate the egress semantics against Cilium on hetzner-prod before relying on it — a
+    # wrong policy either WEDGES the notifier (no DB/DNS → CrashLoop/never-Ready) or FAILS to isolate
+    # (internal SSRF still reachable). Verify: (a) Cilium honours ipBlock `except` as CIDR exceptions;
+    # (b) the CoreDNS namespace/label match resolves DNS; (c) the CNPG podSelector permits :5432.
+    notifier:
+      enabled: false
+      controller: notifier
+      # Force a stable `<fullname>-notifier` name (bjw defaults a single-item networkpolicy to the bare
+      # fullname). With the suffix it renders `lightbridge-ci-notifier` regardless of item count, so
+      # adding a second networkpolicy later never renames/recreates this one.
+      suffix: notifier
+      policyTypes:
+        - Egress
+      rules:
+        egress:
+          # DNS to kube-dns (CoreDNS) in kube-system.
+          - to:
+              - namespaceSelector:
+                  matchLabels:
+                    kubernetes.io/metadata.name: kube-system
+            ports:
+              - protocol: UDP
+                port: 53
+              - protocol: TCP
+                port: 53
+          # Postgres: the CNPG pods of the lightbridge-main-db cluster in converse (both instances).
+          - to:
+              - namespaceSelector:
+                  matchLabels:
+                    kubernetes.io/metadata.name: converse
+                podSelector:
+                  matchLabels:
+                    cnpg.io/cluster: lightbridge-main-db
+            ports:
+              - protocol: TCP
+                port: 5432
+          # Public webhooks: TCP 443 to PUBLIC IPs only. `except` removes RFC1918 (covers the pod CIDR
+          # 10.42.0.0/16 + service CIDR 10.43.0.0/16, both within 10.0.0.0/8), link-local + cloud
+          # metadata (169.254.0.0/16), and loopback (127.0.0.0/8).
+          - to:
+              - ipBlock:
+                  cidr: 0.0.0.0/0
+                  except:
+                    - 10.0.0.0/8
+                    - 172.16.0.0/12
+                    - 192.168.0.0/16
+                    - 169.254.0.0/16
+                    - 127.0.0.0/8
+            ports:
+              - protocol: TCP
+                port: 443
 
   # emptyDir scratch dirs for the read-only-rootfs containers (control-plane, web).
   # Neo4j /data is NOT here — it's a StatefulSet volumeClaimTemplate on the neo4j controller


### PR DESCRIPTION
## 1. Summary

This PR changes:

- Adds an inert `notifier` controller to the `lightbridge-code-intelligence` chart (mirrors `restate-worker`): SAME control-plane image, `CONTROL_PLANE_ROLE=notifier`, headless (no Ingress), metrics-only `/healthz`+`/metrics` on `:9090`. Env: `DATABASE_URL` (values-supplied), `A2A_PUSH_TOKEN_KEY` (from the new secret), `A2A_PUSH_DENIED_CIDRS` (values-supplied). `enabled: false` by default.
- Adds the `<release>-a2a-push` ExternalSecret (codeintel bucket) + the `a2aPushTokenKeyProperty` secret-structure key. **No secret value in the chart** — only the structure. Gated on the property being set, so a defaults-only render emits nothing.
- Wires `A2A_PUSH_TOKEN_KEY` into **both** roles that use it (from the SAME `<release>-a2a-push` secret): the **a2a** role encrypts each push config's webhook auth token at CRUD (`create_push_config`) and decrypts it for the get/list echo; the **notifier** decrypts it at delivery. `optional: true` on the secretKeyRef so a missing key **degrades gracefully** (tokened configs rejected, tokenless still work) instead of crashing — important because the a2a surface is LIVE (also serves the `review` skill).
- Adds an opt-in egress `NetworkPolicy` for the notifier (`networkpolicies.notifier`, `enabled: false` default): the network-layer half of the ADR-0079 §2 push-delivery SSRF defence. Uses `suffix: notifier` so it renders with a **stable `lightbridge-ci-notifier` name** (not the bare fullname) — a future second networkpolicy can't rename/recreate it.
- Adds a **metrics Service (`:9090`) + ServiceMonitor** for the notifier so its push-delivery metrics reach Mimir (mirrors the `dispatcher` scrape pattern). The ServiceMonitor is gated ALSO on the notifier Service being enabled, so it never emits a monitor whose target Service is absent. Both default off.
- `charts/apps`: adds the image-updater `notifier` alias (cosign-verified, newest-build) so the tag tracks the control-plane in lockstep.
- Chart `0.7.1 → 0.8.0`.

It solves:

- **Source of truth: [ADR-0079](https://github.com/vymalo/lightbridge-code-intelligence/blob/main/docs/adr/0079-a2a-push-notifications-webhook-egress.md)** (A2A push-notification `notifier` role), RFC-0006 Phase 3, deploy slice 3b/3c. The control-plane code (the `notifier` role + `A2A_PUSH_TOKEN_KEY` / `A2A_PUSH_DENIED_CIDRS` env) is already merged; this is the chart wiring.

---

## 2. Intent

> The push-notification worker delivers webhook POSTs to caller-registered URLs — an SSRF surface. ADR-0079 §2 mandates defence in depth: an app-level SSRF URL validator, an explicit `A2A_PUSH_DENIED_CIDRS` deny list, and a **network-layer backstop**. This PR ships that backstop as a k8s NetworkPolicy (Cilium-enforced) alongside the headless worker and its token-signing secret structure. Everything is inert on chart defaults so this is safe to merge ahead of the per-env enablement (ai-helm-values PR).

---

## 3. Scope

### In Scope

- `notifier` controller, its `-a2a-push` ExternalSecret + `a2aPushTokenKeyProperty`, its egress NetworkPolicy, the `notifier` image-updater alias, chart version bump.

### Out of Scope

- The secret VALUE (`a2a_push_token_key`) — an operator prereq in the `prod/codeintel/env` SM bucket.
- Per-env enablement (`enabled: true`, DATABASE_URL, denied-CIDRs) — ai-helm-values PR.
- The control-plane `notifier` role code — already merged.

---

## 4. Verification

I verified this change by:

- [x] Running manual tests (`helm lint` + `helm template`)
- [x] Testing permissions/security behavior (server dry-run of the NetworkPolicy; render-neutrality on defaults)

Commands run:

```bash
helm lint charts/lightbridge-code-intelligence            # 0 failed
helm lint charts/lightbridge-code-intelligence -f <overlay>   # 0 failed
# render-neutral on defaults (notifier/NetworkPolicy/a2a-push absent):
helm template lightbridge-ci charts/lightbridge-code-intelligence | grep -ci 'notifier\|NetworkPolicy\|a2a-push'   # 0
# renders correctly with the prod values file overlaid:
helm template lightbridge-ci charts/lightbridge-code-intelligence -f <ai-helm-values prod file>   # OK, exit 0
# NetworkPolicy + Service + ServiceMonitor accepted by the API server:
kubectl --context hetzner-prod -n converse apply --dry-run=server -f <rendered NP+Svc+SM>
helm lint charts/apps                                     # 0 failed
```

Results:

```text
1 chart(s) linted, 0 chart(s) failed
default-values matches for notifier/NetworkPolicy/a2a-push/A2A_PUSH: 0
networkpolicy.networking.k8s.io/lightbridge-ci-notifier created (server dry run)
service/lightbridge-ci-notifier created (server dry run)
servicemonitor.monitoring.coreos.com/lightbridge-ci-notifier created (server dry run)
# ServiceMonitor suppressed when serviceMonitors on but notifier Service off: 0 (no dangling target)
```

Rendered NetworkPolicy (with notifier enabled):

```yaml
apiVersion: networking.k8s.io/v1
kind: NetworkPolicy
metadata:
  name: lightbridge-ci-notifier      # stable name via suffix: notifier
  namespace: converse
spec:
  podSelector:
    matchLabels:
      app.kubernetes.io/controller: notifier
      app.kubernetes.io/instance: lightbridge-ci
      app.kubernetes.io/name: lightbridge-ci
  policyTypes:
    - Egress
  egress:
    - ports:
      - { port: 53, protocol: UDP }
      - { port: 53, protocol: TCP }
      to:
      - namespaceSelector:
          matchLabels:
            kubernetes.io/metadata.name: kube-system
    - ports:
      - { port: 5432, protocol: TCP }
      to:
      - namespaceSelector:
          matchLabels:
            kubernetes.io/metadata.name: converse
        podSelector:
          matchLabels:
            cnpg.io/cluster: lightbridge-main-db
    - ports:
      - { port: 443, protocol: TCP }
      to:
      - ipBlock:
          cidr: 0.0.0.0/0
          except:
          - 10.0.0.0/8
          - 172.16.0.0/12
          - 192.168.0.0/16
          - 169.254.0.0/16
          - 127.0.0.0/8
```

---

## 5. Screenshots / Evidence

- Rendered NetworkPolicy: above. Server dry-run: `created (server dry run)`.

- `A2A_PUSH_TOKEN_KEY` renders identically on **both** controllers (prod values), and is absent on a defaults render:

```yaml
# controller lightbridge-ci-a2a  AND  controller lightbridge-ci-notifier
- name: A2A_PUSH_TOKEN_KEY
  valueFrom:
    secretKeyRef:
      key: push-token-key
      name: lightbridge-ci-a2a-push
      optional: true
```

- Rendered notifier **metrics Service + ServiceMonitor** (prod values; both server-dry-run accepted). The ServiceMonitor selector matches the Service's `app.kubernetes.io/service` label:

```yaml
apiVersion: v1
kind: Service
metadata:
  name: lightbridge-ci-notifier
  labels:
    app.kubernetes.io/service: lightbridge-ci-notifier
  namespace: converse
spec:
  type: ClusterIP
  ports:
    - { port: 9090, targetPort: 9090, protocol: TCP, name: metrics }
  selector:
    app.kubernetes.io/controller: notifier
    app.kubernetes.io/instance: lightbridge-ci
    app.kubernetes.io/name: lightbridge-ci
---
apiVersion: monitoring.coreos.com/v1
kind: ServiceMonitor
metadata:
  name: lightbridge-ci-notifier
  namespace: converse
spec:
  selector:
    matchLabels:
      app.kubernetes.io/instance: lightbridge-ci
      app.kubernetes.io/service: lightbridge-ci-notifier
  endpoints:
    - { port: metrics, path: /metrics, interval: 30s }
```

---

## 6. Risk Assessment

Risk level:

* [x] Medium

Potential risks:

* **NetworkPolicy correctness on Cilium** — a wrong egress policy either WEDGES the notifier (no DB/DNS → CrashLoop/never-Ready) or FAILS to isolate (internal SSRF still reachable). Cilium selecting a pod for Egress denies all egress not explicitly listed, so DNS + Postgres MUST be allowed (they are).
* NetworkPolicy name is the bare fullname (`lightbridge-ci`) since it is the only policy; bjw would auto-append `-notifier` if a second policy is ever added (a delete+recreate on that future change).

Mitigation:

* All additions default-off; inert until the ai-helm-values PR enables them. Postgres/DNS matched by **podSelector/namespaceSelector** (not the ClusterIP) because Cilium evaluates egress against the destination endpoint after DNAT. Postgres matched by `cnpg.io/cluster` (both instances) so a primary→replica failover never wedges egress. **Please validate the egress semantics on hetzner-prod before enabling** (DNS resolves, `:5432` reachable, `ipBlock except` isolates internal ranges).

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [x] Reviewing the diff

Human verification:

* [ ] I understand every meaningful change in this PR
* [ ] I checked generated code manually
* [ ] I removed unsupported AI assumptions
* [ ] I accept responsibility for this PR

---

## 8. Reviewer Focus

Please focus your review on:

* [x] Security — the NetworkPolicy egress semantics on Cilium (DNS/Postgres allows + ipBlock-except isolation)
* [x] Correctness — CNPG podSelector label, kube-dns namespace match
* [x] Edge cases — failover, render-neutrality
