### PR TITLE
fix(lakefs): ci reference copy - oauth2-proxy flag is --upstream

### DIFF
--- a/charts/lakefs/ci/lakefs-auth.yaml
+++ b/charts/lakefs/ci/lakefs-auth.yaml
@@ -25,7 +25,7 @@ extraArgs:
   provider: "keycloak-oidc"
   oidc-issuer-url: "https://auth.verif.fyi/realms/camer-digital"
   redirect-url: "https://lakefs.mlops.ai.camer.digital/oauth2/callback"
-  upstreams: "http://lakefs.mlops.svc.cluster.local:80"
+  upstream: "http://lakefs.mlops.svc.cluster.local:80"
   reverse-proxy: "true"
   cookie-secure: "true"
   skip-provider-button: "true"


### PR DESCRIPTION
Keeps charts/lakefs/ci/lakefs-auth.yaml in sync with the live fix in ADORSYS-GIS/ai-helm-values#114 (documentation/reference-only file, not auto-linted — see comment in the file for why). No functional change to this repo's own CI.