### PR TITLE
style(dashboards): apply ruff formatting and gate it in CI

### DIFF
--- a/.github/workflows/dashboards-drift.yml
+++ b/.github/workflows/dashboards-drift.yml
@@ -3,7 +3,8 @@ name: Dashboard drift check
 # Guards `charts/observability-dashboards/files/**/*.json` (and any chart-local
 # `files/dashboards/**/*.json`) against drift from their generator sources in
 # `tools/dashboards/`. Fails the PR if a committed JSON differs from what the
-# generator would emit.
+# generator would emit, or if the generator sources themselves are not
+# ruff-clean (format + lint).
 #
 # See: docs/playbooks/python-dashboard-generation.md, ADR-0008
 
@@ -42,6 +43,17 @@ jobs:
       - name: Install deps
         working-directory: tools/dashboards
         run: uv sync --frozen
+
+      # ADR-0008 mandates ruff for lint + format, but nothing enforced it, so
+      # formatting drifted silently in the generator sources. Checked before the
+      # drift check: a lint failure is cheaper to read than a JSON diff.
+      - name: Check formatting (ruff)
+        working-directory: tools/dashboards
+        run: uv run ruff format --check .
+
+      - name: Lint (ruff)
+        working-directory: tools/dashboards
+        run: uv run ruff check .
 
       - name: Verify dashboards match generators
         working-directory: tools/dashboards

--- a/tools/dashboards/src/dashboards/envoy_ai_gateway/my_usage.py
+++ b/tools/dashboards/src/dashboards/envoy_ai_gateway/my_usage.py
@@ -32,10 +32,10 @@ from grafana_foundation_sdk.models import piechart as pm
 from dashboards._common import (
     GATEWAY_SERVICE_NAME,
     LABEL_AZP,
-    LABEL_DISPLAY_NAME,
-    LABEL_MODEL,
-    LABEL_EMAIL,
     LABEL_BILLING_PLAN,
+    LABEL_DISPLAY_NAME,
+    LABEL_EMAIL,
+    LABEL_MODEL,
     LOKI_UID,
 )
 
