### PR TITLE
fix(librechat-app): agent-seed sends a browser User-Agent (uaParser)

### DIFF
--- a/charts/librechat-app/files/seed-agents.js
+++ b/charts/librechat-app/files/seed-agents.js
@@ -20,10 +20,20 @@ const AGENT_VIEWER = 'agent_viewer';
 
 function die(msg) { console.error(`[agent-seed] ${msg}`); process.exit(1); }
 
+// LibreChat's uaParser middleware rejects any non-browser User-Agent with an SSE
+// "Illegal request" (NON_BROWSER violation). Node fetch's default UA isn't a
+// browser, so present a browser UA on every call.
+const BROWSER_UA =
+  'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36';
+
 async function api(method, path, token, body) {
   const res = await fetch(`${LIBRECHAT_URL}${path}`, {
     method,
-    headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+      'User-Agent': BROWSER_UA,
+    },
     body: body ? JSON.stringify(body) : undefined,
   });
   const text = await res.text();


### PR DESCRIPTION
## Fix
The agent-seed Job failed at `POST /api/agents` with an SSE `{"message":"Illegal request"}`. Auth was fine (author resolved, JWT accepted) — the cause is LibreChat's `uaParser` middleware, which rejects any request whose **User-Agent is not a recognized browser** (NON_BROWSER violation). Node `fetch` sends a non-browser UA.

Send a Chrome User-Agent on every seed API call. The script change also moves the Job checksum, so it re-runs on the next PostSync.

## Verify
`helm template` + `lint --strict` pass; the rendered seed-script ConfigMap now carries the `User-Agent` header.

**Merge → next PostSync re-runs the seed.** I can watch it live (home-remote) once merged.

AI-assisted; human review required.
