### PR TITLE
feat(rate-limit): add enterprise billing tier for lightbridge API-key plans

### DIFF
--- a/charts/ai-models/values.yaml
+++ b/charts/ai-models/values.yaml
@@ -85,6 +85,17 @@ rateLimitBudgeting:
       burst:
         requestsPerMin: 400
         tokensPerMin: 2000000     # 400k → 2M: a couple of max-context requests/min
+    # Customer "enterprise" tier — the top self-serve plan lightbridge keys can be
+    # minted on (lightbridge-authz billing.plans id `enterprise`, x-billing-plan set
+    # from the key's introspected plan). Explicit HIGH caps (≈2× pro), NOT uncapped —
+    # a bounded ceiling still protects the shared budget/backends. Adjust to taste.
+    # monthlyBudgetUsd DORMANT (see free); the LIVE monthly cap is
+    # core-gateway backendTrafficPolicy.monthlyBudget.plans.enterprise — keep in sync.
+    enterprise:
+      monthlyBudgetUsd: 1000
+      burst:
+        requestsPerMin: 800
+        tokensPerMin: 4000000
     # Remote service accounts (GitHub runners, …) on the EXTERNAL plane.
     # Uncapped budget (no monthlyBudgetUsd) — burst-only.
     service:

--- a/charts/core-gateway/values.yaml
+++ b/charts/core-gateway/values.yaml
@@ -220,6 +220,10 @@ backendTrafficPolicy:
       # models (#532 cutover), the old per-model headroom rationale is gone.
       free: 15
       pro: 200
+      # Customer "enterprise" tier (LIVE monthly $ cap; keep in sync with
+      # ai-models rateLimitBudgeting.plans.enterprise.monthlyBudgetUsd). A key
+      # gets x-billing-plan=enterprise from its lightbridge introspected plan.
+      enterprise: 1000
 
   # Whole-request ceiling for routes this gateway-wide policy governs (the
   # non-model routes — model routes are governed by their own per-model BTP in


### PR DESCRIPTION
## 1. Summary

This PR changes:

- Adds an **`enterprise`** rate-limit tier so lightbridge API keys minted on the `enterprise` billing plan are actually bucketed at the edge.
- `charts/ai-models/values.yaml` `rateLimitBudgeting.plans.enterprise`: burst **800 req/min**, **4M tokens/min** (per-model burst — LIVE).
- `charts/core-gateway/values.yaml` `backendTrafficPolicy.monthlyBudget.plans.enterprise`: **$1000/mo** (the LIVE shared monthly cap).

It solves:

- Follow-up to https://github.com/ADORSYS-GIS/lightbridge-authz/pull/125 (structured per-key billing plans). Source of truth: https://github.com/ADORSYS-GIS/lightbridge-authz/pull/125 · https://github.com/ADORSYS-GIS/lightbridge-authz/issues/126
- Without a bucket for `enterprise`, an `x-billing-plan: enterprise` request matches **no** rate-limit rule → **no cap** applied.

---

## 2. Intent

The intent of this PR is:

> lightbridge-authz now mints API keys on a plan (`free`/`pro`/`enterprise`) and the AuthConfig stamps `x-billing-plan` from the key's introspected plan (companion PR in ai-helm-values). The edge rate-limiter keys buckets on `x-billing-plan`, but only had `free`/`pro` (+`service`/`internal`). This adds the missing `enterprise` tier with **explicit high, bounded** caps (chosen: ~2× `pro`; not uncapped, so the shared budget/backends stay protected). Numbers are a starting point — adjust to the commercial plan.

---

## 3. Scope

### In Scope

- The `enterprise` tier entries in the two tier maps (burst + monthly budget).

### Out of Scope

- The `x-billing-plan` header source switch and the `billing.plans` config — those are in the **ai-helm-values** companion PR.
- Any change to `free`/`pro`/`service`/`internal` limits.

---

## 4. Verification

I verified this change by:

- [x] Running manual tests (`helm template`)
- [x] Checking rendered output
- [x] Testing error cases (YAML lint)

Commands run:

```bash
helm template cg charts/core-gateway            # renders enterprise monthly-budget rule
python3 -c "import yaml; yaml.safe_load(open('charts/ai-models/values.yaml'))"   # OK
python3 -c "import yaml; yaml.safe_load(open('charts/core-gateway/values.yaml'))" # OK
```

Results:

```text
core-gateway BTP renders:  name: x-billing-plan / value: "enterprise"  (monthly cap rule present)
Both values files parse cleanly.
Note: the per-model ai-model BTP uses the identical `range ,  := `
pattern (value: {{ $planName | quote }}); the enterprise entry has the same schema as pro,
so it renders identically once models are present. ArgoCD render at sync is the final gate.
```

---

## 6. Risk Assessment

Risk level:

* [x] Low

Potential risks:

* Additive only — adds rules for `x-billing-plan == "enterprise"`; does not touch existing tiers, so free/pro/service/internal enforcement is unchanged.
* Ordering: land/sync this **before** (or with) the ai-helm-values header switch so an `enterprise` key never briefly hits no bucket. Worst case if reversed: enterprise keys are momentarily uncapped (high tier anyway).

Mitigation:

* Keep `ai-models…enterprise.monthlyBudgetUsd` and `core-gateway…monthlyBudget.plans.enterprise` in sync (both = 1000).

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [x] Drafting documentation

Human verification:

* [ ] I understand every meaningful change in this PR
* [ ] I checked generated code manually
* [ ] I accept responsibility for this PR

---

## 8. Reviewer Focus

Please focus your review on:

* [x] Product intent
* [x] Correctness
* [x] Edge cases

> The enterprise caps (800 req/min, 4M tok/min, $1000/mo) are my proposal scaled above `pro` — please confirm they match the commercial plan.
