### PR TITLE
fix(model-serving): Caddy exec crashloop take 3 — remove seccomp (baseline PSS forbids Unconfined)

### DIFF
--- a/charts/model-serving-deepseek-r1-1-5b/values.yaml
+++ b/charts/model-serving-deepseek-r1-1-5b/values.yaml
@@ -101,8 +101,9 @@ modelServing:
         securityContext:
           runAsNonRoot: false
           runAsUser: 0
-          seccompProfile:
-            type: RuntimeDefault
+          # No seccompProfile here — the Caddy sidecar shares this pod and its
+          # /usr/bin/caddy is a file-capability binary that cannot exec under the
+          # no_new_privs a seccomp profile forces; runAsUser:0 keeps KSV-0118 cleared.
       containers:
         model:
           image:
@@ -188,20 +189,19 @@ modelServing:
           # ⚠️ caddy:2-alpine's /usr/bin/caddy carries FILE CAPABILITIES
           # (cap_net_bind_service). The kernel refuses to exec a file-capability
           # binary once no_new_privs is set (execve -> EPERM -> crashloop), and
-          # BOTH allowPrivilegeEscalation:false AND seccompProfile:RuntimeDefault
-          # (with CAP_SYS_ADMIN dropped) set no_new_privs. So the Caddy sidecar
-          # sets NEITHER: seccomp is Unconfined (overriding the pod's
-          # RuntimeDefault) and allowPrivilegeEscalation is left unset. Dropping
-          # ALL caps still clears KSV-0118 — Caddy runs as root and binds only
-          # the high port :8090, so it needs no capabilities. readOnlyRootFilesystem
-          # omitted (autosave to /config,/data) -> KSV-0014 path-scoped-ignored.
-          # (RuntimeDefault seccomp needs a custom image without the fcap — follow-up.)
+          # no_new_privs is forced by allowPrivilegeEscalation:false OR any
+          # seccompProfile (RuntimeDefault/Localhost/Unconfined) with CAP_SYS_ADMIN
+          # dropped. Unconfined is ALSO forbidden by the namespace's baseline
+          # PodSecurity. So this sidecar sets NO seccompProfile (the pod-level
+          # seccomp above is removed so none is inherited) and leaves
+          # allowPrivilegeEscalation unset — no no_new_privs, exec works, baseline
+          # PSS satisfied. Dropping ALL caps still clears KSV-0118 (Caddy runs as
+          # root, binds only :8090). readOnlyRootFilesystem omitted (autosave to
+          # /config,/data) -> KSV-0014 path-scoped-ignored.
           securityContext:
             capabilities:
               drop:
                 - ALL
-            seccompProfile:
-              type: Unconfined
           env:
             MODEL_API_KEY:
               secretKeyRef:

--- a/charts/model-serving-ministral-3b/values.yaml
+++ b/charts/model-serving-ministral-3b/values.yaml
@@ -85,8 +85,9 @@ modelServing:
         securityContext:
           runAsNonRoot: false
           runAsUser: 0
-          seccompProfile:
-            type: RuntimeDefault
+          # No seccompProfile here — the Caddy sidecar shares this pod and its
+          # /usr/bin/caddy is a file-capability binary that cannot exec under the
+          # no_new_privs a seccomp profile forces; runAsUser:0 keeps KSV-0118 cleared.
       containers:
         model:
           image:
@@ -179,20 +180,19 @@ modelServing:
           # ⚠️ caddy:2-alpine's /usr/bin/caddy carries FILE CAPABILITIES
           # (cap_net_bind_service). The kernel refuses to exec a file-capability
           # binary once no_new_privs is set (execve -> EPERM -> crashloop), and
-          # BOTH allowPrivilegeEscalation:false AND seccompProfile:RuntimeDefault
-          # (with CAP_SYS_ADMIN dropped) set no_new_privs. So the Caddy sidecar
-          # sets NEITHER: seccomp is Unconfined (overriding the pod's
-          # RuntimeDefault) and allowPrivilegeEscalation is left unset. Dropping
-          # ALL caps still clears KSV-0118 — Caddy runs as root and binds only
-          # the high port :8090, so it needs no capabilities. readOnlyRootFilesystem
-          # omitted (autosave to /config,/data) -> KSV-0014 path-scoped-ignored.
-          # (RuntimeDefault seccomp needs a custom image without the fcap — follow-up.)
+          # no_new_privs is forced by allowPrivilegeEscalation:false OR any
+          # seccompProfile (RuntimeDefault/Localhost/Unconfined) with CAP_SYS_ADMIN
+          # dropped. Unconfined is ALSO forbidden by the namespace's baseline
+          # PodSecurity. So this sidecar sets NO seccompProfile (the pod-level
+          # seccomp above is removed so none is inherited) and leaves
+          # allowPrivilegeEscalation unset — no no_new_privs, exec works, baseline
+          # PSS satisfied. Dropping ALL caps still clears KSV-0118 (Caddy runs as
+          # root, binds only :8090). readOnlyRootFilesystem omitted (autosave to
+          # /config,/data) -> KSV-0014 path-scoped-ignored.
           securityContext:
             capabilities:
               drop:
                 - ALL
