### PR TITLE
fix(librechat-app): serve icon assets from public S3, not raw GitHub

### DIFF
--- a/charts/librechat-app/values.yaml
+++ b/charts/librechat-app/values.yaml
@@ -704,7 +704,7 @@ config:
       description: "Provides access to GitHub issues across all repositories the user has access to, with support for filtering by organization, repository, assignee, and more."
       initTimeout: 150000
       url: "https://api.githubcopilot.com/mcp/x/issues"
-      iconPath: https://raw.githubusercontent.com/ADORSYS-GIS/ai-helm/main/assets/images/GitHub_Invertocat_White.png
+      iconPath: https://s3.ssegning.me/ai-ops-backups/public/GitHub_Invertocat_White.png
       oauth:
         authorization_url: https://github.com/login/oauth/authorize
         token_url: https://github.com/login/oauth/access_token
@@ -718,7 +718,7 @@ config:
       description: "Provides access to GitHub projects across all repositories the user has access to, with support for filtering by organization, repository, assignee, and more."
       initTimeout: 150000
       url: "https://api.githubcopilot.com/mcp/x/projects"
-      iconPath: https://raw.githubusercontent.com/ADORSYS-GIS/ai-helm/main/assets/images/GitHub_Invertocat_White.png
+      iconPath: https://s3.ssegning.me/ai-ops-backups/public/GitHub_Invertocat_White.png
       oauth:
         authorization_url: https://github.com/login/oauth/authorize
         token_url: https://github.com/login/oauth/access_token
@@ -732,7 +732,7 @@ config:
       description: "Provides access to GitHub pull requests across all repositories the user has access to, with support for filtering by organization, repository, assignee, and more."
       initTimeout: 150000
       url: "https://api.githubcopilot.com/mcp/x/pull_requests"
-      iconPath: https://raw.githubusercontent.com/ADORSYS-GIS/ai-helm/main/assets/images/GitHub_Invertocat_White.png
+      iconPath: https://s3.ssegning.me/ai-ops-backups/public/GitHub_Invertocat_White.png
       oauth:
         authorization_url: https://github.com/login/oauth/authorize
         token_url: https://github.com/login/oauth/access_token
@@ -746,7 +746,7 @@ config:
       description: "Provides access to GitHub repositories across all repositories the user has access to, with support for filtering by organization, repository, assignee, and more."
       initTimeout: 150000
       url: "https://api.githubcopilot.com/mcp/x/repos"
-      iconPath: https://raw.githubusercontent.com/ADORSYS-GIS/ai-helm/main/assets/images/GitHub_Invertocat_White.png
+      iconPath: https://s3.ssegning.me/ai-ops-backups/public/GitHub_Invertocat_White.png
       oauth:
         authorization_url: https://github.com/login/oauth/authorize
         token_url: https://github.com/login/oauth/access_token
@@ -760,7 +760,7 @@ config:
       description: "Provides access to search across GitHub's support documentation, enabling users to find relevant articles and resources based on their queries."
       initTimeout: 150000
       url: "https://api.githubcopilot.com/mcp/x/github_support_docs_search"
-      iconPath: https://raw.githubusercontent.com/ADORSYS-GIS/ai-helm/main/assets/images/GitHub_Invertocat_White.png
+      iconPath: https://s3.ssegning.me/ai-ops-backups/public/GitHub_Invertocat_White.png
       oauth:
         authorization_url: https://github.com/login/oauth/authorize
         token_url: https://github.com/login/oauth/access_token
@@ -1062,7 +1062,7 @@ config:
           "adorsys-frontend":       { context: 262144,  prompt: 0.20, completion: 0.80, cacheRead: 0.04 }
           "adorsys-frontend-pro":   { context: 262144,  prompt: 0.74, completion: 3.50, cacheRead: 0.15 }
           "adorsys-researcher":     { context: 1048576, prompt: 0.14, completion: 0.28, cacheRead: 0.028 }
-        iconURL: "https://s3.ssegning.me/ai-ops-backups/public/chicken-leg.png"
+        iconURL: "https://s3.ssegning.me/ai-ops-backups/public/adorsys.png"
         titleConvo: false
         titleMethod: "completion"
         titleModel: "gemma-4"


### PR DESCRIPTION
## 1. Summary
Point LibreChat icon URLs at the public S3 bucket instead of `raw.githubusercontent.com/ADORSYS-GIS/ai-helm`:
- 5 GitHub-MCP `iconPath`s → `s3.ssegning.me/ai-ops-backups/public/GitHub_Invertocat_White.png`
- Converse endpoint `iconURL` → `s3.ssegning.me/ai-ops-backups/public/adorsys.png` (was `chicken-leg.png`)

## 2. Intent
> The raw.githubusercontent URLs break once ai-helm goes private (#640) — LibreChat fetches icons anonymously. Consolidate onto the public S3 host already used for the endpoint icon. Source: #640.

## 3. Scope
### In Scope
- `charts/librechat-app/values.yaml` icon URLs (2 distinct URLs).
### Out of Scope
- `adorsys-icon-primary.jpg` iconPaths still on raw.githubusercontent (flagged for a follow-up before the repo flips private).

## 4. Verification
- [x] Running automated tests
```bash
helm template lc charts/librechat-app/   # OK
grep -n "GitHub_Invertocat_White.png\|chicken-leg.png\|adorsys.png" charts/librechat-app/values.yaml
```
Results: 5 iconPaths now on S3; endpoint icon → adorsys.png; no chicken-leg refs remain; render clean.

## 5. Screenshots / Evidence
* n/a (icon URL swap)

## 6. Risk Assessment
Risk level: [x] Low
Risk: the new S3 objects must exist/serve publicly (bucket owner uploads `GitHub_Invertocat_White.png` + `adorsys.png`). Mitigation: cosmetic-only — a missing icon degrades to a broken image, nothing functional. Rollback = `git revert`.

## 7. AI Usage Declaration
AI was used for: [x] Generating code  [x] Reviewing the diff
Human verification:
* [ ] I understand every meaningful change in this PR
* [ ] I accept responsibility for this PR

## 8. Reviewer Focus
* [x] Correctness (URLs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
