### PR TITLE
docs: record the four-dir taxonomy in CLAUDE.md + fix broken ADR cross-ref slugs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -321,9 +321,18 @@ If you're touching `charts/librechat-opencode-wellknown/`, read ADR-0014 first. 
 > **"upgrade the doc"**, they mean **every** affected surface, not just the one
 > nearest doc. For any substantive change, sweep this whole set and update what's
 > relevant:
-> 1. **The design/subsystem doc** under `docs/` (or a new one). Long-lived
+> 1. **The topical doc** under `docs/`, filed by **intent** into one of the four
+>    dirs — **`docs/playbooks/`** (runbooks, setup, how-to), **`docs/integrations/`**
+>    (consuming a specific product/surface: LibreChat, opencode, Coder,
+>    Keycloak-as-IdP), **`docs/patterns/`** (reusable patterns, concept explainers,
+>    reference/research), **`docs/migrations/`** (cutovers, upgrades, point-in-time
+>    audits) — or an existing subsystem subdir (`adr/`, `architecture/`, `models/`,
+>    `models-chart-docs/`, `cnpg-native-backup/`, `secret-management/`, …).
+>    Front-matter docs (`architecture.md`, `arc42.md`, `continuous-delivery.md`,
+>    `commit-conventions.md`) stay at `docs/` root. Each topical dir has a local
+>    `README.md` index — add your file there **and** to `docs/README.md`. Long-lived
 >    subsystem guides drop the date prefix (`self-hosted-model-serving.md`, not
->    `2026-…`); dated files are for point-in-time change-logs/audits.
+>    `2026-…`); dated files are point-in-time change-logs/audits (→ `migrations/`).
 > 2. **ADRs** — write a new ADR for any decision with non-obvious consequences or
 >    a locked-in contract; amend a prior decision with a *new* ADR (the old body
 >    is immutable). Update `docs/adr/README.md`.
@@ -338,7 +347,7 @@ If you're touching `charts/librechat-opencode-wellknown/`, read ADR-0014 first. 
 **Self-hosted models/agents:** the model-agnostic pattern + the "deploy the next one"
 checklist live in [`docs/patterns/self-hosted-model-serving.md`](docs/patterns/self-hosted-model-serving.md)
 §8 (vLLM-vs-llama.cpp engine choice; pricing per ADR-0028). **Per-model papers** are
-under [`docs/models/`](docs/patterns/self-hosted-model-serving.md) — `qwen3.5-4b-q4.md`
+under [`docs/models/`](docs/models/) — `qwen3.5-4b-q4.md`
 (llama.cpp/Q4, **LIVE** = the active model, ADR-0032, chart `charts/model-serving-qwen3-5`;
 §6 = measured capacity/perf), `qwen3-4b.md` (vLLM, chart `charts/model-serving-qwen3-4b`,
 now standby/rollback), `qwen3.5-4b.md` (vLLM/BF16, studied-not-chosen). Follow the guide when adding a model —

--- a/docs/adr/0050-kimi-k2.7-code-supersedes-k2.6-as-frontend-pro-backing.md
+++ b/docs/adr/0050-kimi-k2.7-code-supersedes-k2.6-as-frontend-pro-backing.md
@@ -3,7 +3,7 @@
 **Status:** Accepted
 **Date:** 2026-06-18
 **Deciders:** @stephane-segning
-**Relates to:** supersedes the K2.6 backing choice in [ADR-0044](0044-opencode-role-subagents-and-permission-scoped-tools.md) (branded `adorsys-*` aliases); price methodology unchanged from [ADR-0028](0028-price-self-hosted-models-at-cost-recovery.md)/[ADR-0021](0021-burst-budget-billing-and-dual-plane-authconfigs.md)
+**Relates to:** supersedes the K2.6 backing choice in [ADR-0044](0044-opencode-role-subagents-and-permission-scoped-tools.md) (branded `adorsys-*` aliases); price methodology unchanged from [ADR-0028](0028-owned-hardware-model-pricing.md)/[ADR-0021](0021-burst-budget-billing-and-dual-plane-authconfigs.md)
 
 > **Amended by [ADR-0075](./0075-glm-5.2-price-drop-consolidate-glm-catalog.md) (2026-07-02):** the "do not adopt GLM-5.2" call below was priced against DeepInfra's $1.40/$0.25/$4.40 GLM-5.2 rate at the time. DeepInfra has since dropped GLM-5.2 to $0.93/$0.18/$3.00, undercutting GLM-5.1 on every axis — the catalog now standardizes on GLM-5.2 for every former GLM-5/GLM-5.1 backing. The Kimi K2.7 `adorsys-frontend-pro` decision below is unaffected. Body below is immutable.
 

