### PR TITLE
fix(observability-dashboards): drop model dimension from ratelimit quota board

### DIFF
--- a/charts/observability-dashboards/files/envoy-ai-gateway/ratelimit-quota.json
+++ b/charts/observability-dashboards/files/envoy-ai-gateway/ratelimit-quota.json
@@ -52,35 +52,6 @@
       },
       {
         "type": "query",
-        "name": "model",
-        "label": "Model",
-        "skipUrlSync": false,
-        "query": "label_values(gateway_ratelimit_spend_micro_usd, model)",
-        "datasource": {
-          "type": "prometheus",
-          "uid": "mimir"
-        },
-        "current": {
-          "text": [
-            "All"
-          ],
-          "value": [
-            "$__all"
-          ],
-          "selected": true
-        },
-        "multi": true,
-        "allowCustomValue": true,
-        "refresh": 2,
-        "sort": 1,
-        "includeAll": true,
-        "allValue": ".+",
-        "auto": false,
-        "auto_min": "10s",
-        "auto_count": 30
-      },
-      {
-        "type": "query",
         "name": "account",
         "label": "Account",
         "skipUrlSync": false,
@@ -113,7 +84,7 @@
   "annotations": {},
   "uid": "envoy-ai-gateway-ratelimit-quota",
   "title": "AI Gateway — rate-limit quota",
-  "description": "WHO is consuming the Envoy AI Gateway and HOW MUCH of their budget, read from the rate-limit service's LIVE counters in redis-ha (ADR-0070) — the only place that current-window state exists. Mimir panels rank spend per account/model for the selected 30-day budget window (prometheus-redis-exporter → gateway_ratelimit_spend_micro_usd, ÷1e6 → USD); the bottom table is a direct redis-datasource census (zero scrape-lag). RAW consumption only — budget limits are static Helm config (ADR-0021/0035), not derivable per-user here. $window defaults to the current bucket. Filters: plan, model, account. GENERATED — source: tools/dashboards/envoy_ai_gateway/ratelimit_quota.py.",
+  "description": "WHO is consuming the Envoy AI Gateway and HOW MUCH of their budget, read from the rate-limit service's LIVE counters in redis-ha (ADR-0070) — the only place that current-window state exists. Mimir panels rank spend per account/plan for the selected 30-day budget window (prometheus-redis-exporter → gateway_ratelimit_spend_micro_usd, ÷1e6 → USD); the bottom table is a direct redis-datasource census (zero scrape-lag). RAW consumption only — budget limits are static Helm config (ADR-0021/0035), not derivable per-user here. NO per-model breakdown: since the #532 shared-budget cutover the budget is one counter per (account, plan) spanning ALL models and both planes, so the keys carry no model label — see the Mimir/Loki cost dashboards for per-model spend. $window defaults to the current bucket. Filters: plan, account. GENERATED — source: tools/dashboards/envoy_ai_gateway/ratelimit_quota.py.",
   "tags": [
     "ai-gateway",
     "rate-limit",
@@ -147,7 +118,7 @@
       "type": "stat",
       "targets": [
         {
-          "expr": "((sum(gateway_ratelimit_spend_micro_usd{window=~\"$window\", plan=~\"$plan\", model=~\"$model\", account_id=~\"$account\"})) / 1e6)",
+          "expr": "((sum(gateway_ratelimit_spend_micro_usd{window=~\"$window\", plan=~\"$plan\", account_id=~\"$account\"})) / 1e6)",
           "refId": "A",
           "instant": true,
           "range": false,
@@ -208,7 +179,7 @@
       "type": "stat",
       "targets": [
         {
-          "expr": "count(count by (account_id) (gateway_ratelimit_spend_micro_usd{window=~\"$window\", plan=~\"$plan\", model=~\"$model\", account_id=~\"$account\"}))",
+          "expr": "count(count by (account_id) (gateway_ratelimit_spend_micro_usd{window=~\"$window\", plan=~\"$plan\", account_id=~\"$account\"}))",
           "refId": "A",
           "instant": true,
           "range": false,
@@ -269,7 +240,7 @@
       "type": "stat",
       "targets": [
         {
-          "expr": "count(gateway_ratelimit_spend_micro_usd{window=~\"$window\", plan=~\"$plan\", model=~\"$model\", account_id=~\"$account\"})",
+          "expr": "count(gateway_ratelimit_spend_micro_usd{window=~\"$window\", plan=~\"$plan\", account_id=~\"$account\"})",
           "refId": "A",
           "instant": true,
           "range": false,
@@ -280,7 +251,7 @@
           }
         }
       ],
-      "title": "Tracked counters (account x model)",
+      "title": "Tracked counters (account x plan)",
       "transparent": false,
       "datasource": {
         "type": "prometheus",
@@ -330,7 +301,7 @@
       "type": "stat",
       "targets": [
         {
-          "expr": "count(count by (model) (gateway_ratelimit_spend_micro_usd{window=~\"$window\", plan=~\"$plan\", model=~\"$model\", account_id=~\"$account\"}))",
+          "expr": "count(count by (plan) (gateway_ratelimit_spend_micro_usd{window=~\"$window\", plan=~\"$plan\", account_id=~\"$account\"}))",
           "refId": "A",
           "instant": true,
           "range": false,
@@ -341,7 +312,7 @@
           }
         }
       ],
-      "title": "Models in use",
+      "title": "Plans in use",
       "transparent": false,
       "datasource": {
         "type": "prometheus",
@@ -391,7 +362,7 @@
       "type": "bargauge",
       "targets": [
         {
-          "expr": "((topk(20, sum by (account_id) (gateway_ratelimit_spend_micro_usd{window=~\"$window\", plan=~\"$plan\", model=~\"$model\", account_id=~\"$account\"}))) / 1e6)",
+          "expr": "((topk(20, sum by (account_id) (gateway_ratelimit_spend_micro_usd{window=~\"$window\", plan=~\"$plan\", account_id=~\"$account\"}))) / 1e6)",
           "refId": "A",
           "instant": true,
           "range": false,
@@ -460,19 +431,19 @@
       "type": "piechart",
       "targets": [
         {
-          "expr": "((sum by (model) (gateway_ratelimit_spend_micro_usd{window=~\"$window\", plan=~\"$plan\", model=~\"$model\", account_id=~\"$account\"})) / 1e6)",
+          "expr": "((sum by (plan) (gateway_ratelimit_spend_micro_usd{window=~\"$window\", plan=~\"$plan\", account_id=~\"$account\"})) / 1e6)",
           "refId": "A",
           "instant": true,
           "range": false,
           "format": "time_series",
-          "legendFormat": "{{model}}",
+          "legendFormat": "{{plan}}",
           "datasource": {
             "type": "prometheus",
             "uid": "mimir"
           }
         }
       ],
-      "title": "Spend share by model — this window",
+      "title": "Spend share by plan — this window",
       "transparent": false,
       "datasource": {
         "type": "prometheus",
@@ -511,7 +482,7 @@
       "type": "table",
       "targets": [
         {
-          "expr": "((sum by (account_id, model, plan, plane) (gateway_ratelimit_spend_micro_usd{window=~\"$window\", plan=~\"$plan\", model=~\"$model\", account_id=~\"$account\"})) / 1e6)",
+          "expr": "((sum by (account_id, plan) (gateway_ratelimit_spend_micro_usd{window=~\"$window\", plan=~\"$plan\", account_id=~\"$account\"})) / 1e6)",
           "refId": "A",
           "instant": true,
           "range": false,
@@ -522,7 +493,7 @@
           }
         }
       ],
-      "title": "Consumption by account x model — this window",
+      "title": "Consumption by account x plan — this window",
       "transparent": false,
       "datasource": {
         "type": "prometheus",
@@ -541,9 +512,7 @@
           "options": {
             "renameByName": {
               "account_id": "Account",
-              "model": "Model",
               "plan": "Plan",
-              "plane": "Plane",
               "Value #A": "Spend ($)"
             },
             "excludeByName": {
@@ -552,10 +521,8 @@
             },
             "indexByName": {
               "account_id": 0,
-              "model": 1,
-              "plan": 2,
-              "plane": 3,
-              "Value #A": 4
+              "plan": 1,
+              "Value #A": 2
             }
           }
         },
@@ -617,7 +584,7 @@
       "type": "timeseries",
       "targets": [
         {
-          "expr": "((topk(10, sum by (account_id) (gateway_ratelimit_spend_micro_usd{window=~\"$window\", plan=~\"$plan\", model=~\"$model\", account_id=~\"$account\"}))) / 1e6)",
+          "expr": "((topk(10, sum by (account_id) (gateway_ratelimit_spend_micro_usd{window=~\"$window\", plan=~\"$plan\", account_id=~\"$account\"}))) / 1e6)",
           "refId": "A",
           "instant": false,
           "range": true,

--- a/charts/observability-dashboards/files/envoy-ai-gateway/ratelimit-quota.json
+++ b/charts/observability-dashboards/files/envoy-ai-gateway/ratelimit-quota.json
@@ -689,7 +689,7 @@
           "options": {
             "source": "key",
             "format": "regex",
-            "regExp": "/converse/(?<Model>[^/]+)/.*_rule-\\d+-match-0_(?<Account>.+?)_rule-\\d+-match-1",
+            "regExp": "^(?:.*/converse/(?<Model>[^/]+)/)?.*_rule-\\d+-match-0_(?<Account>.+?)_rule-\\d+-match-1",
             "keepFields": true
           }
         },

--- a/tools/dashboards/src/dashboards/envoy_ai_gateway/ratelimit_quota.py
+++ b/tools/dashboards/src/dashboards/envoy_ai_gateway/ratelimit_quota.py
@@ -225,6 +225,15 @@ def _panel_live_census() -> table.Panel:
     # *-match-0* = an x-account-id-keyed budget/burst counter). Zero scrape-lag,
     # the limiter's own current view. extractFields carves Account + Model out of
     # the raw key (JS RegExp named groups — this transform runs in the browser).
+    #
+    # ⚠️ The `/converse/<model>/` segment is OPTIONAL and must stay so. Only the
+    # PER-MODEL keys carry it; the gateway-wide shared-budget keys (`shared: true`
+    # ⇒ keyed by policy, not route) do not. When that segment was mandatory this
+    # regex failed outright on the shared keys, so the rows holding the ACTUAL
+    # monthly budget showed neither Account nor Model — they rendered as raw
+    # unparsed keys. The leading `.*/` inside the optional group is load-bearing
+    # too: without it the group matches empty at position 0 and Model is dropped
+    # from the per-model keys as well.
     return (
         table.Panel()
         .title("Live limiter counters — direct from Redis (zero scrape-lag)")
@@ -239,8 +248,8 @@ def _panel_live_census() -> table.Panel:
                     "source": "key",
                     "format": "regex",
                     "regExp": (
-                        r"/converse/(?<Model>[^/]+)/.*"
-                        r"_rule-\d+-match-0_(?<Account>.+?)_rule-\d+-match-1"
+                        r"^(?:.*/converse/(?<Model>[^/]+)/)?"
+                        r".*_rule-\d+-match-0_(?<Account>.+?)_rule-\d+-match-1"
                     ),
                     "keepFields": True,
                 },

--- a/tools/dashboards/src/dashboards/envoy_ai_gateway/ratelimit_quota.py
+++ b/tools/dashboards/src/dashboards/envoy_ai_gateway/ratelimit_quota.py
@@ -42,9 +42,7 @@ from dashboards._common import (
     METRIC_RATELIMIT_SPEND_MICRO_USD,
     REDIS_RATELIMIT_UID,
     RL_LABEL_ACCOUNT,
-    RL_LABEL_MODEL,
     RL_LABEL_PLAN,
-    RL_LABEL_PLANE,
     RL_LABEL_WINDOW,
 )
 from dashboards.envoy_ai_gateway import _shared as sh
@@ -53,17 +51,23 @@ OUTPUT_PATH: str = "charts/observability-dashboards/files/envoy-ai-gateway/ratel
 
 _M = METRIC_RATELIMIT_SPEND_MICRO_USD
 _A = RL_LABEL_ACCOUNT
-_MO = RL_LABEL_MODEL
 _PL = RL_LABEL_PLAN
-_PE = RL_LABEL_PLANE
 
+# ⚠️ NO `model` / `plane` dimension here, by design. Since the #532 shared-budget
+# cutover the monthly budget is ONE counter per (account, plan) on the gateway-wide
+# BackendTrafficPolicy (`shared: true` keys the bucket by POLICY name), spanning
+# every model route and both planes — so the exporter's keys carry neither label.
+# Filtering on an absent label with the multi-var default `.+` matches NOTHING, so
+# a `$model` variable here would blank the whole board, not just its own panels.
+# Per-model spend still lives in the Mimir/Loki cost dashboards (ADR-0058/0046).
+#
 # All filters refine the same metric. $window is single-select (default newest)
 # so totals are for ONE budget period; the rest are multi (default All → .+).
-_SEL = f'{{{RL_LABEL_WINDOW}=~"$window", {_PL}=~"$plan", {_MO}=~"$model", {_A}=~"$account"}}'
+_SEL = f'{{{RL_LABEL_WINDOW}=~"$window", {_PL}=~"$plan", {_A}=~"$account"}}'
 _MSEL = f"{_M}{_SEL}"
 
 _LEGEND_ACCOUNT = "{{" + _A + "}}"
-_LEGEND_MODEL = "{{" + _MO + "}}"
+_LEGEND_PLAN = "{{" + _PL + "}}"
 
 _REDIS_DS = dm.DataSourceRef(type_val="redis-datasource", uid=REDIS_RATELIMIT_UID)
 
@@ -116,7 +120,7 @@ def _panel_active_accounts() -> object:
 
 def _panel_counters() -> object:
     return sh.stat_panel(
-        title="Tracked counters (account x model)",
+        title="Tracked counters (account x plan)",
         expr=f"count({_MSEL})",
         unit="short",
         color="purple",
@@ -124,10 +128,12 @@ def _panel_counters() -> object:
     )
 
 
-def _panel_models() -> object:
+def _panel_plans() -> object:
+    # Was "Models in use" before the shared-budget cutover removed the model
+    # dimension from the budget counters. Same grid slot, plan-keyed.
     return sh.stat_panel(
-        title="Models in use",
-        expr=f"count(count by ({_MO}) ({_MSEL}))",
+        title="Plans in use",
+        expr=f"count(count by ({_PL}) ({_MSEL}))",
         unit="short",
         color="green",
         grid=(4, 6, 18, 1),
@@ -145,21 +151,23 @@ def _panel_top_accounts() -> object:
     )
 
 
-def _panel_spend_by_model() -> object:
+def _panel_spend_by_plan() -> object:
+    # Was "Spend share by model". Same grid slot; billing tier is the dimension
+    # the shared budget actually has.
     return sh.pie_panel(
-        title="Spend share by model — this window",
-        expr=sh.usd(f"sum by ({_MO}) ({_MSEL})"),
-        legend_label=_LEGEND_MODEL,
+        title="Spend share by plan — this window",
+        expr=sh.usd(f"sum by ({_PL}) ({_MSEL})"),
+        legend_label=_LEGEND_PLAN,
         grid=(12, 12, 12, 5),
     )
 
 
 def _panel_breakdown_table() -> table.Panel:
-    # One row per account x model x plan x plane, instant → table, ranked by spend.
-    expr = sh.usd(f"sum by ({_A}, {_MO}, {_PL}, {_PE}) ({_MSEL})")
+    # One row per account x plan, instant → table, ranked by spend.
+    expr = sh.usd(f"sum by ({_A}, {_PL}) ({_MSEL})")
     panel = (
         table.Panel()
-        .title("Consumption by account x model — this window")
+        .title("Consumption by account x plan — this window")
         .datasource(sh.MIMIR_DS)
         .grid_pos(dm.GridPos(h=12, w=24, x=0, y=17))
         .filterable(True)
@@ -170,18 +178,14 @@ def _panel_breakdown_table() -> table.Panel:
                 options={
                     "renameByName": {
                         _A: "Account",
-                        _MO: "Model",
                         _PL: "Plan",
-                        _PE: "Plane",
                         "Value #A": "Spend ($)",
                     },
                     "excludeByName": {"Time": True, RL_LABEL_WINDOW: True},
                     "indexByName": {
                         _A: 0,
-                        _MO: 1,
-                        _PL: 2,
-                        _PE: 3,
-                        "Value #A": 4,
+                        _PL: 1,
+                        "Value #A": 2,
                     },
                 },
             )
@@ -258,12 +262,15 @@ def _panel_live_census() -> table.Panel:
 _DESCRIPTION = (
     "WHO is consuming the Envoy AI Gateway and HOW MUCH of their budget, read from "
     "the rate-limit service's LIVE counters in redis-ha (ADR-0070) — the only place "
-    "that current-window state exists. Mimir panels rank spend per account/model "
+    "that current-window state exists. Mimir panels rank spend per account/plan "
     "for the selected 30-day budget window (prometheus-redis-exporter → "
     "gateway_ratelimit_spend_micro_usd, ÷1e6 → USD); the bottom table is a direct "
     "redis-datasource census (zero scrape-lag). RAW consumption only — budget "
     "limits are static Helm config (ADR-0021/0035), not derivable per-user here. "
-    "$window defaults to the current bucket. Filters: plan, model, account. "
+    "NO per-model breakdown: since the #532 shared-budget cutover the budget is one "
+    "counter per (account, plan) spanning ALL models and both planes, so the keys "
+    "carry no model label — see the Mimir/Loki cost dashboards for per-model spend. "
+    "$window defaults to the current bucket. Filters: plan, account. "
     "GENERATED — source: tools/dashboards/envoy_ai_gateway/ratelimit_quota.py."
 )
 
@@ -296,9 +303,8 @@ def _dashboard() -> db.Dashboard:
         .time("now-30d", "now")
         .with_variable(_window_var())
         .with_variable(sh.multi_var(name="plan", label="Plan", definition=sh.label_values(_M, _PL)))
-        .with_variable(
-            sh.multi_var(name="model", label="Model", definition=sh.label_values(_M, _MO))
-        )
+        # NB: no `$model` variable — the shared-budget counters carry no `model`
+        # label, and the multi-var default `.+` would match nothing at all.
         .with_variable(
             sh.multi_var(name="account", label="Account", definition=sh.label_values(_M, _A))
         )
@@ -306,9 +312,9 @@ def _dashboard() -> db.Dashboard:
         .with_panel(_panel_total_spend())
         .with_panel(_panel_active_accounts())
         .with_panel(_panel_counters())
-        .with_panel(_panel_models())
+        .with_panel(_panel_plans())
         .with_panel(_panel_top_accounts())
-        .with_panel(_panel_spend_by_model())
+        .with_panel(_panel_spend_by_plan())
         .with_panel(_panel_breakdown_table())
         .with_panel(sh.row("Spend over time (gauge history)", y=29))
         .with_panel(_panel_spend_over_time())


### PR DESCRIPTION
## 1. Summary

This PR changes:

- Removes the `$model` variable and the `model`/`plane` dimensions from the "AI Gateway — rate-limit quota" dashboard generator.
- Repurposes the two model-keyed panels onto **plan**, reusing their exact grid slots so the layout is unchanged.
- Commits the regenerated `ratelimit-quota.json`.

It solves:

- Unblocks **ADORSYS-GIS/ai-helm-values#108** (exporter repoint). Follows **#695** / ADR-0084.

---

## 2. Intent

The intent of this PR is:

> To align the quota board with the fact that the monthly budget no longer has a per-model dimension — and to stop the exporter repoint from blanking the board.

Since the #532 shared-budget cutover (2026-07-09) the budget is **one counter per (account, plan)** on the gateway-wide BTP. `shared: true` keys the bucket by **policy** name, so it spans every model route and both planes, and the keys carry no `model`/`plane` label.

This is **load-bearing, not cosmetic**: `$model` is a multi-var defaulting to `.+`, which does **not** match an absent label. Merging ai-helm-values#108 without this change would have made every panel selector match nothing — the **entire board blank**, not just the two per-model panels.

Per maintainer: per-model panels aren't needed here for now.

| before | after | query |
|---|---|---|
| "Models in use" | **"Plans in use"** | `count by (plan)` |
| "Spend share by model" | **"Spend share by plan"** | `sum by (plan)` |
| breakdown: account × model × plan × plane | **account × plan** | `sum by (account_id, plan)` |

**Plan attribution stays exact** — the exporter maps the gateway rule index to `enterprise`/`free`/`pro` per the append-only ordered list from ADR-0084, so every counter lands on the right tier.

---

## 3. Scope

### In Scope

- `tools/dashboards/.../ratelimit_quota.py` + regenerated `ratelimit-quota.json`.

### Out of Scope

- **Per-model spend** — still available from the Mimir/Loki cost dashboards (ADR-0058 / ADR-0046). Nothing is lost, it just isn't derivable from *budget counters*.
- ~~The Redis census panel — unchanged.~~ **Corrected in a second commit** — see "Second commit" below. It was *not* safe to leave alone.
- **Pre-existing `ruff format` drift in `my_usage.py`** — `ruff` touched it incidentally; reverted to keep this PR focused. CI runs only `dashboards check`, not `ruff`, so it is not failing anything. Filed separately.

---

## 4. Verification

I verified this change by:

- [x] Running automated tests (`dashboards check` drift gate, `ruff check`)
- [x] Running manual tests (introspected the generated JSON)
- [ ] Checking logs
- [ ] Checking metrics
- [ ] Testing error cases
- [ ] Testing permissions/security behavior
- [ ] Testing rollback or failure behavior, if relevant

Commands run:

```bash
cd tools/dashboards
uv run ruff format . && uv run ruff check .
uv run dashboards build
uv run dashboards check
# then introspect every generated panel target
python3 -c "import json; d=json.load(open('charts/observability-dashboards/files/envoy-ai-gateway/ratelimit-quota.json')); print([v['name'] for v in d['templating']['list']])"
```

Results:

```text
All checks passed!
ok — every dashboard matches its generator

VARIABLES: ['window', 'plan', 'account']

  Total spend — this window            sum(gateway_ratelimit_spend_micro_usd{window=~"$window", plan=~"$plan", account_id=~"$account"})
  Active accounts                      count(count by (account_id) (...))
  Tracked counters (account x plan)    count(...)
  Plans in use                         count(count by (plan) (...))
  Top accounts by spend                topk(20, sum by (account_id) (...))
  Spend share by plan                  sum by (plan) (...)
  Consumption by account x plan        sum by (account_id, plan) (...)
  Spend over time — top accounts       topk(10, sum by (account_id) (...))
```

`grep -c '"model"'` on the generated JSON → **0**. No selector references an absent label. Net −49/+16 lines of JSON.

---

## 4b. Second commit — the Redis census panel

The board has **two** read paths over the same keys (ADR-0070): the Mimir leaderboard *and* a direct `redis-datasource` `tmscan` census. The first commit realigned only the Mimir path. Reviewing the census panel showed it still assumed the per-model key shape — its `extractFields` regex required a `/converse/<model>/` segment **before** the account, which the gateway-wide shared-budget keys do not have (`shared: true` ⇒ keyed by policy, not route).

So it failed outright on them and extracted **neither Account nor Model**: the rows holding the actual monthly budget rendered as raw unparsed keys — exactly the data the panel exists to show.

```diff
- /converse/(?<Model>[^/]+)/.*_rule-\d+-match-0_(?<Account>.+?)_rule-\d+-match-1
+^(?:.*/converse/(?<Model>[^/]+)/)?.*_rule-\d+-match-0_(?<Account>.+?)_rule-\d+-match-1
```

The leading `.*/` inside the optional group is load-bearing: without it the group matches empty at position 0 and `Model` is silently dropped from the per-model keys too.

Verified by replaying **both** regexes against the real key strings scanned out of redis-ha:

| key | OLD account | NEW account | NEW model |
|---|---|---|---|
| gateway shared `rule/1` (free budget) | — | `b3c2e75c-…` | — |
| gateway shared `rule/0` (enterprise) | — | `b3c2e75c-…` | — |
| per-model external | `b3c2e75c-…` | `b3c2e75c-…` | `glm-5` |
| per-model internal | `b3c2e75c-…` | `b3c2e75c-…` | `deepseek-v4-flash` |
| named service caller (non-UUID) | — | `koufan-king` | — |

`Model` stays correctly empty on the shared keys — a shared budget spans every model by definition.

---

## 5. Merge order

Merge **this first**, then ai-helm-values#108. Between the two merges the board reads the old (wrong) exporter labels — the same state as today, so no regression window. The reverse order blanks the board until this lands.

---

## 6. AI Usage Declaration

**What AI was used for:** identifying that the exporter repoint would blank the board (the `.+` vs absent-label interaction), reworking the generator, drafting this PR.

**What was verified by evidence, not assertion:**
- Every generated panel target was introspected out of the built JSON and is listed above — not inferred from the source.
- The drift gate and `ruff check` were run, output pasted.
- The absence of `model` in the output was confirmed by grep (0 hits).
- The claim that CI does not run `ruff` was checked against `.github/workflows/dashboards-drift.yml` before reverting the incidental `my_usage.py` reformat.

**Not verified:** the board has not been rendered against live Mimir data. The panels are correct by construction (selectors reference only labels the exporter emits), but confirm visually after ai-helm-values#108 rolls out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

