### PR TITLE
feat(lightbridge-ci)!: remove Restate egress — reconciler drain is the sole egress (ADR-0093)

### DIFF
--- a/charts/apps/values.yaml
+++ b/charts/apps/values.yaml
@@ -502,35 +502,6 @@ applications:
     destination:
       namespace: converse
 
-  # --- Restate (durable execution) — RFC-0005 / ADR-0074 Phase-1 enabler ---
-  # Single-node Restate durable-execution server for the LCI control plane. The
-  # future `restate-worker` control-plane role (in the lightbridge-code-intelligence
-  # app, default wave 0) registers services with + is invoked by this server, so
-  # Restate is a storage-backend dependency that MUST be up first → sync-wave -2
-  # (storage tier per SYNC_WAVE_PATTERN.md — same wave as the observability storage
-  # backends mimir/loki/tempo). Upstream chart from the Restate OCI registry, pinned
-  # to 1.7.2 (external source form, like eg/aieg). Single node: replicaCount 1,
-  # RocksDB on a PVC, NO cluster/Raft, NO S3. Namespace `converse` (the LCI workload
-  # namespace, ADR-0017 home-remote default). Workload values (resources / rocksdb
-  # budget / PVC size) live in ai-helm-values (ADR-0056), read via the $values ref
-  # the template injects (ignoreMissingValueFiles → renders on chart defaults until
-  # the file lands). No image-updater (upstream image, version-pinned); serviceMonitor
-  # stays off to keep the blast radius to just this new StatefulSet.
-  - name: restate
-    finalizers:
-      - resources-finalizer.argocd.argoproj.io
-    additionalAnnotations:
-      argocd.argoproj.io/sync-wave: "-2"
-    valuesFromRepo: true
-    source:
-      repoURL: oci://ghcr.io/restatedev/restate-helm
-      targetRevision: 1.7.2
-      path: .
-      helm:
-        releaseName: restate
-    destination:
-      namespace: converse
-
   # --- Lightbridge Code Intelligence ---
   # The GitHub-App code-review / repo-Q&A system (repo:
   # vymalo/lightbridge-code-intelligence): Rust control plane + Next.js web console
@@ -562,12 +533,12 @@ applications:
       # declares, which otherwise show a permanent cosmetic OutOfSync + selfHeal churn.
       # ServerSideDiff ignores those server-owned fields so the app reads Synced.
       argocd.argoproj.io/compare-options: ServerSideDiff=true
-      # Images aliased: cp/disp/recon/rw/a2a (control-plane, role-selected), web, runner (the one-shot
+      # Images aliased: cp/disp/recon/a2a (control-plane, role-selected), web, runner (the one-shot
       # agent-runner/indexer image the dispatcher launches), and review (the slimmer review-only Job
       # image — no Python/Graphify — picked for review tasks; ADR-0004 per-kind images, #207).
-      # `rw` = restate-worker (RFC-0005/ADR-0074), `a2a` = the A2A surface (RFC-0006) — both the SAME
-      # control-plane image, kept in lockstep so the new roles never lag the control-plane on a build.
-      argocd-image-updater.argoproj.io/image-list: cp=ghcr.io/vymalo/lightbridge-control-plane,disp=ghcr.io/vymalo/lightbridge-control-plane,recon=ghcr.io/vymalo/lightbridge-control-plane,rw=ghcr.io/vymalo/lightbridge-control-plane,a2a=ghcr.io/vymalo/lightbridge-control-plane,notifier=ghcr.io/vymalo/lightbridge-control-plane,web=ghcr.io/vymalo/lightbridge-web,runner=ghcr.io/vymalo/lightbridge-agent-runner,review=ghcr.io/vymalo/lightbridge-agent-review
+      # `a2a` = the A2A surface (RFC-0006) — the SAME control-plane image, kept in lockstep so the a2a
+      # role never lags the control-plane on a build.
+      argocd-image-updater.argoproj.io/image-list: cp=ghcr.io/vymalo/lightbridge-control-plane,disp=ghcr.io/vymalo/lightbridge-control-plane,recon=ghcr.io/vymalo/lightbridge-control-plane,a2a=ghcr.io/vymalo/lightbridge-control-plane,notifier=ghcr.io/vymalo/lightbridge-control-plane,web=ghcr.io/vymalo/lightbridge-web,runner=ghcr.io/vymalo/lightbridge-agent-runner,review=ghcr.io/vymalo/lightbridge-agent-review
       # ── control-plane ──
       argocd-image-updater.argoproj.io/cp.update-strategy: newest-build
       argocd-image-updater.argoproj.io/cp.allow-tags: regexp:^sha-[0-9a-f]+$
