### PR TITLE
fix(model-serving): Caddy exec crashloop take 4 — remove securityContext (fcap needs default caps)

### DIFF
--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -96,16 +96,36 @@ misconfigurations:
     #    REMOVE this on a subchart bump that adds an epp/pod securityContext hook
     #    — track upstream github.com/llm-d/llm-d-router.
     #
-    # 2. Tracked backlog (pre-existing, revealed by the new deterministic scan;
+    # 2. Image-limited (model-serving Caddy edge-auth sidecar): caddy:2-alpine's
+    #    /usr/bin/caddy ships an EFFECTIVE file-capability (cap_net_bind_service=ep).
+    #    The kernel refuses to exec such a binary when that cap is dropped from the
+    #    bounding set (capabilities.drop) OR when no_new_privs is set
+    #    (allowPrivilegeEscalation:false / any seccompProfile) — and Talos baseline
+    #    PSS forbids the Unconfined seccomp that would dodge the latter. So the
+    #    sidecar cannot take ANY hardened securityContext on this image (verified:
+    #    every variant crashlooped the live pod with "exec /usr/bin/caddy:
+    #    operation not permitted"). The pod + model + seed containers ARE hardened;
+    #    only the Caddy container is exempt. PROPER FIX (tracked): drop the sidecar
+    #    entirely — the model is real vLLM (vllm-openai) and gates VLLM_API_KEY on
+    #    :8080 itself, so Caddy is redundant — or use an fcap-stripped Caddy image.
+    #
+    # 3. Tracked backlog (pre-existing, revealed by the new deterministic scan;
     #    hardening deferred to a follow-up — see PR):
     #    - keycloak-baseline — the keycloak-config-cli CronJob container + pod.
     #    - lmcache — the LMCache server Deployment container + pod.
     statement: >-
-      llm-d EPP: the pinned llm-d-router-standalone v0.9.0 subchart exposes no
-      securityContext hook for the epp container or pod (the envoy sidecar IS
-      hardened) — not fixable via values on v0.9.0. keycloak-baseline + lmcache
-      are pre-existing hardening debt tracked as a follow-up.
+      llm-d EPP has no subchart securityContext hook; the model-serving Caddy
+      sidecar (caddy:2-alpine) ships an fcap binary that cannot exec under any
+      hardened securityContext (caps-drop or no_new_privs) and is slated for
+      removal (vLLM gates the key itself); keycloak-baseline + lmcache are
+      pre-existing hardening debt. All tracked as follow-ups.
     paths:
       - "llm-d.yaml"
       - "keycloak-baseline.yaml"
       - "lmcache.yaml"
+      - "model-serving-deepseek-r1-1-5b.yaml"
+      - "model-serving-ministral-3b.yaml"
+      - "model-serving-qwen2-vl-2b.yaml"
+      - "model-serving-qwen25-3b-awq.yaml"
+      - "model-serving-qwen3-4b.yaml"
+      - "model-serving-qwen3-8b.yaml"

--- a/charts/model-serving-deepseek-r1-1-5b/values.yaml
+++ b/charts/model-serving-deepseek-r1-1-5b/values.yaml
@@ -186,22 +186,15 @@ modelServing:
             repository: caddy
             tag: 2-alpine
             pullPolicy: IfNotPresent
