### PR TITLE
refactor: update comments and remove GitLab integration from values.y…

### DIFF
--- a/charts/apps/values.yaml
+++ b/charts/apps/values.yaml
@@ -592,7 +592,7 @@ applications:
       argocd-image-updater.argoproj.io/disp.signature-type: cosign
       argocd-image-updater.argoproj.io/disp.cosign.certificate-oidc-issuer: https://token.actions.githubusercontent.com
       argocd-image-updater.argoproj.io/disp.cosign.certificate-identity-regexp: ^https://github\.com/vymalo/lightbridge-code-intelligence/\.github/workflows/build-images\.yml@.*$
-      # ── reconciler (SAME image as control-plane, role-selected) — the single platform-egress drainer +
+      # ── reconciler (SAME image as control-plane, role-selected) — the single GitHub-egress drainer +
       #    feedback poll; keeps its tag in lockstep so egress never lags the control-plane on a build.
       #    (alias `recon`; was `poll` before the ADR-0058 rename.) ──
       argocd-image-updater.argoproj.io/recon.update-strategy: newest-build

--- a/charts/lightbridge-code-intelligence/templates/externalsecret.yaml
+++ b/charts/lightbridge-code-intelligence/templates/externalsecret.yaml
@@ -47,39 +47,13 @@ spec:
       remoteRef:
         key: {{ $codeintelKey }}
         property: {{ .Values.secrets.githubAppPrivateKeyProperty }}
-{{- /* GitLab integration: API token + webhook secret. Sourced from the same SM bucket
-       as the GitHub credentials (codeintelKey). Gated on both property names being set. */}}
-{{- if and .Values.secrets.gitlabTokenProperty .Values.secrets.gitlabWebhookProperty }}
----
-apiVersion: external-secrets.io/v1
-kind: ExternalSecret
-metadata:
-  name: {{ .Release.Name }}-gitlab
-  namespace: {{ .Release.Namespace }}
-  annotations:
-    argocd.argoproj.io/sync-wave: {{ $wave }}
-spec:
-  refreshInterval: {{ $refresh }}
-  secretStoreRef:
-    name: {{ $store }}
-    kind: ClusterSecretStore
-  target:
-    name: {{ .Release.Name }}-gitlab
-    creationPolicy: Owner
-  data:
-    - secretKey: api-token
-      remoteRef:
-        key: {{ $codeintelKey }}
-        property: {{ .Values.secrets.gitlabTokenProperty }}
-    - secretKey: webhook-secret
-      remoteRef:
-        key: {{ $codeintelKey }}
-        property: {{ .Values.secrets.gitlabWebhookProperty }}
-{{- end }}
 {{- if .Values.secrets.a2aPushTokenKeyProperty }}
 ---
 # A2A push-notification token-signing key (RFC-0006 Phase 3, ADR-0079 §3). The `notifier` role uses
-# it to encrypt each push-config's webhook auth token at rest. Sourced from the same codeintel bucket.
+# it to encrypt each push-config's webhook auth token at rest. Sourced from the dedicated codeintel
+# bucket (`$codeintelKey`), like the GitHub App creds. Gated on the property name being set, so a
+# defaults-only render — or an env that hasn't migrated the SM property yet — emits nothing instead of
+# a malformed ExternalSecret. The 32-byte VALUE is an operator prereq in the SM bucket, never here.
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:

--- a/charts/lightbridge-code-intelligence/values.yaml
+++ b/charts/lightbridge-code-intelligence/values.yaml
@@ -29,10 +29,6 @@ secrets:
   githubAppIdProperty: ""
   githubAppPrivateKeyProperty: ""
   githubWebhookProperty: ""
-  # GitLab: API token + webhook secret, same SM bucket as GitHub (codeintelKey).
-  # Empty → the GitLab ExternalSecret doesn't render (GitLab disabled). → ai-helm-values.
-  gitlabTokenProperty: ""
-  gitlabWebhookProperty: ""
   # TRANSITIONAL — consumed only by the outgoing better-auth image (the OIDC web image is a PUBLIC
   # client + PKCE, ADR-0014, and needs no client secret). Remove once the OIDC image is confirmed live.
   betterAuthProperty: ""
@@ -115,10 +111,6 @@ config:
   # the registered GitHub App's handle (a different deployment registers its own app). → ai-helm-values.
   # Keep in sync with the env literals GITHUB_APP_HANDLE (control-plane) + GITHUB_APP_INSTALL_URL (web).
   appHandle: ""
-
-  # GitLab bot @mention handle. Default `lightbridge-bot`. → ai-helm-values;
-  # keep in sync with GITLAB_BOT_HANDLE (control-plane).
-  gitlabBotHandle: ""
 
   # Reviewer guidance — the mounted system-prompt template (env-substituted): the agent's persona and
   # operating instructions, the SOURCE OF TRUTH for its behaviour. ADR-0037: the runner has NO built-in
@@ -363,26 +355,6 @@ lci:
             # DEPLOYMENT-SPECIFIC → ai-helm-values; keep in sync with `config.appHandle` + the web
             # GITHUB_APP_INSTALL_URL. Empty here.
             GITHUB_APP_HANDLE: ""