@@ -604,17 +575,6 @@ applications:
       argocd-image-updater.argoproj.io/recon.signature-type: cosign
       argocd-image-updater.argoproj.io/recon.cosign.certificate-oidc-issuer: https://token.actions.githubusercontent.com
       argocd-image-updater.argoproj.io/recon.cosign.certificate-identity-regexp: ^https://github\.com/vymalo/lightbridge-code-intelligence/\.github/workflows/build-images\.yml@.*$
-      # ── restate-worker (SAME image as control-plane, role-selected; RFC-0005/ADR-0074) — keeps its
-      #    tag in lockstep so the Restate SDK worker never lags the control-plane on a build. ──
-      argocd-image-updater.argoproj.io/rw.update-strategy: newest-build
-      argocd-image-updater.argoproj.io/rw.allow-tags: regexp:^sha-[0-9a-f]+$
-      argocd-image-updater.argoproj.io/rw.force-update: "true"
-      argocd-image-updater.argoproj.io/rw.pull-secret: pullsecret:argocd/adorsys-gis-ghcr-pull
-      argocd-image-updater.argoproj.io/rw.helm.image-name: lci.controllers.restate-worker.containers.main.image.repository
-      argocd-image-updater.argoproj.io/rw.helm.image-tag: lci.controllers.restate-worker.containers.main.image.tag
-      argocd-image-updater.argoproj.io/rw.signature-type: cosign
-      argocd-image-updater.argoproj.io/rw.cosign.certificate-oidc-issuer: https://token.actions.githubusercontent.com
-      argocd-image-updater.argoproj.io/rw.cosign.certificate-identity-regexp: ^https://github\.com/vymalo/lightbridge-code-intelligence/\.github/workflows/build-images\.yml@.*$
       # ── a2a (SAME image as control-plane, role-selected; RFC-0006) — keeps its tag in lockstep so
       #    the A2A surface never lags the control-plane on a build. ──
       argocd-image-updater.argoproj.io/a2a.update-strategy: newest-build

--- a/charts/lightbridge-code-intelligence/templates/config.yaml
+++ b/charts/lightbridge-code-intelligence/templates/config.yaml
@@ -45,18 +45,6 @@ interprets `{{ }}`).
 {{- $mcps := list }}
 {{- range $s := $cfg.knowledgeTools.mcpServers }}{{- if and $s.name $s.url }}{{- $mcps = append $mcps (dict "name" $s.name "url" $s.url) }}{{- end }}{{- end }}
 {{- if $mcps }}{{- $_ := set $cp "knowledge_tools" (dict "mcp_servers" $mcps) }}{{- end }}
