### PR TITLE
feat(lci): roll config-reading roles on read-once config flips (completes egress=restate activation)

### DIFF
--- a/charts/lightbridge-code-intelligence/Chart.yaml
+++ b/charts/lightbridge-code-intelligence/Chart.yaml
@@ -12,7 +12,7 @@ description: |
   matching the librechat-app pattern; ExternalSecrets are chart templates resolving
   against the ssegning-aws ClusterSecretStore; ingress is Traefik + cert-home-cert-http.
 type: application
-version: 0.9.0
+version: 0.10.0
 appVersion: "0.7.0"
 dependencies:
   - name: bjw-template

--- a/charts/lightbridge-code-intelligence/values.yaml
+++ b/charts/lightbridge-code-intelligence/values.yaml
@@ -1251,6 +1251,35 @@ lci:
   # Neo4j /data is NOT here — it's a StatefulSet volumeClaimTemplate on the neo4j controller
   # (see `statefulset.volumeClaimTemplates` above); neo4j runs with a writable rootfs so it
   # needs no scratch emptyDirs. advancedMounts scope each volume to one container.
+  # ── config-rollout: force the config-reading roles to restart on a read-once-at-boot config flip ──────
+  # The control plane reads FILE config (control-plane.json — egress.mode, dispatcher tuning, review knobs)
+  # ONCE at startup; it is deploy-scoped, NOT live-reloadable. But the real config lives in STANDALONE
+  # ConfigMaps rendered by templates/config.yaml, and editing a ConfigMap's *content* does NOT roll the
+  # pods that mount it — so a config flip (notably egress.mode drain↔restate) would silently no-op until
+  # the role happens to restart for another reason (next image deploy). That is a foot-gun: e.g. flipping
+  # egress.mode=restate while the reconciler keeps running the old `drain` config → double-posts.
+  #
+  # bjw-s can only auto-checksum ConfigMaps IT manages (this `configMaps` block), and its tpl runs in the
+  # subchart context — it cannot see the top-level `config.*` values that drive the standalone ConfigMaps,
+  # so it cannot content-hash them directly. Instead this is a tiny UNMOUNTED marker ConfigMap: listing it
+  # in `includeChecksumInControllers` makes bjw-s stamp a `checksum/configMaps` annotation on those roles'
+  # pods. **Bump `data.generation` in ai-helm-values in the SAME change as any read-once config flip** and
+  # all three config-reading roles roll together to pick it up. (Introducing the annotation also rolls them
+  # once on first deploy — brief RollingUpdate egress overlap, the same trade-off the roles already accept.)
+  configMaps:
+    config-rollout:
+      enabled: true
+      # Explicit stable name (`<release>-config-rollout`). Without this, bjw-s collapses a lone managed
+      # configMap to the bare release name, which would silently rename (and needlessly re-roll) if another
+      # bjw-s configMap is ever added. The checksum hashes only `data`, so the suffix doesn't affect it.
+      suffix: config-rollout
+      includeChecksumInControllers:
+        - control-plane
+        - dispatcher
+        - reconciler
+      data:
+        generation: "1"
+
   persistence:
     # control-plane.json (ADR-0021), mounted read-only into the serve + dispatcher roles. `name`
     # references the standalone ConfigMap from templates/config.yaml (not a bjw-created one).


### PR DESCRIPTION
## Summary