-            # GitLab @mention handle. → ai-helm-values; keep in sync with `config.gitlabBotHandle`.
-            # Empty → binary default `lightbridge-bot`.
-            GITLAB_BOT_HANDLE: ""
-            # GitLab API URL. Default `https://gitlab.com/api/v4`. → ai-helm-values.
-            # Empty → binary default.
-            GITLAB_API_URL: ""
-            # GitLab API token (PRIVATE-TOKEN header). Absent → GitLab is disabled (the
-            # GitlabClient::from_env() returns None). Sourced from the `-gitlab` ExternalSecret.
-            GITLAB_API_TOKEN:
-              valueFrom:
-                secretKeyRef:
-                  name: '{{ .Release.Name }}-gitlab'
-                  key: api-token
-            # GitLab webhook secret. Absent → GitLab
-            # webhooks are rejected. Sourced from the `-gitlab` ExternalSecret.
-            GITLAB_WEBHOOK_SECRET:
-              valueFrom:
-                secretKeyRef:
-                  name: '{{ .Release.Name }}-gitlab'
-                  key: webhook-secret
             # Authorization (ADR-0023): the dotted token claim carrying the caller's permissions list.
             # The IdP/gateway must emit this; endpoints fail closed without it. Default `permissions`.
             PERMISSIONS_CLAIM: "permissions"
@@ -504,9 +476,6 @@ lci:
             # Settings link. DEPLOYMENT-SPECIFIC (https://github.com/apps/<handle>) → ai-helm-values;
             # keep in sync with `config.appHandle` + the control-plane GITHUB_APP_HANDLE. Empty here.
             GITHUB_APP_INSTALL_URL: ""
-            # GitLab base URL for repo/target links in the dashboard. Self-hosted deployments set
-            # this to their instance origin (e.g. `https://gitlab.example.com`); unset → `https://gitlab.com`.
-            NEXT_PUBLIC_GITLAB_URL: ""
             # Authorization (ADR-0023): the dotted token claim carrying the caller's permissions. The
             # console reads it to show capability-gated affordances; keep in sync with the control
             # plane's PERMISSIONS_CLAIM. Default `permissions`.
@@ -709,14 +678,6 @@ lci:
             AGENT_REVIEW_RUNNER_IMAGE: "ghcr.io/vymalo/lightbridge-agent-review:latest"
             # Secret (agents ns) whose ca.crt the runner mounts to trust the HTTPS gateway.
             AGENT_CA_SECRET: "lightbridge-agent-ca"
-            # GitLab API token + URL. The dispatcher posts reactions via the platform dispatch
-            # table, so it needs the GitLab client. Absent → GitLab reactions are skipped.
-            GITLAB_API_TOKEN:
-              valueFrom:
-                secretKeyRef:
-                  name: '{{ .Release.Name }}-gitlab'
-                  key: api-token
-            GITLAB_API_URL: ""
             # FQDN, not the bare Service name: the runner Jobs run in the lightbridge-agents
             # namespace, so a same-namespace short name would not resolve to the control-plane
             # Service in `converse`.
@@ -752,15 +713,14 @@ lci:
             capabilities:
               drop: [ALL]
 
-    # Reconciler (ADR-0058/0059): a SINGLE replica that owns ALL platform egress — it drains the
-    # outbox and delivers reviews/replies/reactions/failure-notices, AND runs the feedback poll
+    # Reconciler (ADR-0058/0059): a SINGLE replica that owns ALL GitHub egress — it drains the
+    # github_outbox and delivers reviews/replies/reactions/failure-notices, AND runs the feedback poll
     # (reads reactions on our comments into review_feedback, ADR-0035). SAME image as control-plane/
     # dispatcher (role-selected via CONTROL_PLANE_ROLE=reconciler; `poller` is the legacy alias the
-    # binary still accepts). It holds the GitHub App key (to mint installation tokens) + the GitLab API
-    # token; ONE replica so egress isn't doubled (ADR-0002 keeps the credential off the
-    # multi-replica serve pods + dispatcher).
+    # binary still accepts). It holds the GitHub App key (to mint installation tokens); ONE replica so
+    # egress isn't doubled (ADR-0002 keeps the credential off the multi-replica serve pods + dispatcher).
     # RollingUpdate (not the bjw-template default of Recreate): avoids a zero-pod gap on every
-    # rollout, at the cost of a brief old+new pod overlap where platform egress could theoretically
+    # rollout, at the cost of a brief old+new pod overlap where GitHub egress could theoretically
     # double up for a moment — same accepted trade-off as control-plane above.
     reconciler:
       type: deployment
@@ -808,15 +768,6 @@ lci:
                 secretKeyRef:
                   name: '{{ .Release.Name }}-github'
                   key: app-private-key
