### PR TITLE
fix(mlflow): ci reference copy - bump memory after live OOMKill

### DIFF
--- a/charts/mlflow/ci/mlflow-app.yaml
+++ b/charts/mlflow/ci/mlflow-app.yaml
@@ -84,10 +84,10 @@ replicaCount: 1
 resources:
   requests:
     cpu: 250m
-    memory: 512Mi
+    memory: 1Gi
   limits:
     cpu: 1000m
-    memory: 1Gi
+    memory: 2Gi
 
 ingress:
   enabled: true


### PR DESCRIPTION
Keeps charts/mlflow/ci/mlflow-app.yaml in sync with the live fix in ADORSYS-GIS/ai-helm-values#115 (documentation/reference-only file). No functional change to this repo's own CI.