--- a/docs/adr/0058-precompute-gateway-usage-metrics-to-mimir.md
+++ b/docs/adr/0058-precompute-gateway-usage-metrics-to-mimir.md
@@ -3,7 +3,7 @@
 **Status:** Accepted
 **Date:** 2026-06-25
 **Deciders:** @stephane-segning
-**Builds on:** [ADR-0005](./0005-per-user-observability.md), [ADR-0046](./0046-per-user-attribution-otlp-envelope-repair.md), [ADR-0008](./0008-python-dashboard-generation.md), [ADR-0028](./0028-self-hosted-model-pricing.md)/[ADR-0051]
+**Builds on:** [ADR-0005](./0005-per-user-attribution-via-authorino-headers.md), [ADR-0046](./0046-per-user-attribution-otlp-envelope-repair.md), [ADR-0008](./0008-python-dashboard-generation.md), [ADR-0028](./0028-owned-hardware-model-pricing.md)/[ADR-0051]
 **Relates to:** the Loki chunk/results cache enablement + the cost-dashboard taming (`ai-helm-values`)
 
 ## Context

--- a/docs/adr/0059-grafana-unified-alerting-to-discord.md
+++ b/docs/adr/0059-grafana-unified-alerting-to-discord.md
@@ -3,7 +3,7 @@
 **Status:** Accepted
 **Date:** 2026-06-25
 **Deciders:** @stephane-segning
-**Builds on:** [ADR-0023](./0023-stateless-grafana.md) (stateless Grafana), [ADR-0020](./0020-observability-app-of-apps.md), [ADR-0058](./0058-precompute-gateway-usage-metrics-to-mimir.md) (the gen_ai metrics some alerts use)
+**Builds on:** [ADR-0023](./0023-grafana-stateless-no-pvc.md) (stateless Grafana), [ADR-0020](./0020-observability-app-of-apps-orchestrator.md), [ADR-0058](./0058-precompute-gateway-usage-metrics-to-mimir.md) (the gen_ai metrics some alerts use)
 **Relates to:** [ADR-0036](./0036-remove-apprise-notification-path.md) (the removed apprise path)
 
 ## Context

--- a/docs/adr/0060-gamified-app-scoreboard.md
+++ b/docs/adr/0060-gamified-app-scoreboard.md
@@ -3,8 +3,8 @@
 **Status:** Accepted
 **Date:** 2026-06-26
 **Deciders:** @stephane-segning
-**Builds on:** [ADR-0058](./0058-precompute-gateway-usage-metrics-to-mimir.md) (the Mimir metrics backbone), [ADR-0059](./0059-grafana-unified-alerting-to-discord.md) (unified alerting), [ADR-0008](./0008-python-dashboard-generation.md) (dashboards-as-code), [ADR-0046](./0046-per-user-attribution-otlp-envelope-repair.md) (attribution labels), [ADR-0023](./0023-stateless-grafana.md) (stateless Grafana → operator CRs)
-**Relates to:** [ADR-0028](./0028-self-hosted-model-pricing.md)/ADR-0051 (cost is µ$ ÷1e6)
+**Builds on:** [ADR-0058](./0058-precompute-gateway-usage-metrics-to-mimir.md) (the Mimir metrics backbone), [ADR-0059](./0059-grafana-unified-alerting-to-discord.md) (unified alerting), [ADR-0008](./0008-python-dashboard-generation.md) (dashboards-as-code), [ADR-0046](./0046-per-user-attribution-otlp-envelope-repair.md) (attribution labels), [ADR-0023](./0023-grafana-stateless-no-pvc.md) (stateless Grafana → operator CRs)
+**Relates to:** [ADR-0028](./0028-owned-hardware-model-pricing.md)/ADR-0051 (cost is µ$ ÷1e6)
 
 > ⚠️ **Correction (2026-06-26) — see [ADR-0061](./0061-same-origin-proxy-for-grafana-news-feed.md).** The
 > "news panel reads the governance repo's GitHub Atom feed … needs `github.com`


