### PR TITLE
feat(librechat-app): enable Code Interpreter (LIBRECHAT_CODE_API_KEY via ESO)

### DIFF
--- a/charts/librechat-app/values.yaml
+++ b/charts/librechat-app/values.yaml
@@ -90,7 +90,8 @@ librechatSecrets:
     # LibreChat Code Interpreter API key (the managed sandbox service — code runs
     # on LibreChat/Clickhouse infra, not our cluster). Activates the already-on
     # `execute_code` agent capability. Injected as LIBRECHAT_CODE_API_KEY below.
-    # Get the key from a LibreChat Code Interpreter subscription (paid).
+    # Get the key from your librechat.ai account (Code Interpreter is GA/free
+    # now — no pricing; a key is still required to call the managed API).
     librechat-code-config:
       code_api_key: { key: ai/camer/digital/prod/env, property: librechat_code_api_key }
 

--- a/charts/librechat-app/values.yaml
+++ b/charts/librechat-app/values.yaml
@@ -87,6 +87,12 @@ librechatSecrets:
     # once ai-helm is private, #640). Injected as GITHUB_SKILLS_TOKEN below.
     librechat-skills-sync:
       github_token: { key: ai/camer/digital/prod/env, property: librechat_skills_sync_github_token }
+    # LibreChat Code Interpreter API key (the managed sandbox service — code runs
+    # on LibreChat/Clickhouse infra, not our cluster). Activates the already-on
+    # `execute_code` agent capability. Injected as LIBRECHAT_CODE_API_KEY below.
+    # Get the key from a LibreChat Code Interpreter subscription (paid).
+    librechat-code-config:
+      code_api_key: { key: ai/camer/digital/prod/env, property: librechat_code_api_key }
 
 # ────────────────────────────────────────────────────────────────────────
 # Agent-seed Job (ADR-0088). Idempotently provisions the LibreChat agent fleet
@@ -333,6 +339,12 @@ librechat:
               secretKeyRef:
                 name: librechat-skills-sync
                 key: github_token
+
+            # Code Interpreter (managed sandbox API) — activates execute_code.
+            LIBRECHAT_CODE_API_KEY:
+              secretKeyRef:
+                name: librechat-code-config
+                key: code_api_key
 
             OPENID_CLIENT_ID:
               secretKeyRef:


### PR DESCRIPTION
## Summary
Enable LibreChat **Code Interpreter** — the managed secure-sandbox API. Add `LIBRECHAT_CODE_API_KEY` via ESO (`librechat-code-config`) + env, mirroring the skills-PAT wiring. `execute_code` is already on (defaults + our `executeCode:true` specs); the key activates it.

## What it is
Code executes on LibreChat/Clickhouse **managed sandboxes**, not our cluster (the isolation model). No public self-hostable runtime.

## Getting the key (correction: it is FREE)
The Code Interpreter is **GA / free** since the Clickhouse acquisition — no pricing. A `LIBRECHAT_CODE_API_KEY` is still required to call the managed API; obtain it free from a **librechat.ai account**.

## Prerequisite
Add `librechat_code_api_key` to `ssegning-aws` `ai/camer/digital/prod/env`. Until then the ExternalSecret sits in `SecretSyncedError` (fails closed).

## Verification
`helm template` + `lint --strict` pass; ExternalSecret + env render.

AI-assisted; human review required.