-            seccompProfile:
-              type: Unconfined
           env:
             MODEL_API_KEY:
               secretKeyRef:

--- a/charts/model-serving-qwen2-vl-2b/values.yaml
+++ b/charts/model-serving-qwen2-vl-2b/values.yaml
@@ -89,8 +89,9 @@ modelServing:
         securityContext:
           runAsNonRoot: false
           runAsUser: 0
-          seccompProfile:
-            type: RuntimeDefault
+          # No seccompProfile here — the Caddy sidecar shares this pod and its
+          # /usr/bin/caddy is a file-capability binary that cannot exec under the
+          # no_new_privs a seccomp profile forces; runAsUser:0 keeps KSV-0118 cleared.
       containers:
         model:
           image:
@@ -169,20 +170,19 @@ modelServing:
           # ⚠️ caddy:2-alpine's /usr/bin/caddy carries FILE CAPABILITIES
           # (cap_net_bind_service). The kernel refuses to exec a file-capability
           # binary once no_new_privs is set (execve -> EPERM -> crashloop), and
-          # BOTH allowPrivilegeEscalation:false AND seccompProfile:RuntimeDefault
-          # (with CAP_SYS_ADMIN dropped) set no_new_privs. So the Caddy sidecar
-          # sets NEITHER: seccomp is Unconfined (overriding the pod's
-          # RuntimeDefault) and allowPrivilegeEscalation is left unset. Dropping
-          # ALL caps still clears KSV-0118 — Caddy runs as root and binds only
-          # the high port :8090, so it needs no capabilities. readOnlyRootFilesystem
-          # omitted (autosave to /config,/data) -> KSV-0014 path-scoped-ignored.
-          # (RuntimeDefault seccomp needs a custom image without the fcap — follow-up.)
+          # no_new_privs is forced by allowPrivilegeEscalation:false OR any
+          # seccompProfile (RuntimeDefault/Localhost/Unconfined) with CAP_SYS_ADMIN
+          # dropped. Unconfined is ALSO forbidden by the namespace's baseline
+          # PodSecurity. So this sidecar sets NO seccompProfile (the pod-level
+          # seccomp above is removed so none is inherited) and leaves
+          # allowPrivilegeEscalation unset — no no_new_privs, exec works, baseline
+          # PSS satisfied. Dropping ALL caps still clears KSV-0118 (Caddy runs as
+          # root, binds only :8090). readOnlyRootFilesystem omitted (autosave to
+          # /config,/data) -> KSV-0014 path-scoped-ignored.
           securityContext:
             capabilities:
               drop:
                 - ALL
-            seccompProfile:
-              type: Unconfined
           env:
             MODEL_API_KEY:
               secretKeyRef:

--- a/charts/model-serving-qwen25-3b-awq/values.yaml
+++ b/charts/model-serving-qwen25-3b-awq/values.yaml
@@ -84,8 +84,9 @@ modelServing:
         securityContext:
           runAsNonRoot: false
           runAsUser: 0
-          seccompProfile:
-            type: RuntimeDefault
+          # No seccompProfile here — the Caddy sidecar shares this pod and its
+          # /usr/bin/caddy is a file-capability binary that cannot exec under the
+          # no_new_privs a seccomp profile forces; runAsUser:0 keeps KSV-0118 cleared.
       containers:
         model:
           image:
@@ -191,20 +192,19 @@ modelServing:
           # ⚠️ caddy:2-alpine's /usr/bin/caddy carries FILE CAPABILITIES
           # (cap_net_bind_service). The kernel refuses to exec a file-capability
           # binary once no_new_privs is set (execve -> EPERM -> crashloop), and
-          # BOTH allowPrivilegeEscalation:false AND seccompProfile:RuntimeDefault
-          # (with CAP_SYS_ADMIN dropped) set no_new_privs. So the Caddy sidecar
-          # sets NEITHER: seccomp is Unconfined (overriding the pod's
-          # RuntimeDefault) and allowPrivilegeEscalation is left unset. Dropping
-          # ALL caps still clears KSV-0118 — Caddy runs as root and binds only
-          # the high port :8090, so it needs no capabilities. readOnlyRootFilesystem
-          # omitted (autosave to /config,/data) -> KSV-0014 path-scoped-ignored.
-          # (RuntimeDefault seccomp needs a custom image without the fcap — follow-up.)
+          # no_new_privs is forced by allowPrivilegeEscalation:false OR any
+          # seccompProfile (RuntimeDefault/Localhost/Unconfined) with CAP_SYS_ADMIN
+          # dropped. Unconfined is ALSO forbidden by the namespace's baseline
+          # PodSecurity. So this sidecar sets NO seccompProfile (the pod-level
+          # seccomp above is removed so none is inherited) and leaves
+          # allowPrivilegeEscalation unset — no no_new_privs, exec works, baseline
+          # PSS satisfied. Dropping ALL caps still clears KSV-0118 (Caddy runs as
+          # root, binds only :8090). readOnlyRootFilesystem omitted (autosave to
+          # /config,/data) -> KSV-0014 path-scoped-ignored.
           securityContext:
             capabilities:
               drop:
                 - ALL
