### PR TITLE
fix(librechat-app): harden LibreChat Deployment securityContext (Trivy KSV-0118)

### DIFF
--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -40,3 +40,14 @@ misconfigurations:
       control-plane and web containers keep readOnlyRootFilesystem:true.
     paths:
       - "lightbridge-code-intelligence/charts/lci/templates/common.yaml"
+      # The LibreChat Deployment (bjw-template alias `librechat`) needs a WRITABLE
+      # rootfs: the app writes winston logs (/app/api/logs) and stages uploads on
+      # its rootfs at runtime, so readOnlyRootFilesystem:true crashloops the live
+      # user-facing app (same class as the neo4j exemption above). KSV-0118 (the
+      # "allows root" finding) IS hardened for this Deployment — pod + container
+      # securityContext in charts/librechat-app/values.yaml (runAsNonRoot uid 1000,
+      # drop ALL caps, no priv-esc, seccomp RuntimeDefault); only the read-only
+      # rootfs is exempt. The mongodb subchart (`db`) DOES set
+      # readOnlyRootFilesystem:true (it only needs a /tmp emptyDir) and is not
+      # exempt.
+      - "librechat-app/charts/librechat/templates/common.yaml"

--- a/charts/librechat-app/values.yaml
+++ b/charts/librechat-app/values.yaml
@@ -253,6 +253,24 @@ librechat:
           port: 8000
           targetPort: 8000
 
+  # Pod + container hardening so the LibreChat Deployment clears Trivy KSV-0118
+  # (non-default securityContext / "allows root"). The official
+  # ghcr.io/danny-avila/librechat image runs as USER node (uid/gid 1000, from
+  # node:24-alpine), so runAsNonRoot at 1000 is a no-op on the image's own user.
+  # fsGroup 1000 keeps the mounted config/CA (readOnly secrets/CMs) group-owned.
+  # NOTE: readOnlyRootFilesystem is intentionally NOT set — LibreChat writes
+  # winston logs + upload staging to its rootfs at runtime; a read-only rootfs
+  # would crashloop the live app (KSV-0014 is path-scoped-ignored in
+  # .trivyignore.yaml with that justification).
+  defaultPodOptions:
+    securityContext:
+      runAsNonRoot: true
+      runAsUser: 1000
+      runAsGroup: 1000
+      fsGroup: 1000
+      seccompProfile:
+        type: RuntimeDefault
+
   controllers:
     librechat:
       type: deployment
@@ -265,6 +283,16 @@ librechat:
           app: librechat-app
       containers:
         librechat:
+          # Container hardening for KSV-0118. readOnlyRootFilesystem omitted on
+          # purpose (see defaultPodOptions note above + .trivyignore KSV-0014).
+          securityContext:
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
           image:
             repository: ghcr.io/danny-avila/librechat
             tag: "{{ .Values.global.librechat.version }}"


### PR DESCRIPTION
## Summary

The **Release Helm Charts** workflow was red: its Trivy config scan reported **3 HIGH** findings, all on the LibreChat Deployment (`librechat-app/charts/librechat/templates/common.yaml`, the bjw-template `librechat` alias):

| ID | Level | What |
|---|---|---|
| KSV-0118 | HIGH | container `librechat-app` — default security context |
| KSV-0118 | HIGH | deployment `librechat-app` — default security context (**allows root**) |
| KSV-0014 | HIGH | container `librechat` — `readOnlyRootFilesystem` not set |

The existing hardening block in `values.yaml` was only on the `db` (mongodb) subchart — the LibreChat Deployment itself had **no** securityContext.

## Fix

**KSV-0118 → hardened (real fix, safe).** The official `ghcr.io/danny-avila/librechat` image runs as `USER node` (uid/gid **1000**, from `node:24-alpine`), verified in its Dockerfile — so this is a no-op on the image's own user:
- `defaultPodOptions.securityContext`: `runAsNonRoot`, `runAsUser/Group 1000`, `fsGroup 1000`, `seccompProfile RuntimeDefault`
- container `securityContext`: `runAsNonRoot`, `allowPrivilegeEscalation: false`, `capabilities.drop: [ALL]`, `seccompProfile RuntimeDefault`

**KSV-0014 → path-scoped ignore** (`.trivyignore.yaml`), justified: LibreChat writes winston logs (`/app/api/logs`) + upload staging to its rootfs at runtime, so `readOnlyRootFilesystem: true` crashloops the **live** user-facing app — same class as the existing neo4j exemption. Only the read-only rootfs is exempt; KSV-0118 is fully hardened. (mongodb only needs a `/tmp` emptyDir, so it keeps `readOnlyRootFilesystem: true` and is **not** exempt.)

## Intent

Source of truth: the failed run [30071110580](https://github.com/ADORSYS-GIS/ai-helm/actions/runs/30071110580). Restores the Release Helm Charts gate to green.

## Scope

- `charts/librechat-app/values.yaml` — pod + container securityContext on the `librechat` controller.
- `.trivyignore.yaml` — one path-scoped, justified KSV-0014 entry for the LibreChat Deployment.

## Verification

- `trivy config charts/` (scanning `charts/` exactly as CI does) → `librechat-app/charts/librechat/templates/common.yaml` now reports **0 misconfigurations**.
- `helm lint charts/librechat-app` → `0 chart(s) failed`; `helm template` renders clean.
- Confirmed the mongodb subchart securityContext (incl. `readOnlyRootFilesystem: true`) is **unchanged**.
- Confirmed the securityContext lands on the rendered Deployment (pod-level + container-level).

**Note (separate latent gap, not fixed here):** CI's `trivy-action@v0.36.0` renders Helm assuming k8s v1.20.0 and **skips `llm-d` entirely** (`chart requires kubeVersion: >=1.28.0-0`), so llm-d's workloads — which also trip KSV-0118/0014 under a newer Trivy — are currently unscanned by this gate. Flagging for a follow-up; out of scope for this PR.

## Risk Assessment

**Low–medium.** Adds a securityContext that matches the image's own runtime user (uid 1000) — no privilege change — but it *will* roll the live LibreChat Deployment (RollingUpdate, replicas 2, PDB minAvailable 1). `readOnlyRootFilesystem` deliberately not enabled (would break the live app). Watch the rollout come Ready.

## AI Usage Declaration

AI (Claude Opus 4.8) diagnosed the failure from the CI log, verified the image's runtime UID against the LibreChat Dockerfile, applied the hardening + scoped ignore, and re-ran Trivy locally to confirm 0 findings. The human maintainer owns the merge and the live-rollout watch.

- [x] I verified the image runs as non-root (uid 1000) before setting `runAsNonRoot`.
- [x] I ran `trivy config charts/` locally and confirmed 0 misconfigurations for the LibreChat template.
- [x] I confirmed `readOnlyRootFilesystem` would break the app and justified the scoped ignore.

## Reviewer Focus

Confirm the KSV-0014 ignore stays **path-scoped** to the LibreChat template (not blanket), and that hardening `runAsUser: 1000` is acceptable for the live rollout.