### PR TITLE
fix(model-serving): Caddy exec crashloop take 2 — seccomp Unconfined (fcap/no_new_privs)

### DIFF
--- a/charts/model-serving-deepseek-r1-1-5b/values.yaml
+++ b/charts/model-serving-deepseek-r1-1-5b/values.yaml
@@ -185,22 +185,23 @@ modelServing:
             repository: caddy
             tag: 2-alpine
             pullPolicy: IfNotPresent
-          # Sidecar hardening for KSV-0118. Caddy keeps the pod's root uid
-          # (it writes autosave config to /config and /data on the rootfs) but
-          # drops ALL caps + disables privilege escalation. readOnlyRootFilesystem
-          # is omitted (those writable paths) — KSV-0014 path-scoped-ignored.
+          # ⚠️ caddy:2-alpine's /usr/bin/caddy carries FILE CAPABILITIES
+          # (cap_net_bind_service). The kernel refuses to exec a file-capability
+          # binary once no_new_privs is set (execve -> EPERM -> crashloop), and
+          # BOTH allowPrivilegeEscalation:false AND seccompProfile:RuntimeDefault
+          # (with CAP_SYS_ADMIN dropped) set no_new_privs. So the Caddy sidecar
+          # sets NEITHER: seccomp is Unconfined (overriding the pod's
+          # RuntimeDefault) and allowPrivilegeEscalation is left unset. Dropping
+          # ALL caps still clears KSV-0118 — Caddy runs as root and binds only
+          # the high port :8090, so it needs no capabilities. readOnlyRootFilesystem
+          # omitted (autosave to /config,/data) -> KSV-0014 path-scoped-ignored.
+          # (RuntimeDefault seccomp needs a custom image without the fcap — follow-up.)
           securityContext:
-          # NOTE: NO allowPrivilegeEscalation:false here. caddy:2-alpine's
-          # /usr/bin/caddy carries file-capabilities (cap_net_bind_service);
-          # allowPrivilegeEscalation:false sets no_new_privs, which makes the
-          # kernel REFUSE to exec a file-capability binary (EPERM -> crashloop).
-          # Caddy runs as root + binds only high ports, so dropping ALL caps +
-          # seccomp still clears KSV-0118 without breaking exec.
             capabilities:
               drop:
                 - ALL
             seccompProfile:
-              type: RuntimeDefault
+              type: Unconfined
           env:
             MODEL_API_KEY:
               secretKeyRef:

--- a/charts/model-serving-ministral-3b/values.yaml
+++ b/charts/model-serving-ministral-3b/values.yaml
@@ -176,22 +176,23 @@ modelServing:
             repository: caddy
             tag: 2-alpine
             pullPolicy: IfNotPresent
-          # Sidecar hardening for KSV-0118. Caddy keeps the pod's root uid
-          # (it writes autosave config to /config and /data on the rootfs) but
-          # drops ALL caps + disables privilege escalation. readOnlyRootFilesystem
-          # is omitted (those writable paths) — KSV-0014 path-scoped-ignored.
+          # ⚠️ caddy:2-alpine's /usr/bin/caddy carries FILE CAPABILITIES
+          # (cap_net_bind_service). The kernel refuses to exec a file-capability
+          # binary once no_new_privs is set (execve -> EPERM -> crashloop), and
+          # BOTH allowPrivilegeEscalation:false AND seccompProfile:RuntimeDefault
+          # (with CAP_SYS_ADMIN dropped) set no_new_privs. So the Caddy sidecar
+          # sets NEITHER: seccomp is Unconfined (overriding the pod's
+          # RuntimeDefault) and allowPrivilegeEscalation is left unset. Dropping
+          # ALL caps still clears KSV-0118 — Caddy runs as root and binds only
+          # the high port :8090, so it needs no capabilities. readOnlyRootFilesystem
+          # omitted (autosave to /config,/data) -> KSV-0014 path-scoped-ignored.
+          # (RuntimeDefault seccomp needs a custom image without the fcap — follow-up.)
           securityContext:
-          # NOTE: NO allowPrivilegeEscalation:false here. caddy:2-alpine's
-          # /usr/bin/caddy carries file-capabilities (cap_net_bind_service);
-          # allowPrivilegeEscalation:false sets no_new_privs, which makes the
-          # kernel REFUSE to exec a file-capability binary (EPERM -> crashloop).
-          # Caddy runs as root + binds only high ports, so dropping ALL caps +
-          # seccomp still clears KSV-0118 without breaking exec.
             capabilities:
               drop:
                 - ALL
             seccompProfile:
-              type: RuntimeDefault
+              type: Unconfined
           env:
             MODEL_API_KEY:
               secretKeyRef:

--- a/charts/model-serving-qwen2-vl-2b/values.yaml
+++ b/charts/model-serving-qwen2-vl-2b/values.yaml
@@ -166,22 +166,23 @@ modelServing:
             repository: caddy
             tag: 2-alpine
             pullPolicy: IfNotPresent
-          # Sidecar hardening for KSV-0118. Caddy keeps the pod's root uid
-          # (it writes autosave config to /config and /data on the rootfs) but
-          # drops ALL caps + disables privilege escalation. readOnlyRootFilesystem
-          # is omitted (those writable paths) — KSV-0014 path-scoped-ignored.
+          # ⚠️ caddy:2-alpine's /usr/bin/caddy carries FILE CAPABILITIES
+          # (cap_net_bind_service). The kernel refuses to exec a file-capability
+          # binary once no_new_privs is set (execve -> EPERM -> crashloop), and
+          # BOTH allowPrivilegeEscalation:false AND seccompProfile:RuntimeDefault
+          # (with CAP_SYS_ADMIN dropped) set no_new_privs. So the Caddy sidecar
+          # sets NEITHER: seccomp is Unconfined (overriding the pod's
+          # RuntimeDefault) and allowPrivilegeEscalation is left unset. Dropping
+          # ALL caps still clears KSV-0118 — Caddy runs as root and binds only
+          # the high port :8090, so it needs no capabilities. readOnlyRootFilesystem
+          # omitted (autosave to /config,/data) -> KSV-0014 path-scoped-ignored.
+          # (RuntimeDefault seccomp needs a custom image without the fcap — follow-up.)
           securityContext:
-          # NOTE: NO allowPrivilegeEscalation:false here. caddy:2-alpine's
-          # /usr/bin/caddy carries file-capabilities (cap_net_bind_service);
-          # allowPrivilegeEscalation:false sets no_new_privs, which makes the
-          # kernel REFUSE to exec a file-capability binary (EPERM -> crashloop).
-          # Caddy runs as root + binds only high ports, so dropping ALL caps +
-          # seccomp still clears KSV-0118 without breaking exec.
             capabilities:
               drop:
                 - ALL
             seccompProfile:
-              type: RuntimeDefault
+              type: Unconfined
           env:
             MODEL_API_KEY:
               secretKeyRef:

--- a/charts/model-serving-qwen25-3b-awq/values.yaml
+++ b/charts/model-serving-qwen25-3b-awq/values.yaml
@@ -188,22 +188,23 @@ modelServing:
             repository: caddy
             tag: 2-alpine
             pullPolicy: IfNotPresent
-          # Sidecar hardening for KSV-0118. Caddy keeps the pod's root uid
-          # (it writes autosave config to /config and /data on the rootfs) but
-          # drops ALL caps + disables privilege escalation. readOnlyRootFilesystem
-          # is omitted (those writable paths) — KSV-0014 path-scoped-ignored.
+          # ⚠️ caddy:2-alpine's /usr/bin/caddy carries FILE CAPABILITIES
+          # (cap_net_bind_service). The kernel refuses to exec a file-capability
+          # binary once no_new_privs is set (execve -> EPERM -> crashloop), and
+          # BOTH allowPrivilegeEscalation:false AND seccompProfile:RuntimeDefault
+          # (with CAP_SYS_ADMIN dropped) set no_new_privs. So the Caddy sidecar
+          # sets NEITHER: seccomp is Unconfined (overriding the pod's
+          # RuntimeDefault) and allowPrivilegeEscalation is left unset. Dropping
+          # ALL caps still clears KSV-0118 — Caddy runs as root and binds only
+          # the high port :8090, so it needs no capabilities. readOnlyRootFilesystem
+          # omitted (autosave to /config,/data) -> KSV-0014 path-scoped-ignored.
+          # (RuntimeDefault seccomp needs a custom image without the fcap — follow-up.)
           securityContext:
-          # NOTE: NO allowPrivilegeEscalation:false here. caddy:2-alpine's
-          # /usr/bin/caddy carries file-capabilities (cap_net_bind_service);
-          # allowPrivilegeEscalation:false sets no_new_privs, which makes the
-          # kernel REFUSE to exec a file-capability binary (EPERM -> crashloop).
-          # Caddy runs as root + binds only high ports, so dropping ALL caps +
-          # seccomp still clears KSV-0118 without breaking exec.
             capabilities:
               drop:
                 - ALL
             seccompProfile:
-              type: RuntimeDefault
+              type: Unconfined
           env:
             MODEL_API_KEY:
               secretKeyRef:

--- a/charts/model-serving-qwen3-4b/values.yaml
+++ b/charts/model-serving-qwen3-4b/values.yaml
@@ -221,23 +221,23 @@ modelServing:
             repository: caddy
             tag: 2-alpine
             pullPolicy: IfNotPresent
-          # Sidecar hardening for KSV-0118. Caddy keeps the pod's root uid (it
-          # writes its autosave config to /config and /data on the rootfs), but
-          # drops ALL caps + disables privilege escalation. readOnlyRootFilesystem
-          # is intentionally omitted (those writable paths) — KSV-0014 is
-          # path-scoped-ignored in .trivyignore.yaml.
+          # ⚠️ caddy:2-alpine's /usr/bin/caddy carries FILE CAPABILITIES
+          # (cap_net_bind_service). The kernel refuses to exec a file-capability
+          # binary once no_new_privs is set (execve -> EPERM -> crashloop), and
+          # BOTH allowPrivilegeEscalation:false AND seccompProfile:RuntimeDefault
+          # (with CAP_SYS_ADMIN dropped) set no_new_privs. So the Caddy sidecar
+          # sets NEITHER: seccomp is Unconfined (overriding the pod's
+          # RuntimeDefault) and allowPrivilegeEscalation is left unset. Dropping
+          # ALL caps still clears KSV-0118 — Caddy runs as root and binds only
+          # the high port :8090, so it needs no capabilities. readOnlyRootFilesystem
+          # omitted (autosave to /config,/data) -> KSV-0014 path-scoped-ignored.
+          # (RuntimeDefault seccomp needs a custom image without the fcap — follow-up.)
           securityContext:
-          # NOTE: NO allowPrivilegeEscalation:false here. caddy:2-alpine's
-          # /usr/bin/caddy carries file-capabilities (cap_net_bind_service);
-          # allowPrivilegeEscalation:false sets no_new_privs, which makes the
-          # kernel REFUSE to exec a file-capability binary (EPERM -> crashloop).
-          # Caddy runs as root + binds only high ports, so dropping ALL caps +
-          # seccomp still clears KSV-0118 without breaking exec.
             capabilities:
               drop:
                 - ALL
             seccompProfile:
-              type: RuntimeDefault
+              type: Unconfined
           env:
             MODEL_API_KEY:
               secretKeyRef:

--- a/charts/model-serving-qwen3-8b/values.yaml
+++ b/charts/model-serving-qwen3-8b/values.yaml
@@ -163,22 +163,23 @@ modelServing:
             repository: caddy
             tag: 2-alpine
             pullPolicy: IfNotPresent
-          # Sidecar hardening for KSV-0118. Caddy keeps the pod's root uid
-          # (it writes autosave config to /config and /data on the rootfs) but
-          # drops ALL caps + disables privilege escalation. readOnlyRootFilesystem
-          # is omitted (those writable paths) — KSV-0014 path-scoped-ignored.
+          # ⚠️ caddy:2-alpine's /usr/bin/caddy carries FILE CAPABILITIES
+          # (cap_net_bind_service). The kernel refuses to exec a file-capability
+          # binary once no_new_privs is set (execve -> EPERM -> crashloop), and
+          # BOTH allowPrivilegeEscalation:false AND seccompProfile:RuntimeDefault
+          # (with CAP_SYS_ADMIN dropped) set no_new_privs. So the Caddy sidecar
+          # sets NEITHER: seccomp is Unconfined (overriding the pod's
+          # RuntimeDefault) and allowPrivilegeEscalation is left unset. Dropping
+          # ALL caps still clears KSV-0118 — Caddy runs as root and binds only
+          # the high port :8090, so it needs no capabilities. readOnlyRootFilesystem
+          # omitted (autosave to /config,/data) -> KSV-0014 path-scoped-ignored.
+          # (RuntimeDefault seccomp needs a custom image without the fcap — follow-up.)
           securityContext:
-          # NOTE: NO allowPrivilegeEscalation:false here. caddy:2-alpine's
-          # /usr/bin/caddy carries file-capabilities (cap_net_bind_service);
-          # allowPrivilegeEscalation:false sets no_new_privs, which makes the
-          # kernel REFUSE to exec a file-capability binary (EPERM -> crashloop).
-          # Caddy runs as root + binds only high ports, so dropping ALL caps +
-          # seccomp still clears KSV-0118 without breaking exec.
             capabilities:
               drop:
                 - ALL
             seccompProfile:
-              type: RuntimeDefault
+              type: Unconfined
           env:
             MODEL_API_KEY:
               secretKeyRef:


### PR DESCRIPTION
## Summary

**Production hotfix, take 2.** #743's fix was incomplete — the live model `qwen2-vl-2b` still crashlooped (`exec /usr/bin/caddy: operation not permitted`). `no_new_privs` (which blocks exec of caddy's file-capability binary) is set by **two** things; #743 removed only `allowPrivilegeEscalation: false` but kept `seccompProfile: RuntimeDefault`, which *also* forces `no_new_privs` when `CAP_SYS_ADMIN` is dropped. This sets the Caddy container's `seccompProfile` to **Unconfined** so neither forces `no_new_privs`.

## Intent

Actually restore the live self-hosted model (down since the #741 roll). Source of truth: **#741** / **#743** and the live pod (`exec /usr/bin/caddy: operation not permitted`, `no_new_privs` root cause).

## Scope

Caddy `proxy` container SC across all 6 `model-serving-*` edgeAuth charts → `{capabilities.drop:[ALL], seccompProfile:{type: Unconfined}}`, `allowPrivilegeEscalation` left unset. `capabilities.drop:[ALL]` still clears KSV-0118 (Caddy runs as root, binds only `:8090`). Model + seed containers keep `RuntimeDefault` (not fcap binaries).

## Verification

- `helm template … --skip-tests | trivy config` — **green** (only ignored KSV-0014). Rendered proxy SC: `{capabilities.drop:[ALL], seccompProfile:{type:Unconfined}}`.
- `helm lint --strict` passes for all 6.
- KSV-0001 (allowPrivilegeEscalation) is MEDIUM, below the gate's HIGH threshold.
- Runtime: `Unconfined` = no seccomp filter → no `no_new_privs`; matches how Caddy ran pre-#741 (no seccomp) plus dropped caps. Local docker repro was unavailable (daemon down), but the `no_new_privs`/fcap mechanism is well-documented and the pre-#741 behaviour confirms it.

## Risk Assessment

Low + **urgent** — merge to restore the live model. Trade-off: `Unconfined` is weaker than `RuntimeDefault`; running `caddy:2-alpine` with `RuntimeDefault` needs a custom image that strips the fcap from `/usr/bin/caddy` — **tracked follow-up**.

⚠️ **After merge**: the roll will be wedged again (the current pod is CrashLoopBackOff; a StatefulSet RollingUpdate won't replace a not-Ready pod). Once the chart publishes and syncs (~3–5 min), delete the pod to complete the roll:
`kubectl --context admin@homeos -n converse-poc delete pod qwen2-vl-2b-main-0`

## AI Usage Declaration

AI (Claude Opus 4.8) diagnosed the incomplete #743 fix (seccomp→`no_new_privs`), corrected it, and verified render/lint/scan. Human maintainer accountable for review + merge.

- [x] I reviewed the AI-generated changes and understand them.
- [x] I verified the changes.
- [x] I take responsibility for this change.

## Reviewer Focus

Acceptability of `seccomp: Unconfined` on the Caddy sidecar (caps still dropped, root, high-port-only) vs. building a custom fcap-stripped image to keep `RuntimeDefault`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
