### PR TITLE
feat(librechat-app): roll pods on config change via checksum marker (Option A)

### DIFF
--- a/charts/librechat-app/values.yaml
+++ b/charts/librechat-app/values.yaml
@@ -545,6 +545,30 @@ librechat:
                 failureThreshold: 30
                 periodSeconds: 5
 
+  # config-rollout — force the librechat pods to redeploy on a config change.
+  # The librechat.yaml `config:` object is a STANDALONE ConfigMap
+  # (templates/configmap.yaml, rendered from top-level .Values.config which now
+  # comes from ai-helm-values). bjw-s can't content-hash a ConfigMap it doesn't
+  # manage, and the config's subPath mount does NOT auto-update — so editing the
+  # config alone would silently keep the old config until the pod restarts for
+  # another reason. This tiny UNMOUNTED marker ConfigMap, listed in
+  # includeChecksumInControllers, makes bjw-s stamp a `checksum/configMaps`
+  # annotation on the librechat pods. ⚠️ Bump `data.generation` (overridden from
+  # ai-helm-values, co-located with the config) in the SAME commit as any
+  # `config:` change and the pods roll to pick it up. Pattern: ADR-0087 +
+  # lightbridge-code-intelligence.
+  configMaps:
+    config-rollout:
+      enabled: true
+      # Pin the name to <release>-config-rollout (else bjw-s collapses a lone
+      # managed configMap to the bare release name). The checksum hashes only
+      # `data`, so the suffix doesn't affect it.
+      suffix: config-rollout
+      includeChecksumInControllers:
+        - librechat
+      data:
+        generation: "1"
+
   persistence:
     config:
       enabled: true


### PR DESCRIPTION
## 1. Summary
Make the librechat pods **redeploy on a config change** (Option A). ADR-0087 moved the `config:` object to ai-helm-values; a config edit updates the standalone ConfigMap but doesn't roll the pods (bjw-s can't hash a ConfigMap it doesn't manage; the subPath mount doesn't auto-update). Add a tiny **unmounted bjw-s marker ConfigMap** `config-rollout` with `includeChecksumInControllers: [librechat]` → bjw-s stamps `checksum/configMaps` on the pods. Bumping `data.generation` (from ai-helm-values, co-located with the config) rolls them.

## 2. Intent
> Close the config-change → no-rollout foot-gun without moving the config into bjw-s (which would drag the parent-scope `mongo_uri` helper into the subchart scope — see the maintainer's concern). Same pattern as `lightbridge-code-intelligence`. Source: ADR-0087.

## 3. Scope
### In / Out
- In: `charts/librechat-app/values.yaml` — the `librechat.configMaps.config-rollout` marker.
- Out: config itself (unchanged), the `generation` value (lands in ai-helm-values).

## 4. Verification
- [x] Running automated tests
```bash
helm template lc charts/librechat-app/   # OK; lint --strict OK
# checksum/configMaps annotation present on the librechat Deployment,
# and CHANGES on a generation bump:
#   gen=1 -> a434b7…  ;  gen=2 -> 7e38f6…
```
Results: annotation renders + changes on bump → ArgoCD rolls pods. Marker CM `lc-config-rollout` renders with `data.generation`.

## 5. Evidence
* checksum diff on bump (above).

## 6. Risk Assessment
Risk level: [x] Low
* Introducing the annotation rolls the pods once (first appearance) — a brief RollingUpdate, already tolerated (replicas:2, PDB minAvailable:1).
* Semi-automatic by design: a config edit only rolls if `generation` is bumped in the same ai-helm-values commit (documented loudly next to the config).

## 7. AI Usage Declaration
AI was used for: [x] Understanding existing code  [x] Generating code  [x] Reviewing the diff
Human verification:
* [ ] I understand every meaningful change in this PR
* [ ] I accept responsibility for this PR

## 8. Reviewer Focus
* [x] Correctness (checksum changes on bump)  [x] Architecture (bjw-s marker vs full-bjw-s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
