### PR TITLE
feat(librechat-app): rename default model-spec to Converse + icon

### DIFF
--- a/charts/librechat-app/values.yaml
+++ b/charts/librechat-app/values.yaml
@@ -663,8 +663,8 @@ config:
     enforce: false
     prioritize: true
     list:
-      - name: general
-        label: "General"
+      - name: converse
+        label: "Converse"
         default: true
         description: "Everyday assistant — web search, file search, and code execution."
         showIconInMenu: true
@@ -676,7 +676,7 @@ config:
           endpoint: "Converse"
           model: "glm-5p2"
           promptPrefix: |
-            You are the Converse general assistant. Be concise, accurate, and
+            You are the Converse assistant. Be concise, accurate, and
             practical. Prefer web search for anything time-sensitive, run code to
             verify non-trivial claims, and cite sources when you searched.
       - name: repo-concierge
@@ -1096,7 +1096,7 @@ config:
           "adorsys-frontend":       { context: 262144,  prompt: 0.20, completion: 0.80, cacheRead: 0.04 }
           "adorsys-frontend-pro":   { context: 262144,  prompt: 0.74, completion: 3.50, cacheRead: 0.15 }
           "adorsys-researcher":     { context: 1048576, prompt: 0.14, completion: 0.28, cacheRead: 0.028 }
-        iconURL: "https://s3.ssegning.me/ai-ops-backups/public/adorsys.png"
+        iconURL: "https://s3.ssegning.me/ai-ops-backups/public/adorsys-icon-white.png"
         titleConvo: false
         titleMethod: "completion"
         titleModel: "gemma-4"


### PR DESCRIPTION
## 1. Summary
Rebrand the default (main) LibreChat persona and its endpoint icon:
- default model-spec: `name` general→converse, `label` "General"→"Converse", promptPrefix "Converse general assistant"→"Converse assistant".
- Converse endpoint `iconURL`: adorsys.png → adorsys-icon-white.png.

## 2. Intent
> The main model should read as "Converse", not "General"; use the white adorsys icon. Cosmetic/branding. Source: maintainer request.

## 3. Scope
### In Scope
- `charts/librechat-app/values.yaml` (inline `config:` — modelSpec label/name/prompt + endpoint icon).
### Out of Scope
- Everything else.

## 4. Verification
- [x] Running automated tests
```bash
helm template lc charts/librechat-app/   # OK
grep -n 'name: converse\|label: "Converse"\|adorsys-icon-white.png' charts/librechat-app/values.yaml
```
Results: renders clean; label/name/icon updated; no `adorsys.png`/`General` left.

## 5. Screenshots / Evidence
* n/a (label + icon)

## 6. Risk Assessment
Risk level: [x] Low — branding only.
Note: the new icon object `adorsys-icon-white.png` must exist in the public S3 bucket (a missing icon degrades to a broken image, nothing functional).

## ⚠️ Migration coupling
This edits the inline `config:` that ADR-0087 moves to ai-helm-values. The values-repo snapshot (adorsys-gis/ai-helm-values#129) is updated in lockstep, so the split stays behaviour-neutral and won't revert this. Merge order is unaffected (values-repo-first still holds); if this merges after the split, apply the same two lines to the values file instead.

## 7. AI Usage Declaration
AI was used for: [x] Generating code  [x] Reviewing the diff
Human verification:
* [ ] I understand every meaningful change in this PR
* [ ] I accept responsibility for this PR

## 8. Reviewer Focus
* [x] Product intent (naming/branding)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