@@ -120,8 +120,9 @@ def _loki_target(
     if legend:
         q = q.legend_format(legend)
     return q
-def _single_color_thresholds(color: str) -> db.ThresholdsConfig:
 
+
+def _single_color_thresholds(color: str) -> db.ThresholdsConfig:
 
     return db.ThresholdsConfig().mode(dm.ThresholdsMode.ABSOLUTE).steps([dm.Threshold(color=color)])
 
@@ -187,9 +188,6 @@ def _pie_panel(
 # ---------------------------------------------------------------------------
 # Panels
 # ---------------------------------------------------------------------------
-
-
-
 
 
 # ---------------------------------------------------------------------------
@@ -360,12 +358,7 @@ def _panel_display_name() -> stat.Panel:
         .datasource(_LOKI_DS)
         .grid_pos(dm.GridPos(h=8, w=6, x=12, y=32))
         .thresholds(_single_color_thresholds("blue"))
-        .reduce_options(
-            cb.ReduceDataOptions()
-            .calcs(["lastNotNull"])
-            .fields("")
-            .values(False)
-        )
+        .reduce_options(cb.ReduceDataOptions().calcs(["lastNotNull"]).fields("").values(False))
         .orientation(cm.VizOrientation.HORIZONTAL)
         .text_mode(cm.BigValueTextMode.NAME)
         .color_mode(cm.BigValueColorMode.NONE)
@@ -388,12 +381,7 @@ def _panel_billing_plan() -> stat.Panel:
         .datasource(_LOKI_DS)
         .grid_pos(dm.GridPos(h=8, w=6, x=18, y=32))
         .thresholds(_single_color_thresholds("blue"))
-        .reduce_options(
-            cb.ReduceDataOptions()
-            .calcs(["lastNotNull"])
-            .fields("")
-            .values(False)
-        )
+        .reduce_options(cb.ReduceDataOptions().calcs(["lastNotNull"]).fields("").values(False))
         .orientation(cm.VizOrientation.HORIZONTAL)
         .text_mode(cm.BigValueTextMode.NAME)
         .color_mode(cm.BigValueColorMode.NONE)


### PR DESCRIPTION
## 1. Summary

This PR changes:

- Reformats `tools/dashboards/src/dashboards/envoy_ai_gateway/my_usage.py` to the ruff rules the project already mandates (mechanical `ruff format` + `ruff check --fix` output, no hand edits).
- Adds `ruff format --check .` and `ruff check .` steps to `.github/workflows/dashboards-drift.yml`.

It solves:

- Follow-up to #696, where the same `my_usage.py` reformat was deliberately reverted to keep that PR focused on `ratelimit_quota.py`.

---

## 2. Intent

The intent of this PR is:

> CLAUDE.md and ADR-0008 make ruff the sole lint+format authority for `tools/dashboards/`, but **nothing ever enforced it**. The `dashboards-drift` workflow only runs `uv run dashboards check`, which compares the *generated JSON* against what the generators emit — a purely cosmetic reformat of a generator source is completely invisible to it. So formatting could rot indefinitely while CI stayed green, and it did: `my_usage.py` had drifted (unsorted imports, stray blank lines, two over-wrapped `reduce_options(...)` chains).
>
> Fixing the one file without closing the hole would just let it happen again, so this PR does both: clean the drift, then gate it.

---

## 3. Scope

### In Scope

- The mechanical ruff reformat of `my_usage.py` (I001 import sort, blank lines around `_single_color_thresholds`, two collapsed `reduce_options(...)` chains).
- Two ruff steps in the existing `dashboards-drift` job.

### Out of Scope

- Any behavioural or query change to any dashboard — **explicitly none**, see Verification.
- A `make fmt` / `make lint` target in `tools/dashboards/Makefile`. Plausible companion so contributors catch this locally before CI, deliberately left out to keep this diff minimal — happy to follow up.
- Extending the ruff gate to any other Python in the repo (there is none; `tools/dashboards/` is the only Python project).

---

## 4. Verification

I verified this change by:

- [x] Running automated tests
- [ ] Running manual tests
- [ ] Checking logs
- [ ] Checking metrics
- [ ] Testing error cases
- [ ] Testing permissions/security behavior
- [ ] Testing rollback or failure behavior, if relevant

Commands run:

```bash
cd tools/dashboards
uv run ruff format . && uv run ruff check --fix .   # the change itself
uv run ruff format --check . && uv run ruff check . # gate starts green?
uv run dashboards build && uv run dashboards check  # behaviourally inert?
# plus: sha256 of all 14 JSON under charts/observability-dashboards/files/, before vs after
```

Results:

```text
=== the reformat ===
1 file reformatted, 16 files left unchanged
Found 1 error (1 fixed, 0 remaining).

=== gate starts green (re-run after rebase onto main @ 4ded010) ===
17 files already formatted
All checks passed!

=== behaviourally inert ===
ok — every dashboard matches its generator
JSON IDENTICAL      <- sha256 of all 14 files, before vs after
```

**The load-bearing check is the third one.** A reformat that altered behaviour would show up as regenerated JSON. All 14 committed files under `charts/observability-dashboards/files/` are byte-identical by sha256 before and after, `my-usage.json` included, and `dashboards check` reports no drift. Nothing is re-rendered by this PR.

Re-verified after rebasing onto current `main` (`4ded010`), which matters because #696 landed changes to `ratelimit_quota.py` in the meantime — that file is ruff-clean as merged, so the new gate does not go red on arrival.

---

## 5. Screenshots / Evidence

Add evidence here:

* Screenshot: n/a — no rendered dashboard changes (that is the point; the JSON is byte-identical)
* Logs: command output inline in §4
* Metrics: n/a
* Recording: n/a

---

## 6. Risk Assessment

Risk level:

* [x] Low
* [ ] Medium
* [ ] High

Potential risks:

* A reformat silently changing generator output — the exact failure this PR must not cause.
* The new gate turning the next unrelated PR red if any file in the tree were still unclean.

Mitigation:

* Verified byte-identical generated JSON (sha256 across all 14 files) plus a clean `dashboards check`. Nothing deploys differently.
* Swept the whole tree, not just the edited file: `17 files already formatted`, `All checks passed!`, re-confirmed post-rebase against the newly-merged `ratelimit_quota.py`.
* Ruff steps are ordered **before** the drift check on purpose: when a PR both reformats and regenerates, a ruff diff is far easier to read than a multi-thousand-line JSON diff, so CI fails on the cheap signal first.
* No new tooling or actions — ruff is already a dev dependency pinned in `uv.lock`, and the steps reuse the `uv sync --frozen` already in the job.

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [ ] Generating code
* [x] Refactoring
* [ ] Generating tests
* [x] Drafting documentation
* [x] Reviewing the diff
* [ ] Not used

The "refactoring" here is mechanical ruff output rather than authored code — no formatting decision was made by hand or by the model; the diff is exactly what `ruff format` + `ruff check --fix` produce. "Documentation" is the commit bodies and this PR description. The CI steps were written by hand.

Human verification:

* [x] I understand every meaningful change in this PR
* [x] I checked generated code manually
* [ ] I checked generated tests manually
* [x] I removed unsupported AI assumptions
* [x] I accept responsibility for this PR

---

## 8. Reviewer Focus

Please focus your review on:

* [ ] Correctness
* [ ] Architecture
* [ ] Security
* [ ] Performance
* [ ] Tests
* [x] Maintainability
* [ ] Product intent
* [ ] Edge cases

Two things worth a second pair of eyes:

1. **Is the "formatting-only" claim actually watertight?** The evidence is the byte-identical JSON — if you accept that, the `my_usage.py` diff needs no line-by-line review.
2. **Step ordering in the workflow.** Ruff runs before `dashboards check`. If you would rather see drift fail first, that is a one-line move.

Split into two commits (`style(dashboards)` then `ci(dashboards)`) specifically so the formatting commit stays independently verifiable as inert rather than being mixed with the workflow change.