-            seccompProfile:
-              type: Unconfined
           env:
             MODEL_API_KEY:
               secretKeyRef:

--- a/charts/model-serving-qwen3-4b/values.yaml
+++ b/charts/model-serving-qwen3-4b/values.yaml
@@ -114,8 +114,9 @@ modelServing:
         securityContext:
           runAsNonRoot: false
           runAsUser: 0
-          seccompProfile:
-            type: RuntimeDefault
+          # No seccompProfile here — the Caddy sidecar shares this pod and its
+          # /usr/bin/caddy is a file-capability binary that cannot exec under the
+          # no_new_privs a seccomp profile forces; runAsUser:0 keeps KSV-0118 cleared.
       containers:
         # 1) the model server (vLLM + in-process LMCache via LMCacheConnectorV1)
         model:
@@ -224,20 +225,19 @@ modelServing:
           # ⚠️ caddy:2-alpine's /usr/bin/caddy carries FILE CAPABILITIES
           # (cap_net_bind_service). The kernel refuses to exec a file-capability
           # binary once no_new_privs is set (execve -> EPERM -> crashloop), and
-          # BOTH allowPrivilegeEscalation:false AND seccompProfile:RuntimeDefault
-          # (with CAP_SYS_ADMIN dropped) set no_new_privs. So the Caddy sidecar
-          # sets NEITHER: seccomp is Unconfined (overriding the pod's
-          # RuntimeDefault) and allowPrivilegeEscalation is left unset. Dropping
-          # ALL caps still clears KSV-0118 — Caddy runs as root and binds only
-          # the high port :8090, so it needs no capabilities. readOnlyRootFilesystem
-          # omitted (autosave to /config,/data) -> KSV-0014 path-scoped-ignored.
-          # (RuntimeDefault seccomp needs a custom image without the fcap — follow-up.)
+          # no_new_privs is forced by allowPrivilegeEscalation:false OR any
+          # seccompProfile (RuntimeDefault/Localhost/Unconfined) with CAP_SYS_ADMIN
+          # dropped. Unconfined is ALSO forbidden by the namespace's baseline
+          # PodSecurity. So this sidecar sets NO seccompProfile (the pod-level
+          # seccomp above is removed so none is inherited) and leaves
+          # allowPrivilegeEscalation unset — no no_new_privs, exec works, baseline
+          # PSS satisfied. Dropping ALL caps still clears KSV-0118 (Caddy runs as
+          # root, binds only :8090). readOnlyRootFilesystem omitted (autosave to
+          # /config,/data) -> KSV-0014 path-scoped-ignored.
           securityContext:
             capabilities:
               drop:
                 - ALL
-            seccompProfile:
-              type: Unconfined
           env:
             MODEL_API_KEY:
               secretKeyRef:

--- a/charts/model-serving-qwen3-8b/values.yaml
+++ b/charts/model-serving-qwen3-8b/values.yaml
@@ -84,8 +84,9 @@ modelServing:
         securityContext:
           runAsNonRoot: false
           runAsUser: 0
-          seccompProfile:
-            type: RuntimeDefault
+          # No seccompProfile here — the Caddy sidecar shares this pod and its
+          # /usr/bin/caddy is a file-capability binary that cannot exec under the
+          # no_new_privs a seccomp profile forces; runAsUser:0 keeps KSV-0118 cleared.
       containers:
         model:
           image:
@@ -166,20 +167,19 @@ modelServing:
           # ⚠️ caddy:2-alpine's /usr/bin/caddy carries FILE CAPABILITIES
           # (cap_net_bind_service). The kernel refuses to exec a file-capability
           # binary once no_new_privs is set (execve -> EPERM -> crashloop), and
