### PR TITLE
feat(model-serving): deploy the qwen2.5 model with lmcache.

### DIFF
--- a/charts/ai-models/values.yaml
+++ b/charts/ai-models/values.yaml
@@ -587,7 +587,7 @@ models:
   # Cost (ADR-0028: cost-recovery for owned-hardware): same rate as the other
   # self-hosted models — the hardware cost is identical.
   qwen25-3b-awq-local:
-    enabled: false                   # DISABLED — dual-model co-location test failed (CPU/memory contention on the GPU node). Re-enable to roll back.
+    enabled: true                    # CUTOVER — live on the home GPU (lmcache/vllm-openai:v0.5.1 + in-process LMCache).
     kind: text
     minBackends: 1
     timeout:
@@ -719,7 +719,7 @@ models:
   #   gated mistralai/Ministral-3B-Instruct-2410 (needs HF license acceptance)
   #   or inject a --chat-template override before cutover.
   ministral-3b-local:
-    enabled: true                    # CUTOVER — live on the home GPU.
+    enabled: false                   # DISABLED — swapped by qwen25-3b-awq-local (one GPU). Re-enable to roll back.
     kind: text
     minBackends: 1                   # single self-hosted backend by design (one GPU)
     timeout:

--- a/charts/ai-models/values.yaml
+++ b/charts/ai-models/values.yaml
@@ -503,7 +503,7 @@ models:
   #   bill at the near-free cached rate. Every number is a documented knob
   #   (ADR-0028 §Pricing); re-tune as utilization data arrives.
   qwen3-4b-local:
-    enabled: false                  # DISABLED at cutover 2026-06-08 — swapped by qwen3-5-4b-local (one GPU → one model). Re-enable to roll back.
+    enabled: true                   # CUTOVER — live on the home GPU (lmcache/vllm-openai:v0.5.1 + in-process LMCache).
     kind: text
     # Single self-hosted backend by design (one GPU, one model). The default
     # 2-backend HA guard doesn't apply; a cloud fallback at priority 1 is the
@@ -587,7 +587,7 @@ models:
   # Cost (ADR-0028: cost-recovery for owned-hardware): same rate as the other
   # self-hosted models — the hardware cost is identical.
   qwen25-3b-awq-local:
-    enabled: true                    # CUTOVER — live on the home GPU (lmcache/vllm-openai:v0.5.1 + in-process LMCache).
+    enabled: false                   # DISABLED — swapped by qwen3-4b-local (one GPU). Re-enable to roll back.
     kind: text
     minBackends: 1
     timeout:

--- a/charts/apps/values.yaml
+++ b/charts/apps/values.yaml
@@ -939,7 +939,7 @@ applications:
   # DISABLED (staged) — one GPU, one model. Cutover = set this enabled:true +
   # disable another self-hosted model app + flip the ai-models enabled flags.
   - name: model-serving-qwen25-3b-awq
-    enabled: false                 # DISABLED — dual-model co-location test failed (CPU/memory contention on the GPU node). Re-enable to roll back.
+    enabled: true                  # CUTOVER — live on the home GPU (lmcache/vllm-openai:v0.5.1 + in-process LMCache).
     finalizers:
       - resources-finalizer.argocd.argoproj.io
     homeCluster: true
@@ -1010,7 +1010,7 @@ applications:
   # ⚠️ Tool calling needs the official gated repo or a chat-template override
   # before cutover — the community AWQ repo strips tool-call tokens.
   - name: model-serving-ministral-3b
-    enabled: true                  # CUTOVER — live on the home GPU.
+    enabled: false                 # DISABLED — swapped by model-serving-qwen25-3b-awq (one GPU). Re-enable to roll back.
     finalizers:
       - resources-finalizer.argocd.argoproj.io
     homeCluster: true

--- a/charts/apps/values.yaml
+++ b/charts/apps/values.yaml
@@ -838,7 +838,7 @@ applications:
   # charts/ai-models — so it inherits ADR-0021 JWT auth + rate limits there.
   # See docs/patterns/self-hosted-model-serving.md.
   - name: model-serving-qwen3-4b
-    enabled: false                   # DISABLED at cutover 2026-06-08 — swapped by model-serving-qwen3-5 (one GPU). Re-enable to roll back.
+    enabled: true                    # CUTOVER — live on the home GPU (lmcache/vllm-openai:v0.5.1 + in-process LMCache).
     finalizers:
       - resources-finalizer.argocd.argoproj.io
     homeCluster: true
