### PR TITLE
feat: add otlp tracing configuration for control-plane and dispatcher

### DIFF
--- a/charts/lightbridge-code-intelligence/values.yaml
+++ b/charts/lightbridge-code-intelligence/values.yaml
@@ -373,6 +373,10 @@ lci:
           env:
             BIND_ADDR: "0.0.0.0:8080"
             RUST_LOG: "info"
+            # OpenTelemetry tracing: export traces to Alloy collector (ADR-0046)
+            OTEL_EXPORTER_OTLP_ENDPOINT: "http://alloy.observability.svc.cluster.local:4318"
+            # Sampling ratio (default 0.1 = 10% of traces)
+            OTEL_TRACES_SAMPLER_ARG: "0.1"
             # File config (ADR-0021): read control-plane.json from the mounted ConfigMap (review
             # labels/reactions + the embedding-dimension guard). Absent the file the binary uses env.
             CONTROL_PLANE_CONFIG: "/etc/lightbridge/control-plane.json"
@@ -673,6 +677,10 @@ lci:
             CONTROL_PLANE_ROLE: "dispatcher"
             RUST_LOG: "info"
             METRICS_ADDR: "0.0.0.0:9090"
+            # OpenTelemetry tracing: export traces to Alloy collector (ADR-0046)
+            OTEL_EXPORTER_OTLP_ENDPOINT: "http://alloy.observability.svc.cluster.local:4318"
+            # Sampling ratio (default 0.1 = 10% of traces)
+            OTEL_TRACES_SAMPLER_ARG: "0.1"
             # File config (ADR-0021): control-plane.json drives the runner Job resources + dispatcher
             # tuning; the binary falls back to the AGENT_*/defaults below when a field is absent.
             CONTROL_PLANE_CONFIG: "/etc/lightbridge/control-plane.json"


### PR DESCRIPTION
## 1. Summary

This PR changes:

- Added `OTEL_EXPORTER_OTLP_ENDPOINT` environment variable to Helm chart values for control-plane container
- Added `OTEL_EXPORTER_OTLP_ENDPOINT` environment variable to Helm chart values for dispatcher container
- Added `OTEL_TRACES_SAMPLER_ARG` environment variable for trace sampling configuration

It solves:

[#669](https://github.com/ADORSYS-GIS/ai-helm/issues/669)
---

## 2. Intent

The intent of this PR is:

> Enable OTLP tracing for Lightbridge Code Intelligence by setting the required `OTEL_EXPORTER_OTLP_ENDPOINT` environment variable on control-plane and dispatcher deployments. The tracing code was already deployed in the codebase, but the OTLP layer only activates when this environment variable is set. This change makes tracing active so that traces can be collected by the Alloy collector and forwarded to Tempo.

---

## 3. Scope

### In Scope

- Adding `OTEL_EXPORTER_OTLP_ENDPOINT` environment variable to Helm chart values for both control-plane and dispatcher
- Adding `OTEL_TRACES_SAMPLER_ARG` environment variable for trace sampling configuration
- Ensuring the endpoint points to the Alloy collector on port 4318

### Out of Scope

- Modifying the Alloy collector configuration
- Modifying the Tempo configuration
- Modifying the OTel tracing code itself
- Deploying to production (deployment is out of scope for this PR)

---

## 4. Verification

I verified this change by:

- [x] Checking existing code in `services/observability/src/lib.rs` to confirm OTLP layer activation logic
- [x] Verifying dispatcher code in `services/control-plane/src/integrations/k8s.rs` already injects TRACEPARENT
- [x] Confirming Alloy collector configuration to receive OTLP traces on port 4318
- [ ] Running automated tests
- [ ] Running manual tests
- [ ] Checking logs
- [ ] Checking metrics
- [ ] Testing error cases
- [ ] Testing permissions/security behavior
- [ ] Testing rollback or failure behavior, if relevant

Commands run:

Results:

---

## 5. Screenshots / Evidence

Add evidence here:

* Screenshot: N/A (configuration changes)
* Logs: N/A (deployment pending)
* Metrics: N/A (deployment pending)
* Recording: N/A

---

## 6. Risk Assessment

Risk level:

* [x] Low

Potential risks:

* No significant risks identified. The change only adds environment variables without modifying existing behavior.
* If the Alloy collector is not running or accessible on port 4318, traces will not be exported, but this is expected behavior.

Mitigation:

* Deploy to staging environment first to verify Alloy collector is accessible
* Monitor logs for any OTLP export errors after deployment
* Have rollback plan ready if issues arise

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [ ] Refactoring
* [x] Drafting documentation
* [ ] Reviewing the diff
* [ ] Not used

Human verification:

* [x] I understand every meaningful change in this PR
* [x] I checked generated code manually
* [ ] I checked generated tests manually
* [x] I removed unsupported AI assumptions
* [x] I accept responsibility for this PR

---

## 8. Reviewer Focus

Please focus your review on:

* [x] Correctness
* [x] Architecture
* [ ] Security
* [ ] Performance
* [ ] Tests
* [x] Maintainability
* [x] Product intent
* [x] Edge cases