### PR TITLE
feat(lci): reconciler honors egress.mode=restate via egress-only config (RFC-0005 Phase A)

### DIFF
--- a/charts/lightbridge-code-intelligence/Chart.yaml
+++ b/charts/lightbridge-code-intelligence/Chart.yaml
@@ -12,7 +12,7 @@ description: |
   matching the librechat-app pattern; ExternalSecrets are chart templates resolving
   against the ssegning-aws ClusterSecretStore; ingress is Traefik + cert-home-cert-http.
 type: application
-version: 0.8.0
+version: 0.9.0
 appVersion: "0.7.0"
 dependencies:
   - name: bjw-template

--- a/charts/lightbridge-code-intelligence/templates/config.yaml
+++ b/charts/lightbridge-code-intelligence/templates/config.yaml
@@ -45,6 +45,18 @@ interprets `{{ }}`).
 {{- $mcps := list }}
 {{- range $s := $cfg.knowledgeTools.mcpServers }}{{- if and $s.name $s.url }}{{- $mcps = append $mcps (dict "name" $s.name "url" $s.url) }}{{- end }}{{- end }}
 {{- if $mcps }}{{- $_ := set $cp "knowledge_tools" (dict "mcp_servers" $mcps) }}{{- end }}
+{{- /* Egress routing (RFC-0005 Phase A / ADR-0074) → control-plane.json `egress`. The PRODUCER roles
+       (serve + dispatcher, which mount THIS ConfigMap) read `mode` to decide whether to `send`
+       PlatformEgress::post to the Restate ingress. Default `drain` (chart) = no behavior change; flip to
+       `restate` in ai-helm-values to activate the pilot. `restate_ingress_url` is required in restate
+       mode (or the RESTATE_INGRESS_URL env). The RECONCILER reads the SAME $eg via its own egress-ONLY
+       ConfigMap below — deliberately NOT this full config, so it never picks up the `review` block (see
+       there for why). deny_unknown_fields on the binary's EgressSection accepts exactly
+       {mode, restate_ingress_url}; the deployed image (≥ ADR-0074) carries the field. */}}
+{{- $eg := dict }}
+{{- if ne (toString $cfg.egress.mode) "" }}{{- $_ := set $eg "mode" $cfg.egress.mode }}{{- end }}
+{{- if ne (toString $cfg.egress.restateIngressUrl) "" }}{{- $_ := set $eg "restate_ingress_url" $cfg.egress.restateIngressUrl }}{{- end }}
+{{- if $eg }}{{- $_ := set $cp "egress" $eg }}{{- end }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -54,6 +66,27 @@ metadata:
     argocd.argoproj.io/sync-wave: {{ $wave }}
 data:
   control-plane.json: {{ $cp | toJson | quote }}
+---
+{{- /* ── reconciler egress config (RFC-0005 Phase A / ADR-0074) ────────────────────────────────────
+       The reconciler is the role that owns the outbox drain (ADR-0059). When the pilot is active it MUST
+       read `egress.mode = restate` to turn that drain OFF — otherwise it keeps draining while the
+       producers also `send` to Restate, and every intent posts twice.
+       It gets an egress-ONLY control-plane.json, NOT the producers' full one, on purpose: the full config
+       carries the `review` block (outcome labels/reactions), and the reconciler's deliver_review() reads
+       ReviewSection to apply the `label_findings`/`label_error` labels. Today the reconciler mounts no
+       config, so it runs on ReviewSection::default() (no labels). Handing it the full config would make it
+       START applying those labels — an unrelated behavior change. Egress-only keeps its review behavior
+       identical while still delivering the mode. mode + url come from the SAME $eg as the producers'
+       copy above, so the two egress views cannot drift. Inert while $eg.mode = drain. */}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-reconciler-config
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    argocd.argoproj.io/sync-wave: {{ $wave }}
+data:
+  control-plane.json: {{ (dict "egress" $eg) | toJson | quote }}
 {{- if .Values.agents.enabled }}
 ---
 {{- /* ── agent.json + review-system.md (agents namespace) ───────────────────── */}}

--- a/charts/lightbridge-code-intelligence/values.yaml
+++ b/charts/lightbridge-code-intelligence/values.yaml
@@ -232,6 +232,19 @@ config:
     labelFindings: needs-review  # ≥1 finding of any severity
     labelError: bug        # ≥1 error-severity finding
 
+  # Egress routing (RFC-0005 Phase A / ADR-0074). Which path delivers `github_outbox` intents to the
+  # forge. `drain` (default) keeps the reconciler outbox drain (ADR-0059) as the sole egress path — no
+  # behavior change, the pilot is inert. Flip to `restate` in ai-helm-values to route egress through the
+  # PlatformEgress virtual object (per-`platform:installation` exclusivity makes the single-writer
+  # invariant STRUCTURAL). Rendered into control-plane.json for the producers (serve/dispatcher) AND into
+  # a dedicated egress-only ConfigMap for the reconciler (so it disables its drain in restate mode).
+  #   mode:              drain | restate
+  #   restateIngressUrl: the Restate server INGRESS (:8080). REQUIRED in restate mode unless the
+  #                      RESTATE_INGRESS_URL env is set on the producers; ignored in drain mode.
+  egress:
+    mode: drain
+    restateIngressUrl: ""
+
   # External-knowledge MCP servers (lightbridge-ci ADR-0066): already-running REMOTE HTTP MCP servers
   # the control plane discovers tools from + proxies calls to. Declare the servers here; each entry is
   # {name, url} (url must be http(s)://). The per-tier tool SELECTION (which discovered tools each tier
@@ -727,6 +740,12 @@ lci:
             CONTROL_PLANE_ROLE: "reconciler"
             RUST_LOG: "info"
             METRICS_ADDR: "0.0.0.0:9090"
+            # File config (ADR-0021): the reconciler reads an egress-ONLY control-plane.json (the
+            # <release>-reconciler-config ConfigMap, mounted below) so it can see egress.mode and turn
+            # its outbox drain OFF when the RFC-0005 pilot is active (egress.mode=restate). Egress-only
+            # on purpose — it must NOT read the `review` block or it would start applying outcome labels
+            # it doesn't today. Absent/drain → the drain stays on (no behavior change).
+            CONTROL_PLANE_CONFIG: "/etc/lightbridge/control-plane.json"
             # Optional cadence knobs; absent → run_reconciler defaults (300s interval / 14-day window).
             # DATABASE_URL `value` (cluster host/namespace/db) → ai-helm-values; `dependsOn` stays here.
             DB_PASSWORD:
@@ -1244,6 +1263,17 @@ lci:
             - path: /etc/lightbridge
               readOnly: true
         dispatcher:
+          main:
+            - path: /etc/lightbridge
+              readOnly: true
+    # Egress-only control-plane.json for the reconciler (RFC-0005 Phase A / ADR-0074). Separate from the
+    # producers' ConfigMap above so the reconciler sees `egress` (to disable its drain in restate mode)
+    # but NOT the `review` block (which would make it start applying outcome labels — see config.yaml).
+    reconciler-config:
+      type: configMap
+      name: lightbridge-ci-reconciler-config
+      advancedMounts:
+        reconciler:
           main:
             - path: /etc/lightbridge
               readOnly: true


### PR DESCRIPTION
## Summary

Enables the reconciler to honor `egress.mode = restate` so the **RFC-0005 Phase A / ADR-0074 Restate egress pilot** can be activated **without double-posting**. Chart-only, inert on merge (default `mode: drain` → no behavior change).

Source of truth:
- ADR-0074 (Restate egress pilot): https://github.com/vymalo/lightbridge-code-intelligence/blob/main/docs/adr/0074-restate-egress-pilot.md
- RFC-0005 (durable orchestration on Restate): https://github.com/vymalo/lightbridge-code-intelligence/blob/main/docs/rfc/0005-durable-orchestration-on-restate.md
- Activation runbook: https://github.com/vymalo/lightbridge-code-intelligence/blob/main/docs/runbooks/restate-egress-pilot-activation.md
- Companion cutover PR (held): ADORSYS-GIS/ai-helm-values#78

## Intent

The pilot routes forge egress through the `PlatformEgress` virtual object instead of the reconciler's `github_outbox` drain (ADR-0059). Activating it means the **producers** (serve/dispatcher) `send` to Restate **and** the **reconciler** stops draining. Today the reconciler mounts no config file, so it can never see `egress.mode` — flipping the producers to `restate` while the reconciler keeps draining would post **every intent twice**. This wires the reconciler to read the mode.

Discovered while tracing the activation: the chart's `config.yaml` never rendered an `egress` block at all, so `egress.mode` was previously **unsettable** from values. This adds that plumbing.

## Scope

- `templates/config.yaml`:
  - Render `config.egress` → `control-plane.json` `egress` (for serve/dispatcher, which already mount it).
  - Add a **dedicated egress-only** ConfigMap `<release>-reconciler-config` (`{"egress":{…}}` and nothing else) for the reconciler.
- `values.yaml`:
  - `config.egress` defaults (`mode: drain`, `restateIngressUrl: ""`).
  - Mount `reconciler-config` into the `reconciler` controller + `CONTROL_PLANE_CONFIG` env.
- `Chart.yaml`: `0.8.0` → `0.9.0`.

**Why egress-only for the reconciler (the key design point):** the full `control-plane.json` also carries the `review` block. The reconciler's `deliver_review()` reads `ReviewSection` to apply the `label_findings`/`label_error` outcome labels. Today it runs on `ReviewSection::default()` (no labels), so handing it the full config would make it **start applying** `needs-review`/`bug` labels — an unrelated behavior change. The egress-only ConfigMap gives it exactly `egress` and nothing else. Both egress views derive from the same `config.egress`, so they can't drift.

> Side note (out of scope, will be filed separately): those outcome labels appear **dead in prod today** — the reconciler is the only role that applies them and it never reads the config. Not touched here.

## Verification

- `helm lint` → clean (0 failed).
- `helm template` rendered in both modes:
  - **drain (default):** producers' `control-plane.json` → `"egress":{"mode":"drain"}`; reconciler ConfigMap → `{"egress":{"mode":"drain"}}` (no `review` block). Reconciler drain stays **on** — no behavior change.
  - **restate:** both carry `"egress":{"mode":"restate","restate_ingress_url":"http://restate.converse.svc.cluster.local:8080"}`; reconciler ConfigMap remains egress-only.
- Confirmed the `reconciler` Deployment mounts `/etc/lightbridge` read-only from `lightbridge-ci-reconciler-config` and sets `CONTROL_PLANE_CONFIG=/etc/lightbridge/control-plane.json`; volume↔ConfigMap names match.
- Confirmed the currently-deployed control-plane image (`sha-da15159`, ≥ ADR-0074) carries the `FileConfig.egress` field, so rendering `egress` into `control-plane.json` does not trip `deny_unknown_fields`.

## Risk Assessment

**Low.** Inert on merge — default `mode: drain` renders the same drain behavior. The only runtime change is the reconciler now mounting a `{"egress":{"mode":"drain"}}` file, which parses to the same defaults it uses today (review labels/reactions unchanged). No image change required. The actual cutover is a separate, held **ai-helm-values** PR that flips `config.egress.mode: restate` — merge this first, let it deploy, then flip.

## AI Usage Declaration

- **AI used for:** tracing the activation path across the control-plane source + chart, identifying the double-post and label-side-effect hazards, drafting the chart changes and this description.
- **Human accountability:**
  - [x] A human reviewed and verified the AI-assisted changes before merge.
  - [x] The intent and source of truth (RFC-0005 / ADR-0074 + runbook) are real and linked.
  - [x] Verification evidence (helm lint/template renders) is included above.

## Reviewer Focus

1. The egress-only ConfigMap decision — is keeping the reconciler off the `review` block the right call vs. fixing the dead-label bug here? (I kept them separate on purpose.)
2. `restateIngressUrl` is required in `restate` mode; the reconciler's egress-only config carries it too so `from_config` doesn't fail-fast at boot. Confirm that's acceptable even though the reconciler never sends.
