### PR TITLE
feat(librechat-app): agent-seed — equip agents with skills + MCP; add security-review skill

### DIFF
--- a/charts/librechat-app/files/seed-agents.js
+++ b/charts/librechat-app/files/seed-agents.js
@@ -6,8 +6,11 @@
  * LibreChat JWT ({id}, signed with JWT_SECRET — what requireJwtAuth expects),
  * then GET-by-name → PATCH/POST each agent and grant PUBLIC view. Two-phase:
  * leaves first, then orchestrators whose `subagentNames` resolve to agent_ids.
- * Finally prunes platform-authored agents no longer in the fleet (declarative:
- * a rename or removal self-cleans; scoped to this author, never user agents).
+ * Equips agents from declarative fleet knobs: `mcpServers: [name]` → whole-server
+ * MCP tool tokens, `skills: [name]` → skill ObjectIds (+ skills_enabled),
+ * `tools: [name]` → built-in tool ids. Finally prunes platform-authored agents no
+ * longer in the fleet (declarative: a rename or removal self-cleans; scoped to
+ * this author, never user agents).
  *
  * Env: MONGO_URI, JWT_SECRET, LIBRECHAT_URL, PLATFORM_USER_EMAIL, FLEET_PATH.
  * Fails closed (non-zero exit) on any error — the platform user must have logged
@@ -19,6 +22,13 @@ const fs = require('fs');
 
 const { MONGO_URI, JWT_SECRET, LIBRECHAT_URL, PLATFORM_USER_EMAIL, FLEET_PATH } = process.env;
 const AGENT_VIEWER = 'agent_viewer';
+
+// A DB agent references a WHOLE MCP server via the mcp_all wildcard token
+// (Constants.mcp_all `sys__all__sys` + mcp_delimiter `_mcp_`): `sys__all__sys_mcp_<server>`.
+// Unlike the UI-only `mcp_server` placeholder, this token IS resolved to the
+// server's tools at runtime (LibreChat packages/api/src/agents/load.ts). Fleet
+// `mcpServers: [name]` entries expand to these tool ids on the agent's `tools`.
+const MCP_ALL = 'sys__all__sys_mcp_';
 
 function die(msg) { console.error(`[agent-seed] ${msg}`); process.exit(1); }
 
