### PR TITLE
fix(lmcache): downgrade lmcache/vllm-openai to v0.4.2

### DIFF
--- a/charts/model-serving-qwen25-3b-awq/values.yaml
+++ b/charts/model-serving-qwen25-3b-awq/values.yaml
@@ -79,11 +79,15 @@ modelServing:
       containers:
         model:
           image:
-            # lmcache/vllm-openai bundles LMCache 0.5.1 + vLLM with CUDA support.
+            # lmcache/vllm-openai bundles LMCache + vLLM with CUDA support.
+            #
+            # Pinned to v0.4.2: last default tag on CUDA 12.8 (driver 570.124.06).
+            # Tags v0.4.6+ flipped to CUDA 13.0 (driver 580+), too new for the home
+            # RTX A2000 570.x driver (reports 12080 = CUDA 12.8.0).
             # The kserve/huggingfaceserver image does NOT include LMCache, so
             # LMCacheConnectorV1 cannot be imported and vLLM rejects --kv-transfer-config.
             repository: lmcache/vllm-openai
-            tag: v0.5.1
+            tag: v0.4.2
             pullPolicy: IfNotPresent
           args:
             - --model=/mnt/models


### PR DESCRIPTION
## 1. Summary

This PR changes:

- downgrade the lmcache/vllm

It solves:

- #665 

---

## 2. Intent

The intent of this PR is:

>  fix the problems of cuda version compatibility with hardware

---

## 3. Scope

### In Scope

- [Included change 1]
- [Included change 2]

### Out of Scope

- [Excluded change 1]
- [Excluded change 2]

---

## 4. Verification

I verified this change by:
tests

- [ ] Running automated tests
- [ ] Running manual tests
- [ ] Checking logs
- [ ] Checking metrics
- [ ] Testing error cases
- [ ] Testing permissions/security behavior
- [ ] Testing rollback or failure behavior, if relevant

Commands run:

```bash
helm lint .
```

Results:

```text
success
```

---

## 5. Screenshots / Evidence

Add evidence here:
<img width="954" height="168" alt="image" src="https://github.com/user-attachments/assets/01f12568-55e6-4acf-8b10-6647d756d1ea" />


* Screenshot: [link]
* Logs: [link]
* Metrics: [link]
* Recording: [link]

---

## 6. Risk Assessment

Risk level:

* [x] Low
* [ ] Medium
* [ ] High

Potential risks:

* [Risk 1]
* [Risk 2]

Mitigation:

* [Mitigation 1]
* [Mitigation 2]

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [ ] Generating code
* [ ] Refactoring
* [ ] Generating tests
* [ ] Drafting documentation
* [ ] Reviewing the diff
* [ ] Not used

Human verification:

* [ ] I understand every meaningful change in this PR
* [ ] I checked generated code manually
* [ ] I checked generated tests manually
* [ ] I removed unsupported AI assumptions
* [ ] I accept responsibility for this PR

---

## 8. Reviewer Focus

Please focus your review on:

* [x] Correctness
* [ ] Architecture
* [ ] Security
* [ ] Performance
* [ ] Tests
* [ ] Maintainability
* [ ] Product intent
* [ ] Edge cases
