### PR TITLE
fix(skills): kebab-case the code-review skill name (sync validation)

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -22,6 +22,13 @@ skills/
 skill body. The `description` is what LibreChat matches on to decide relevance,
 so make it specific about *when* to use the skill.
 
+⚠️ **`name` must be kebab-case** — `^[a-z0-9][a-z0-9-]*$`, ≤64 chars, not
+starting `anthropic-`/`claude-`, and not a reserved word (`help`, `clear`,
+`compact`, `model`, `exit`, `quit`, `settings`, `anthropic`, `claude`). A
+non-conforming name (e.g. `Code Review`) fails sync with
+`[GitHubSkillSync] … Skill validation failed`. Put the human-friendly label in
+`displayTitle` (≤128 chars); `description` ≤1024, body ≤100k.
+
 ## Adding a skill
 
 1. Create `skills/<kebab-name>/SKILL.md` with `name` + `description` frontmatter.

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -1,5 +1,6 @@
 ---
-name: Code Review
+name: code-review
+displayTitle: Code Review
 description: A structured procedure for reviewing a code change (pull/merge request) — what to evaluate, how to calibrate severity, and how to phrase feedback. Use when reviewing a diff, a PR, or deciding whether a change is ready to merge.
 ---
 


### PR DESCRIPTION
## 1. Summary
Fix the `code-review` skill so LibreChat's GitHub skill sync accepts it. Live error in the LibreChat pods:
```
[GitHubSkillSync] Source "ai-helm-skills" failed: Skill validation failed
```
Cause: skill `name` must be kebab-case (`^[a-z0-9][a-z0-9-]*$`, v0.8.7 `schema/skill.ts`), but it was `Code Review`.

- `name: Code Review` → `code-review`
- human label moved to `displayTitle: Code Review`
- documented the naming rule + reserved words in `skills/README.md`

## 2. Intent
> Make the first synced skill actually validate. The sync auth + discovery already work — only the skill's frontmatter was invalid. Source: live pod logs.

## 3. Scope
### In Scope
- `skills/code-review/SKILL.md` (frontmatter), `skills/README.md` (docs).
### Out of Scope
- Skill content unchanged.

## 4. Verification
- [x] Running automated tests
- [x] Checking logs (the failing log is what prompted this)
```bash
echo "code-review" | grep -qE '^[a-z0-9][a-z0-9-]*$'   # passes the v0.8.7 regex
# name ≤64, displayTitle ≤128, description ≤1024, not a reserved word
```
Results: name now matches LibreChat's `skillNamePattern`; sync should validate on the next interval/pod start.

## 5. Screenshots / Evidence
* LibreChat pod log line above.

## 6. Risk Assessment
Risk level: [x] Low — a frontmatter rename; no behavioural code.

## 7. AI Usage Declaration
AI was used for: [x] Understanding existing code  [x] Generating code  [x] Reviewing the diff
Human verification:
* [ ] I understand every meaningful change in this PR
* [ ] I accept responsibility for this PR

## 8. Reviewer Focus
* [x] Correctness (skill validates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