Makes the config-reading roles (serve, dispatcher, reconciler) **roll on a read-once-at-boot config change**, closing a foot-gun surfaced while activating the Restate egress pilot. Merging this also **completes that activation**: it rolls the three roles once, so they pick up the already-merged `egress.mode: restate` (they're still running the old `drain` config).

Source of truth:
- ADR-0074 (Restate egress pilot): https://github.com/vymalo/lightbridge-code-intelligence/blob/main/docs/adr/0074-restate-egress-pilot.md
- Activation runbook: https://github.com/vymalo/lightbridge-code-intelligence/blob/main/docs/runbooks/restate-egress-pilot-activation.md
- Builds on ADORSYS-GIS/ai-helm#637 (reconciler egress-only config) + the cutover ADORSYS-GIS/ai-helm-values#78.

## Intent

The control plane reads file config (`control-plane.json` — `egress.mode`, dispatcher/review knobs) **once at boot**; it's deploy-scoped, not live-reloadable. The real config lives in **standalone ConfigMaps** (`templates/config.yaml`), and editing a ConfigMap's *content* does **not** roll the pods that mount it. So after #637 + #78 flipped `egress.mode: restate`, the ConfigMaps updated but the 8h-old serve/dispatcher pods (and the reconciler booted at the #637 rollout) kept running the old `drain` config — the pilot silently stayed inactive. Worse, the half-flipped state (ConfigMaps say `restate`, pods say `drain`) has a latent double-post trigger: an uncontrolled producer restart before the reconciler rolls would send to Restate while the reconciler still drains.

## Scope

- `values.yaml`: add `lci.configMaps.config-rollout` — a tiny **unmounted** marker ConfigMap flagged `includeChecksumInControllers: [control-plane, dispatcher, reconciler]`, with an explicit `suffix: config-rollout` name and `data.generation: "1"`.
- `Chart.yaml`: `0.9.0` → `0.10.0`.

**Why this shape:** bjw-s only auto-checksums ConfigMaps *it* manages, and its `tpl` runs in the subchart context — it can't see the top-level `config.*` that drives the standalone ConfigMaps, so it can't content-hash them directly. The marker gives bjw-s something it *can* hash; listing the three roles makes it stamp a `checksum/configMaps` annotation on their pods. Bump `data.generation` in ai-helm-values in the **same** change as any future read-once config flip to roll them.

## Verification

Annotation lands on exactly the three config-reading roles (no others):
```console
$ helm template lightbridge-ci . | awk '/kind: Deployment/{k=1} k&&/^  name:/{n=$2} /checksum.configMaps/{print n}' | sort -u
lightbridge-ci-control-plane
lightbridge-ci-dispatcher
lightbridge-ci-reconciler
```
A `generation` bump changes the hash → the pods roll:
```console
$ helm template lightbridge-ci . --set lci.configMaps.config-rollout.data.generation=1 | grep -m1 checksum.configMaps
    checksum/configMaps: a434b7ee035c977522858ff9fca4031630f29497f27f392541593dd977aad427
$ helm template lightbridge-ci . --set lci.configMaps.config-rollout.data.generation=2 | grep -m1 checksum.configMaps
    checksum/configMaps: 7e38f618a21f32e897c3870a6c7480a5d8387688e2119b88d49aa0b994bed71f
$ helm lint .
1 chart(s) linted, 0 chart(s) failed
```

- `helm lint` → clean.
- `helm template` (release `lightbridge-ci`):
  - `checksum/configMaps` annotation present on **exactly** `control-plane`, `dispatcher`, `reconciler` (no other role).
  - Bumping `generation` `1`→`2` changes the annotation hash (`a434b7ee…` → `7e38f618…`) — confirms a bump rolls the pods.
  - Marker ConfigMap renders as `lightbridge-ci-config-rollout` (explicit, stable regardless of item count); no collision with the existing `-control-plane-config` / `-reconciler-config` / `-agent-config`.
- Post-merge (operator): the three roles roll; reconciler logs `egress.mode = restate — outbound drain disabled; running feedback poll only`; producers log the Restate routing line; a triggered review posts **once**.

## Risk Assessment

**Low-medium — this is the live egress cutover completing.** Merging rolls the three roles into `restate` mode. Brief RollingUpdate overlap is possible (a new producer sending while the old reconciler drains for a few seconds) — the same egress-overlap trade-off the roles' `RollingUpdate` strategy already documents. Fully reversible: set `config.egress.mode: drain` (ai-helm-values) and bump `generation` to roll back; the shared `outbox` ledger makes the handoff lossless.

## AI Usage Declaration

- **AI used for:** diagnosing the read-once-at-boot + no-checksum foot-gun during activation, designing the bjw-s marker-configMap workaround within the parent/subchart boundary, and drafting this PR.
- **Human accountability:**
  - [x] A human reviewed and verified the AI-assisted change before merge.
  - [x] The intent and source of truth (ADR-0074 / runbook + #637 / #78) are real and linked.
  - [x] Verification evidence (helm lint/template renders, hash-change proof) is included above.

## Reviewer Focus

1. The marker-configMap approach vs. a proper content hash — the latter is blocked by the parent/subchart values boundary (documented in the values comment). Is the operator-bumped `generation` acceptable, or worth a larger refactor to migrate `control-plane.json` into bjw-s-managed configMaps?
2. Merge = live cutover. Confirm you're ready for the three roles to roll into `restate` on sync.
