### PR TITLE
fix(mlflow): ci reference copy - round 2 OOM fix

### DIFF
--- a/charts/mlflow/ci/mlflow-app.yaml
+++ b/charts/mlflow/ci/mlflow-app.yaml
@@ -81,13 +81,19 @@ oidcAuth:
 
 replicaCount: 1
 
+# 2Gi limit still OOMKilled (round 1 of live verification, ADR-0085) — the
+# gunicorn default of 4 workers each duplicate the FastAPI+SQLAlchemy+OIDC
+# process memory. Cut to 2 workers and give more headroom.
+extraArgs:
+  workers: "2"
+
 resources:
   requests:
-    cpu: 250m
-    memory: 1Gi
-  limits:
-    cpu: 1000m
+    cpu: 500m
     memory: 2Gi
+  limits:
+    cpu: 1500m
+    memory: 4Gi
 
 ingress:
   enabled: true


### PR DESCRIPTION
Keeps charts/mlflow/ci/mlflow-app.yaml in sync with ADORSYS-GIS/ai-helm-values#119 (documentation/reference-only file). No functional change to this repo's own CI.