### PR TITLE
fix(model-serving): Caddy sidecar exec crashloop (fcap + no_new_privs)

### DIFF
--- a/charts/model-serving-deepseek-r1-1-5b/values.yaml
+++ b/charts/model-serving-deepseek-r1-1-5b/values.yaml
@@ -190,7 +190,12 @@ modelServing:
           # drops ALL caps + disables privilege escalation. readOnlyRootFilesystem
           # is omitted (those writable paths) — KSV-0014 path-scoped-ignored.
           securityContext:
-            allowPrivilegeEscalation: false
+          # NOTE: NO allowPrivilegeEscalation:false here. caddy:2-alpine's
+          # /usr/bin/caddy carries file-capabilities (cap_net_bind_service);
+          # allowPrivilegeEscalation:false sets no_new_privs, which makes the
+          # kernel REFUSE to exec a file-capability binary (EPERM -> crashloop).
+          # Caddy runs as root + binds only high ports, so dropping ALL caps +
+          # seccomp still clears KSV-0118 without breaking exec.
             capabilities:
               drop:
                 - ALL

--- a/charts/model-serving-ministral-3b/values.yaml
+++ b/charts/model-serving-ministral-3b/values.yaml
@@ -181,7 +181,12 @@ modelServing:
           # drops ALL caps + disables privilege escalation. readOnlyRootFilesystem
           # is omitted (those writable paths) — KSV-0014 path-scoped-ignored.
           securityContext:
-            allowPrivilegeEscalation: false
+          # NOTE: NO allowPrivilegeEscalation:false here. caddy:2-alpine's
+          # /usr/bin/caddy carries file-capabilities (cap_net_bind_service);
+          # allowPrivilegeEscalation:false sets no_new_privs, which makes the
+          # kernel REFUSE to exec a file-capability binary (EPERM -> crashloop).
+          # Caddy runs as root + binds only high ports, so dropping ALL caps +
+          # seccomp still clears KSV-0118 without breaking exec.
             capabilities:
               drop:
                 - ALL

--- a/charts/model-serving-qwen2-vl-2b/values.yaml
+++ b/charts/model-serving-qwen2-vl-2b/values.yaml
@@ -171,7 +171,12 @@ modelServing:
           # drops ALL caps + disables privilege escalation. readOnlyRootFilesystem
           # is omitted (those writable paths) — KSV-0014 path-scoped-ignored.
           securityContext:
-            allowPrivilegeEscalation: false
+          # NOTE: NO allowPrivilegeEscalation:false here. caddy:2-alpine's
+          # /usr/bin/caddy carries file-capabilities (cap_net_bind_service);
+          # allowPrivilegeEscalation:false sets no_new_privs, which makes the
+          # kernel REFUSE to exec a file-capability binary (EPERM -> crashloop).
+          # Caddy runs as root + binds only high ports, so dropping ALL caps +
+          # seccomp still clears KSV-0118 without breaking exec.
             capabilities:
               drop:
                 - ALL

--- a/charts/model-serving-qwen25-3b-awq/values.yaml
+++ b/charts/model-serving-qwen25-3b-awq/values.yaml
@@ -193,7 +193,12 @@ modelServing:
           # drops ALL caps + disables privilege escalation. readOnlyRootFilesystem
           # is omitted (those writable paths) — KSV-0014 path-scoped-ignored.
           securityContext:
-            allowPrivilegeEscalation: false
+          # NOTE: NO allowPrivilegeEscalation:false here. caddy:2-alpine's
+          # /usr/bin/caddy carries file-capabilities (cap_net_bind_service);
+          # allowPrivilegeEscalation:false sets no_new_privs, which makes the
+          # kernel REFUSE to exec a file-capability binary (EPERM -> crashloop).
+          # Caddy runs as root + binds only high ports, so dropping ALL caps +
+          # seccomp still clears KSV-0118 without breaking exec.
             capabilities:
               drop:
                 - ALL

--- a/charts/model-serving-qwen3-4b/values.yaml
+++ b/charts/model-serving-qwen3-4b/values.yaml
@@ -227,7 +227,12 @@ modelServing:
           # is intentionally omitted (those writable paths) — KSV-0014 is
           # path-scoped-ignored in .trivyignore.yaml.
           securityContext:
-            allowPrivilegeEscalation: false
+          # NOTE: NO allowPrivilegeEscalation:false here. caddy:2-alpine's
+          # /usr/bin/caddy carries file-capabilities (cap_net_bind_service);
+          # allowPrivilegeEscalation:false sets no_new_privs, which makes the
+          # kernel REFUSE to exec a file-capability binary (EPERM -> crashloop).
+          # Caddy runs as root + binds only high ports, so dropping ALL caps +
+          # seccomp still clears KSV-0118 without breaking exec.
             capabilities:
               drop:
                 - ALL

--- a/charts/model-serving-qwen3-8b/values.yaml
+++ b/charts/model-serving-qwen3-8b/values.yaml
@@ -168,7 +168,12 @@ modelServing:
           # drops ALL caps + disables privilege escalation. readOnlyRootFilesystem
           # is omitted (those writable paths) — KSV-0014 path-scoped-ignored.
           securityContext:
-            allowPrivilegeEscalation: false
+          # NOTE: NO allowPrivilegeEscalation:false here. caddy:2-alpine's
+          # /usr/bin/caddy carries file-capabilities (cap_net_bind_service);
+          # allowPrivilegeEscalation:false sets no_new_privs, which makes the
+          # kernel REFUSE to exec a file-capability binary (EPERM -> crashloop).
+          # Caddy runs as root + binds only high ports, so dropping ALL caps +
+          # seccomp still clears KSV-0118 without breaking exec.
             capabilities:
               drop:
                 - ALL


### PR DESCRIPTION
## Summary

**Production hotfix.** #741 hardened the Caddy edge-auth sidecar with `allowPrivilegeEscalation: false`, which crashlooped the **live** `model-serving-qwen2-vl-2b` proxy container (`exec /usr/bin/caddy: operation not permitted`, exit 255). The `caddy:2-alpine` binary carries file-capabilities (`cap_net_bind_service`); `allowPrivilegeEscalation: false` sets `no_new_privs`, under which the kernel refuses to exec a file-capability binary (EPERM). This removes that one field from the Caddy container SC across all 6 edgeAuth charts.

## Intent

Restore the live self-hosted model (its edge-auth proxy is down) while keeping the KSV-0118 hardening from #741. Source of truth: **#741** (the change that introduced the regression) + the live incident (`kubectl -n converse-poc logs qwen2-vl-2b-main-0 -c proxy`).

## Scope

Remove `allowPrivilegeEscalation: false` from the **Caddy `proxy`** container `securityContext` only, in all 6 `model-serving-*` edgeAuth charts. Caddy runs as root and binds only `:8090` (high port), so it needs no capabilities — `capabilities.drop: [ALL]` + `seccompProfile: RuntimeDefault` still clears KSV-0118 (non-default SC) without the `no_new_privs` exec block. The model + seed containers keep `allowPrivilegeEscalation: false` (they are not file-capability binaries).

## Verification

- `helm template <chart> --kube-version 1.31 --skip-tests | trivy config` — **green** (only the already-ignored KSV-0014 writable-rootfs remains; KSV-0118 stays cleared).
- Rendered proxy SC: `{capabilities.drop: [ALL], seccompProfile: {type: RuntimeDefault}}`, no `allowPrivilegeEscalation`.
- `helm lint --strict` passes for all 6 charts.
- Root cause reproduced from the live pod: `exec /usr/bin/caddy: operation not permitted`.

## Risk Assessment

Low + urgent. Removing `allowPrivilegeEscalation: false` restores the exact exec behaviour Caddy ran under for the prior 2d23h; the container is still hardened (no caps, seccomp). **Merge ASAP** — the live `qwen2-vl-2b` proxy is crashlooping until this rolls out.

## AI Usage Declaration

AI (Claude Opus 4.8) diagnosed the crashloop from the live pod logs, identified the fcap/`no_new_privs` root cause, applied + verified the fix. The human maintainer is accountable for reviewing and merging.

- [x] I reviewed the AI-generated changes and understand them.
- [x] I verified the changes (commands/logs above).
- [x] I take responsibility for this change.

## Reviewer Focus

Confirm the Caddy container is still acceptably hardened without `allowPrivilegeEscalation: false` (caps-drop + seccomp, root uid, high-port bind only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