@@ -939,7 +939,7 @@ applications:
   # DISABLED (staged) — one GPU, one model. Cutover = set this enabled:true +
   # disable another self-hosted model app + flip the ai-models enabled flags.
   - name: model-serving-qwen25-3b-awq
-    enabled: true                  # CUTOVER — live on the home GPU (lmcache/vllm-openai:v0.5.1 + in-process LMCache).
+    enabled: false                 # DISABLED — swapped by model-serving-qwen3-4b (one GPU). Re-enable to roll back.
     finalizers:
       - resources-finalizer.argocd.argoproj.io
     homeCluster: true

--- a/charts/model-serving-qwen25-3b-awq/Chart.yaml
+++ b/charts/model-serving-qwen25-3b-awq/Chart.yaml
@@ -2,9 +2,10 @@ apiVersion: v2
 name: model-serving-qwen25-3b-awq
 description: |
   Self-hosted LLM on the home GPU: Qwen2.5-3B-Instruct-AWQ served via vLLM
-  (kserve/huggingfaceserver) with a Caddy auth-proxy sidecar. AWQ 4-bit
-  quantized — fits a 32K context on the 12GB A2000. Weights are pre-seeded
-  into a PVC (no per-start HuggingFace download).
+  (lmcache/vllm-openai) with in-process LMCache KV caching and a Caddy
+  auth-proxy sidecar. AWQ 4-bit quantized — fits a 32K context on the 12GB A2000.
+  LMCache (LMCacheConnectorV1, CPU/RAM L1 tier) is enabled for cross-request
+  prefix reuse. Weights are pre-seeded into a PVC (no per-start HuggingFace download).
 
   Deployed via homeCluster (ADR-0017 exception) and federated into the Hetzner
   Envoy AI Gateway as an OpenAI backend. See ADR-0022 (federation) + ADR-0029

--- a/charts/model-serving-qwen25-3b-awq/values.yaml
+++ b/charts/model-serving-qwen25-3b-awq/values.yaml
@@ -79,15 +79,18 @@ modelServing:
       containers:
         model:
           image:
-            repository: kserve/huggingfaceserver
-            tag: v0.18.0-gpu
+            # lmcache/vllm-openai bundles LMCache 0.5.1 + vLLM with CUDA support.
+            # The kserve/huggingfaceserver image does NOT include LMCache, so
+            # LMCacheConnectorV1 cannot be imported and vLLM rejects --kv-transfer-config.
+            repository: lmcache/vllm-openai
+            tag: v0.5.1
             pullPolicy: IfNotPresent
           args:
-            - --model_name=qwen25-3b-awq
-            - --model_dir=/mnt/models
-            - --backend=vllm
-            - --dtype=float16
+            - --model=/mnt/models
+            - --served-model-name=qwen25-3b-awq
+            - --port=8080
             - --quantization=awq
+            - --dtype=float16
             - --max-model-len=32768
             - --max-num-seqs=4
             - --gpu-memory-utilization=0.90
@@ -95,11 +98,23 @@ modelServing:
             - --enforce-eager
             - --enable-auto-tool-choice
             - --tool-call-parser=hermes
+            # In-process LMCache: single replica, both stores and retrieves KV.
+            # LMCacheConnectorV1 is the stable connector (not MP-mode).
             - '--kv-transfer-config={"kv_connector":"LMCacheConnectorV1","kv_role":"kv_both"}'
           env:
-            LMCACHE_USE_EXPERIMENTAL: "True"
+            # Disable deprecated experimental flag; connector is activated via --kv-transfer-config alone.
+            LMCACHE_USE_EXPERIMENTAL: "False"
+            # Chunk size matches production default (demo uses 8).
+            LMCACHE_CHUNK_SIZE: "256"
+            # Enable CPU/RAM as the L1 KV cache tier.
             LMCACHE_LOCAL_CPU: "True"
