### PR TITLE
feat(apps): deploy Stakater Reloader (opt-in) for cert-rotation restarts

### DIFF
--- a/charts/apps/values.yaml
+++ b/charts/apps/values.yaml
@@ -261,6 +261,34 @@ applications:
   # gateway's ACME cert won't be issued. Tracked out-of-band.
   # Do not re-add a cert Application here.
 
+  # Stakater Reloader — restarts a workload when a ConfigMap/Secret it mounts
+  # changes. OPT-IN only (autoReloadAll:false): a workload is reloaded solely
+  # when it carries a `reloader.stakater.com/*` annotation, so this is a no-op
+  # for everything unannotated. Deployed so the lightbridge-mcp pod picks up
+  # cert-manager's Let's Encrypt rotation of `mcp.ai.camer.digital-tls` — the
+  # Rust server reads its TLS cert only at startup, and with the verified
+  # `mcp-verify` backend transport a stale cert would fail closed. Watches all
+  # namespaces; lands on home-remote like the other workloads.
+  - name: reloader
+    finalizers:
+      - resources-finalizer.argocd.argoproj.io
+    source:
+      repoURL: https://stakater.github.io/stakater-charts
+      # 2.2.14 → app v1.4.19 (latest at stakater-charts). Verify with
+      # `helm show chart stakater/reloader` before bumping.
+      targetRevision: 2.2.14
+      chart: reloader
+      helm:
+        releaseName: reloader
+        # Defaults, pinned explicitly: watch every namespace but only act on
+        # annotated workloads (no cluster-wide auto-reload surprise).
+        values: |
+          reloader:
+            watchGlobally: true
+            autoReloadAll: false
+    destination:
+      namespace: reloader
+
   # --- Secret Management ---
   # NOTE: the External Secrets Operator (controller + CRDs) is NOT
   # installed by this repo — it's deployed externally (Helm-managed in


### PR DESCRIPTION
## 1. Summary

Registers the **Stakater Reloader** controller (chart `2.2.14` / app `v1.4.19`) as an ArgoCD Application (`aii-reloader`) on `home-remote`, in a dedicated `reloader` namespace. Reloader restarts a workload when a ConfigMap/Secret it mounts changes.

Config is defaults-pinned: `watchGlobally: true`, `autoReloadAll: false` — it watches every namespace but **only** restarts workloads carrying a `reloader.stakater.com/*` annotation. It is a no-op for everything currently deployed.

---

## 2. Intent

The `lightbridge-mcp` pod now serves cert-manager's Let's Encrypt cert (`mcp.ai.camer.digital-tls`), and the Rust MCP server reads its TLS cert **only at startup**. With the new verified `mcp-verify` Traefik backend transport, a stale/expired cert fails closed (502 on `/mcp`). Reloader restarts the pod when cert-manager rotates the cert (~60d), closing that operational gap without a manual bounce.

**Source of truth:** sibling PR https://github.com/ADORSYS-GIS/ai-helm-values/pull/74 (switches the MCP pod to serve the LE cert + verify) and its Risk Assessment, which flagged the missing reloader. Consumer annotation: https://github.com/ADORSYS-GIS/ai-helm-values/pull/76.

---

## 3. Scope

### In Scope
- `charts/apps/values.yaml`: one new `reloader` application entry (source `stakater/reloader` 2.2.14, ns `reloader`, `watchGlobally:true`/`autoReloadAll:false`).

### Out of Scope
- The MCP deployment annotation (`secret.reloader.stakater.com/reload: mcp.ai.camer.digital-tls`) — lands separately in ai-helm-values#76 so the controller and its first consumer stay in their respective repos.
- `sync-wave` / `ServerSideDiff` annotations — matched to the peer operator `authorino-operator`, which sets neither (no deploy-time dependents; simple Deployment + RBAC). See Reviewer Focus.

---

## 4. Verification

I verified this change by:

- [x] Running automated validation (`helm dependency build` + `helm template apps charts/apps` → exit 0; rendered `aii-reloader`: source `stakater-charts` chart `reloader`@`2.2.14`, values `watchGlobally:true`/`autoReloadAll:false`, destination `home-remote`/ns `reloader`, syncOptions incl. `CreateNamespace=true`)
- [x] Rendering the upstream chart (`helm template reloader stakater/reloader --version 2.2.14` → exit 0; `image: ghcr.io/stakater/reloader:v1.4.19`, args `--log-level=info` — no `--auto-reload-all`, confirming opt-in; cluster-scoped RBAC consistent with `watchGlobally`)
- [x] Checking live cluster state (confirmed no reloader controller exists today — net-new, non-conflicting)
- [ ] Running manual tests (pending post-merge — observe `aii-reloader` Synced/Healthy and an MCP pod restart on the next cert rotation)

---

## 5. Screenshots / Evidence

Render excerpt (`aii-reloader`): `destination: {name: home-remote, namespace: reloader}`; `helm.values: reloader: {watchGlobally: true, autoReloadAll: false}`. Controller render: `image: ghcr.io/stakater/reloader:v1.4.19`, `args: [--log-level=info]`.

---

## 6. Risk Assessment

* [x] Low
* [ ] Medium

- **Blast radius:** near-zero on deploy. Opt-in annotations mean no existing workload is affected until annotated (ai-helm-values#76). New namespace `reloader`, one small Deployment + RBAC.
- **RBAC:** cluster-scoped read/watch on ConfigMaps/Secrets/workloads (standard for `watchGlobally`). Tighter scope possible via `watchGlobally:false` + namespace list, but would miss future cross-namespace consumers.
- **Rollback:** delete the app entry; ArgoCD prunes the controller. No workload depends on it for correctness, only for timely cert-rotation restarts.

**Reviewer Focus / opencode review response:** the bot suggested `sync-wave: "-1"` and `compare-options: ServerSideDiff=true`, claiming `authorino-operator` sets them. Verified against the file: `authorino-operator` sets **neither** — `sync-wave` here is reserved for hard storage-tier ordering (`restate: -2`), and `ServerSideDiff` for apps whose ESO/CNPG/StatefulSet controllers stamp defaulted fields (`lightbridge-code-intelligence`). A plain Reloader Deployment has no deploy-time dependents and no such controllers, so I matched `authorino-operator` and set neither. Happy to add `sync-wave` as hygiene if preferred.

---

## 7. AI Usage Declaration

AI was used for:
* [x] Understanding existing code
* [x] Generating code
* [x] Reviewing the diff

Human verification:
* [ ] I understand every meaningful change in this PR
* [ ] I checked generated code manually
* [ ] I accept responsibility for this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
