### PR TITLE
feat(lightbridge-code-intelligence): map config.model.<tier>.maxCycles to review.<tier>.max_cycles

### DIFF
--- a/charts/lightbridge-code-intelligence/templates/config.yaml
+++ b/charts/lightbridge-code-intelligence/templates/config.yaml
@@ -162,6 +162,14 @@ data:
 {{- if $tv.topP }}{{- $_ := set $t "top_p" $tv.topP }}{{- end }}
 {{- if $tv.maxTokens }}{{- $_ := set $t "max_tokens" $tv.maxTokens }}{{- end }}
 {{- if $tv.maxTurns }}{{- $_ := set $t "max_turns" $tv.maxTurns }}{{- end }}
+{{- /* OpenCode re-prompt ceiling (lightbridge-code-intelligence fast-tier-parity plan): opencode's own
+       `maxSteps` was proven NOT to cap anything over ACP, so this Rust-side counter (how many whole
+       `session/prompt` cycles the supervisor re-drives) is the real stuck-model backstop on the
+       OpenCode path — tier-configurable so fast can run a smaller budget than deep. Unrelated to
+       `maxTurns` above (a CoverageGate wind-down heuristic input, not an enforcement mechanism).
+       ⚠️ REQUIRES a runner image carrying review.<tier>.max_cycles before this is set, else
+       deny_unknown_fields fails every Job (ship the runner first). */}}
+{{- if $tv.maxCycles }}{{- $_ := set $t "max_cycles" $tv.maxCycles }}{{- end }}
 {{- if $tv.maxBatchSize }}{{- $_ := set $t "max_batch_size" $tv.maxBatchSize }}{{- end }}
 {{- if $tv.maxFilesRead }}{{- $_ := set $t "max_files_read" $tv.maxFilesRead }}{{- end }}
 {{- if $tv.maxSearches }}{{- $_ := set $t "max_searches" $tv.maxSearches }}{{- end }}

--- a/charts/lightbridge-code-intelligence/values.yaml
+++ b/charts/lightbridge-code-intelligence/values.yaml
@@ -185,7 +185,14 @@ config:
     # COMPLETE, independent per-tier config: it shares the gateway (env) + system prompt, and carries its
     # OWN model + the same generation/budget knobs as above (model, extra, maxTurns, stream,
     # requestTimeoutSecs, contextWindow, maxTokens, temperature, topP, maxDiffChars, max* read budgets,
-    # maxCoverageBounces, opencode).
+    # maxCoverageBounces, maxCycles, opencode).
+    #
+    # maxCycles (fast-tier-parity plan) → agent.json `review.<tier>.max_cycles`: how many whole
+    # `session/prompt` re-prompt cycles the OpenCode-path supervisor drives before declaring exhaustion —
+    # the real stuck-model backstop (opencode's own step cap doesn't work over ACP). Empty → the runner's
+    # built-in default (8). Set fast smaller than deep here for a genuinely cheaper budget, now that both
+    # tiers share the same gate/tool mechanics. ⚠️ REQUIRES a runner image carrying
+    # `review.<tier>.max_cycles` before it's set, else deny_unknown_fields fails every Job.
     #
     # Per-tier OpenCode config overlay (lightbridge-code-intelligence ADR-0099) → agent.json
     # `review.<tier>.opencode`. Arbitrary OpenCode config — most commonly a custom `agent.*` sub-agent on


### PR DESCRIPTION
## 1. Summary

This PR changes:

- Adds a `config.model.<tier>.maxCycles` values key, mapped to `review.<tier>.max_cycles` in the
  rendered `agent.json` (`charts/lightbridge-code-intelligence/templates/config.yaml`), mirroring
  the existing `maxTurns` per-tier mapping pattern.
- Documents the new key in `values.yaml` alongside the other per-tier generation/budget knobs.

It solves:

- Companion chart change for [lightbridge-code-intelligence#488](https://github.com/vymalo/lightbridge-code-intelligence/pull/488) (merged) — the fast-tier-parity rework
  makes the OpenCode-path re-prompt-cycle ceiling tier-configurable instead of one hardcoded
  Rust constant, so fast can keep a genuinely smaller budget now that its gates run identically
  to deep's.

---

## 2. Intent

> #488 removed the `fast: bool` short-circuit from the review agent's coverage/refute/SAST-anchor
> gates — fast tier now investigates and verifies exactly like deep. The one place fast still
> legitimately differs (besides model class and prompt) is a smaller step budget. That budget was
> previously a single hardcoded constant (`MAX_REVIEW_CYCLES = 8`) shared by both tiers; the
> runner now reads it per-tier from `review.<tier>.max_cycles`. This chart change is what lets an
> operator actually set that per tier from `ai-helm-values`.

---

## 3. Scope

### In Scope

- The `config.model.<tier>.maxCycles` → `review.<tier>.max_cycles` template mapping.
- `values.yaml` documentation for the new key.

### Out of Scope

- The `ai-helm-values` change that actually sets `maxCycles` per tier and equalizes the fast/deep
  tool allowlists — separate PR, must merge AFTER this one (and after #488's runner image is
  live), not before: `deny_unknown_fields` fails every review Job if the values file sets
  `maxCycles` before the runner image + this chart both carry it.
- Everything else in #488 (gate unification, the `agent.review`→`agent.build` config fix) — pure
  runner-side, no chart change needed there.

---

## 4. Verification

I verified this change by:

- [x] Running automated tests
- [ ] Running manual tests
- [ ] Checking logs
- [ ] Checking metrics
- [ ] Testing error cases
- [ ] Testing permissions/security behavior
- [ ] Testing rollback or failure behavior, if relevant

Commands run:

```bash
helm template charts/lightbridge-code-intelligence -f charts/lightbridge-code-intelligence/values.yaml
```

Results:

```text
$ helm template charts/lightbridge-code-intelligence -f charts/lightbridge-code-intelligence/values.yaml
renders cleanly, exit 0 — maxCycles is truthiness-gated (mirrors maxTurns) so it emits nothing
against the default empty fast/deep tier blocks, same as every other per-tier knob.
```

---

## 5. Screenshots / Evidence

N/A — Helm chart template change, no UI surface. Evidence is the successful `helm template` render
above and the mirrored `maxTurns` pattern it's copied from.

---

## 6. Risk Assessment

Risk level:

* [x] Low
* [ ] Medium
* [ ] High

Potential risks:

* Merged before the runner image from #488 is live, or before the matching `ai-helm-values` PR:
  the field is inert either way (an unset `maxCycles` in values emits nothing — truthiness-gated,
  same as `maxTurns`), so this alone cannot break anything on its own.
* Merged into `ai-helm-values` before the runner image ships → `deny_unknown_fields` fails every
  review Job. Documented inline in both this chart and the values comment.

Mitigation:

* The template guard is truthiness-only (`{{- if $tv.maxCycles }}`) — a values file that never
  sets it renders byte-identical to before this change.
* Deploy-order warning left in both `config.yaml` and `values.yaml` comments, matching this
  chart's existing convention for every other runner-image-gated field.

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [ ] Refactoring
* [ ] Generating tests
* [x] Drafting documentation
* [x] Reviewing the diff

Human verification:

* [ ] I understand every meaningful change in this PR
* [ ] I checked generated code manually
* [ ] I checked generated tests manually
* [ ] I removed unsupported AI assumptions
* [ ] I accept responsibility for this PR

Authored end-to-end by Claude (Sonnet 5) in the same agentic session as
[lightbridge-code-intelligence#488](https://github.com/vymalo/lightbridge-code-intelligence/pull/488). Human-verification checkboxes intentionally left
unchecked pending the repo owner's own review.

---

## 8. Reviewer Focus

Please focus your review on:

* [x] Correctness
* [ ] Architecture
* [ ] Security
* [ ] Performance
* [ ] Tests
* [x] Maintainability
* [ ] Product intent
* [ ] Edge cases
