### PR TITLE
fix(core-gateway): trace all gateway traffic — per-route sampling doesn't exist

### DIFF
--- a/charts/ai-model/templates/backendtrafficpolicy.yaml
+++ b/charts/ai-model/templates/backendtrafficpolicy.yaml
@@ -65,15 +65,6 @@ spec:
   retry:
     numRetries: 0
   {{- end }}
-  # Trace this model's route at 100%, overriding the gateway-wide
-  # samplingRate: 0 default (charts/core-gateway EnvoyProxy). Model routes
-  # are the only routes we want traced — chat completions + embeddings —
-  # not MCP routes or anything else on the shared gateway.
-  telemetry:
-    tracing:
-      samplingFraction:
-        numerator: 100
-        denominator: 100
   {{- /*
   Per-model upstream timeout.
   */ -}}

--- a/charts/core-gateway/templates/envoy-proxy.yaml
+++ b/charts/core-gateway/templates/envoy-proxy.yaml
@@ -72,16 +72,23 @@ spec:
     metrics:
       prometheus: {}
     tracing:
-      # Gateway-wide default is OFF. We deliberately don't want a span for
-      # every request through this listener (MCP routes, health checks) —
-      # only the AI Gateway model routes (chat completions + embeddings)
-      # should be traced, and those opt back in to 100% via the per-model
-      # BackendTrafficPolicy's telemetry.tracing.samplingFraction
-      # (charts/ai-model/templates/backendtrafficpolicy.yaml), which
-      # overrides this route-by-route. Auth (Authorino ext_authz) isn't a
-      # separate routed request, so it rides inside whichever request
-      # triggered it — no separate opt-in needed for auth visibility.
-      samplingRate: 0
+      # Gateway-wide, ALL requests through this listener are traced (MCP
+      # routes and health checks included). We tried to scope this to just
+      # the AI Gateway model routes via the per-model BackendTrafficPolicy's
+      # telemetry.tracing.samplingFraction, but that field is backend/cluster
+      # -scoped telemetry (custom tags + a secondary sampling gate that only
+      # applies "if no prior sampling decision has been made" — see Envoy
+      # Gateway's own Tracing type docs), NOT a per-route override of
+      # whether the downstream request is sampled at all. Verified live: the
+      # xDS RouteConfiguration never carried a route-level `tracing:` block
+      # despite the BackendTrafficPolicy being accepted. Envoy Gateway
+      # v1.8.2 has no CRD field for genuine per-route sampling (raw Envoy
+      # supports it — config.route.v3.Tracing — Envoy Gateway just doesn't
+      # expose it); the only real per-route mechanism would be an
+      # EnvoyPatchPolicy JSON-patching the RouteConfiguration directly,
+      # which we decided against for now. Revisit if a future EG version
+      # adds real per-route sampling, or if span volume becomes a problem.
+      samplingRate: 100
       provider:
         type: OpenTelemetry
         # Same Alloy OTLP endpoint the access log sink below already uses —


### PR DESCRIPTION
## 1. Summary

This PR changes:

- `EnvoyProxy.telemetry.tracing.samplingRate`: `0` → `100` (trace every request through core-gateway, not just AI Gateway model routes).
- Removes the per-model `BackendTrafficPolicy.spec.telemetry.tracing.samplingFraction` block added in #630 — confirmed live to do nothing toward request-level sampling.

It solves:

- #630 shipped a per-route scoping design (gateway default off, per-model `BackendTrafficPolicy` opts each model route back to 100%) that turned out not to work — verified live, not a merge/sync issue.

---

## 2. Intent

> Live-tested #630 against Grafana/Tempo right after it deployed: trace still showed only the extproc's lone `ChatCompletion` span, none of the promised Envoy-level spans (root span, `ext_authz`, upstream `router egress`). Pulled the actual xDS `RouteConfiguration` off a running envoy pod (`/config_dump?resource=dynamic_route_configs`) — zero routes carry a `tracing:` block, even though every model's `BackendTrafficPolicy` declares the override and is `Accepted`. Checked Envoy Gateway's own source (`internal/gatewayapi/backendtrafficpolicy.go` `buildBackendTracing`) and API docs: `BackendTrafficPolicy.telemetry.tracing` is documented as **backend/cluster-scoped telemetry** — its `samplingFraction` only ever applies "if no prior sampling decision has been made" on an already-open trace context. It cannot flip a request from unsampled to sampled once the gateway-wide `EnvoyProxy` decision already said no. Envoy Gateway v1.8.2 has no CRD field for genuine per-route sampling (raw Envoy has one, `config.route.v3.Tracing`; EG just doesn't expose it).
>
> Given that, this PR switches to gateway-wide tracing (accepting the volume/cost tradeoff) rather than leave a design that silently doesn't do what its comments claimed.

---

## 3. Scope

### In Scope
- `samplingRate: 100` gateway-wide.
- Removing the now-confirmed-ineffective per-model override + its misleading comment.

### Out of Scope
- An `EnvoyPatchPolicy`-based genuine per-route sampling override — the only mechanism that would actually achieve the original scoping goal. Deliberately deferred (fragile, targets xDS structure directly); revisit if span volume becomes a real problem.

---

## 4. Verification

I verified this change by:

- [x] Running automated tests
- [x] Checking logs
- [ ] Running manual tests (pending post-merge/deploy — repeat the Tempo/Loki checklist from #630)

Commands run:

```bash
helm lint charts/core-gateway/ --strict
helm template x charts/core-gateway/ --dry-run   # confirms samplingRate: 100
helm lint charts/ai-model/ -f charts/ai-model/ci/lint-values.yaml
helm template x charts/ai-model/ -f charts/ai-model/ci/lint-values.yaml --dry-run   # confirms no telemetry: block
```

Root-cause diagnosis performed live against the cluster:

```bash
kubectl get envoyproxy,gateway,backendtrafficpolicy -A -o yaml   # confirmed #630 fully synced, no drift
kubectl exec (port-forward) envoy admin :19000/config_dump?resource=dynamic_listeners     # gateway-wide HCM tracing config present
kubectl exec (port-forward) envoy admin :19000/config_dump?resource=dynamic_route_configs # zero routes carry a tracing: override
```

Results: all charts `0 chart(s) failed`; live xDS dump confirmed the root cause described above.

---

## 6. Risk Assessment

Risk level:
* [ ] Low
* [x] Medium

Potential risks:
* Full gateway-wide trace volume (every MCP call, health check, everything through core-gateway) instead of the originally-scoped model-routes-only design.

Mitigation:
* No new backend — same Alloy OTLP endpoint already receiving access logs and the extproc's own spans. If volume becomes a real problem, the fallback is an `EnvoyPatchPolicy` route-level override (documented as the real mechanism, deferred here) or lowering `samplingRate`.

---

## 7. AI Usage Declaration

AI was used for:
* [x] Understanding existing code
* [x] Generating code
* [x] Reviewing the diff

Human verification:
* [ ] I understand every meaningful change in this PR
* [ ] I checked generated code manually
* [ ] I accept responsibility for this PR