### PR TITLE
fix(skills): drop displayTitle — not an allowed sync frontmatter key

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -24,10 +24,17 @@ so make it specific about *when* to use the skill.
 
 ⚠️ **`name` must be kebab-case** — `^[a-z0-9][a-z0-9-]*$`, ≤64 chars, not
 starting `anthropic-`/`claude-`, and not a reserved word (`help`, `clear`,
-`compact`, `model`, `exit`, `quit`, `settings`, `anthropic`, `claude`). A
-non-conforming name (e.g. `Code Review`) fails sync with
-`[GitHubSkillSync] … Skill validation failed`. Put the human-friendly label in
-`displayTitle` (≤128 chars); `description` ≤1024, body ≤100k.
+`compact`, `model`, `exit`, `quit`, `settings`, `anthropic`, `claude`).
+`description` ≤1024 chars, body ≤100k.
+
+⚠️ **The sync validates frontmatter against a strict allowlist** — only these
+keys are permitted: `name`, `description`, `when-to-use`, `allowed-tools`,
+`arguments`, `argument-hint`, `user-invocable`, `disable-model-invocation`,
+`always-apply`/`alwaysApply`, `model`, `effort`, `context`, `agent`, `paths`,
+`shell`, `hooks`, `version`, `license`, `metadata`. **Any other key
+(e.g. `displayTitle`, `title`) fails sync** with `[GitHubSkillSync] … Skill
+validation failed`. There is no frontmatter field for a pretty display name in a
+synced skill — the skill shows under its `name`.
 
 ## Adding a skill
 

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: code-review
-displayTitle: Code Review
 description: A structured procedure for reviewing a code change (pull/merge request) — what to evaluate, how to calibrate severity, and how to phrase feedback. Use when reviewing a diff, a PR, or deciding whether a change is ready to merge.
 ---
 


### PR DESCRIPTION
## 1. Summary
The `code-review` skill still failed sync after #727 (even on a fresh pod):
```
[GitHubSkillSync] Source "ai-helm-skills" failed: Skill validation failed
```
Root cause: #727 added `displayTitle`, but the sync validates frontmatter against a **strict allowlist** (`ALLOWED_FRONTMATTER_KEYS` in `methods/skill.ts`) and `displayTitle` isn't on it. Remove it; the skill now has only `name` + `description` (both allowlisted). Also corrected `skills/README.md` (it wrongly recommended `displayTitle`).

## 2. Intent
> Make the skill actually validate + document the real allowlist so it doesn't recur. Source: live pod logs.

## 3. Scope
### In / Out
- In: `skills/code-review/SKILL.md` (drop `displayTitle`), `skills/README.md` (allowlist).
- Out: skill body.

## 4. Verification
- [x] Checking logs (the persistent failure prompted this)
```bash
# frontmatter now only: name (kebab-case), description — both in ALLOWED_FRONTMATTER_KEYS
sed -n '1,4p' skills/code-review/SKILL.md
```
Results: only allowlisted keys remain; validates against v0.8.7 `methods/skill.ts`.

## 5. Evidence
* `[GitHubSkillSync] … Skill validation failed` (persisted after a pod restart, pre-this-fix).

## 6. Risk Assessment
Risk level: [x] Low — frontmatter only.

## 7. AI Usage Declaration
AI was used for: [x] Understanding existing code  [x] Generating code  [x] Reviewing the diff
Human verification:
* [ ] I understand every meaningful change in this PR
* [ ] I accept responsibility for this PR

## 8. Reviewer Focus
* [x] Correctness (skill validates on next sync)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