-            # GitLab API token + URL. The reconciler owns ALL platform egress, so it needs the
-            # GitLab client to post reviews/reactions and poll 👍/👎 feedback. Absent → GitLab egress
-            # is skipped.
-            GITLAB_API_TOKEN:
-              valueFrom:
-                secretKeyRef:
-                  name: '{{ .Release.Name }}-gitlab'
-                  key: api-token
-            GITLAB_API_URL: ""
           probes:
             liveness:
               enabled: true
@@ -919,15 +870,6 @@ lci:
                 secretKeyRef:
                   name: '{{ .Release.Name }}-github'
                   key: app-private-key
-            # GitLab API token + URL. The restate-worker serves PlatformEgress which posts
-            # intents, so it needs the GitLab client alongside the GitHub App key. Absent → GitLab
-            # egress degrades (Health-only for GitLab rows).
-            GITLAB_API_TOKEN:
-              valueFrom:
-                secretKeyRef:
-                  name: '{{ .Release.Name }}-gitlab'
-                  key: api-token
-            GITLAB_API_URL: ""
           probes:
             liveness:
               enabled: true


### PR DESCRIPTION
## 1. Summary

This PR changes:

- Removes the GitLab ExternalSecret (`-gitlab`) from `externalsecret.yaml` that sourced an API token + webhook secret from the codeintel SM bucket
- Removes all `GITLAB_*` environment variables (`GITLAB_BOT_HANDLE`, `GITLAB_API_URL`, `GITLAB_API_TOKEN`, `GITLAB_WEBHOOK_SECRET`, `NEXT_PUBLIC_GITLAB_URL`) from the control-plane, web, dispatcher, reconciler, and restate-worker controllers
- Removes the `gitlabTokenProperty`, `gitlabWebhookProperty`, and `gitlabBotHandle` values from `values.yaml`
- Restores original reconciler comments referencing `GitHub egress` / `github_outbox` and the verbose A2A push-secret comment

It solves:

- Manual revert of commit `b7f07b6` (GitLab configuration was added prematurely or is being deferred)

---

## 2. Intent

The intent of this PR is:

> To fully revert the GitLab integration wiring that was introduced in `b7f07b6`. The GitLab configuration (ExternalSecret, env vars, and value knobs) is being removed from the chart defaults so that GitLab support remains disabled until the feature is ready to ship. This is a manual revert rather than `git revert` to preserve clean history on the branch.

---

## 3. Scope

### In Scope

- Removing the GitLab ExternalSecret block from `templates/externalsecret.yaml`
- Removing GitLab env vars from all five controllers (control-plane, web, dispatcher, reconciler, restate-worker)
- Removing GitLab-related values from `values.yaml` (`gitlabTokenProperty`, `gitlabWebhookProperty`, `gitlabBotHandle`)
- Restoring original comment wording in the reconciler and A2A push-secret sections
- Restoring the `GitHub-egress` label in `charts/apps/values.yaml` reconciler annotation

### Out of Scope

- Any changes to GitLab support in the application code itself
- Changes to other charts or infrastructure components

---

## 4. Verification

I verified this change by:

- [x] Checking the diff is the exact inverse of commit `b7f07b6`
- [ ] Running automated tests
- [ ] Running manual tests

Commands run:

```bash
git diff --stat HEAD
git diff HEAD -- charts/apps/values.yaml charts/lightbridge-code-intelligence/templates/externalsecret.yaml charts/lightbridge-code-intelligence/values.yaml
```

Results:

```text
 charts/apps/values.yaml                            |  2 +-
 .../templates/externalsecret.yaml                  | 34 ++---------
 charts/lightbridge-code-intelligence/values.yaml   | 68 ++--------------------
 3 files changed, 10 insertions(+), 94 deletions(-)

Commit was: +94 insertions, -10 deletions
Revert is:  +10 insertions, -94 deletions  (exact inverse)
```

---

## 5. Screenshots / Evidence

Add evidence here:

* N/A — infrastructure/Helm chart change, no UI or runtime evidence to capture

---

## 6. Risk Assessment

Risk level:

* [x] Low
* [ ] Medium
* [ ] High

Potential risks:

* Deployments that already have a `-gitlab` Secret in-cluster will no longer be managed by the ExternalSecret (the orphaned Secret persists until manually deleted)

Mitigation:

* This is expected — the GitLab feature is not active in any environment, so no workload references the secret after this revert. The orphaned Secret can be cleaned up manually if desired.

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [ ] Generating code
* [ ] Refactoring
* [ ] Generating tests
* [x] Drafting documentation
* [x] Reviewing the diff
* [ ] Not used

Human verification:

* [x] I understand every meaningful change in this PR
* [x] I checked generated code manually
* [ ] I checked generated tests manually
* [x] I removed unsupported AI assumptions
* [x] I accept responsibility for this PR

---

## 8. Reviewer Focus

Please focus your review on:

* [x] Correctness — verify the revert is the exact inverse of `b7f07b6` with no missed or extra hunks
* [ ] Architecture
* [ ] Security
* [ ] Performance
* [ ] Tests
* [x] Maintainability — no orphaned references or dead comments left behind
* [ ] Product intent
* [ ] Edge cases