-          # ⚠️ caddy:2-alpine's /usr/bin/caddy carries FILE CAPABILITIES
-          # (cap_net_bind_service). The kernel refuses to exec a file-capability
-          # binary once no_new_privs is set (execve -> EPERM -> crashloop), and
-          # no_new_privs is forced by allowPrivilegeEscalation:false OR any
-          # seccompProfile (RuntimeDefault/Localhost/Unconfined) with CAP_SYS_ADMIN
-          # dropped. Unconfined is ALSO forbidden by the namespace's baseline
-          # PodSecurity. So this sidecar sets NO seccompProfile (the pod-level
-          # seccomp above is removed so none is inherited) and leaves
-          # allowPrivilegeEscalation unset — no no_new_privs, exec works, baseline
-          # PSS satisfied. Dropping ALL caps still clears KSV-0118 (Caddy runs as
-          # root, binds only :8090). readOnlyRootFilesystem omitted (autosave to
-          # /config,/data) -> KSV-0014 path-scoped-ignored.
-          securityContext:
-            capabilities:
-              drop:
-                - ALL
+          # NO securityContext on this sidecar. caddy:2-alpine's /usr/bin/caddy
+          # ships an EFFECTIVE file-capability (cap_net_bind_service=ep); the kernel
+          # refuses to exec such a binary if that cap is dropped from the bounding
+          # set (capabilities.drop) OR if no_new_privs is set (allowPrivilegeEscalation:
+          # false / any seccompProfile), and Talos baseline PSS forbids the Unconfined
+          # seccomp that would dodge the latter — so this image cannot take a hardened
+          # SC at all. KSV-0118 for it is path-scoped-ignored (.trivyignore.yaml); the
+          # pod + model container ARE hardened. PROPER FIX: drop this sidecar — vLLM
+          # gates VLLM_API_KEY on :8080 itself, making Caddy redundant (tracked).
           env:
             MODEL_API_KEY:
               secretKeyRef:

--- a/charts/model-serving-ministral-3b/values.yaml
+++ b/charts/model-serving-ministral-3b/values.yaml
@@ -177,22 +177,15 @@ modelServing:
             repository: caddy
             tag: 2-alpine
             pullPolicy: IfNotPresent
-          # ⚠️ caddy:2-alpine's /usr/bin/caddy carries FILE CAPABILITIES
-          # (cap_net_bind_service). The kernel refuses to exec a file-capability
-          # binary once no_new_privs is set (execve -> EPERM -> crashloop), and
-          # no_new_privs is forced by allowPrivilegeEscalation:false OR any
-          # seccompProfile (RuntimeDefault/Localhost/Unconfined) with CAP_SYS_ADMIN
-          # dropped. Unconfined is ALSO forbidden by the namespace's baseline
-          # PodSecurity. So this sidecar sets NO seccompProfile (the pod-level
-          # seccomp above is removed so none is inherited) and leaves
-          # allowPrivilegeEscalation unset — no no_new_privs, exec works, baseline
-          # PSS satisfied. Dropping ALL caps still clears KSV-0118 (Caddy runs as
-          # root, binds only :8090). readOnlyRootFilesystem omitted (autosave to
-          # /config,/data) -> KSV-0014 path-scoped-ignored.
-          securityContext:
-            capabilities:
-              drop:
-                - ALL
+          # NO securityContext on this sidecar. caddy:2-alpine's /usr/bin/caddy
+          # ships an EFFECTIVE file-capability (cap_net_bind_service=ep); the kernel
+          # refuses to exec such a binary if that cap is dropped from the bounding
+          # set (capabilities.drop) OR if no_new_privs is set (allowPrivilegeEscalation:
+          # false / any seccompProfile), and Talos baseline PSS forbids the Unconfined
+          # seccomp that would dodge the latter — so this image cannot take a hardened
+          # SC at all. KSV-0118 for it is path-scoped-ignored (.trivyignore.yaml); the
+          # pod + model container ARE hardened. PROPER FIX: drop this sidecar — vLLM
+          # gates VLLM_API_KEY on :8080 itself, making Caddy redundant (tracked).
           env:
             MODEL_API_KEY:
               secretKeyRef:

--- a/charts/model-serving-qwen2-vl-2b/values.yaml
+++ b/charts/model-serving-qwen2-vl-2b/values.yaml
@@ -167,22 +167,15 @@ modelServing:
             repository: caddy
             tag: 2-alpine
             pullPolicy: IfNotPresent
