### PR TITLE
feat(librechat-app): agent-seed — prune platform-authored agents not in the fleet

### DIFF
--- a/charts/librechat-app/files/seed-agents.js
+++ b/charts/librechat-app/files/seed-agents.js
@@ -6,6 +6,8 @@
  * LibreChat JWT ({id}, signed with JWT_SECRET — what requireJwtAuth expects),
  * then GET-by-name → PATCH/POST each agent and grant PUBLIC view. Two-phase:
  * leaves first, then orchestrators whose `subagentNames` resolve to agent_ids.
+ * Finally prunes platform-authored agents no longer in the fleet (declarative:
+ * a rename or removal self-cleans; scoped to this author, never user agents).
  *
  * Env: MONGO_URI, JWT_SECRET, LIBRECHAT_URL, PLATFORM_USER_EMAIL, FLEET_PATH.
  * Fails closed (non-zero exit) on any error — the platform user must have logged
@@ -91,6 +93,23 @@ async function main() {
   // Phase A: leaves (no subagents), Phase B: orchestrators (resolve names -> ids)
   for (const s of agents.filter((a) => !(a.subagentNames && a.subagentNames.length))) await upsert(s);
   for (const s of agents.filter((a) => a.subagentNames && a.subagentNames.length)) await upsert(s);
+
+  // Prune: delete platform-authored agents no longer in the fleet, so the fleet
+  // is DECLARATIVE — a rename (name is the idempotency key, so a rename creates a
+  // new agent + orphans the old) or a removal self-cleans on the next seed. Scoped
+  // to `author == platform user` so it NEVER touches agents real users created
+  // (only the seed authors as this user). Runs after upserts so fleet agents exist.
+  const fleetNames = new Set(agents.map((a) => a.name));
+  const authored = await mongoose.connection
+    .collection('agents')
+    .find({ author: user._id })
+    .project({ id: 1, name: 1 })
+    .toArray();
+  for (const a of authored) {
+    if (fleetNames.has(a.name)) continue;
+    await api('DELETE', `/api/agents/${a.id}`, token);
+    console.log(`[agent-seed] pruned ${a.name} (${a.id})`);
+  }
 
   await mongoose.disconnect();
   console.log(`[agent-seed] done: ${Object.keys(idByName).length} agents`);


### PR DESCRIPTION
## Summary

Make the seeded agent fleet **declarative**. The seed is idempotent by `name` (GET-by-name → PATCH/POST), so a **rename** (e.g. `deep-reviewer` → `Deep Reviewer`) creates a NEW agent and orphans the old one; a **removal** leaves the agent behind entirely. Neither self-cleaned.

After the upsert passes, delete every agent authored by the platform user whose name is not in the current fleet:

```js
const authored = await agents.find({ author: user._id })   // platform user only
for (a of authored) if (!fleetNames.has(a.name)) DELETE /api/agents/<a.id>
```

> Re-do of the commit that was orphaned when #738 merged before it landed (same fast-merge timing as the #736→#738 split). Content identical to the reviewed commit on #738's branch.

## Intent

Source of truth: the incoming fleet rename to Title-Case display names ([ai-helm-values #137](https://github.com/adorsys-gis/ai-helm-values/pull/137)) would otherwise leave 3 orphaned kebab-named agents. This makes the rename (and any future fleet edit) self-clean.

## Scope

`charts/librechat-app/files/seed-agents.js` only.

## Verification

- Scoped to `author == platform user` (the only principal the seed authors as), so it **never** touches agents real users created.
- Uses the supported `DELETE /api/agents/:id` route (DELETE permission the author/owner holds), not a Mongo-direct delete. Verified against `danny-avila/LibreChat @ v0.8.7`: `routes/agents/v1.js` DELETE route + `packages/data-schemas/src/schema/agent.ts` `author` field.
- Runs **after** the upserts so fleet agents already exist and are never pruned.
- `node --check seed-agents.js` → syntax OK.
- Live check: next PostSync seed logs `[agent-seed] pruned <name> (<id>)` for the orphaned kebab agents.

## Risk Assessment

**Low–medium.** Destructive but tightly scoped (`author == platform user` AND name-not-in-fleet). Guarded on `agentSeed.enabled`; fails closed. First prune run is worth watching in the seed logs.

## AI Usage Declaration

AI (Claude Opus 4.8) implemented the prune and verified the author-scoped DELETE route against pinned source. The human maintainer owns the merge + the first live prune verification.

- [x] I verified the prune filter cannot match a real user's agent (only the seed authors as the platform user).
- [x] I confirmed it uses the supported DELETE route, not a Mongo-direct delete.

## Reviewer Focus

Confirm `{ author: user._id }` + `!fleetNames.has(a.name)` cannot delete a user-created agent.