### PR TITLE
feat(lightbridge-code-intelligence): update GitLab base URL configuration for dashboard links

### DIFF
--- a/charts/lightbridge-code-intelligence/values.yaml
+++ b/charts/lightbridge-code-intelligence/values.yaml
@@ -504,9 +504,9 @@ lci:
             # Settings link. DEPLOYMENT-SPECIFIC (https://github.com/apps/<handle>) → ai-helm-values;
             # keep in sync with `config.appHandle` + the control-plane GITHUB_APP_HANDLE. Empty here.
             GITHUB_APP_INSTALL_URL: ""
-            # GitLab base URL for repo/target links in the dashboard. Self-hosted deployments set
-            # this to their instance origin (e.g. `https://gitlab.example.com`); unset → `https://gitlab.com`.
-            NEXT_PUBLIC_GITLAB_URL: ""
+            # GitLab base URL for repo/target links in the dashboard. Set by server-side env var
+            # (runtime-configurable); unset → `https://gitlab.com`.
+            GITLAB_URL: ""
             # Authorization (ADR-0023): the dotted token claim carrying the caller's permissions. The
             # console reads it to show capability-gated affordances; keep in sync with the control
             # plane's PERMISSIONS_CLAIM. Default `permissions`.


### PR DESCRIPTION
## 1. Summary

This PR changes:

- Renames the GitLab URL environment variable from `NEXT_PUBLIC_GITLAB_URL` → `GITLAB_URL` in the Lightbridge Code Intelligence chart's `values.yaml`
- Updates the associated comment to reflect that the variable is now set by a server-side env var (runtime-configurable) rather than as a client-side build-time config

It solves:

It aligns with this pr [here](https://github.com/vymalo/lightbridge-code-intelligence/pull/374)
---

## 2. Intent

The intent of this PR is:

> Remove the `NEXT_PUBLIC_` prefix from the GitLab URL env var so it is no longer baked in at build time. This makes the value configurable at runtime via a server-side environment variable, enabling the same build to target different GitLab instances without a rebuild.

---

## 3. Scope

### In Scope

- Rename `NEXT_PUBLIC_GITLAB_URL` → `GITLAB_URL` in `charts/lightbridge-code-intelligence/values.yaml`
- Update the inline comments to clarify runtime-configurable behaviour

### Out of Scope

- [Excluded change 1]
- [Excluded change 2]

---

## 4. Verification

I verified this change by:

- [ ] Running automated tests
- [x] Running manual tests
- [ ] Checking logs
- [ ] Checking metrics
- [ ] Testing error cases
- [ ] Testing permissions/security behavior
- [ ] Testing rollback or failure behavior, if relevant

Commands run:

```bash
[command 1]
[command 2]
```

Results:

```text
[paste result or link]
```

---

## 5. Screenshots / Evidence

Add evidence here:

* Screenshot: [link]
* Logs: [link]
* Metrics: [link]
* Recording: [link]

---

## 6. Risk Assessment

Risk level:

* [x] Low
* [ ] Medium
* [ ] High

Potential risks:

- Any consumer referencing the old `NEXT_PUBLIC_GITLAB_URL` key will need to be updated to `GITLAB_URL`
- Downstream deployments relying on build-time injection of this value may break if the server-side env var is not set

Mitigation:

- Single-file, single-variable rename — easily auditable
- Comment explicitly states the default fallback (`https://gitlab.com`) so unset values resolve safely

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [ ] Generating code
* [ ] Refactoring
* [ ] Generating tests
* [ ] Drafting documentation
* [ ] Reviewing the diff
* [ ] Not used

Human verification:

* [x] I understand every meaningful change in this PR
* [ ] I checked generated code manually
* [ ] I checked generated tests manually
* [ ] I removed unsupported AI assumptions
* [ ] I accept responsibility for this PR

---

## 8. Reviewer Focus

Please focus your review on:

* [x] Correctness
* [ ] Architecture
* [ ] Security
* [ ] Performance
* [ ] Tests
* [ ] Maintainability
* [ ] Product intent
* [ ] Edge cases
