### PR TITLE
fix(librechat-app): agent-seed — use the generic resource-ACL endpoint

### DIFF
--- a/charts/librechat-app/files/seed-agents.js
+++ b/charts/librechat-app/files/seed-agents.js
@@ -74,8 +74,11 @@ async function main() {
     let id = idByName[spec.name];
     if (id) { await api('PATCH', `/api/agents/${id}`, token, body); console.log(`[agent-seed] patched ${spec.name} (${id})`); }
     else { const a = await api('POST', '/api/agents', token, body); id = a.id || (a.agent && a.agent.id); if (!id) die(`create returned no id for ${spec.name}: ${JSON.stringify(a).slice(0,300)}`); idByName[spec.name] = id; console.log(`[agent-seed] created ${spec.name} (${id})`); }
-    // grant PUBLIC view (visible to all users) — same mechanism skill-sync uses
-    await api('PUT', `/api/agents/${id}/permissions`, token, { public: true, publicAccessRoleId: AGENT_VIEWER });
+    // grant PUBLIC view (visible to all users) via the generic resource-ACL endpoint
+    // PUT /api/permissions/<resourceType>/<id> — `updated`/`removed` are REQUIRED
+    // arrays; the top-level public+publicAccessRoleId is expanded to a PUBLIC
+    // principal server-side (PermissionsController.updateResourcePermissions).
+    await api('PUT', `/api/permissions/agent/${id}`, token, { updated: [], removed: [], public: true, publicAccessRoleId: AGENT_VIEWER });
     return id;
   }
 

--- a/docs/adr/0088-agent-seed-job-system-user-and-visibility.md
+++ b/docs/adr/0088-agent-seed-job-system-user-and-visibility.md
@@ -25,11 +25,13 @@ two pins resolved:
    User doc is provisioned (ObjectId ↔ OIDC `sub`); the Job then looks that
    ObjectId up in Mongo and **mints a LibreChat JWT** (`jwt.sign({id}, JWT_SECRET)`
    — the payload `requireJwtAuth` expects). No fake service account.
-2. **Visibility = a public ACL grant.** After create, the Job calls
-   **`PUT /api/agents/<id>/permissions`** with
-   `{ public: true, publicAccessRoleId: "agent_viewer" }` — the same
-   `PrincipalType.PUBLIC` + access-role mechanism the skill sync uses
-   (`SKILL_VIEWER`). Every seeded agent is world-visible under the Agents endpoint.
+2. **Visibility = a public ACL grant.** After create, the Job calls the generic
+   resource-ACL endpoint **`PUT /api/permissions/agent/<id>`** with
+   `{ updated: [], removed: [], public: true, publicAccessRoleId: "agent_viewer" }`
+   (`updated`/`removed` are required arrays; the top-level `public` +
+   `publicAccessRoleId` is expanded to a `PrincipalType.PUBLIC` principal
+   server-side). This is the same access-role mechanism the skill sync uses
+   (`skill_viewer`). Every seeded agent is world-visible under the Agents endpoint.
 
 ### Seed flow (all verified against v0.8.7)
 


### PR DESCRIPTION
## Summary

The agent-seed Job (ADR-0088) authored the fleet correctly but failed on the **public-visibility grant** with a 404 in prod:

```
[agent-seed] patched security-reviewer (agent_RyI7_jBSK6yJ98AzW8Dqm)
[agent-seed] Error: PUT /api/agents/agent_RyI7_jBSK6yJ98AzW8Dqm/permissions -> 404 {"message":"Endpoint not found"}
```

LibreChat v0.8.7 has **no per-agent `/permissions` sub-route**. Resource sharing is a *generic* ACL surface mounted at `/api/permissions`, keyed by `resourceType`:

```
PUT /api/permissions/{resourceType}/{resourceId}
```

So the correct call is `PUT /api/permissions/agent/<id>`. Its request schema makes `updated`/`removed` **required arrays**; the top-level `public` + `publicAccessRoleId` is expanded to a `PrincipalType.PUBLIC` principal server-side. The old payload used both the wrong path and omitted the required arrays.

**Fix:** `PUT /api/permissions/agent/<id>` with `{ updated: [], removed: [], public: true, publicAccessRoleId: 'agent_viewer' }`. The PATCH/POST create path was already correct (the log shows a successful `patched` before the 404), so this is the sole blocker to the public grant.

## Intent

Source of truth: the failed prod run above + the LibreChat v0.8.7 route contract. Fixes ADR-0088's documented endpoint (still `Proposed`, so amended in place).

## Scope

- `charts/librechat-app/files/seed-agents.js` — the ACL call.
- `docs/adr/0088-…md` — endpoint corrected in the decision body.

No chart-template, values, or image changes.

## Verification

Endpoint + payload verified against `danny-avila/LibreChat @ v0.8.7`:

| Fact | Source |
|---|---|
| `PUT /:resourceType/:resourceId` route | `api/server/routes/accessPermissions.js` |
| mounted at `/api/permissions` | `api/server/routes/index.js` → `app.use('/api/permissions', accessPermissions)` |
| URL builder `updateResourcePermissions` | `packages/data-provider/src/api-endpoints.ts` |
| `ResourceType.AGENT='agent'`, `AccessRoleIds.AGENT_VIEWER='agent_viewer'`, `updated`/`removed` required | `packages/data-provider/src/accessPermissions.ts` |
| top-level `public`+`publicAccessRoleId` → PUBLIC principal | `api/server/controllers/PermissionsController.js` (L78-82) |

Live smoke test: next ArgoCD PostSync re-runs the idempotent seed Job in `converse` — watch `kubectl -n converse logs job/librechat-app-agent-seed -f` for `[agent-seed] done`.

## Risk Assessment

**Low.** One-line endpoint/payload correction in a run-once, idempotent seed script guarded on `agentSeed.enabled`; fails closed. No effect on the running LibreChat workload.

## AI Usage Declaration

AI (Claude Opus 4.8) diagnosed the 404 by reading the LibreChat v0.8.7 source, located the correct ACL endpoint + payload schema, and wrote the fix. The human maintainer reviewed the diagnosis against the actual prod failure and owns the merge + live verification.

- [x] I verified the endpoint and payload against the pinned LibreChat source.
- [x] I can explain why the original route 404'd and why the new one is correct.

## Reviewer Focus

The `updated: []`/`removed: []` arrays are required by the schema — confirm they're present in the payload.