### PR TITLE
feat(ai-models): add MiMo V2.5(-Pro), Ornith-1.0-35B, MiniMax M3, Claude Sonnet 5/Fable 5 catalog entries

### DIFF
--- a/charts/ai-models/values.yaml
+++ b/charts/ai-models/values.yaml
@@ -1118,6 +1118,164 @@ models:
         <<: *deepinfraBackendSecondary
         modelNameOverride: "MiniMaxAI/MiniMax-M2.7"
 
+  mimo-v2p5:
+    kind: multimodal
+    # DeepInfra · XiaomiMiMo/MiMo-V2.5 — native omnimodal (text/image/video/audio
+    # in), sparse MoE 310B total / 15B active, hybrid attention + multi-token
+    # prediction, agentic tool calling. 1,048,576-token context.
+    info:
+      displayName: "MiMo V2.5"
+      contextLength: 1048576
+      maxOutputTokens: 131072
+      supportedParameters: *spReasoning
+    pricing:
+      strategy: weighted
+      standard:
+        inputPer1M: 0.40
+        cachedInputPer1M: 0.08
+        outputPer1M: 2.00
+    backends:
+      deepinfra-01:
+        <<: *deepinfraBackendPrimary
+        modelNameOverride: "XiaomiMiMo/MiMo-V2.5"
+      deepinfra-02:
+        <<: *deepinfraBackendSecondary
+        modelNameOverride: "XiaomiMiMo/MiMo-V2.5"
+
+  mimo-v2p5-pro:
+    kind: text
+    # DeepInfra · XiaomiMiMo/MiMo-V2.5-Pro — 1.02T total / 42B active MoE, hybrid
+    # attention + multi-token prediction, tuned for complex agentic and
+    # software-engineering tasks. Text-only (no vision), no exposed thinking
+    # mode. 1,048,576-token context.
+    info:
+      displayName: "MiMo V2.5 Pro (Non-Thinking)"
+      contextLength: 1048576
+      maxOutputTokens: 131072
+      supportedParameters: *spStandard
+    pricing:
+      strategy: weighted
+      standard:
+        inputPer1M: 1.00
+        cachedInputPer1M: 0.20
+        outputPer1M: 3.00
+    backends:
+      deepinfra-01:
+        <<: *deepinfraBackendPrimary
+        modelNameOverride: "XiaomiMiMo/MiMo-V2.5-Pro"
+      deepinfra-02:
+        <<: *deepinfraBackendSecondary
+        modelNameOverride: "XiaomiMiMo/MiMo-V2.5-Pro"
+
+  ornith-1p0-35b:
+    kind: multimodal
+    # DeepInfra · deepreinforce-ai/Ornith-1.0-35B — MIT-licensed agentic coding
+    # model (RL post-training of Qwen3.5-35B-A3B MoE), hybrid Gated-DeltaNet
+    # attention, image + video understanding, reasoning + tool calling.
+    # 75.6 SWE-bench Verified / 64.2 Terminal-Bench 2.1 — beats Qwen3.5-397B on
+    # Terminal-Bench 2.1 despite being far smaller. 262,144-token context.
+    info:
+      displayName: "Ornith 1.0 35B"
+      contextLength: 262144
+      maxOutputTokens: 131072
+      supportedParameters: *spReasoning
+    pricing:
+      strategy: weighted
+      standard:
+        inputPer1M: 0.14
+        cachedInputPer1M: 0.05
+        outputPer1M: 1.00
+    backends:
+      deepinfra-01:
+        <<: *deepinfraBackendPrimary
+        modelNameOverride: "deepreinforce-ai/Ornith-1.0-35B"
+      deepinfra-02:
+        <<: *deepinfraBackendSecondary
+        modelNameOverride: "deepreinforce-ai/Ornith-1.0-35B"
+
+  minimax-m3:
+    kind: multimodal
+    # DeepInfra · MiniMaxAI/MiniMax-M3 — ~428B total / 23B active MoE, mixed-
+    # modality (text/image/video) training from the first step, MiniMax Sparse
+    # Attention for long-context efficiency, strong coding/agentic benchmarks.
+    # No exposed thinking mode. Context configured at 524,288 tokens (catalog
+    # lists up to 1M; clamped like minimax-m2p5's 400k → 204,800 caveat).
+    info:
+      displayName: "MiniMax M3 (Non-Thinking)"
+      contextLength: 524288
+      maxOutputTokens: 131072
+      supportedParameters: *spStandard
+    pricing:
+      strategy: weighted
+      standard:
+        inputPer1M: 0.30
+        cachedInputPer1M: 0.06
+        outputPer1M: 1.20
+    backends:
+      deepinfra-01:
+        <<: *deepinfraBackendPrimary
+        modelNameOverride: "MiniMaxAI/MiniMax-M3"
+      deepinfra-02:
+        <<: *deepinfraBackendSecondary
+        modelNameOverride: "MiniMaxAI/MiniMax-M3"
+
+  claude-sonnet-5:
+    kind: multimodal
+    # DeepInfra · anthropic/claude-sonnet-5 — Anthropic's Sonnet-tier model
+    # resold via DeepInfra (a "Partner" model on their catalog), near-Opus
+    # quality on coding/agentic work, adaptive thinking, vision. DeepInfra's
+    # price matches Anthropic's own intro API rate ($2/$10, through
+    # 2026-08-31 per Anthropic's pricing table); cachedInputPer1M estimated at
+    # the standard ~10% cache-read ratio (unconfirmed on DeepInfra's page).
+    # 1,048,576-token context, 128k max output.
+    info:
+      displayName: "Claude Sonnet 5 (DeepInfra)"
+      contextLength: 1048576
+      maxOutputTokens: 131072
+      supportedParameters: *spReasoning
+    pricing:
+      strategy: weighted
+      standard:
+        inputPer1M: 2.00
+        cachedInputPer1M: 0.20
+        outputPer1M: 10.00
+    backends:
+      deepinfra-01:
+        <<: *deepinfraBackendPrimary
+        modelNameOverride: "anthropic/claude-sonnet-5"
+      deepinfra-02:
+        <<: *deepinfraBackendSecondary
+        modelNameOverride: "anthropic/claude-sonnet-5"
+
+  claude-fable-5:
+    enabled: false                   # DISABLED for now — priced at $10/$50 per 1M (2x Sonnet 5's intro rate); holding off until we've validated demand. Re-enable to roll forward.
+    kind: multimodal
+    # DeepInfra · anthropic/claude-fable-5 — Anthropic's most capable widely
+    # released model, resold via DeepInfra. Long-running autonomous agentic
+    # work (multi-day sessions), vision (diagrams/charts/tables in files and
+    # PDFs), always-on adaptive thinking. DeepInfra's price matches Anthropic's
+    # own API rate ($10/$50); cachedInputPer1M estimated at the standard ~10%
+    # cache-read ratio (unconfirmed on DeepInfra's page). 1,048,576-token
+    # context, 128k max output.
+    info:
+      displayName: "Claude Fable 5 (DeepInfra)"
+      contextLength: 1048576
+      maxOutputTokens: 131072
+      supportedParameters: *spReasoning
+    pricing:
+      strategy: weighted
+      standard:
+        inputPer1M: 10.00
+        cachedInputPer1M: 1.00
+        outputPer1M: 50.00
+    backends:
+      deepinfra-01:
+        <<: *deepinfraBackendPrimary
+        modelNameOverride: "anthropic/claude-fable-5"
+      deepinfra-02:
+        <<: *deepinfraBackendSecondary
+        modelNameOverride: "anthropic/claude-fable-5"
+
   # ── Branded "Adorsys" model aliases ───────────────────────────────────────
   # Stable, user-facing model IDs whose BACKING model can be swapped later
   # WITHOUT changing the id a user/agent selected — only the