-          # ⚠️ caddy:2-alpine's /usr/bin/caddy carries FILE CAPABILITIES
-          # (cap_net_bind_service). The kernel refuses to exec a file-capability
-          # binary once no_new_privs is set (execve -> EPERM -> crashloop), and
-          # no_new_privs is forced by allowPrivilegeEscalation:false OR any
-          # seccompProfile (RuntimeDefault/Localhost/Unconfined) with CAP_SYS_ADMIN
-          # dropped. Unconfined is ALSO forbidden by the namespace's baseline
-          # PodSecurity. So this sidecar sets NO seccompProfile (the pod-level
-          # seccomp above is removed so none is inherited) and leaves
-          # allowPrivilegeEscalation unset — no no_new_privs, exec works, baseline
-          # PSS satisfied. Dropping ALL caps still clears KSV-0118 (Caddy runs as
-          # root, binds only :8090). readOnlyRootFilesystem omitted (autosave to
-          # /config,/data) -> KSV-0014 path-scoped-ignored.
-          securityContext:
-            capabilities:
-              drop:
-                - ALL
+          # NO securityContext on this sidecar. caddy:2-alpine's /usr/bin/caddy
+          # ships an EFFECTIVE file-capability (cap_net_bind_service=ep); the kernel
+          # refuses to exec such a binary if that cap is dropped from the bounding
+          # set (capabilities.drop) OR if no_new_privs is set (allowPrivilegeEscalation:
+          # false / any seccompProfile), and Talos baseline PSS forbids the Unconfined
+          # seccomp that would dodge the latter — so this image cannot take a hardened
+          # SC at all. KSV-0118 for it is path-scoped-ignored (.trivyignore.yaml); the
+          # pod + model container ARE hardened. PROPER FIX: drop this sidecar — vLLM
+          # gates VLLM_API_KEY on :8080 itself, making Caddy redundant (tracked).
           env:
             MODEL_API_KEY:
               secretKeyRef:

--- a/charts/model-serving-qwen25-3b-awq/values.yaml
+++ b/charts/model-serving-qwen25-3b-awq/values.yaml
@@ -189,22 +189,15 @@ modelServing:
             repository: caddy
             tag: 2-alpine
             pullPolicy: IfNotPresent
-          # ⚠️ caddy:2-alpine's /usr/bin/caddy carries FILE CAPABILITIES
-          # (cap_net_bind_service). The kernel refuses to exec a file-capability
-          # binary once no_new_privs is set (execve -> EPERM -> crashloop), and
-          # no_new_privs is forced by allowPrivilegeEscalation:false OR any
-          # seccompProfile (RuntimeDefault/Localhost/Unconfined) with CAP_SYS_ADMIN
-          # dropped. Unconfined is ALSO forbidden by the namespace's baseline
-          # PodSecurity. So this sidecar sets NO seccompProfile (the pod-level
-          # seccomp above is removed so none is inherited) and leaves
-          # allowPrivilegeEscalation unset — no no_new_privs, exec works, baseline
-          # PSS satisfied. Dropping ALL caps still clears KSV-0118 (Caddy runs as
-          # root, binds only :8090). readOnlyRootFilesystem omitted (autosave to
-          # /config,/data) -> KSV-0014 path-scoped-ignored.
-          securityContext:
-            capabilities:
-              drop:
-                - ALL
+          # NO securityContext on this sidecar. caddy:2-alpine's /usr/bin/caddy
+          # ships an EFFECTIVE file-capability (cap_net_bind_service=ep); the kernel
+          # refuses to exec such a binary if that cap is dropped from the bounding
+          # set (capabilities.drop) OR if no_new_privs is set (allowPrivilegeEscalation:
+          # false / any seccompProfile), and Talos baseline PSS forbids the Unconfined
+          # seccomp that would dodge the latter — so this image cannot take a hardened
+          # SC at all. KSV-0118 for it is path-scoped-ignored (.trivyignore.yaml); the
+          # pod + model container ARE hardened. PROPER FIX: drop this sidecar — vLLM
+          # gates VLLM_API_KEY on :8080 itself, making Caddy redundant (tracked).
           env:
             MODEL_API_KEY:
               secretKeyRef:

--- a/charts/model-serving-qwen3-4b/values.yaml
+++ b/charts/model-serving-qwen3-4b/values.yaml
@@ -222,22 +222,15 @@ modelServing:
             repository: caddy
             tag: 2-alpine
             pullPolicy: IfNotPresent
-          # ⚠️ caddy:2-alpine's /usr/bin/caddy carries FILE CAPABILITIES
-          # (cap_net_bind_service). The kernel refuses to exec a file-capability
-          # binary once no_new_privs is set (execve -> EPERM -> crashloop), and
-          # no_new_privs is forced by allowPrivilegeEscalation:false OR any
-          # seccompProfile (RuntimeDefault/Localhost/Unconfined) with CAP_SYS_ADMIN
-          # dropped. Unconfined is ALSO forbidden by the namespace's baseline
-          # PodSecurity. So this sidecar sets NO seccompProfile (the pod-level
-          # seccomp above is removed so none is inherited) and leaves
-          # allowPrivilegeEscalation unset — no no_new_privs, exec works, baseline
-          # PSS satisfied. Dropping ALL caps still clears KSV-0118 (Caddy runs as
-          # root, binds only :8090). readOnlyRootFilesystem omitted (autosave to
-          # /config,/data) -> KSV-0014 path-scoped-ignored.
-          securityContext:
-            capabilities:
-              drop:
-                - ALL
+          # NO securityContext on this sidecar. caddy:2-alpine's /usr/bin/caddy
+          # ships an EFFECTIVE file-capability (cap_net_bind_service=ep); the kernel
+          # refuses to exec such a binary if that cap is dropped from the bounding
+          # set (capabilities.drop) OR if no_new_privs is set (allowPrivilegeEscalation:
+          # false / any seccompProfile), and Talos baseline PSS forbids the Unconfined
+          # seccomp that would dodge the latter — so this image cannot take a hardened
+          # SC at all. KSV-0118 for it is path-scoped-ignored (.trivyignore.yaml); the
+          # pod + model container ARE hardened. PROPER FIX: drop this sidecar — vLLM
+          # gates VLLM_API_KEY on :8080 itself, making Caddy redundant (tracked).
           env:
             MODEL_API_KEY:
               secretKeyRef:

--- a/charts/model-serving-qwen3-8b/values.yaml
+++ b/charts/model-serving-qwen3-8b/values.yaml
@@ -164,22 +164,15 @@ modelServing:
             repository: caddy
             tag: 2-alpine
             pullPolicy: IfNotPresent
-          # ⚠️ caddy:2-alpine's /usr/bin/caddy carries FILE CAPABILITIES
-          # (cap_net_bind_service). The kernel refuses to exec a file-capability
-          # binary once no_new_privs is set (execve -> EPERM -> crashloop), and
-          # no_new_privs is forced by allowPrivilegeEscalation:false OR any
-          # seccompProfile (RuntimeDefault/Localhost/Unconfined) with CAP_SYS_ADMIN
-          # dropped. Unconfined is ALSO forbidden by the namespace's baseline
-          # PodSecurity. So this sidecar sets NO seccompProfile (the pod-level
-          # seccomp above is removed so none is inherited) and leaves
-          # allowPrivilegeEscalation unset — no no_new_privs, exec works, baseline
-          # PSS satisfied. Dropping ALL caps still clears KSV-0118 (Caddy runs as
-          # root, binds only :8090). readOnlyRootFilesystem omitted (autosave to
-          # /config,/data) -> KSV-0014 path-scoped-ignored.
-          securityContext:
-            capabilities:
-              drop:
-                - ALL
+          # NO securityContext on this sidecar. caddy:2-alpine's /usr/bin/caddy
+          # ships an EFFECTIVE file-capability (cap_net_bind_service=ep); the kernel
+          # refuses to exec such a binary if that cap is dropped from the bounding
+          # set (capabilities.drop) OR if no_new_privs is set (allowPrivilegeEscalation:
+          # false / any seccompProfile), and Talos baseline PSS forbids the Unconfined
+          # seccomp that would dodge the latter — so this image cannot take a hardened
+          # SC at all. KSV-0118 for it is path-scoped-ignored (.trivyignore.yaml); the
+          # pod + model container ARE hardened. PROPER FIX: drop this sidecar — vLLM
+          # gates VLLM_API_KEY on :8080 itself, making Caddy redundant (tracked).
           env:
             MODEL_API_KEY:
               secretKeyRef:


### PR DESCRIPTION
## Summary

**Production hotfix, take 4 — the guaranteed one.** #745 removed the seccomp half, but the live pod still crashlooped: `no_new_privs` was never the *only* trigger. `caddy:2-alpine`'s `/usr/bin/caddy` has an **effective file-capability** (`cap_net_bind_service=ep`), and the kernel refuses to exec such a binary when that capability isn't in the bounding set — which is exactly what **`capabilities.drop:[ALL]`** does. So caps-drop alone is fatal (confirmed on the #745 pod: pod-seccomp gone, proxy SC only `{capabilities.drop:[ALL]}`, still `operation not permitted`).

There is **no hardened securityContext this image can take**: caps-drop breaks it, `no_new_privs` (allowPrivEsc:false / any seccomp) breaks it, and Talos baseline PSS forbids the `Unconfined` that would dodge `no_new_privs`. So this reverts the Caddy container to **no securityContext** — exactly how it ran for 2d23h before #741 — and scope-ignores its KSV-0118.

## Intent

End the outage with the known-good config. Source of truth: #741/#743/#744/#745 and the live pod (`exec /usr/bin/caddy: operation not permitted` under caps-drop with seccomp already removed).

## Scope

All 6 `model-serving-*` edgeAuth charts: remove the Caddy container `securityContext` (default caps, no seccomp, no `no_new_privs` → fcap execs). Scope-ignore Caddy KSV-0118 (`.trivyignore.yaml`). Pod SC (`runAsUser:0`, no seccomp — from #745), model container SC, and seed stay hardened; only the fcap Caddy container is exempt.

## Verification

- Rendered `qwen2-vl-2b`: `pod.securityContext = {runAsNonRoot:false, runAsUser:0}` (no seccomp), `proxy` container has **no securityContext**, `model` unchanged.
- Runtime: default caps (cap in bounding set) + no `no_new_privs` → fcap execs; identical to pre-#741. Baseline PSS compliant (no Unconfined, default caps).
- `helm template … | trivy config` green; `helm lint --strict` passes for all 6.

## Risk Assessment

Low + **urgent** — restores the exact pre-#741 Caddy behaviour. **After merge**, delete the crashlooping pod to complete the wedged roll:
`kubectl --context admin@homeos -n converse-poc delete pod qwen2-vl-2b-main-0`

## Follow-up (recommended, separate PR)

**Delete the Caddy sidecar entirely.** Its Caddyfile only does `require Bearer <MODEL_API_KEY>, else 401, else reverse_proxy → :8080`, and the model is real vLLM (`lmcache/vllm-openai`) which gates the **same** key via `VLLM_API_KEY` on `:8080` — so Caddy is redundant on every chart that moved off `huggingfaceserver`. Removing it (drop the container + Caddyfile ConfigMap, point Service/Ingress at `:8080`) eliminates this fcap class of problem for good. Needs a quick check that the model returns 401 without the key before flipping the Ingress.

## AI Usage Declaration

AI (Claude Opus 4.8) diagnosed the caps-drop/fcap exec failure (the second, independent trigger) after the seccomp fix, reverted to the known-good no-SC config, and verified render/lint/scan/PSS. Human maintainer accountable for review + merge.

- [x] I reviewed the AI-generated changes and understand them.
- [x] I verified the changes.
- [x] I take responsibility for this change.

## Reviewer Focus

Sanity-check the follow-up: confirm `lmcache/vllm-openai` enforces `VLLM_API_KEY` (401 without it) so the Caddy sidecar can be deleted next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
