### PR TITLE
fix(lakefs): ci reference copy - round 2 probe timing

### DIFF
--- a/charts/lakefs/ci/lakefs-app.yaml
+++ b/charts/lakefs/ci/lakefs-app.yaml
@@ -72,13 +72,13 @@ replicaCount: 1
 readinessProbe:
   # This chart's readinessProbe template has no initialDelaySeconds field
   # (silently dropped if set) — periodSeconds/failureThreshold still give
-  # the same ~60s grace window.
+  # the same grace window.
   periodSeconds: 10
-  failureThreshold: 6
+  failureThreshold: 12
 livenessProbe:
-  initialDelaySeconds: 20
+  initialDelaySeconds: 30
   periodSeconds: 10
-  failureThreshold: 6
+  failureThreshold: 12
 
 resources:
   requests:


### PR DESCRIPTION
Keeps charts/lakefs/ci/lakefs-app.yaml in sync with ADORSYS-GIS/ai-helm-values (round 1 grace period still too tight). Documentation/reference-only, no functional change to this repo.