### PR DESCRIPTION
## 1. Summary

This PR changes:

- Adds six new DeepInfra-backed models to `charts/ai-models/values.yaml`: `mimo-v2p5`, `mimo-v2p5-pro`, `ornith-1p0-35b`, `minimax-m3`, `claude-sonnet-5`, `claude-fable-5`.
- Each is wired the same way as the existing catalog (primary/secondary `deepinfra-01`/`deepinfra-02` backends, `weighted` pricing strategy) so it flows straight into `charts/ai-models-info`'s OpenRouter-shape catalog with no extra work.
- `mimo-v2p5-pro` and `minimax-m3` have no exposed thinking mode — `displayName` calls this out as "(Non-Thinking)" so it's visible in the model picker, not just buried in `supported_parameters`.
- `claude-fable-5` ships with `enabled: false` — priced at $10/$50 per 1M (2x Sonnet 5's intro rate), holding off until we've validated demand.

It solves:

- Requested addition of these six DeepInfra models to the catalog, with pricing/capabilities populated so opencode's models-info plugin picks them up correctly.

---

## 2. Intent

Expand the model catalog with newly available DeepInfra offerings (Xiaomi MiMo V2.5 family, DeepReinforce's Ornith coding model, MiniMax M3, and Anthropic's Sonnet 5 / Fable 5 resold via DeepInfra), keeping Fable 5 disabled pending a pricing/demand check.

---

## 3. Scope

### In Scope

- New `models:` entries in `charts/ai-models/values.yaml` (pricing, context/output limits, supported_parameters, backend refs).

### Out of Scope

- Branded `adorsys-*` alias backing swaps.
- Rate-limit/budget tier changes.
- Enabling `claude-fable-5`.

---

## 4. Verification

I verified this change by:

- [x] Running automated tests (`helm lint --strict`, `helm template --dry-run`)
- [ ] Running manual tests
- [ ] Checking logs
- [ ] Checking metrics
- [ ] Testing error cases
- [ ] Testing permissions/security behavior
- [ ] Testing rollback or failure behavior, if relevant

Commands run:

```bash
helm dep build charts/ai-models/
helm lint charts/ai-models/ --strict
helm template x charts/ai-models/ --dry-run
helm template x charts/ai-models-info -f <extracted models.yaml> --show-only templates/configmap.yaml
```

Results:

```text
1 chart(s) linted, 0 chart(s) failed
Render succeeds; ApplicationSet generator lists x-mimo-v2p5, x-mimo-v2p5-pro,
x-ornith-1p0-35b, x-minimax-m3, x-claude-sonnet-5 (claude-fable-5 correctly
absent — enabled: false).
Rendered ai-models-info catalog JSON confirmed correct pricing/architecture/
supported_parameters/context_length for all 6 entries.
```

---

## 5. Screenshots / Evidence

N/A — chart-only change, verified via `helm template` output above.

---

## 6. Risk Assessment

Risk level:

* [x] Low

Potential risks:

* Pricing/context/capability data was scraped from DeepInfra's model pages and may drift if DeepInfra changes pricing.
* Cached-input pricing for `claude-sonnet-5`/`claude-fable-5` was estimated (DeepInfra doesn't publish it) at the standard ~10% cache-read ratio, not directly confirmed.

Mitigation:

* `claude-fable-5` shipped disabled to limit blast radius on the higher-priced, less-validated entry.
* Pricing is easy to correct in a follow-up commit once billing data confirms actuals.

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [ ] Refactoring
* [ ] Generating tests
* [ ] Drafting documentation
* [x] Reviewing the diff

Human verification:

* [ ] I understand every meaningful change in this PR
* [ ] I checked generated code manually
* [ ] I checked generated tests manually
* [ ] I removed unsupported AI assumptions
* [ ] I accept responsibility for this PR

---

## 8. Reviewer Focus

Please focus your review on:

* [x] Correctness
* [ ] Architecture
* [ ] Security
* [ ] Performance
* [ ] Tests
* [ ] Maintainability
* [x] Product intent
* [ ] Edge cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)