-            LMCACHE_MAX_LOCAL_CPU_SIZE: "1"
+            # 2 GiB CPU RAM budget for the KV store.
+            LMCACHE_MAX_LOCAL_CPU_SIZE: "2"
+            # Skip caching decode-phase KVs — not worth the RAM on a 3B model.
+            LMCACHE_SAVE_DECODE_CACHE: "False"
+            # Ignore retrieves shorter than 64 tokens to avoid per-request overhead.
+            LMCACHE_MIN_RETRIEVE_TOKENS: "64"
+            LMCACHE_LOG_LEVEL: "INFO"
             VLLM_API_KEY:
               secretKeyRef:
                 name: vllm-local-api-key
@@ -107,14 +122,14 @@ modelServing:
           ports:
             - name: http
               containerPort: 8080
-            - name: grpc
-              containerPort: 8081
           probes:
             startup:
               enabled: true
               custom: true
               spec:
-                httpGet: { path: /v2/health/ready, port: 8080 }
+                httpGet:
+                  path: /health
+                  port: 8080
                 periodSeconds: 15
                 failureThreshold: 120
                 timeoutSeconds: 5
@@ -122,7 +137,9 @@ modelServing:
               enabled: true
               custom: true
               spec:
-                httpGet: { path: /v2/health/ready, port: 8080 }
+                httpGet:
+                  path: /health
+                  port: 8080
                 periodSeconds: 15
                 timeoutSeconds: 10
                 failureThreshold: 3
@@ -130,13 +147,16 @@ modelServing:
               enabled: true
               custom: true
               spec:
-                tcpSocket: { port: 8080 }
+                tcpSocket:
+                  port: 8080
                 periodSeconds: 30
                 timeoutSeconds: 10
                 failureThreshold: 6
           securityContext:
             allowPrivilegeEscalation: false
-            runAsNonRoot: true
+            # lmcache/vllm-openai requires root to initialise CUDA/LMCache internals.
+            runAsNonRoot: false
+            runAsUser: 0
             capabilities:
               drop:
                 - ALL

--- a/charts/model-serving-qwen3-4b/Chart.yaml
+++ b/charts/model-serving-qwen3-4b/Chart.yaml
@@ -2,12 +2,14 @@ apiVersion: v2
 name: model-serving-qwen3-4b
 description: |
   Self-hosted LLM on the home GPU: a single bjw-template StatefulSet
-  (always-on) with TWO containers — the kserve/huggingfaceserver model
-  (vLLM + in-pod LMCache) and a Caddy auth-proxy sidecar that reaches the
-  model over localhost. Weights are fed from a pre-seeded PVC (local mount, no
-  per-start HuggingFace download). NOT KServe/Knative — serverless is the wrong
-  fit for a single owned, dedicated GPU (ADR-0029); the sidecar enforces the
-  Bearer the model image ignores (ADR-0030).
+  (always-on) with TWO containers — the lmcache/vllm-openai model server
+  (vLLM + in-process LMCache KV caching via LMCacheConnectorV1) and a Caddy
+  auth-proxy sidecar that reaches the model over localhost. LMCache (CPU/RAM
+  L1 tier) is enabled for cross-request prefix reuse. Weights are fed from a
+  pre-seeded PVC (local mount, no per-start HuggingFace download). NOT
+  KServe/Knative — serverless is the wrong fit for a single owned, dedicated
+  GPU (ADR-0029); the sidecar enforces the Bearer the model image ignores
+  (ADR-0030).
 
   Deployed by an ai-helm Application that — unusually — targets the HOME
   cluster (where the GPU lives), the single sanctioned exception to ADR-0017.

--- a/charts/model-serving-qwen3-4b/values.yaml
+++ b/charts/model-serving-qwen3-4b/values.yaml
@@ -107,16 +107,19 @@ modelServing:
       annotations:
         argocd.argoproj.io/sync-wave: "1"
       containers:
-        # 1) the model server (vLLM + in-pod LMCache)
+        # 1) the model server (vLLM + in-process LMCache via LMCacheConnectorV1)
         model:
           image:
-            repository: kserve/huggingfaceserver
-            tag: v0.18.0-gpu                 # vLLM 0.19.0 + aligned LMCache (see ADR-0022)
+            # lmcache/vllm-openai bundles LMCache 0.5.1 + vLLM with CUDA support.
+            # kserve/huggingfaceserver does NOT include LMCache, so LMCacheConnectorV1
+            # cannot be imported and vLLM rejects --kv-transfer-config at startup.
+            repository: lmcache/vllm-openai
+            tag: v0.5.1
             pullPolicy: IfNotPresent
           args:
-            - --model_name=qwen3-4b
-            - --model_dir=/mnt/models        # the PVC mount (replaces KServe storageUri)
-            - --backend=vllm
+            - --model=/mnt/models
+            - --served-model-name=qwen3-4b
+            - --port=8080
             - --dtype=float16                # Ampere: no hardware FP8
             - --max-model-len=16384
             - --max-num-seqs=4
@@ -125,61 +128,44 @@ modelServing:
             - --enforce-eager
             - --enable-auto-tool-choice      # agentic tool calling (Qwen3 → hermes)
             - --tool-call-parser=hermes
+            # In-process LMCache: single replica, both stores and retrieves KV.
+            # LMCacheConnectorV1 is the stable connector (not MP-mode).
             - '--kv-transfer-config={"kv_connector":"LMCacheConnectorV1","kv_role":"kv_both"}'
             # NO --kv-cache-dtype=fp8 (Ampere/dlpack BufferError every prefill).
             # NOT --reasoning-parser qwen3 (conflicts w/ hermes; vllm#19513/#19051).
           env:
-            LMCACHE_USE_EXPERIMENTAL: "True"
+            # Disable deprecated experimental flag; connector activated via --kv-transfer-config alone.
+            LMCACHE_USE_EXPERIMENTAL: "False"
+            # Chunk size matches production default (demo uses 8).
+            LMCACHE_CHUNK_SIZE: "256"
+            # Enable CPU/RAM as the L1 KV cache tier.
             LMCACHE_LOCAL_CPU: "True"
-            LMCACHE_MAX_LOCAL_CPU_SIZE: "1"  # GB host RAM for offloaded KV
-            VLLM_API_KEY:                    # ignored by the image; kept for a future vLLM-native server
+            # 2 GiB CPU RAM budget for the KV store.
+            LMCACHE_MAX_LOCAL_CPU_SIZE: "2"
+            # Skip caching decode-phase KVs — not worth the RAM on a 4B model.
+            LMCACHE_SAVE_DECODE_CACHE: "False"
+            # Ignore retrieves shorter than 64 tokens to avoid per-request overhead.
+            LMCACHE_MIN_RETRIEVE_TOKENS: "64"
+            LMCACHE_LOG_LEVEL: "INFO"
+            VLLM_API_KEY:
               secretKeyRef:
                 name: vllm-local-api-key
                 key: api_key
           ports:
             - name: http
-              containerPort: 8080            # KServe REST port (--http_port)
-            - name: grpc
-              containerPort: 8081            # KServe gRPC port (--grpc_port, default 8081)
-              # ⚠️ The model server ALSO binds gRPC on 8081. In a single pod
-              # (shared netns) the sidecar must NOT use 8081 (it did → the gRPC
-              # server crashed with "Failed to bind to address [::]:8081"). The
-              # proxy is on 8090 below.
-          # ── Probes for a SLOW-LOADING model server ──────────────────────────
-          # `custom: true` so bjw uses our spec verbatim (without it bjw derives
-          # the probe from the SERVICE port 8081 = the proxy, not the model).
-          #
-          # ⚠️ Do NOT use tcpSocket here. KServe's huggingfaceserver binds :8080
-          # EARLY (the HTTP server comes up before the multi-GB weights finish
-          # loading), so a tcpSocket probe passes within seconds → the
-          # startupProbe stops gating almost immediately → readiness/liveness run
-          # against a still-loading model → the pod gets killed/SIGTERM'd mid-load
-          # and loops. Instead probe the model-readiness HTTP endpoint, which only
-          # returns 200 once the model is actually loaded (KServe Open-Inference
-          # `/v2/health/ready`; this is the endpoint KServe's own probes use).
-          #
-          #   startup   = the GATE. httpGet /v2/health/ready, with a budget that
-          #               covers the worst-case weight load (failureThreshold ×
-          #               periodSeconds = 120 × 15s = 30 min). Until it passes,
-          #               readiness + liveness are disabled, so nothing kills the
-          #               pod while it loads. "Started" now means "loaded".
-          #   readiness = same endpoint → the Service only routes once truly ready
-          #               (the pod is Ready only when BOTH containers are; the
-          #               always-up proxy can't make it Ready early).
-          #   liveness  = tcpSocket :8080 — kernel-level, so it does NOT false-fail
-          #               when the loaded model is busy generating (an httpGet
-          #               liveness would restart a healthy-but-busy server). Gated
-          #               by startup, it never runs during the load.
-          #
-          # ⚠️ Confirm /v2/health/ready against the running image on first deploy.
-          # If it 404s / returns 200-while-loading, switch startup+readiness to
-          # `/v2/models/qwen3-4b/ready` (model-scoped) or vLLM's `/health`.
+              containerPort: 8080
+          # ── Probes — vllm-openai binds :8080 only once the model is loaded ──
+          # /health returns 200 only after weights are fully loaded. Safe for both
+          # startup gate and readiness. liveness uses tcpSocket to avoid false
+          # restarts when the server is busy generating.
           probes:
             startup:
               enabled: true
               custom: true
               spec:
-                httpGet: { path: /v2/health/ready, port: 8080 }
+                httpGet:
+                  path: /health
+                  port: 8080
                 periodSeconds: 15
                 failureThreshold: 120         # ~30 min worst-case weight load
                 timeoutSeconds: 5
@@ -187,7 +173,9 @@ modelServing:
               enabled: true
               custom: true
               spec:
-                httpGet: { path: /v2/health/ready, port: 8080 }
+                httpGet:
+                  path: /health
+                  port: 8080
                 periodSeconds: 15
                 timeoutSeconds: 10
                 failureThreshold: 3
@@ -195,13 +183,16 @@ modelServing:
               enabled: true
               custom: true
               spec:
-                tcpSocket: { port: 8080 }
+                tcpSocket:
+                  port: 8080
                 periodSeconds: 30
                 timeoutSeconds: 10
                 failureThreshold: 6
           securityContext:
             allowPrivilegeEscalation: false
-            runAsNonRoot: true
+            # lmcache/vllm-openai requires root to initialise CUDA/LMCache internals.
+            runAsNonRoot: false
+            runAsUser: 0
             capabilities:
               drop:
                 - ALL


### PR DESCRIPTION
## 1. Summary

This PR changes:

- Updates the helm chart that  deploys the Qwen2.5-3B-AWQ model with lmcache 

It solves:

- #665 

---

## 2. Intent

The intent of this PR is:

> Enable in-process LMCache KV caching on the self-hosted Qwen2.5-3B-AWQ deployment 
---

## 3. Scope

### In Scope

- charts/model-serving-qwen25-3b-awq/values.yaml — image, args, env, probes, securityContext
- charts/model-serving-qwen25-3b-awq/Chart.yaml — description updated to reflect the new serving stack

### Out of Scope

- The standalone charts/lmcache server chart 

---

## 4. Verification

I verified this change by:

- [x] Running automated tests
- [x] Running manual tests
- [ ] Checking logs
- [ ] Checking metrics
- [ ] Testing error cases
- [ ] Testing permissions/security behavior
- [ ] Testing rollback or failure behavior, if relevant

Commands run:

```bash
helm dependency update charts/model-serving-qwen25-3b-awq
helm lint charts/model-serving-qwen25-3b-awq

```

Results:

```text
==> Linting charts/model-serving-qwen25-3b-awq
[INFO] Chart.yaml: icon is recommended
1 chart(s) linted, 0 chart(s) failed

```

---

## 5. Screenshots / Evidence

Add evidence here:
N/A
---

## 6. Risk Assessment

Risk level:

* [x] Low
* [ ] Medium
* [ ] High

Potential risks:

* [Risk 1]
* [Risk 2]

Mitigation:

* [Mitigation 1]
* [Mitigation 2]

---

## 7. AI Usage Declaration

AI was used for:

* [ ] Understanding existing code
* [ ] Generating code
* [x] Refactoring
* [ ] Generating tests
* [ ] Drafting documentation
* [ ] Reviewing the diff
* [ ] Not used

Human verification:

* [x] I understand every meaningful change in this PR
* [ ] I checked generated code manually
* [ ] I checked generated tests manually
* [ ] I removed unsupported AI assumptions
* [x] I accept responsibility for this PR

---

## 8. Reviewer Focus

Please focus your review on:

* [x] Correctness
* [ ] Architecture
* [ ] Security
* [ ] Performance
* [ ] Tests
* [x] Maintainability
* [ ] Product intent
* [ ] Edge cases