-{{- /* Egress routing (RFC-0005 Phase A / ADR-0074) → control-plane.json `egress`. The PRODUCER roles
-       (serve + dispatcher, which mount THIS ConfigMap) read `mode` to decide whether to `send`
-       PlatformEgress::post to the Restate ingress. Default `drain` (chart) = no behavior change; flip to
-       `restate` in ai-helm-values to activate the pilot. `restate_ingress_url` is required in restate
-       mode (or the RESTATE_INGRESS_URL env). The RECONCILER reads the SAME $eg via its own egress-ONLY
-       ConfigMap below — deliberately NOT this full config, so it never picks up the `review` block (see
-       there for why). deny_unknown_fields on the binary's EgressSection accepts exactly
-       {mode, restate_ingress_url}; the deployed image (≥ ADR-0074) carries the field. */}}
-{{- $eg := dict }}
-{{- if ne (toString $cfg.egress.mode) "" }}{{- $_ := set $eg "mode" $cfg.egress.mode }}{{- end }}
-{{- if ne (toString $cfg.egress.restateIngressUrl) "" }}{{- $_ := set $eg "restate_ingress_url" $cfg.egress.restateIngressUrl }}{{- end }}
-{{- if $eg }}{{- $_ := set $cp "egress" $eg }}{{- end }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -66,27 +54,6 @@ metadata:
     argocd.argoproj.io/sync-wave: {{ $wave }}
 data:
   control-plane.json: {{ $cp | toJson | quote }}
----
-{{- /* ── reconciler egress config (RFC-0005 Phase A / ADR-0074) ────────────────────────────────────
-       The reconciler is the role that owns the outbox drain (ADR-0059). When the pilot is active it MUST
-       read `egress.mode = restate` to turn that drain OFF — otherwise it keeps draining while the
-       producers also `send` to Restate, and every intent posts twice.
-       It gets an egress-ONLY control-plane.json, NOT the producers' full one, on purpose: the full config
-       carries the `review` block (outcome labels/reactions), and the reconciler's deliver_review() reads
-       ReviewSection to apply the `label_findings`/`label_error` labels. Today the reconciler mounts no
-       config, so it runs on ReviewSection::default() (no labels). Handing it the full config would make it
-       START applying those labels — an unrelated behavior change. Egress-only keeps its review behavior
-       identical while still delivering the mode. mode + url come from the SAME $eg as the producers'
-       copy above, so the two egress views cannot drift. Inert while $eg.mode = drain. */}}
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: {{ .Release.Name }}-reconciler-config
-  namespace: {{ .Release.Namespace }}
-  annotations:
-    argocd.argoproj.io/sync-wave: {{ $wave }}
-data:
-  control-plane.json: {{ (dict "egress" $eg) | toJson | quote }}
 {{- if .Values.agents.enabled }}
 ---
 {{- /* ── agent.json + review-system.md (agents namespace) ───────────────────── */}}

--- a/charts/lightbridge-code-intelligence/values.yaml
+++ b/charts/lightbridge-code-intelligence/values.yaml
@@ -235,19 +235,6 @@ config:
     labelFindings: needs-review  # ≥1 finding of any severity
     labelError: bug        # ≥1 error-severity finding
 
-  # Egress routing (RFC-0005 Phase A / ADR-0074). Which path delivers `github_outbox` intents to the
-  # forge. `drain` (default) keeps the reconciler outbox drain (ADR-0059) as the sole egress path — no
-  # behavior change, the pilot is inert. Flip to `restate` in ai-helm-values to route egress through the
-  # PlatformEgress virtual object (per-`platform:installation` exclusivity makes the single-writer
-  # invariant STRUCTURAL). Rendered into control-plane.json for the producers (serve/dispatcher) AND into
-  # a dedicated egress-only ConfigMap for the reconciler (so it disables its drain in restate mode).
-  #   mode:              drain | restate
-  #   restateIngressUrl: the Restate server INGRESS (:8080). REQUIRED in restate mode unless the
-  #                      RESTATE_INGRESS_URL env is set on the producers; ignored in drain mode.
-  egress:
-    mode: drain
-    restateIngressUrl: ""
-
   # External-knowledge MCP servers (lightbridge-ci ADR-0066): already-running REMOTE HTTP MCP servers
   # the control plane discovers tools from + proxies calls to. Declare the servers here; each entry is
   # {name, url} (url must be http(s)://). The per-tier tool SELECTION (which discovered tools each tier
@@ -758,12 +745,6 @@ lci:
             CONTROL_PLANE_ROLE: "reconciler"
             RUST_LOG: "info"
             METRICS_ADDR: "0.0.0.0:9090"
-            # File config (ADR-0021): the reconciler reads an egress-ONLY control-plane.json (the
-            # <release>-reconciler-config ConfigMap, mounted below) so it can see egress.mode and turn
-            # its outbox drain OFF when the RFC-0005 pilot is active (egress.mode=restate). Egress-only
-            # on purpose — it must NOT read the `review` block or it would start applying outcome labels
-            # it doesn't today. Absent/drain → the drain stays on (no behavior change).
-            CONTROL_PLANE_CONFIG: "/etc/lightbridge/control-plane.json"
             # Optional cadence knobs; absent → run_reconciler defaults (300s interval / 14-day window).
             # DATABASE_URL `value` (cluster host/namespace/db) → ai-helm-values; `dependsOn` stays here.
             DB_PASSWORD:
@@ -776,108 +757,6 @@ lci:
               value: ""
             # The reconciler mints installation tokens (for GitHub egress + reading reactions), so it
             # needs the GitHub App key (the dispatcher does not). Same secret the control-plane uses.
-            GITHUB_APP_ID:
-              valueFrom:
-                secretKeyRef:
-                  name: '{{ .Release.Name }}-github'
-                  key: app-id
-            GITHUB_APP_PRIVATE_KEY:
-              valueFrom:
-                secretKeyRef:
-                  name: '{{ .Release.Name }}-github'
-                  key: app-private-key
-          probes:
-            liveness:
-              enabled: true
-              custom: true
-              spec:
-                httpGet:
-                  path: /healthz
-                  port: 9090
-                initialDelaySeconds: 5
-                periodSeconds: 15
-            readiness:
-              enabled: true
-              custom: true
-              spec:
-                httpGet:
-                  path: /healthz
-                  port: 9090
-                initialDelaySeconds: 5
-                periodSeconds: 10
-            startup:
-              enabled: false
-          resources:
-            requests: { cpu: 50m, memory: 64Mi }
-            limits: { cpu: 500m, memory: 256Mi }
-          securityContext:
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            runAsUser: 1000
-            capabilities:
-              drop: [ALL]
-
-    # ── restate-worker (RFC-0005 / ADR-0074) ──────────────────────────────────────────────────────
-    # The SAME control-plane image in the `restate-worker` role: it serves the Restate SDK endpoint
-    # (plain h2c on :9080) that the Restate server (StatefulSet `restate`, ns converse) discovers and
-    # invokes, plus the metrics-only listener on :9090 like the other headless roles. It serves the
-    # `PlatformEgress` virtual object — the RFC-0005 Phase-A egress pilot — whose per-key exclusivity
-    # makes ADR-0059's single-writer-per-installation egress invariant STRUCTURAL (no more replicas=1
-    # comment). Serving PlatformEgress needs a DB pool + a platform impl (the GitHub App key); absent
-    # either it degrades to Health-only.
-    #
-    # ⚠️ DEPLOYED-BUT-IDLE by design: egress.mode stays `drain` (the reconciler drain remains the sole
-    # egress path), so the object is registered/served but NEVER invoked until the pilot is activated.
-    # Two operator steps gate activation (NOT this chart): (1) register the endpoint with the Restate
-    # server — `restate deployments register
-    # http://lightbridge-ci-restate-worker.converse.svc.cluster.local:9080` (or via the operator);
-    # (2) flip egress.mode=restate on the producer. The idle worker is safe and changes nothing until
-    # then. `enabled: false` here → inert on chart defaults; ai-helm-values enables it and supplies the
-    # image tag + DATABASE_URL + RESTATE_INGRESS_URL per-env.
-    restate-worker:
-      enabled: false
-      type: deployment
-      # RollingUpdate: the worker is stateless (durable state lives in the Restate server + Postgres),
-      # so a brief old+new overlap on rollout is safe.
-      strategy: RollingUpdate
-      replicas: 1
-      annotations:
-        argocd.argoproj.io/sync-wave: "2"
-      containers:
-        main:
-          image:
-            repository: ghcr.io/vymalo/lightbridge-control-plane
-            # Default/fallback; the deployed tag is overridden at sync time by ai-helm-values via the
-            # image-updater `rw` alias (charts/apps/values.yaml), in lockstep with control-plane.
-            tag: "0.1.0"
-            pullPolicy: IfNotPresent
-          env:
-            CONTROL_PLANE_ROLE: "restate-worker"
-            RUST_LOG: "info"
-            # Metrics-only listener (like dispatcher/reconciler) — /metrics + /healthz on :9090.
-            METRICS_ADDR: "0.0.0.0:9090"
-            # The Restate SDK endpoint (h2c). The Restate server connects here to discover + invoke;
-            # 9080 is the SDK's conventional port. The restate-worker Service (below) exposes it.
-            RESTATE_WORKER_BIND: "0.0.0.0:9080"
-            # Where the Restate server's INGRESS is (the producer submits invocations here once the
-            # egress pilot is activated). Points at the Restate server Service in converse. Consumed by
-            # the egress path in `restate` mode only; harmless while egress.mode stays `drain`.
-            # DEPLOYMENT-SPECIFIC → ai-helm-values; empty here.
-            RESTATE_INGRESS_URL: ""
-            # Same CNPG queue the serve/dispatcher/reconciler roles use. DATABASE_URL `value` (cluster
-            # host/namespace/db) → ai-helm-values; `dependsOn` stays here.
-            DB_PASSWORD:
-              valueFrom:
-                secretKeyRef:
-                  name: lightbridge-codeintel-db-role
-                  key: password
-            DATABASE_URL:
-              dependsOn: DB_PASSWORD
-              value: ""
-            # A platform impl (GitHub App key) is required to SERVE PlatformEgress (it posts intents);
-            # the same secret the control-plane + reconciler use. Absent it the role degrades to
-            # Health-only. Single replica + `drain` mode preserve the ADR-0002/0059 egress-credential
-            # posture until the pilot flip.
             GITHUB_APP_ID:
               valueFrom:
                 secretKeyRef:
@@ -1149,15 +1028,6 @@ lci:
       ports:
         metrics:
           port: 9090
-    # SDK-endpoint Service for the restate-worker role (h2c :9080). The Restate server (ns converse)
-    # reaches the worker here to discover + invoke its services once the endpoint is registered.
-    # `enabled` tracks the controller (both flipped on in ai-helm-values).
-    restate-worker:
-      enabled: false
-      controller: restate-worker
-      ports:
-        http:
-          port: 9080
     # A2A HTTP surface Service (:8080) — the Ingress routes to it. `enabled` tracks the controller.
     a2a:
       enabled: false
@@ -1270,20 +1140,21 @@ lci:
   # (see `statefulset.volumeClaimTemplates` above); neo4j runs with a writable rootfs so it
   # needs no scratch emptyDirs. advancedMounts scope each volume to one container.
   # ── config-rollout: force the config-reading roles to restart on a read-once-at-boot config flip ──────
-  # The control plane reads FILE config (control-plane.json — egress.mode, dispatcher tuning, review knobs)
-  # ONCE at startup; it is deploy-scoped, NOT live-reloadable. But the real config lives in STANDALONE
-  # ConfigMaps rendered by templates/config.yaml, and editing a ConfigMap's *content* does NOT roll the
-  # pods that mount it — so a config flip (notably egress.mode drain↔restate) would silently no-op until
-  # the role happens to restart for another reason (next image deploy). That is a foot-gun: e.g. flipping
-  # egress.mode=restate while the reconciler keeps running the old `drain` config → double-posts.
+  # The control plane reads FILE config (control-plane.json — dispatcher tuning, review knobs) ONCE at
+  # startup; it is deploy-scoped, NOT live-reloadable. But the real config lives in STANDALONE ConfigMaps
+  # rendered by templates/config.yaml, and editing a ConfigMap's *content* does NOT roll the pods that
+  # mount it — so a config flip would silently no-op until the role happens to restart for another reason
+  # (next image deploy). That is a foot-gun: e.g. changing a dispatcher/review knob while the pods keep
+  # running the old config.
   #
   # bjw-s can only auto-checksum ConfigMaps IT manages (this `configMaps` block), and its tpl runs in the
   # subchart context — it cannot see the top-level `config.*` values that drive the standalone ConfigMaps,
   # so it cannot content-hash them directly. Instead this is a tiny UNMOUNTED marker ConfigMap: listing it
   # in `includeChecksumInControllers` makes bjw-s stamp a `checksum/configMaps` annotation on those roles'
   # pods. **Bump `data.generation` in ai-helm-values in the SAME change as any read-once config flip** and
-  # all three config-reading roles roll together to pick it up. (Introducing the annotation also rolls them
-  # once on first deploy — brief RollingUpdate egress overlap, the same trade-off the roles already accept.)
+  # both config-reading roles roll together to pick it up. (Introducing the annotation also rolls them once
+  # on first deploy — a brief RollingUpdate overlap, the same trade-off the roles already accept.) The
+  # reconciler is intentionally NOT listed: it mounts no file config (ADR-0059 drain is unconditional).
   configMaps:
     config-rollout:
       enabled: true
@@ -1294,7 +1165,6 @@ lci:
       includeChecksumInControllers:
         - control-plane
         - dispatcher
-        - reconciler
       data:
         generation: "1"
 
@@ -1310,17 +1180,6 @@ lci:
             - path: /etc/lightbridge
               readOnly: true
         dispatcher:
-          main:
-            - path: /etc/lightbridge
-              readOnly: true
-    # Egress-only control-plane.json for the reconciler (RFC-0005 Phase A / ADR-0074). Separate from the
-    # producers' ConfigMap above so the reconciler sees `egress` (to disable its drain in restate mode)
-    # but NOT the `review` block (which would make it start applying outcome labels — see config.yaml).
-    reconciler-config:
-      type: configMap
-      name: lightbridge-ci-reconciler-config
-      advancedMounts:
-        reconciler:
           main:
             - path: /etc/lightbridge
               readOnly: true


### PR DESCRIPTION
## 1. Summary

This PR changes:

- `charts/lightbridge-code-intelligence`: removes the `restate-worker` controller, its Service, and the `config.egress` schema; stops rendering `egress` into `control-plane.json` and deletes the reconciler egress-only ConfigMap (`templates/config.yaml`); drops the reconciler from the config-rollout checksum list.
- `charts/apps`: removes the `restate` durable-execution server Application (tears down the StatefulSet) and the `rw` (restate-worker) argocd-image-updater alias.

It solves:

- **ADR-0093** (Restate egress pilot no-go). Final repo of a 3-repo teardown: code = [lightbridge-code-intelligence#436](https://github.com/vymalo/lightbridge-code-intelligence/pull/436) (merged), prod values = [ai-helm-values#94](https://github.com/ADORSYS-GIS/ai-helm-values/pull/94) (merged), chart = this PR.

---

## 2. Intent

The intent of this PR is:

> The Restate `PlatformEgress` egress pilot (ADR-0074) was a no-go (ADR-0093) and the control-plane binary no longer has an egress config surface or a `restate-worker` role (#436). This chart still defined that controller, the `egress` config schema, a reconciler egress-only ConfigMap, and (via `charts/apps`) the Restate **server** StatefulSet — all now dead weight. Remove them so the reconciler `outbox` drain (ADR-0059) is the sole, unconditional egress and the Restate server is torn down.

---

## 3. Scope

### In Scope

- `restate-worker` controller + Service removal.
- `config.egress` schema + its rendering into `control-plane.json` + the reconciler egress-only ConfigMap.
- Reconciler reverts to mounting no file config (drops the `reconciler-config` volume/mount, `CONTROL_PLANE_CONFIG` env, and config-rollout checksum entry) — its pre-pilot state.
- `restate` server Application + `rw` image alias in `charts/apps`.

### Out of Scope

- The control-plane image already dropped the egress code (#436); the binary's config tombstone absorbs any residual `egress:` block, so ordering between this PR and the image roll is safe.
- Non-Restate egress (the reconciler's GitHub egress, Cilium NetworkPolicies) — untouched.

---

## 4. Verification

I verified this change by:

- [x] Running automated tests (`helm lint`)
- [x] Running manual tests (`helm template` before/after diff)
- [x] Reviewing the diff
- [x] Testing rollback/failure behavior (behavior-neutrality proven by render diff)

Commands run:

```bash
$ helm lint charts/lightbridge-code-intelligence   # 0 failed
$ helm lint charts/apps                            # 0 failed
$ helm template lci charts/lightbridge-code-intelligence   # before vs after
$ helm template apps charts/apps                           # before vs after
```

Results:

```text
helm lint: 1 chart(s) linted, 0 chart(s) failed (both charts; only the pre-existing "icon recommended" info)

lci render diff (921 → 898 lines) — the ONLY changes:
  - "egress":{"mode":"drain"} removed from the producer control-plane.json
  - lci-reconciler-config ConfigMap removed
  - reconciler Deployment: checksum/configMaps annotation, CONTROL_PLANE_CONFIG env,
    and reconciler-config volume+mount removed
  - control-plane Service unchanged (only reordered in the document stream)
  - 0 egress/restate/reconciler-config refs remain in the rendered output; reconciler still renders

apps render diff (1027 → 977 lines):
  - restatedev/restate-helm server Application removed (baseline had 1, now 0)
  - rw.* image-updater annotations removed (baseline 9, now 0)
```

The reconciler will do a one-time RollingUpdate when this deploys (pod template lost the config mount/env) — benign, and it rolls for the #436 image anyway.

---

## 5. Screenshots / Evidence

* Render diffs summarized above; every non-Restate resource is byte-identical between baseline and new.
* Chart versions are left to release-please (conventional `feat!:`), not hand-bumped.

---

## 6. Risk Assessment

Risk level:

* [ ] Low
* [x] Medium
* [ ] High

Potential risks:

* The reconciler is the sole GitHub egress; a mistake in dropping its config mount could crash-loop it.
* Removing the `restate` server Application prunes the StatefulSet on sync.

Mitigation:

* The `helm template` diff proves the reconciler Deployment still renders and only loses the egress-only config it never functionally needed (drain is unconditional post-#436; it always ran on `ReviewSection::default()`).
* File config is optional (ADR-0021) — the reconciler runs fine with no `CONTROL_PLANE_CONFIG`.
* Restate server teardown is the intended end state (nothing invokes it in drain mode).

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Refactoring
* [x] Reviewing the diff

Human verification:

* [ ] I understand every meaningful change in this PR
* [ ] I checked generated code manually
* [ ] I accept responsibility for this PR

AI (Claude) authored the change and ran the `helm lint` + before/after `helm template` diffs above; a human owns intent, review, and merge. Behavior-neutrality is proven by the render diff, not asserted.

---

## 8. Reviewer Focus

Please focus your review on:

* [x] Correctness (reconciler still renders + functions without the egress-only config)
* [x] Architecture (role/Application/config-surface removal)
* [x] Edge cases (StatefulSet prune, deploy ordering vs the #436 image)
