### PR TITLE
fix(lakefs-secrets): correct the broken cookie-secret generation command

### DIFF
--- a/charts/lakefs-secrets/values.yaml
+++ b/charts/lakefs-secrets/values.yaml
@@ -56,8 +56,12 @@ externalSecrets:
   # credentials + the session cookie signing secret. Matches the upstream
   # oauth2-proxy chart's config.existingSecret schema, which reads all three
   # keys (client-id/client-secret/cookie-secret) from ONE Secret
-  # (config.requiredSecretKeys default). cookie-secret is a 32-byte
-  # base64 value (generate with `openssl rand -base64 32 | head -c 32 | base64`).
+  # (config.requiredSecretKeys default). cookie-secret MUST base64-decode to
+  # exactly 16, 24, or 32 raw bytes (oauth2-proxy uses it as an AES cipher
+  # key) — generate with `openssl rand -base64 32` (no extra piping; a
+  # `head -c 32` truncating the base64 TEXT, or double-encoding, produces a
+  # value of the wrong decoded length and oauth2-proxy refuses to start:
+  # "cookie_secret must be 16, 24, or 32 bytes ... but is N bytes").
   lakefs-proxy-secret:
     data:
       - secretKey: client-id


### PR DESCRIPTION
Live crash found while verifying the mlops platform deploy (ADR-0085): lakefs-auth-oauth2-proxy failed with `cookie_secret must be 16, 24, or 32 bytes to create an AES cipher, but is 96 bytes`.

Root cause: the comment's suggested command `openssl rand -base64 32 | head -c 32 | base64` truncates the base64 TEXT (not the underlying bytes) and re-encodes it, producing a value whose decoded length is wrong. Correct command is just `openssl rand -base64 32`.

Docs-only — the live `lakefs_proxy_cookie_secret` ASM property still needs to be regenerated with the correct command for lakefs-auth to actually start.

AI Usage Declaration: found + fixed by Claude during live post-deploy verification (oauth2-proxy startup logs).