### PR TITLE
feat(lightbridge-code-intelligence): wire RUNNER_TOKEN_SIGNING_KEY (#243, ADR-0092)

### DIFF
--- a/charts/lightbridge-code-intelligence/templates/externalsecret.yaml
+++ b/charts/lightbridge-code-intelligence/templates/externalsecret.yaml
@@ -122,35 +122,14 @@ spec:
         property: {{ .Values.secrets.neo4jPasswordProperty }}
 {{- end }}
 {{- if .Values.agents.enabled }}
----
-# Shared bearer the dispatcher injects into each agent Job and the serve control plane checks on its
-# internal API (ADR-0017). Lives in the release namespace; consumed by control-plane + dispatcher.
-apiVersion: external-secrets.io/v1
-kind: ExternalSecret
-metadata:
-  name: {{ .Release.Name }}-agent
-  namespace: {{ .Release.Namespace }}
-  annotations:
-    argocd.argoproj.io/sync-wave: {{ $wave }}
-spec:
-  refreshInterval: {{ $refresh }}
-  secretStoreRef:
-    name: {{ $store }}
-    kind: ClusterSecretStore
-  target:
-    name: {{ .Release.Name }}-agent
-    creationPolicy: Owner
-  data:
-    - secretKey: runner-token
-      remoteRef:
-        key: {{ $codeintelKey }}
-        property: {{ .Values.secrets.agentRunnerTokenProperty }}
 {{- if .Values.secrets.runnerTokenSigningKeyProperty }}
 ---
-# Per-task runner-token signing key (lightbridge-code-intelligence#243, ADR-0092). Replaces the
-# shared AGENT_RUNNER_TOKEN bearer above as the control plane's OWN secret: `serve` verifies with it,
-# `dispatcher` mints a fresh, task-scoped token with it and injects ONLY the minted token (never this
-# key) into each Job's AGENT_RUNNER_TOKEN env. Never read by the Job itself. Gated on the property
+# Per-task runner-token signing key (lightbridge-code-intelligence#243, ADR-0092) — control-plane's
+# own secret: `serve` verifies with it, `dispatcher` mints a fresh, task-scoped token with it and
+# injects ONLY the minted token (never this key) into each Job's AGENT_RUNNER_TOKEN env. Never read
+# by the Job itself. Supersedes the old shared AGENT_RUNNER_TOKEN bearer secret (purged from this
+# chart in the same change — the hard cutover in #410 already stopped any code from reading it).
+# Gated on the property
 # name being set — same "defaults-only render stays render-neutral" reasoning as the a2a-push secret
 # above — so an environment that hasn't provisioned the SM property yet gets no ExternalSecret instead
 # of one with an empty `property:`. The 32+ byte VALUE is an operator prereq in the SM bucket, never

--- a/charts/lightbridge-code-intelligence/templates/externalsecret.yaml
+++ b/charts/lightbridge-code-intelligence/templates/externalsecret.yaml
@@ -145,6 +145,37 @@ spec:
       remoteRef:
         key: {{ $codeintelKey }}
         property: {{ .Values.secrets.agentRunnerTokenProperty }}
+{{- if .Values.secrets.runnerTokenSigningKeyProperty }}
+---
+# Per-task runner-token signing key (lightbridge-code-intelligence#243, ADR-0092). Replaces the
+# shared AGENT_RUNNER_TOKEN bearer above as the control plane's OWN secret: `serve` verifies with it,
+# `dispatcher` mints a fresh, task-scoped token with it and injects ONLY the minted token (never this
+# key) into each Job's AGENT_RUNNER_TOKEN env. Never read by the Job itself. Gated on the property
+# name being set — same "defaults-only render stays render-neutral" reasoning as the a2a-push secret
+# above — so an environment that hasn't provisioned the SM property yet gets no ExternalSecret instead
+# of one with an empty `property:`. The 32+ byte VALUE is an operator prereq in the SM bucket, never
+# generated or stored here.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: {{ .Release.Name }}-runner-signing
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    argocd.argoproj.io/sync-wave: {{ $wave }}
+spec:
+  refreshInterval: {{ $refresh }}
+  secretStoreRef:
+    name: {{ $store }}
+    kind: ClusterSecretStore
+  target:
+    name: {{ .Release.Name }}-runner-signing
+    creationPolicy: Owner
+  data:
+    - secretKey: signing-key
+      remoteRef:
+        key: {{ $codeintelKey }}
+        property: {{ .Values.secrets.runnerTokenSigningKeyProperty }}
+{{- end }}
 ---
 # The per-Job config Secret, in the AGENTS namespace (the Job's secretKeyRef target — see the app
 # repo's k8s.rs). Base URLs + the embeddings model are stable literals; the API key reuses the eaig

--- a/charts/lightbridge-code-intelligence/values.yaml
+++ b/charts/lightbridge-code-intelligence/values.yaml
@@ -36,6 +36,10 @@ secrets:
   # gateway API key (remoteKey, reused from the shared eaig key). The review chat model is NOT a secret —
   # it's agents.llm.model (also env-owned).
   agentRunnerTokenProperty: ""
+  # Per-task runner-token signing key (lightbridge-code-intelligence#243, ADR-0092), superseding
+  # agentRunnerTokenProperty above as control-plane's OWN secret. Empty by default (ADR-0057) — see
+  # externalsecret.yaml's runner-signing ExternalSecret, gated on this being set.
+  runnerTokenSigningKeyProperty: ""
   openaiKeyProperty: ""
   # GHCR pull credential for the agent Jobs' namespace (private-image cutover). The runner images
   # (ghcr.io/vymalo/*) are private, so the Jobs the dispatcher launches into `agents.namespace` need
@@ -404,14 +408,29 @@ lci:
                 secretKeyRef:
                   name: '{{ .Release.Name }}-neo4j-auth'
                   key: password
-            # Shared bearer for the internal runner API (ADR-0017). Present → serve enables the
-            # /internal/* routes; absent → they fail closed (503). The dispatcher injects the same
-            # value into each Job.
+            # SUPERSEDED by RUNNER_TOKEN_SIGNING_KEY below (lightbridge-code-intelligence#243,
+            # ADR-0092) — serve's own code no longer reads this env var at all. Left wired, unused,
+            # while a rollback pin to a pre-#243 image is possibly still in effect in some
+            # environments; a follow-up should drop this once that rollback is fully retired.
             AGENT_RUNNER_TOKEN:
               valueFrom:
                 secretKeyRef:
                   name: '{{ .Release.Name }}-agent'
                   key: runner-token
+            # Mints/verifies per-task runner tokens (ADR-0092). Present → serve enables the
+            # /internal/* routes (verifying each request's task-scoped token); absent → they fail
+            # closed (503), same posture as the old AGENT_RUNNER_TOKEN-absent degrade. The dispatcher
+            # holds the SAME key to mint; it never leaves this process into a Job. `optional: true`
+            # MATTERS (mirrors A2A_PUSH_TOKEN_KEY below): the `-runner-signing` Secret only exists once
+            # runnerTokenSigningKeyProperty is set, and a hard secretKeyRef to a not-yet-provisioned
+            # secret would crash-loop the WHOLE control plane instead of just leaving serve's
+            # /internal/* routes degraded-closed as designed.
+            RUNNER_TOKEN_SIGNING_KEY:
+              valueFrom:
+                secretKeyRef:
+                  name: '{{ .Release.Name }}-runner-signing'
+                  key: signing-key
+                  optional: true
           probes:
             liveness:
               enabled: true
@@ -656,12 +675,25 @@ lci:
             DATABASE_URL:
               dependsOn: DB_PASSWORD
               value: ""
-            # Injected into each Job + presented by the runner on the callback (ADR-0017).
+            # SUPERSEDED by RUNNER_TOKEN_SIGNING_KEY below (lightbridge-code-intelligence#243,
+            # ADR-0092) — the dispatcher no longer reads this env var; it mints a fresh per-task token
+            # with the signing key instead and injects ONLY that into each Job's own AGENT_RUNNER_TOKEN
+            # env (via k8s.rs, not this static block). Left wired, unused; drop in a follow-up cleanup.
             AGENT_RUNNER_TOKEN:
               valueFrom:
                 secretKeyRef:
                   name: '{{ .Release.Name }}-agent'
                   key: runner-token
+            # Mints per-task runner tokens the dispatcher injects into each Job (ADR-0092); the SAME
+            # key `serve` verifies with. `optional: true` (mirrors A2A_PUSH_TOKEN_KEY): without it the
+            # dispatcher mints nothing and Jobs get an empty AGENT_RUNNER_TOKEN — degraded, not a
+            # crash — rather than this pod itself failing to start on a not-yet-provisioned secret.
+            RUNNER_TOKEN_SIGNING_KEY:
+              valueFrom:
+                secretKeyRef:
+                  name: '{{ .Release.Name }}-runner-signing'
+                  key: signing-key
+                  optional: true
             # Where Jobs run, who they run as, what image, and where they call back (the serve Svc).
             # Literals (not {{ .Values.agents.* }}): bjw renders env against the sub-chart scope where
             # the top-level `agents` values aren't visible. Keep in sync with the `agents:` block.

--- a/charts/lightbridge-code-intelligence/values.yaml
+++ b/charts/lightbridge-code-intelligence/values.yaml
@@ -32,13 +32,12 @@ secrets:
   # TRANSITIONAL — consumed only by the outgoing better-auth image (the OIDC web image is a PUBLIC
   # client + PKCE, ADR-0014, and needs no client secret). Remove once the OIDC image is confirmed live.
   betterAuthProperty: ""
-  # Agent runner wiring (epic #5): the shared internal-API bearer (codeintelKey) + the embeddings/LLM
-  # gateway API key (remoteKey, reused from the shared eaig key). The review chat model is NOT a secret —
-  # it's agents.llm.model (also env-owned).
-  agentRunnerTokenProperty: ""
-  # Per-task runner-token signing key (lightbridge-code-intelligence#243, ADR-0092), superseding
-  # agentRunnerTokenProperty above as control-plane's OWN secret. Empty by default (ADR-0057) — see
-  # externalsecret.yaml's runner-signing ExternalSecret, gated on this being set.
+  # Agent runner wiring (epic #5): the embeddings/LLM gateway API key (remoteKey, reused from the
+  # shared eaig key). The review chat model is NOT a secret — it's agents.llm.model (also env-owned).
+  # Per-task runner-token signing key (lightbridge-code-intelligence#243, ADR-0092) — control-plane's
+  # own secret (supersedes the old shared AGENT_RUNNER_TOKEN bearer property, removed with #410's
+  # hard cutover). Empty by default (ADR-0057) — see externalsecret.yaml's runner-signing
+  # ExternalSecret, gated on this being set.
   runnerTokenSigningKeyProperty: ""
   openaiKeyProperty: ""
   # GHCR pull credential for the agent Jobs' namespace (private-image cutover). The runner images
@@ -408,19 +407,12 @@ lci:
                 secretKeyRef:
                   name: '{{ .Release.Name }}-neo4j-auth'
                   key: password
-            # SUPERSEDED by RUNNER_TOKEN_SIGNING_KEY below (lightbridge-code-intelligence#243,
-            # ADR-0092) — serve's own code no longer reads this env var at all. Left wired, unused,
-            # while a rollback pin to a pre-#243 image is possibly still in effect in some
-            # environments; a follow-up should drop this once that rollback is fully retired.
-            AGENT_RUNNER_TOKEN:
-              valueFrom:
-                secretKeyRef:
-                  name: '{{ .Release.Name }}-agent'
-                  key: runner-token
             # Mints/verifies per-task runner tokens (ADR-0092). Present → serve enables the
             # /internal/* routes (verifying each request's task-scoped token); absent → they fail
-            # closed (503), same posture as the old AGENT_RUNNER_TOKEN-absent degrade. The dispatcher
-            # holds the SAME key to mint; it never leaves this process into a Job. `optional: true`
+            # closed (503) — the same degrade posture the old shared AGENT_RUNNER_TOKEN bearer secret
+            # had (purged from this chart: #410's hard cutover means serve's own code has never read
+            # it). The dispatcher holds the SAME key to mint; it never leaves this process into a Job.
+            # `optional: true`
             # MATTERS (mirrors A2A_PUSH_TOKEN_KEY below): the `-runner-signing` Secret only exists once
             # runnerTokenSigningKeyProperty is set, and a hard secretKeyRef to a not-yet-provisioned
             # secret would crash-loop the WHOLE control plane instead of just leaving serve's
@@ -675,17 +667,11 @@ lci:
             DATABASE_URL:
               dependsOn: DB_PASSWORD
               value: ""
-            # SUPERSEDED by RUNNER_TOKEN_SIGNING_KEY below (lightbridge-code-intelligence#243,
-            # ADR-0092) — the dispatcher no longer reads this env var; it mints a fresh per-task token
-            # with the signing key instead and injects ONLY that into each Job's own AGENT_RUNNER_TOKEN
-            # env (via k8s.rs, not this static block). Left wired, unused; drop in a follow-up cleanup.
-            AGENT_RUNNER_TOKEN:
-              valueFrom:
-                secretKeyRef:
-                  name: '{{ .Release.Name }}-agent'
-                  key: runner-token
-            # Mints per-task runner tokens the dispatcher injects into each Job (ADR-0092); the SAME
-            # key `serve` verifies with. `optional: true` (mirrors A2A_PUSH_TOKEN_KEY): without it the
+            # Mints per-task runner tokens the dispatcher injects into each Job (ADR-0092) via
+            # k8s.rs — never a static env value; the SAME key `serve` verifies with. Supersedes the
+            # old shared AGENT_RUNNER_TOKEN bearer secret (purged from this chart: #410's hard
+            # cutover means the dispatcher's own code has never read it). `optional: true` (mirrors
+            # A2A_PUSH_TOKEN_KEY): without it the
             # dispatcher mints nothing and Jobs get an empty AGENT_RUNNER_TOKEN — degraded, not a
             # crash — rather than this pod itself failing to start on a not-yet-provisioned secret.
             RUNNER_TOKEN_SIGNING_KEY:


### PR DESCRIPTION
## 1. Summary

This PR changes:

- Adds a new, separately-gated `ExternalSecret` (`<release>-runner-signing`, key `signing-key`)
  sourced from a new `secrets.runnerTokenSigningKeyProperty` value, mirroring the existing
  `a2aPushTokenKeyProperty` pattern (empty by default, render-neutral until an env sets it).
- Adds `RUNNER_TOKEN_SIGNING_KEY` env to `serve` (verifies) and `dispatcher` (mints), both with
  `optional: true` on the `secretKeyRef`.
- **Purges** the old shared-bearer `AGENT_RUNNER_TOKEN` wiring entirely: the `<release>-agent`
  `ExternalSecret` (key `runner-token`), the `agentRunnerTokenProperty` default, and both static
  `AGENT_RUNNER_TOKEN` env blocks on `serve`/`dispatcher`. Confirmed via a chart-wide grep that
  nothing else references that secret or property before removing it.

It solves:

- vymalo/lightbridge-code-intelligence#243 (PR #410, ADR-0092)

---

## 2. Intent

The intent of this PR is:

> `vymalo/lightbridge-code-intelligence#243` (PR #410) replaced control-plane's own internal-API
> secret — `AGENT_RUNNER_TOKEN` → `RUNNER_TOKEN_SIGNING_KEY` — as a deliberate hard cutover
> (ADR-0092). This repo was never updated to provision the new secret before that image rolled out
> to prod, causing a live outage: every dispatched Job got an empty `AGENT_RUNNER_TOKEN` and was
> marked permanently failed after the reaper exhausted retries (confirmed via `kubectl` — task
> `48f2a16f-...` failed 2026-07-15T05:34:47Z after 5 requeue attempts). This PR wires the chart
> side of that cutover through, and — since the repo's own hard-cutover convention is "no dormant
> old path left behind" — removes the now-dead old secret/env instead of leaving it unused.

---

## 3. Scope

### In Scope

- The new `runner-signing` `ExternalSecret` + `RUNNER_TOKEN_SIGNING_KEY` env wiring.
- Full removal of the old `<release>-agent` / `runner-token` `ExternalSecret`,
  `agentRunnerTokenProperty` default, and the two static `AGENT_RUNNER_TOKEN` env blocks.

### Out of Scope

- Creating the actual secret value. `prod/codeintel/env` / `runner_token_signing_key` is an
  **operator prereq in Secrets Manager** (e.g. `openssl rand -hex 32`) — not something a chart PR
  generates or stores.
- The companion values PR (ADORSYS-GIS/ai-helm-values#89) that sets the property name in prod —
  merge that after this one.

---

## 4. Verification

I verified this change by:

- [x] Running automated tests
- [x] Checking logs

Commands run:

```bash
grep -rn "Release.Name }}-agent\b|runner-token|agentRunnerTokenProperty|AGENT_RUNNER_TOKEN" \
  charts/lightbridge-code-intelligence/
helm lint charts/lightbridge-code-intelligence
helm template test charts/lightbridge-code-intelligence \
  -f <values with runnerTokenSigningKeyProperty set> \
  --show-only templates/externalsecret.yaml
helm template test charts/lightbridge-code-intelligence \
  -f <values without runnerTokenSigningKeyProperty> \
  --show-only templates/externalsecret.yaml | grep -c runner-signing
helm template test charts/lightbridge-code-intelligence \
  -f <values with property set> | grep -B2 -A6 "RUNNER_TOKEN_SIGNING_KEY|AGENT_RUNNER_TOKEN"
```

Results:

```text
# Pre-removal grep confirmed zero OTHER references to the old secret/property before deleting them
# (only the exact 3 sites removed in this PR touched them).

$ helm lint charts/lightbridge-code-intelligence
1 chart(s) linted, 0 chart(s) failed

# With runnerTokenSigningKeyProperty set: new ExternalSecret renders correctly (name/key/property
# wired as expected).

# Without the property set: 0 matches for "runner-signing" — render-neutral, matches the
# a2a-push precedent.

# Full template render with the property set: RUNNER_TOKEN_SIGNING_KEY present on both serve and
# dispatcher with optional: true; AGENT_RUNNER_TOKEN no longer appears as an env var name anywhere
# (only in historical comments) — the purge is complete and confirmed by the render itself.
```

---

## 5. Screenshots / Evidence

* Screenshot: n/a (backend-only change, no UI)
* Logs: pasted under Verification above
* Metrics: n/a
* Recording: n/a

---

## 6. Risk Assessment

Risk level:

* [x] Medium

Potential risks:

* If this PR merges (and the companion values PR sets the property) before the actual secret
  value exists in Secrets Manager, `serve`/`dispatcher` would run with no signing key at all —
  `optional: true` means this degrades exactly like the pre-#410 posture (serve's `/internal/*`
  fails closed 503, dispatcher mints nothing), not a crash, but Jobs still won't get a working
  token until the SM value is created.
* Removing the old `AGENT_RUNNER_TOKEN` wiring is irreversible without a follow-up revert PR if
  anything else turns out to depend on it — mitigated by the pre-removal grep confirming nothing
  else in the chart referenced it.

Mitigation:

* `optional: true` on both new secretKeyRefs (verified by rendering with the property both set
  and unset) is the load-bearing safety property — it is what prevents this PR from crash-looping
  control-plane if merged ahead of the Secrets Manager step.
* A chart-wide grep before removal, re-verified by `helm template` showing zero remaining
  `AGENT_RUNNER_TOKEN`/`agentRunnerTokenProperty` references post-change.

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [x] Drafting documentation
* [x] Reviewing the diff

Human verification:

* [ ] I understand every meaningful change in this PR
* [ ] I checked generated code manually
* [ ] I checked generated tests manually
* [ ] I removed unsupported AI assumptions
* [ ] I accept responsibility for this PR

(Drafted by Claude Code investigating a live production incident, at the repo owner's direction —
human-verification boxes left for the repo owner's own review pass, not checked on their behalf.)

---

## 8. Reviewer Focus

Please focus your review on:

* [x] Correctness
* [x] Security
* [x] Edge cases
* [ ] Architecture
* [ ] Performance
* [ ] Tests
* [ ] Maintainability
* [x] Product intent