@@ -65,8 +75,24 @@ async function main() {
   for (const a of arr) if (a && a.name) idByName[a.name] = a.id;
 
   async function upsert(spec) {
-    const { subagentNames, ...rest } = spec;
-    const body = { provider: 'converse', tools: [], ...rest };
+    // Fleet knobs that need translating before hitting the create API:
+    //  - `mcpServers: [name]` -> tools `sys__all__sys_mcp_<name>` (whole server)
+    //  - `tools: [name]`      -> built-in tool ids (web_search/file_search/…) as-is
+    //  - `skills: [name]`     -> skill ObjectIds (+ skills_enabled), resolved below
+    const { subagentNames, skills: skillNames, mcpServers, tools: builtinTools, ...rest } = spec;
+    const tools = [...(builtinTools || [])];
+    for (const s of mcpServers || []) tools.push(`${MCP_ALL}${s}`);
+    const body = { provider: 'converse', tools, ...rest };
+    if (skillNames && skillNames.length) {
+      const ids = skillNames.map((n) => skillIdByName[n]).filter(Boolean);
+      const missing = skillNames.filter((n) => !skillIdByName[n]);
+      if (missing.length)
+        // Not fatal: a skill may not be synced yet (skillSync runs on pod start;
+        // the seed is a PostSync hook, so it can race ahead). The idempotent
+        // re-seed attaches it once synced; a genuine typo just never resolves.
+        console.warn(`[agent-seed] skills not found for ${spec.name} (unsynced?): ${missing.join(', ')}`);
+      if (ids.length) { body.skills = ids; body.skills_enabled = true; }
+    }
     if (subagentNames && subagentNames.length) {
       const agent_ids = subagentNames.map((n) => idByName[n]).filter(Boolean);
       if (agent_ids.length !== subagentNames.length)
@@ -89,6 +115,16 @@ async function main() {
     await api('PUT', `/api/permissions/agent/${doc._id}`, token, { updated: [], removed: [], public: true, publicAccessRoleId: AGENT_VIEWER });
     return id;
   }
+
+  // Skill name -> ObjectId map. An agent's `skills` field stores skill _ids, not
+  // names; skills are synced from git by skillSync (a separate subsystem). Resolve
+  // the whole catalog once here so upsert() can map fleet `skills: [name]` -> ids.
+  const skillIdByName = {};
+  for (const sk of await mongoose.connection
+    .collection('skills')
+    .find({}, { projection: { _id: 1, name: 1 } })
+    .toArray())
+    if (sk && sk.name) skillIdByName[sk.name] = sk._id.toString();
 
   // Phase A: leaves (no subagents), Phase B: orchestrators (resolve names -> ids)
   for (const s of agents.filter((a) => !(a.subagentNames && a.subagentNames.length))) await upsert(s);

--- a/skills/security-review/SKILL.md
+++ b/skills/security-review/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: security-review
+description: A security-focused review procedure for a code change — the threat lenses to apply (injection, authz/IDOR, secrets, SSRF, deserialization, crypto, supply chain), how to grade findings P0–P3, and how to prove a vulnerability before claiming it. Use when reviewing a diff for security, or when a change touches auth, input handling, secrets, network calls, or dependencies.
+---
+
+# Security Review
+
+Think like an attacker reviewing THIS change: what can a malicious actor make it
+do that the author didn't intend? A security review is not a checklist you skim —
+it's an adversarial read of the new attack surface. Pair it with the
+`code-review` skill: this one goes deep on the security dimension; that one owns
+correctness, tests, and the merge verdict.
+
+## The one rule
+
+> **Prove it, then raise it.** A security finding names the concrete exploit —
+> the input, the path it takes, and the sink it reaches — and cites the exact
+> lines. An unprovable "this looks unsafe" is a *question* (at most P3), not a
+> vulnerability. A false P0 costs more trust than a missed P2.
+
+Be adversarial in *hunting*; be precise in the *claim*. Don't manufacture CVEs to
+look thorough, and don't wave a change through because it "isn't a security PR" —
+every change is until you've looked.
+
+## Scope: the change, not the repo
+
+Review the new/changed attack surface this diff introduces. A pre-existing flaw
+in untouched code is at most one terse "pre-existing, worth a separate fix" note,
+never a P0/P1 against this PR. But if the change *reaches into* or *depends on*
+that flaw (calls the vulnerable function with new untrusted input), it's in scope.
+
+## Threat lenses — apply every relevant one
+
+For each, trace **untrusted input → dangerous sink** and confirm the path is
+reachable in this change:
+
+1. **Injection.** Untrusted data concatenated into an interpreter: SQL/NoSQL,
+   shell/`exec`, path (`../` traversal), template (SSTI), LDAP, XPath, header/CRLF,
+   log injection. Look for string-built queries/commands instead of
+   parameterized/escaped APIs.
+2. **AuthN / AuthZ.** New or changed endpoints, routes, RPCs, jobs: is
+   authentication required, and is **authorization** checked for *this* user on
+   *this* object? IDOR (acting on an id without an ownership/tenant check),
+   missing role/scope gate, privilege escalation, auth logic that fails open.
+3. **Secrets & credentials.** Hardcoded keys/tokens/passwords, secrets in logs or
+   error messages, secrets in URLs/query strings, secrets committed to git or
+   baked into images/config. Verify secrets come from the secret store, not code.
+4. **SSRF & outbound requests.** A new HTTP/DNS/file call whose URL/host is
+   attacker-influenced — can it hit internal metadata endpoints, cloud IMDS, or
+   the cluster network? Is there an allowlist?
+5. **Deserialization & parsing.** Untrusted input into native deserializers,
+   `pickle`/`yaml.load`/`Marshal`, XML (XXE), or zip/tar (zip-slip). Unbounded
+   parsing → DoS.
+6. **Crypto & randomness.** Weak/again-rolled crypto, ECB, static IV/nonce,
+   missing TLS or disabled cert verification, `Math.random()` for tokens,
+   predictable ids, timing-unsafe comparisons on secrets.
+7. **Sensitive-data exposure.** PII/tokens returned in responses or logs, overly
+   broad serializers leaking fields, missing redaction, caching of private data.
+8. **Web-specific.** XSS (unescaped output, `dangerouslySetInnerHTML`), CSRF on
+   state-changing routes, missing/loosened security headers or CORS `*`, open
+   redirect.
+9. **Supply chain.** New/updated dependency with a known CVE, an unpinned or
+   typosquatted package, a new install script or build step that runs untrusted
+   code, a widened image/base.
+10. **Resource & DoS.** Unbounded loops/allocations on user input, missing
+    rate-limit/quota on an expensive new path, ReDoS (catastrophic regex).
+
+## Severity — grade every finding P0–P3
+
+- **P0 — critical, blocks merge.** A *proven* exploitable flaw: working injection,
+  auth bypass / IDOR, secret in code or logs, RCE, SSRF to internal, data
+  loss/corruption. If you can describe the exploit, it's P0.
+- **P1 — should fix.** A plausible, evidence-backed risk you can't fully prove
+  exploitable, or a dependency with a known CVE on a reachable path, or defense
+  removed with no compensating control.
+- **P2 — medium.** Hardening gaps and weakened-but-not-broken controls: missing
+  defense-in-depth, over-broad permissions, a missing security header on a
+  non-critical path.
+- **P3 — might fix.** Minor hygiene, speculative "what ifs", style-level nits.
+  Never blocks.
+
+Calibration: grade on a demonstrated path, not on the presence of a scary
+keyword. `eval` on a compile-time constant is not a finding; `eval` on request
+data is P0. When you assert a flaw is exploitable, show the input.
+
+## How to report a finding
+
+- **Exploit first:** one sentence of *how* an attacker triggers it (the input +
+  the path), then the file:line, then the fix direction.
+- **Name the control, not just the bug:** "add an ownership check on `orderId`
+  before the update", "parameterize the query", "pull the token from ESO, not the
+  ConfigMap".
+- **No new surface? Say so explicitly** — "reviewed for injection/authz/secrets;
+  this change adds no new attack surface" is a valid, valuable result. But only
+  after you've actually applied the lenses.
+
+## Definition of done
+
+- [ ] Every relevant threat lens applied to the new/changed surface.
+- [ ] Each finding names a concrete exploit path and cites exact lines.
+- [ ] AuthZ verified on every new/changed state-changing entry point.
+- [ ] No secret introduced into code, logs, URLs, or images.
+- [ ] New dependencies checked for known CVEs and pinned.
+- [ ] **No unresolved P0/P1.** Verdict stated with the residual risk, even if "no
+      new attack surface".


### PR DESCRIPTION
## Summary

The seeded DB agents carried **only** instructions — no skills, tools, or MCP — so a reviewer could reason over a *pasted* diff but couldn't fetch a PR or apply a shared review skill. This teaches the seed to translate three declarative fleet knobs into what the agent-create API expects, and adds a new `security-review` skill.

**Seed (`seed-agents.js`):**

| Fleet knob | Becomes | Why |
|---|---|---|
| `mcpServers: [name]` | `tools: ["sys__all__sys_mcp_<name>"]` | the `mcp_all` wildcard token expands to ALL of a server's tools at runtime (`packages/api/src/agents/load.ts`) |
| `skills: [name]` | `skills: [<_id>]` + `skills_enabled: true` | agent `skills` stores skill **ObjectIds**; the seed resolves the synced catalog name→_id from Mongo |
| `tools: [name]` | passed through | built-in tool ids (web_search/file_search/execute_code) |

Missing skills **warn, not fail** — `skillSync` runs on pod start while the seed is a PostSync hook, so a not-yet-synced skill just attaches on the next (idempotent) re-seed instead of breaking the run.

**New skill (`skills/security-review/SKILL.md`):** an adversarial, threat-lens security review procedure (injection, authz/IDOR, secrets, SSRF, deserialization, crypto, supply chain), graded on the same **P0–P3** framework as `code-review`, with "prove the exploit before you claim it". Frontmatter is `name` + `description` only (strict sync allowlist).

## Intent

Source of truth: maintainer request — "Are the agents using the code-review skill? … We'll need more skills too, e.g for security … give them mcp access too, e.g github for security." Fleet architecture per the [opencode well-known](charts/librechat-opencode-wellknown/values.yaml) primary/subagent model.

## Scope

- `charts/librechat-app/files/seed-agents.js` — knob translation (MCP/skills/tools).
- `skills/security-review/SKILL.md` — new skill (synced via `config.skillSync`).

## Verification

- Wiring verified against `danny-avila/LibreChat @ v0.8.7`: `mcp_all`/`mcp_delimiter` tokens + `mcpAllToken` (`client/.../items/selectors.ts`), runtime expansion (`agents/load.ts:103`), agent `skills`-as-ObjectIds + `skills_enabled` (`controllers/agents/v1.js` `sanitizeViewerSkillScope`), create schema `tools`/`skills` arrays (`packages/api/src/agents/validation.ts`).
- `node --check seed-agents.js` → OK.
- Skill frontmatter uses only allowlisted keys (`name`, `description`).
- Live check: next seed logs show the reviewers created with skills + the github MCP tools; `skills not found` warnings only for a not-yet-synced skill.

## ⚠️ Merge order

Merge **this first** (so `security-review` is syncable and the seed can translate the knobs), then the companion **ai-helm-values** PR that sets `skills`/`mcpServers` on the review fleet + adds the Designer (refero) persona. Reversed, the old seed would forward `skills: [names]` as unresolved names (dropped) and ignore `mcpServers`.

## Risk Assessment

**Low.** Additive translation in the seed (guarded on `agentSeed.enabled`, idempotent); a new read-only skill. No change to existing agents until the values PR sets the knobs.

## AI Usage Declaration

AI (Claude Opus 4.8) verified the MCP/skill wiring formats against pinned source, implemented the seed translation, and authored the security-review skill. The human maintainer owns the merge order + the live seed verification.

- [x] I verified the `mcp_all` token expands server tools at runtime (not a UI-only placeholder).
- [x] I verified agent `skills` are ObjectIds and the seed resolves them from the synced catalog.
- [x] Skill frontmatter uses only allowlisted keys.

## Reviewer Focus

The name→_id skill resolution + the not-fatal missing-skill path (sync/seed race). And whether the security-review skill's severity calibration matches `code-review`.