### PR TITLE
feat(librechat): add coder_mcp MCP server(OAuth2, streamable-http).

### DIFF
--- a/charts/librechat-app/values.yaml
+++ b/charts/librechat-app/values.yaml
@@ -75,6 +75,9 @@ librechatSecrets:
     librechat-mcp-github:
       client_id: { key: ai/camer/digital/prod/env, property: librechat_mcp_github_client_id }
       client_secret: { key: ai/camer/digital/prod/env, property: librechat_mcp_github_client_secret }
+    librechat-mcp-coder-credentials:
+      client_id: { key: ai/camer/digital/prod/env, property: librechat_mcp_coder_credentials_client_id }
+      client_secret: { key: ai/camer/digital/prod/env, property: librechat_mcp_coder_credentials_client_secret }
     librechat-websearch-config:
       serper_api_key: { key: ai/camer/digital/prod/env, property: librechat_websearch_config_serper_api_key }
       firecrawl_api_key: { key: ai/camer/digital/prod/env, property: librechat_websearch_config_firecrawl_api_key }
@@ -288,6 +291,15 @@ librechat:
             GITHUB_MCP_SECRET_ID:
               secretKeyRef:
                 name: librechat-mcp-github
+                key: client_secret
+
+            CODERS_MCP_CLIENT_ID:
+              secretKeyRef:
+                name: librechat-mcp-coder-credentials
+                key: client_id
+            CODERS_MCP_SECRET:
+              secretKeyRef:
+                name: librechat-mcp-coder-credentials
                 key: client_secret
 
             OPENID_CLIENT_ID:
@@ -720,7 +732,33 @@ config:
         redirect_uri: https://ai.camer.digital/api/mcp/lightbridge_self_service/oauth/callback
         scope: "email openid offline_access"
 
-    # coder_mcp REMOVED 2026-06-06 with the Coder workload (ADR-0027).
+    coder_mcp:
+      title: "Coder"
+      description: "Coder - Development environments in your cloud"
+      type: "streamable-http"
+      initTimeout: 150000
+      url: "https://coder.ai.camer.digital/api/experimental/mcp/http"
+      headers:
+        X-ACCOUNT-ID: 'LIBRECHAT'
+        X-PROJECT-ID: 'sso:{{ `{{` }}LIBRECHAT_USER_OPENIDID{{ `}}` }}'
+        X-USER-ID: '{{ `{{` }}LIBRECHAT_USER_ID{{ `}}` }}'
+        X-USER-EMAIL: '{{ `{{` }}LIBRECHAT_USER_EMAIL{{ `}}` }}'
+        X-USER-ROLE: '{{ `{{` }}LIBRECHAT_USER_ROLE{{ `}}` }}'
+        X-USER-NAME: '{{ `{{` }}LIBRECHAT_USER_NAME{{ `}}` }}'
+      iconPath: https://raw.githubusercontent.com/ADORSYS-GIS/ai-helm/main/assets/images/adorsys-icon-primary.jpg
+      requiresOAuth: true
+      serverInstructions: |
+        Provides development environment management capabilities:
+        - Create, start, stop, and delete workspaces
+        - List templates, users, and workspace resources
+        - Manage workspace builds and transitions
+      oauth:
+        authorization_url: https://coder.ai.camer.digital/oauth2/authorize
+        token_url: https://coder.ai.camer.digital/oauth2/tokens
+        client_id: ${CODERS_MCP_CLIENT_ID}
+        client_secret: ${CODERS_MCP_SECRET}
+        redirect_uri: https://ai.camer.digital/api/mcp/coder_mcp/oauth/callback
+        scope: "openid profile email"
 
   fileConfig:
     endpoints:


### PR DESCRIPTION
## 1. Summary

This PR changes:

- Re-adds the `coder_mcp` MCP server configuration (streamable-http, OAuth2) to LibreChat, previously removed with the Coder workload (ADR-0027).
- Adds a new `librechat-mcp-coder-credentials` secret reference for OAuth2 `client_id`/`client_secret`.
- Wires the coder credentials into the LibreChat deployment as `CODERS_MCP_CLIENT_ID` and `CODERS_MCP_SECRET` env vars.

It solves:

- #671 

---

## 2. Intent

The intent of this PR is:

> Re-integrate the Coder MCP server into LibreChat so users can manage development environments (workspaces, templates, builds) directly from chat, after it was removed alongside the Coder workload. The server uses streamable-http with OAuth2 and per-user identity headers propagated from LibreChat's authenticated session.

---

## 3. Scope

### In Scope

- `coder_mcp` MCP server block in `config.mcpServers` (OAuth2, streamable-http, headers).
- New `librechat-mcp-coder-credentials` secret entry.
- Deployment env injection of `CODERS_MCP_CLIENT_ID` / `CODERS_MCP_SECRET`.

### Out of Scope

- Coder workload/chart deployment itself (previously removed in ADR-0027).
- Other MCP servers (github, websearch, lightbridge_self_service).
---

## 4. Verification

I verified this change by:

- [ ] Running automated tests
- [x] Running manual tests
- [ ] Checking logs
- [ ] Checking metrics
- [ ] Testing error cases
- [ ] Testing permissions/security behavior
- [ ] Testing rollback or failure behavior, if relevant

Commands run:

```bash
helm lint charts/librechat-app
```

Results:

```text
==> Linting charts/librechat-app
[INFO] Chart.yaml: icon is recommended

1 chart(s) linted, 0 chart(s) failed
```

---

## 5. Screenshots / Evidence

Add evidence here:

* Screenshot: [link]
* Logs: [link]
* Metrics: [link]
* Recording: [link]

---

## 6. Risk Assessment

Risk level:

* [x] Low
* [ ] Medium
* [ ] High

Potential risks:

* OAuth2 client credentials must exist in ai/camer/digital/prod/env with the declared property names, otherwise auth fails silently.

Mitigation:

* Validate secret creation before deploy
---

## 7. AI Usage Declaration

AI was used for:

* [ ] Understanding existing code
* [x] Generating code
* [ ] Refactoring
* [ ] Generating tests
* [ ] Drafting documentation
* [ ] Reviewing the diff
* [ ] Not used

Human verification:

* [x] I understand every meaningful change in this PR
* [x] I checked generated code manually
* [ ] I checked generated tests manually
* [ ] I removed unsupported AI assumptions
* [x] I accept responsibility for this PR

---

## 8. Reviewer Focus

Please focus your review on:

* [x] Correctness
* [ ] Architecture
* [ ] Security
* [ ] Performance
* [ ] Tests
* [x] Maintainability
* [ ] Product intent
* [x] Edge cases
