### PR TITLE
ci: run workflows on the self-hosted adorsys-gis-runner

### DIFF
--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -26,7 +26,7 @@ concurrency:
 
 jobs:
   commit-lint:
-    runs-on: ubuntu-latest
+    runs-on: adorsys-gis-runner
     steps:
       - name: Checkout (full history for the PR commit range)
         uses: actions/checkout@v7

--- a/.github/workflows/dashboards-drift.yml
+++ b/.github/workflows/dashboards-drift.yml
@@ -25,7 +25,7 @@ permissions:
 
 jobs:
   check:
-    runs-on: ubuntu-latest
+    runs-on: adorsys-gis-runner
     steps:
       - uses: actions/checkout@v7
 

--- a/.github/workflows/helm-lint.yaml
+++ b/.github/workflows/helm-lint.yaml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: adorsys-gis-runner
     steps:
       - uses: actions/checkout@v7
 

--- a/.github/workflows/publish-charts-oci.yml
+++ b/.github/workflows/publish-charts-oci.yml
@@ -46,7 +46,7 @@ env:
 
 jobs:
   publish:
-    runs-on: ubuntu-latest
+    runs-on: adorsys-gis-runner
     steps:
       - name: Checkout
         uses: actions/checkout@v7

--- a/.github/workflows/release-helm-charts.yml
+++ b/.github/workflows/release-helm-charts.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
+    runs-on: adorsys-gis-runner
     steps:
       - name: Checkout
         uses: actions/checkout@v7

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -44,7 +44,7 @@ concurrency:
 
 jobs:
   release-please:
-    runs-on: ubuntu-latest
+    runs-on: adorsys-gis-runner
     steps:
       - uses: googleapis/release-please-action@v5
         with:


### PR DESCRIPTION
## Summary

Move every ai-helm workflow with a local `runs-on` off `ubuntu-latest` onto the org's self-hosted ARC scale set **`adorsys-gis-runner`** (ubuntu/amd64), ahead of ai-helm going private.

**Source of truth:** the billing block that hit the private ai-helm-values repo — GitHub Actions *"The job was not started because recent account payments have failed or your spending limit needs to be increased"* (https://github.com/ADORSYS-GIS/ai-helm-values/actions/runs/29145445848). Pre-empting the same on ai-helm at its public→private flip.

## Intent

Public repos get free GitHub-hosted minutes; private repos are metered and can hit the org spending block. ai-helm and the runner are both in ADORSYS-GIS, so moving now keeps CI working after the flip. (home-os intentionally left on `ubuntu-latest` — different org, and staying public.)

## Scope

Swapped (6, local `runs-on` only): `commit-lint`, `dashboards-drift`, `helm-lint`, `publish-charts-oci`, `release-helm-charts`, `release-please`.

**Not swapped** — `governance.yml`, `opencode.yml`, `security.yml` only `uses:` a reusable workflow in another repo (ai-governance / ai-ops); their runner is defined there. Post-private those may still run GitHub-hosted (caller-billed) — a follow-up in those repos.

## Verification

- [x] `adorsys-gis-runner` scale set is online (3 runners) and already proven working on ai-helm-values PR #80 (commit-lint passed on it in 7s).
- [x] All 6 files still parse as YAML; no `ubuntu-latest` remains in any workflow.
- [x] **This PR is the live test:** `lint` (helm-lint) and `commit-lint` are *required* checks and now run on the self-hosted runner — green here proves ai-helm has runner-group access and helm tooling works on it.

```
runs-on across workflows → all adorsys-gis-runner; ubuntu-latest: none remaining ✓
```

## Risk Assessment

Low–moderate, reversible. If the `adorsys-gis-runner` group doesn't grant ai-helm access, the required `lint`/`commit-lint` checks would queue — visible immediately on this PR; mitigations = grant the repo in the runner group, or revert. If the ARC image lacks helm/yq/uv, the setup-actions install them at run time (same as before). Rollback = revert the 6 one-line changes.

## AI Usage Declaration

- **AI (Claude Opus 4.8):** surveyed all workflow `runs-on`, swapped the 6 local ones (left the 3 reusable-workflow callers, which can't be changed here), validated YAML, authored this PR.
- **Human accountability:**
  - [x] I reviewed the diff (6 one-line label changes).
  - [ ] Confirm the PR's own `lint`/`commit-lint` run green on the self-hosted runner before merge.

## Reviewer Focus

- Does the `adorsys-gis-runner` runner group grant ai-helm access? (This PR's checks answer it.)
- OK to leave `governance`/`opencode`/`security` on their reusable-workflow runners for now?