-          # BOTH allowPrivilegeEscalation:false AND seccompProfile:RuntimeDefault
-          # (with CAP_SYS_ADMIN dropped) set no_new_privs. So the Caddy sidecar
-          # sets NEITHER: seccomp is Unconfined (overriding the pod's
-          # RuntimeDefault) and allowPrivilegeEscalation is left unset. Dropping
-          # ALL caps still clears KSV-0118 — Caddy runs as root and binds only
-          # the high port :8090, so it needs no capabilities. readOnlyRootFilesystem
-          # omitted (autosave to /config,/data) -> KSV-0014 path-scoped-ignored.
-          # (RuntimeDefault seccomp needs a custom image without the fcap — follow-up.)
+          # no_new_privs is forced by allowPrivilegeEscalation:false OR any
+          # seccompProfile (RuntimeDefault/Localhost/Unconfined) with CAP_SYS_ADMIN
+          # dropped. Unconfined is ALSO forbidden by the namespace's baseline
+          # PodSecurity. So this sidecar sets NO seccompProfile (the pod-level
+          # seccomp above is removed so none is inherited) and leaves
+          # allowPrivilegeEscalation unset — no no_new_privs, exec works, baseline
+          # PSS satisfied. Dropping ALL caps still clears KSV-0118 (Caddy runs as
+          # root, binds only :8090). readOnlyRootFilesystem omitted (autosave to
+          # /config,/data) -> KSV-0014 path-scoped-ignored.
           securityContext:
             capabilities:
               drop:
                 - ALL
-            seccompProfile:
-              type: Unconfined
           env:
             MODEL_API_KEY:
               secretKeyRef:


### PR DESCRIPTION
## Summary

**Production hotfix, take 3 (this one is correct).** #744 set the Caddy sidecar's `seccompProfile` to `Unconfined` to avoid the `no_new_privs` that blocks exec of its file-capability binary — but the **Talos cluster enforces `baseline` PodSecurity cluster-wide**, and baseline **forbids** an explicit `Unconfined` seccomp profile, so the kubelet rejected the pod:

```
violates PodSecurity "baseline:latest": seccompProfile (container "proxy")
must not set securityContext.seccompProfile.type to "Unconfined"
```

The bind: Caddy's fcap binary needs **no** `no_new_privs` (so seccomp can't be RuntimeDefault/Localhost with caps dropped, and `allowPrivilegeEscalation` can't be false), yet baseline forbids `Unconfined`. The only value that is **both** baseline-compliant **and** avoids `no_new_privs` is **unset** — baseline allows an absent seccompProfile.

## Intent

Restore the live self-hosted model without downgrading namespace security. Source of truth: **#741 / #743 / #744** and the live PodSecurity rejection. (A namespace `pod-security.kubernetes.io/enforce: privileged` label would also allow it, but that disables baseline PSS for the whole `converse-poc` namespace — rejected in favour of this.)

## Scope

Across all 6 `model-serving-*` edgeAuth charts: **remove the pod-level `seccompProfile: RuntimeDefault`** (added in #741, which propagated to Caddy), and drop the `Unconfined` line so Caddy is left with `capabilities.drop:[ALL]` only. No seccomp anywhere in the main pod → baseline-compliant; no `no_new_privs` on Caddy → fcap execs; KSV-0118 still cleared (pod `runAsUser:0` + Caddy caps-drop + model container SC). Exactly Caddy's pre-#741 seccomp posture (none) plus dropped caps.

## Verification

- Rendered `qwen2-vl-2b`: pod SC `{runAsNonRoot:false, runAsUser:0}` (no seccomp); `proxy` SC `{capabilities.drop:[ALL]}` (no seccomp, no allowPrivEsc); `model` SC unchanged.
- Baseline PSS: no `Unconfined` anywhere, seccomp unset (allowed), root allowed, caps only dropped → compliant.
- Runtime: no `no_new_privs` on Caddy (no allowPrivEsc:false, no seccomp) → the fcap binary execs — matches how Caddy ran for 2d23h pre-#741.
- `helm template … | trivy config` green (only ignored KSV-0014); `helm lint --strict` passes for all 6.

## Risk Assessment

Low + **urgent**. Restores exact pre-#741 Caddy behaviour. Follow-up (tracked): to run Caddy/model under seccomp `RuntimeDefault`, build a Caddy image with the fcap stripped from `/usr/bin/caddy`.

⚠️ **After merge**: the current pod is `CrashLoopBackOff`, so the StatefulSet roll will wedge again. Once the chart publishes + syncs (~3–5 min), delete the pod to complete the roll:
`kubectl --context admin@homeos -n converse-poc delete pod qwen2-vl-2b-main-0`

## AI Usage Declaration

AI (Claude Opus 4.8) diagnosed the baseline-PSS rejection of the take-2 fix and corrected it (remove seccomp entirely rather than Unconfined). Verified render/lint/scan/PSS. Human maintainer accountable for review + merge.

- [x] I reviewed the AI-generated changes and understand them.
- [x] I verified the changes.
- [x] I take responsibility for this change.

## Reviewer Focus

Confirm removing seccomp from the main pod is acceptable (baseline-compliant, matches pre-#741) vs. building an fcap-stripped Caddy image to keep RuntimeDefault.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
