### PR TITLE
feat(core-gateway): trace-log correlation + scoped AI Gateway tracing

### DIFF
--- a/charts/ai-model/templates/backendtrafficpolicy.yaml
+++ b/charts/ai-model/templates/backendtrafficpolicy.yaml
@@ -65,6 +65,15 @@ spec:
   retry:
     numRetries: 0
   {{- end }}
+  # Trace this model's route at 100%, overriding the gateway-wide
+  # samplingRate: 0 default (charts/core-gateway EnvoyProxy). Model routes
+  # are the only routes we want traced — chat completions + embeddings —
+  # not MCP routes or anything else on the shared gateway.
+  telemetry:
+    tracing:
+      samplingFraction:
+        numerator: 100
+        denominator: 100
   {{- /*
   Per-model upstream timeout.
   */ -}}

--- a/charts/core-gateway/templates/envoy-proxy.yaml
+++ b/charts/core-gateway/templates/envoy-proxy.yaml
@@ -71,6 +71,23 @@ spec:
     # templates/podmonitors-observability.yaml is documented in one place.
     metrics:
       prometheus: {}
+    tracing:
+      # Gateway-wide default is OFF. We deliberately don't want a span for
+      # every request through this listener (MCP routes, health checks) —
+      # only the AI Gateway model routes (chat completions + embeddings)
+      # should be traced, and those opt back in to 100% via the per-model
+      # BackendTrafficPolicy's telemetry.tracing.samplingFraction
+      # (charts/ai-model/templates/backendtrafficpolicy.yaml), which
+      # overrides this route-by-route. Auth (Authorino ext_authz) isn't a
+      # separate routed request, so it rides inside whichever request
+      # triggered it — no separate opt-in needed for auth visibility.
+      samplingRate: 0
+      provider:
+        type: OpenTelemetry
+        # Same Alloy OTLP endpoint the access log sink below already uses —
+        # no new backend/collector needed.
+        host: alloy.observability.svc.cluster.local
+        port: 4317
     accessLog:
       settings:
         - sinks:
@@ -119,6 +136,15 @@ spec:
               x-forwarded-for: "%REQ(X-FORWARDED-FOR)%"
               user-agent: "%REQ(USER-AGENT)%"
               x-request-id: "%REQ(X-REQUEST-ID)%"
+              # Tempo trace correlation: the AI Gateway extproc's tracer
+              # injects `traceparent` into the request headers when it
+              # starts a ChatCompletion span (same mechanism used for
+              # x-ai-eg-model). Logging the header here — rather than
+              # %TRACE_ID%, which needs Envoy's own tracing provider
+              # configured (it isn't) — lets Grafana pull the trace ID
+              # straight out of this access log line and jump to the
+              # matching Tempo span (see the Loki derivedFields config).
+              traceparent: "%REQ(TRACEPARENT)%"
               ":authority": "%REQ(:AUTHORITY)%"
               upstream_host: "%UPSTREAM_HOST%"
               upstream_cluster: "%UPSTREAM_CLUSTER%"


### PR DESCRIPTION
## 1. Summary

This PR changes:

- Adds `traceparent` to the Envoy access log JSON format (`charts/core-gateway/templates/envoy-proxy.yaml`), so a Loki log line can be joined back to its Tempo trace.
- Enables Envoy's own HTTP Connection Manager tracing (`EnvoyProxy.telemetry.tracing`) with a gateway-wide default of `samplingRate: 0`.
- Adds `telemetry.tracing.samplingFraction: 100/100` to the existing per-model `BackendTrafficPolicy` (`charts/ai-model/templates/backendtrafficpolicy.yaml`), overriding the gateway default back to 100% sampling — but only on that model's own `HTTPRoute`.

It solves:

- A requirement to map Tempo spans to Loki logs with enough fidelity to reconstruct exactly what happened during one gateway exchange (identity + content + auth outcome), without tracing every request the gateway handles (MCP routes, health checks stay untraced).

---

## 2. Intent

The intent of this PR is:

> Close the trace<->log correlation gap: the extproc's `ChatCompletion` span had no parent and no identity, and the Loki access log had a dead `derivedFields` regex pointing at a `trace_id` key that no log line ever emitted. Scoping the sampling to AI Gateway model routes only (not the whole gateway) is a deliberate cost/blast-radius decision — Envoy Gateway hardcodes `spawn_upstream_span: true` and `ext_authz` always spans its own Authorino round-trip once tracing is on, so this gets a real span tree (ingress -> auth check -> extproc span -> upstream call) for free, including for auth-rejected requests that never reach the extproc.

---

## 3. Scope

### In Scope

- `traceparent` in the access log format.
- `EnvoyProxy.telemetry.tracing` (OTel provider pointed at the existing Alloy OTLP endpoint, `samplingRate: 0` default).
- Per-model `BackendTrafficPolicy` sampling override to 100%.

### Out of Scope

- Grafana datasource wiring (Tempo<->Loki derived fields / `tracesToLogsV2`) — companion change in `ai-helm-values` (private repo).
- Authorino's own internal instrumentation (its span only shows round-trip duration, not internal steps) — not needed per this round's decision.
- Any new dashboard — this is a per-request drill-down capability (Tempo "Logs for this span" / Loki derived-field link), not an aggregate view, so no new dashboard was built.

---

## 4. Verification

I verified this change by:

- [x] Running automated tests
- [ ] Running manual tests
- [x] Checking logs
- [ ] Checking metrics
- [ ] Testing error cases
- [ ] Testing permissions/security behavior
- [ ] Testing rollback or failure behavior, if relevant

Commands run:

```bash
helm lint charts/core-gateway/ --strict
helm template x charts/core-gateway/ --dry-run
helm lint charts/ai-model/ -f charts/ai-model/ci/lint-values.yaml
helm template x charts/ai-model/ -f charts/ai-model/ci/lint-values.yaml --dry-run
helm lint charts/ai-models/ --strict
helm lint charts/mcp/
helm lint charts/mcps/ --strict
```

Results:

```text
All charts: 0 chart(s) failed. Rendered EnvoyProxy shows the tracing block;
rendered BackendTrafficPolicy (via the ai-model CI fixture) shows the
samplingFraction override. mcp/mcps/ai-models unaffected (not targeted by
the new BackendTrafficPolicy field, confirmed by inspection - they don't
opt in).
```

Manual verification against the live cluster (Grafana Explore, real chat + MCP + auth-rejected requests) is pending post-merge/deploy — see the companion checklist provided in the driving conversation.

---

## 5. Screenshots / Evidence

N/A — pending live manual verification post-deploy.

---

## 6. Risk Assessment

Risk level:

* [x] Low

Potential risks:

* Additional span volume to Tempo for every chat-completion/embeddings request (was previously zero for the Envoy-level spans; the extproc's own `ChatCompletion` span already existed). Bounded by design to model routes only, not gateway-wide.
* If `spawn_upstream_span`/`ext_authz` tracing behavior differs from what's documented for the deployed Envoy Gateway version, the span tree shape could be thinner than expected (harmless, just less detail).

Mitigation:

* Gateway-wide `samplingRate: 0` default keeps blast radius to opt-in-only routes.
* No new backend/collector — reuses the same Alloy OTLP endpoint already receiving access logs.

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [x] Reviewing the diff

Human verification:

* [ ] I understand every meaningful change in this PR
* [ ] I checked generated code manually
* [ ] I removed unsupported AI assumptions
* [ ] I accept responsibility for this PR

---

## 8. Reviewer Focus

Please focus your review on:

* [x] Correctness
* [x] Architecture
* [x] Security
* [x] Performance