### PR TITLE
fix(lightbridge-secrets): materialise redis-ha AUTH password in converse

### DIFF
--- a/charts/lightbridge-secrets/values.yaml
+++ b/charts/lightbridge-secrets/values.yaml
@@ -52,3 +52,20 @@ externalSecrets:
       - secretKey: s3_secret_access_key
         key: prod/meta/test-app
         property: s3_backup_cnpg_secret
+  # Shared redis-ha AUTH password (secretKeyRef name: redis-ha-redis-auth, key:
+  # redis-password) for the api component's Redis-backed rate limiting
+  # (lightbridge-authz#135 / ADR-0003 "Rate limiting (Redis-backed)"). The api pod
+  # reaches the shared redis-ha (home-os, redis-system) through a haproxy TLS
+  # sidecar and presents this password as Redis AUTH (see the redis block +
+  # sidecar in ai-helm-values environments/prod/values/lightbridge-app.yaml).
+  #
+  # SAME platform secret + property the observability exporter, LibreChat and the
+  # Envoy rate-limiter use (prod/meta/test-app # redis_password) — NOT the
+  # consolidated app secret. Each consumer namespace needs its own copy; this
+  # materialises the converse-namespace copy. Key `redis-password` matches what
+  # the other consumers read.
+  redis-ha-redis-auth:
+    data:
+      - secretKey: redis-password
+        key: prod/meta/test-app
+        property: redis_password


### PR DESCRIPTION
## 1. Summary

This PR changes:

- Adds a `redis-ha-redis-auth` ExternalSecret to `charts/lightbridge-secrets` — the converse-namespace copy of the shared redis-ha AUTH password (`redis-password` ← `prod/meta/test-app`#`redis_password`).

It solves:

- **A live crash-loop of the `lightbridge-api` pods.** The [lightbridge-authz#135](https://github.com/ADORSYS-GIS/lightbridge-authz/pull/135) cratestack migration made authz-api's Redis-backed rate limiting a **hard startup requirement** — `start_api_server` returns `"redis config is required for authz-api rate limiting"` when Redis isn't configured. The new image floated live (argocd-image-updater) with no Redis wired, so the api pods fail to start. This secret is the first half of the fix (the sidecar + config wiring lives in the paired ai-helm-values PR).

---

## 2. Intent

The intent of this PR is:

> To give the `lightbridge-api` pods the credential they need to authenticate to the shared `redis-ha` (home-os, `redis-system`). authz-api's Redis client (`cratestack-redis` → the `redis` crate built **without** a TLS feature) cannot speak `rediss://`, so it reaches redis-ha through a haproxy TLS sidecar and presents this password as plain Redis `AUTH` over the local tunnel. ESO ExternalSecrets are namespace-scoped, so the `converse` namespace needs its own copy of the same platform password the observability exporter, LibreChat and the Envoy rate-limiter already consume.

---

## 3. Scope

### In Scope

- One new `externalSecrets` entry (`redis-ha-redis-auth`) in `charts/lightbridge-secrets/values.yaml`, reusing the chart's existing values-driven ExternalSecret template unchanged.

### Out of Scope

- The haproxy TLS sidecar, the `redis:` config block, and the `REDIS_PASSWORD`/`REDIS_URL` env wiring — those live in the paired **ai-helm-values** PR (`environments/prod/values/lightbridge-app.yaml`).
- Any change to redis-ha itself (home-os, `redis-system`) — unchanged; this only consumes its existing password.

---

## 4. Verification

I verified this change by:

- [x] Running manual tests
- [x] Reviewing the diff

Commands run:

```bash
helm template lbs charts/lightbridge-secrets
```

Results:

```text
Renders a valid ExternalSecret:
  kind: ExternalSecret
  metadata: { name: redis-ha-redis-auth, namespace: <release ns = converse> }
  spec.secretStoreRef: { name: ssegning-aws, kind: ClusterSecretStore }
  spec.target: { name: redis-ha-redis-auth, creationPolicy: Owner }
  spec.data: [ { secretKey: redis-password, remoteRef: { key: prod/meta/test-app, property: redis_password } } ]
Full-chart render exits 0 (no template errors).
```

---

## 5. Screenshots / Evidence

- Root-cause reference: [lightbridge-authz#135](https://github.com/ADORSYS-GIS/lightbridge-authz/pull/135) — the migration that made Redis a hard requirement (`start_api_server`, `crates/lightbridge-authz-rest/src/lib.rs`).
- Precedent for the same password/property: `charts/librechat-app/values.yaml` (`redisExternalSecret`), `ai-helm-values` `environments/base/deps/prometheus-redis-exporter/external-secret.yaml`.

---

## 6. Risk Assessment

Risk level:

* [x] Low

Potential risks:

* The property `redis_password` must exist under `prod/meta/test-app` in the `ssegning-aws` store — it does (same key the exporter/LibreChat/Envoy already resolve), so the ES won't sit in `SecretSyncedError`.
* On its own this secret is inert; the pod only consumes it once the paired ai-helm-values PR lands.

Mitigation:

* Land this PR first (or together) so the Secret exists before the api pod references it.

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [x] Reviewing the diff

Human verification:

* [x] I understand every meaningful change in this PR
* [x] I checked generated code manually
* [x] I removed unsupported AI assumptions
* [x] I accept responsibility for this PR

Produced by Claude Code (Claude Opus 4.8) under live human direction. The root cause (authz-api hard-requires Redis; its client has no TLS feature so it can't use redis-ha directly) was verified against the actual lightbridge-authz source and the `cratestack-redis` crate's `Cargo.toml` feature set, not assumed. The password source (`prod/meta/test-app`#`redis_password`) was matched to the existing exporter/LibreChat/Envoy consumers rather than invented.

Source of truth: https://github.com/ADORSYS-GIS/lightbridge-authz/pull/135
Governance: https://adorsys-gis.github.io/ai-governance/

---

## 8. Reviewer Focus

Please focus your review on:

* [x] Correctness
* [x] Security
* [x] Product intent