### PR DESCRIPTION
## 1. Summary

Two small follow-ups to the docs reorganization ([#654](https://github.com/ADORSYS-GIS/ai-helm/pull/654), merged):

- **Record the new docs taxonomy in `CLAUDE.md`.** The reorg introduced `docs/{playbooks,integrations,patterns,migrations}/`, but the "Documentation conventions" rule still described the old flat layout — so the next doc would drift back to `docs/` root. Rule #1 now files a new doc by **intent** into one of the four dirs (or a subsystem subdir), notes the front-matter that stays at root, and reminds to update both the per-dir README and `docs/README.md`. Also fixes a stale `[docs/models/]` link.
- **Fix broken ADR cross-reference slugs (errata).** Four ADRs (0050, 0058, 0059, 0060) had header/"builds-on" links pointing at ADR filenames that never existed (e.g. `0023-stateless-grafana.md` → `0023-grafana-stateless-no-pvc.md`). These predated the reorg. With them fixed, the broken-relative-link count across `docs/` is **0**.

It solves:

- Convention drift after the [#654](https://github.com/ADORSYS-GIS/ai-helm/pull/654) reorg, and the last pre-existing broken links in the ADR set.

---

## 2. Intent

The intent of this PR is:

> Make the four-dir docs taxonomy self-sustaining (documented in the one place agents/contributors read for conventions) and finish the link-integrity cleanup that #654 deliberately left out of scope (ADR bodies are immutable, so those slug fixes are isolated here as clearly-labelled errata — link targets only, no decision-content changes).

---

## 3. Scope

### In Scope

- `CLAUDE.md` "Documentation conventions" rule #1 + one stale-link fix.
- Repoint four broken ADR header-note cross-reference links to real filenames.

### Out of Scope

- No decision-body content changes in any ADR (link targets only).
- No doc moves (that was #654).

---

## 4. Verification

I verified this change by:

- [x] Running automated tests
- [ ] Running manual tests
- [ ] Checking logs
- [ ] Checking metrics
- [ ] Testing error cases
- [ ] Testing permissions/security behavior
- [ ] Testing rollback or failure behavior, if relevant

Commands run:

```bash
# broken relative-link audit across docs/ (now clean)
python3 <link-checker>        # -> broken: 0

# the four repointed targets exist
for t in 0005-per-user-attribution-via-authorino-headers 0028-owned-hardware-model-pricing \
         0023-grafana-stateless-no-pvc 0020-observability-app-of-apps-orchestrator; do
  test -f "docs/adr/$t.md" && echo "ok $t"; done
```

Results:

```text
broken relative links in docs/: 0
all four repointed ADR targets exist
```

---

## 5. Screenshots / Evidence

- Docs-only; the diff is self-evident.

---

## 6. Risk Assessment

Risk level:

* [x] Low
* [ ] Medium
* [ ] High

Potential risks:

* Editing files under `docs/adr/` could look like amending an accepted ADR.

Mitigation:

* Changes are link-target errata only (header/"builds-on" lines), no decision-body content touched — the ADR immutability convention is preserved.

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [ ] Generating code
* [ ] Refactoring
* [x] Drafting documentation
* [x] Reviewing the diff
* [ ] Not used

Human verification:

* [x] I understand every meaningful change in this PR
* [x] I checked generated code manually
* [ ] I checked generated tests manually
* [x] I removed unsupported AI assumptions
* [x] I accept responsibility for this PR

---

## 8. Reviewer Focus

Please focus your review on:

* [x] Correctness
* [ ] Architecture
* [ ] Security
* [ ] Performance
* [ ] Tests
* [x] Maintainability
* [ ] Product intent
* [ ] Edge cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)
