### PR TITLE
fix: ci reference copies - mlflow scope, argo-workflows RBAC, lakefs redirect

### DIFF
--- a/charts/argo-workflows/ci/argo-workflows-app.yaml
+++ b/charts/argo-workflows/ci/argo-workflows-app.yaml
@@ -40,9 +40,21 @@ server:
       name: argo-server-sso
       key: client-secret
     redirectUrl: "https://argo-workflows.mlops.ai.camer.digital/oauth2/callback"
-    scopes:
-      - groups
+    # No explicit scopes override: the `argo-workflows` Keycloak clientScope
+    # (charts/keycloak-baseline) is a DEFAULT client scope, always included
+    # in every token regardless of what's requested here — no need to name
+    # it. The previous `scopes: [groups]` named a scope that doesn't exist
+    # on this client at all, which made Keycloak reject the WHOLE OIDC
+    # request (invalid_scope), not just omit the claim — that's why nothing
+    # worked, not just RBAC. Found live during ADR-0085 verification.
     customGroupClaimName: "argo_workflows_roles"
+    # NOTE: `secretWhitelist` is documented in this chart's values.yaml but
+    # NOT actually templated by argo-helm 1.0.20's
+    # workflow-controller-config-map.yaml (verified against the template
+    # source) — setting it here would be a silent no-op. RBAC ServiceAccount
+    # selection (see environments/base/deps/argo-workflows/rbac.yaml) is
+    # unaffected: it works purely off the rbac-rule/rbac-rule-precedence
+    # annotations, independent of secretWhitelist.
     rbac:
       enabled: true
 

--- a/charts/lakefs/ci/lakefs-app.yaml
+++ b/charts/lakefs/ci/lakefs-app.yaml
@@ -68,7 +68,10 @@ replicaCount: 1
 # Chart defaults (delay=0s, period=10s, failureThreshold=3 => killed after
 # only 30s) are too tight for LakeFS's first-boot DB migration — the pod
 # was being SIGKILLed (exit 137, "failed liveness probe") before it ever
-# bound :8000. Found live during ADR-0085 verification.
+# bound :8000. Found live during ADR-0085 verification. Round 1
+# (initialDelaySeconds=20, failureThreshold=6, ~80s) still wasn't enough —
+# still got killed mid-migration ("postgres get: context canceled").
+# Round 2: more generous margin, ~150s.
 readinessProbe:
   # This chart's readinessProbe template has no initialDelaySeconds field
   # (silently dropped if set) — periodSeconds/failureThreshold still give
@@ -96,9 +99,14 @@ ingress:
   enabled: true
   ingressClassName: traefik
   annotations:
-    # ForwardAuth Middleware CR shipped by the depsOverlay — gates the whole
-    # app behind the lakefs-auth oauth2-proxy instance (ADR-0085).
-    traefik.ingress.kubernetes.io/router.middlewares: mlops-lakefs-forwardauth@kubernetescrd
+    # Middleware chain shipped by the depsOverlay (ADR-0085). ORDER MATTERS:
+    # Traefik applies middlewares left-to-right on the request, so the
+    # FIRST one listed is outermost and sees the response LAST — it must be
+    # errors-first so it can catch/rewrite the 401 that forwardauth
+    # produces for unauthenticated requests. forwardauth alone (no errors
+    # middleware) returns a bare 401 with no redirect to login — found live
+    # during ADR-0085 verification.
+    traefik.ingress.kubernetes.io/router.middlewares: mlops-lakefs-oauth-errors@kubernetescrd,mlops-lakefs-forwardauth@kubernetescrd
   hosts:
     - host: lakefs.mlops.ai.camer.digital
       paths:

--- a/charts/mlflow/ci/mlflow-app.yaml
+++ b/charts/mlflow/ci/mlflow-app.yaml
@@ -66,7 +66,9 @@ oidcAuth:
   existingSecret:
     name: mlflow-oidc
     clientSecretKey: client-secret
-  scope: "openid,email,profile"
+  # OAuth2/OIDC `scope` is SPACE-separated per spec — Keycloak rejected the
+  # comma-separated form outright. Found live during ADR-0085 verification.
+  scope: "openid email profile"
   providerDisplayName: "Sign in with Keycloak"
   # Client-role claim (oidc-usermodel-client-role-mapper on the `mlflow`
   # Keycloak client, same pattern as coder's coder_roles / argo-workflows'


### PR DESCRIPTION
Keeps the three charts/*/ci/*-app.yaml reference copies in sync with ADORSYS-GIS/ai-helm-values#121. Documentation/reference-only, no functional change to this repo's own CI.