### PR TITLE
fix(model-serving): remove the redundant Caddy sidecar from the vLLM charts

### DIFF
--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -96,36 +96,34 @@ misconfigurations:
     #    REMOVE this on a subchart bump that adds an epp/pod securityContext hook
     #    — track upstream github.com/llm-d/llm-d-router.
     #
-    # 2. Image-limited (model-serving Caddy edge-auth sidecar): caddy:2-alpine's
-    #    /usr/bin/caddy ships an EFFECTIVE file-capability (cap_net_bind_service=ep).
-    #    The kernel refuses to exec such a binary when that cap is dropped from the
-    #    bounding set (capabilities.drop) OR when no_new_privs is set
-    #    (allowPrivilegeEscalation:false / any seccompProfile) — and Talos baseline
-    #    PSS forbids the Unconfined seccomp that would dodge the latter. So the
-    #    sidecar cannot take ANY hardened securityContext on this image (verified:
-    #    every variant crashlooped the live pod with "exec /usr/bin/caddy:
-    #    operation not permitted"). The pod + model + seed containers ARE hardened;
-    #    only the Caddy container is exempt. PROPER FIX (tracked): drop the sidecar
-    #    entirely — the model is real vLLM (vllm-openai) and gates VLLM_API_KEY on
-    #    :8080 itself, so Caddy is redundant — or use an fcap-stripped Caddy image.
+    # 2. Image-limited (Caddy edge-auth sidecar on the huggingfaceserver models):
+    #    caddy:2-alpine's /usr/bin/caddy ships an EFFECTIVE file-capability
+    #    (cap_net_bind_service=ep). The kernel refuses to exec such a binary when
+    #    that cap is dropped from the bounding set (capabilities.drop) OR when
+    #    no_new_privs is set (allowPrivilegeEscalation:false / any seccompProfile),
+    #    and Talos baseline PSS forbids the Unconfined seccomp that would dodge the
+    #    latter — so the sidecar can take NO hardened securityContext on this image
+    #    (verified: every variant crashlooped the live pod). Only these three charts
+    #    still run Caddy: they use kserve/huggingfaceserver, which IGNORES
+    #    VLLM_API_KEY, so the edge-auth proxy is required. The vllm-openai charts
+    #    (qwen2-vl-2b, qwen25-3b-awq, qwen3-4b) DROPPED the redundant sidecar — the
+    #    model gates VLLM_API_KEY on :8080 itself (verified: 401 without the key).
+    #    Pod + model + seed are hardened; only the Caddy container is exempt.
     #
     # 3. Tracked backlog (pre-existing, revealed by the new deterministic scan;
     #    hardening deferred to a follow-up — see PR):
     #    - keycloak-baseline — the keycloak-config-cli CronJob container + pod.
     #    - lmcache — the LMCache server Deployment container + pod.
     statement: >-
-      llm-d EPP has no subchart securityContext hook; the model-serving Caddy
-      sidecar (caddy:2-alpine) ships an fcap binary that cannot exec under any
-      hardened securityContext (caps-drop or no_new_privs) and is slated for
-      removal (vLLM gates the key itself); keycloak-baseline + lmcache are
-      pre-existing hardening debt. All tracked as follow-ups.
+      llm-d EPP has no subchart securityContext hook; the Caddy sidecar on the
+      three huggingfaceserver model charts ships an fcap binary that cannot exec
+      under any hardened securityContext (it is required there because
+      huggingfaceserver ignores VLLM_API_KEY; the vllm-openai charts dropped it);
+      keycloak-baseline + lmcache are pre-existing hardening debt. All tracked.
     paths:
       - "llm-d.yaml"
       - "keycloak-baseline.yaml"
       - "lmcache.yaml"
       - "model-serving-deepseek-r1-1-5b.yaml"
       - "model-serving-ministral-3b.yaml"
-      - "model-serving-qwen2-vl-2b.yaml"
-      - "model-serving-qwen25-3b-awq.yaml"
-      - "model-serving-qwen3-4b.yaml"
       - "model-serving-qwen3-8b.yaml"

--- a/charts/model-serving-deepseek-r1-1-5b/values.yaml
+++ b/charts/model-serving-deepseek-r1-1-5b/values.yaml
@@ -186,15 +186,13 @@ modelServing:
             repository: caddy
             tag: 2-alpine
             pullPolicy: IfNotPresent
-          # NO securityContext on this sidecar. caddy:2-alpine's /usr/bin/caddy
-          # ships an EFFECTIVE file-capability (cap_net_bind_service=ep); the kernel
-          # refuses to exec such a binary if that cap is dropped from the bounding
-          # set (capabilities.drop) OR if no_new_privs is set (allowPrivilegeEscalation:
-          # false / any seccompProfile), and Talos baseline PSS forbids the Unconfined
-          # seccomp that would dodge the latter — so this image cannot take a hardened
-          # SC at all. KSV-0118 for it is path-scoped-ignored (.trivyignore.yaml); the
-          # pod + model container ARE hardened. PROPER FIX: drop this sidecar — vLLM
-          # gates VLLM_API_KEY on :8080 itself, making Caddy redundant (tracked).
+          # NO securityContext: caddy:2-alpine's /usr/bin/caddy is a file-capability
+          # binary (cap_net_bind_service=ep) that cannot exec if that cap is dropped
+          # (capabilities.drop) or under no_new_privs (allowPrivilegeEscalation:false /
+          # any seccompProfile) — Talos baseline PSS also forbids Unconfined. So this
+          # image takes no hardened SC; KSV-0118 is path-scoped-ignored. This chart
+          # uses kserve/huggingfaceserver (IGNORES VLLM_API_KEY) so the Caddy edge-auth
+          # proxy is REQUIRED here (unlike the vllm-openai charts, where it was removed).
           env:
             MODEL_API_KEY:
               secretKeyRef:

--- a/charts/model-serving-ministral-3b/values.yaml
+++ b/charts/model-serving-ministral-3b/values.yaml
@@ -177,15 +177,13 @@ modelServing:
             repository: caddy
             tag: 2-alpine
             pullPolicy: IfNotPresent
-          # NO securityContext on this sidecar. caddy:2-alpine's /usr/bin/caddy
-          # ships an EFFECTIVE file-capability (cap_net_bind_service=ep); the kernel
-          # refuses to exec such a binary if that cap is dropped from the bounding
-          # set (capabilities.drop) OR if no_new_privs is set (allowPrivilegeEscalation:
-          # false / any seccompProfile), and Talos baseline PSS forbids the Unconfined
-          # seccomp that would dodge the latter — so this image cannot take a hardened
-          # SC at all. KSV-0118 for it is path-scoped-ignored (.trivyignore.yaml); the
-          # pod + model container ARE hardened. PROPER FIX: drop this sidecar — vLLM
-          # gates VLLM_API_KEY on :8080 itself, making Caddy redundant (tracked).
+          # NO securityContext: caddy:2-alpine's /usr/bin/caddy is a file-capability
+          # binary (cap_net_bind_service=ep) that cannot exec if that cap is dropped
+          # (capabilities.drop) or under no_new_privs (allowPrivilegeEscalation:false /
+          # any seccompProfile) — Talos baseline PSS also forbids Unconfined. So this
+          # image takes no hardened SC; KSV-0118 is path-scoped-ignored. This chart
+          # uses kserve/huggingfaceserver (IGNORES VLLM_API_KEY) so the Caddy edge-auth
+          # proxy is REQUIRED here (unlike the vllm-openai charts, where it was removed).
           env:
             MODEL_API_KEY:
               secretKeyRef:

--- a/charts/model-serving-qwen2-vl-2b/values.yaml
+++ b/charts/model-serving-qwen2-vl-2b/values.yaml
@@ -63,7 +63,9 @@ apiKey:
     property: vllm_local_api_key
 
 edgeAuth:
-  enabled: true
+  # Caddy sidecar REMOVED — the model is real vLLM (vllm-openai) which gates
+  # VLLM_API_KEY on :8080 natively, so the edge-auth proxy was redundant.
+  enabled: false
   proxyResponseTimeout: 600s
 
 modelServing:
@@ -162,39 +164,6 @@ modelServing:
               cpu: "2"
               memory: 6Gi
 
-        proxy:
-          image:
-            repository: caddy
-            tag: 2-alpine
-            pullPolicy: IfNotPresent
-          # NO securityContext on this sidecar. caddy:2-alpine's /usr/bin/caddy
-          # ships an EFFECTIVE file-capability (cap_net_bind_service=ep); the kernel
-          # refuses to exec such a binary if that cap is dropped from the bounding
-          # set (capabilities.drop) OR if no_new_privs is set (allowPrivilegeEscalation:
-          # false / any seccompProfile), and Talos baseline PSS forbids the Unconfined
-          # seccomp that would dodge the latter — so this image cannot take a hardened
-          # SC at all. KSV-0118 for it is path-scoped-ignored (.trivyignore.yaml); the
-          # pod + model container ARE hardened. PROPER FIX: drop this sidecar — vLLM
-          # gates VLLM_API_KEY on :8080 itself, making Caddy redundant (tracked).
-          env:
-            MODEL_API_KEY:
-              secretKeyRef:
-                name: vllm-local-api-key
-                key: api_key
-          ports:
-            - name: edge
-              containerPort: 8090
-          probes:
-            readiness:
-              enabled: true
-              custom: true
-              spec:
-                tcpSocket: { port: 8090 }
-                periodSeconds: 10
-          resources:
-            requests: { cpu: 10m, memory: 32Mi }
-            limits:   { cpu: 200m, memory: 128Mi }
-
     seed:
       type: job
       annotations:
@@ -254,9 +223,9 @@ modelServing:
       controller: main
       type: ClusterIP
       ports:
-        edge:
-          port: 8090
-          targetPort: 8090
+        http:
+          port: 8080
+          targetPort: 8080
 
   ingress:
     main:
@@ -271,7 +240,7 @@ modelServing:
               pathType: Prefix
               service:
                 identifier: main
-                port: edge
+                port: http
       tls:
         - secretName: qwen2-vl-2b-edge-tls
           hosts:

--- a/charts/model-serving-qwen25-3b-awq/values.yaml
+++ b/charts/model-serving-qwen25-3b-awq/values.yaml
@@ -58,7 +58,9 @@ apiKey:
     property: vllm_local_api_key
 
 edgeAuth:
-  enabled: true
+  # Caddy sidecar REMOVED — the model is real vLLM (vllm-openai) which gates
+  # VLLM_API_KEY on :8080 natively, so the edge-auth proxy was redundant.
+  enabled: false
   proxyResponseTimeout: 600s
 
 modelServing:
@@ -184,39 +186,6 @@ modelServing:
               cpu: "2"
               memory: 6Gi
 
-        proxy:
-          image:
-            repository: caddy
-            tag: 2-alpine
-            pullPolicy: IfNotPresent
-          # NO securityContext on this sidecar. caddy:2-alpine's /usr/bin/caddy
-          # ships an EFFECTIVE file-capability (cap_net_bind_service=ep); the kernel
-          # refuses to exec such a binary if that cap is dropped from the bounding
-          # set (capabilities.drop) OR if no_new_privs is set (allowPrivilegeEscalation:
-          # false / any seccompProfile), and Talos baseline PSS forbids the Unconfined
-          # seccomp that would dodge the latter — so this image cannot take a hardened
-          # SC at all. KSV-0118 for it is path-scoped-ignored (.trivyignore.yaml); the
-          # pod + model container ARE hardened. PROPER FIX: drop this sidecar — vLLM
-          # gates VLLM_API_KEY on :8080 itself, making Caddy redundant (tracked).
-          env:
-            MODEL_API_KEY:
-              secretKeyRef:
-                name: vllm-local-api-key
-                key: api_key
-          ports:
-            - name: edge
-              containerPort: 8090
-          probes:
-            readiness:
-              enabled: true
-              custom: true
-              spec:
-                tcpSocket: { port: 8090 }
-                periodSeconds: 10
-          resources:
-            requests: { cpu: 10m, memory: 32Mi }
-            limits:   { cpu: 200m, memory: 128Mi }
-
     seed:
       type: job
       annotations:
@@ -276,9 +245,9 @@ modelServing:
       controller: main
       type: ClusterIP
       ports:
-        edge:
-          port: 8090
-          targetPort: 8090
+        http:
+          port: 8080
+          targetPort: 8080
 
   ingress:
     main:
@@ -293,7 +262,7 @@ modelServing:
               pathType: Prefix
               service:
                 identifier: main
-                port: edge
+                port: http
       tls:
         - secretName: qwen25-3b-awq-edge-tls
           hosts:

--- a/charts/model-serving-qwen3-4b/values.yaml
+++ b/charts/model-serving-qwen3-4b/values.yaml
@@ -77,7 +77,9 @@ apiKey:
 # Caddy sidecar config (own templates/configmap-caddy.yaml). Only the upstream
 # timeout is tunable; the public host/TLS now live in `modelServing.ingress`.
 edgeAuth:
-  enabled: true
+  # Caddy sidecar REMOVED — the model is real vLLM (vllm-openai) which gates
+  # VLLM_API_KEY on :8080 natively, so the edge-auth proxy was redundant.
+  enabled: false
   # Caddy upstream timeout — must exceed a deploy-time restart (STS reloads
   # multi-GB weights) + a long generation. Keep ≥ the ai-models qwen3-4b-local
   # timeout.requestTimeout (both 600s). Path: Envoy → Ingress → Caddy → model.
@@ -217,39 +219,6 @@ modelServing:
 
         # 2) the Caddy auth-proxy sidecar — validates the Bearer the model image
         # ignores, then reverse-proxies to the model over localhost:8080.
-        proxy:
-          image:
-            repository: caddy
-            tag: 2-alpine
-            pullPolicy: IfNotPresent
-          # NO securityContext on this sidecar. caddy:2-alpine's /usr/bin/caddy
-          # ships an EFFECTIVE file-capability (cap_net_bind_service=ep); the kernel
-          # refuses to exec such a binary if that cap is dropped from the bounding
-          # set (capabilities.drop) OR if no_new_privs is set (allowPrivilegeEscalation:
-          # false / any seccompProfile), and Talos baseline PSS forbids the Unconfined
-          # seccomp that would dodge the latter — so this image cannot take a hardened
-          # SC at all. KSV-0118 for it is path-scoped-ignored (.trivyignore.yaml); the
-          # pod + model container ARE hardened. PROPER FIX: drop this sidecar — vLLM
-          # gates VLLM_API_KEY on :8080 itself, making Caddy redundant (tracked).
-          env:
-            MODEL_API_KEY:
-              secretKeyRef:
-                name: vllm-local-api-key
-                key: api_key
-          ports:
-            - name: edge
-              containerPort: 8090            # NOT 8081 — the model's gRPC owns 8081
-          probes:
-            readiness:
-              enabled: true
-              custom: true
-              spec:
-                tcpSocket: { port: 8090 }
-                periodSeconds: 10
-          resources:
-            requests: { cpu: 10m, memory: 32Mi }
-            limits:   { cpu: 200m, memory: 128Mi }
-
     # ── The weight seed Job (bjw `job` controller, ArgoCD Sync hook) ──────────
     # A Job (not a tracked resource) via the hook annotations: a plain tracked
     # Job goes perpetually OutOfSync (the controller stamps controller-uid into
@@ -319,9 +288,9 @@ modelServing:
       controller: main
       type: ClusterIP
       ports:
-        edge:
-          port: 8090
-          targetPort: 8090          # → the Caddy sidecar (8081 is the model's gRPC)
+        http:
+          port: 8080
+          targetPort: 8080          # → the Caddy sidecar (8081 is the model's gRPC)
 
   # Public entrypoint — a plain k8s Ingress (className traefik), no Traefik
   # IngressRoute CRD / DomainMapping. cert-manager's ingress-shim issues the TLS
@@ -341,7 +310,7 @@ modelServing:
               pathType: Prefix
               service:
                 identifier: main
-                port: edge
+                port: http
       tls:
         - secretName: qwen3-model-edge-tls
           hosts:

--- a/charts/model-serving-qwen3-8b/values.yaml
+++ b/charts/model-serving-qwen3-8b/values.yaml
@@ -164,15 +164,13 @@ modelServing:
             repository: caddy
             tag: 2-alpine
             pullPolicy: IfNotPresent
-          # NO securityContext on this sidecar. caddy:2-alpine's /usr/bin/caddy
-          # ships an EFFECTIVE file-capability (cap_net_bind_service=ep); the kernel
-          # refuses to exec such a binary if that cap is dropped from the bounding
-          # set (capabilities.drop) OR if no_new_privs is set (allowPrivilegeEscalation:
-          # false / any seccompProfile), and Talos baseline PSS forbids the Unconfined
-          # seccomp that would dodge the latter — so this image cannot take a hardened
-          # SC at all. KSV-0118 for it is path-scoped-ignored (.trivyignore.yaml); the
-          # pod + model container ARE hardened. PROPER FIX: drop this sidecar — vLLM
-          # gates VLLM_API_KEY on :8080 itself, making Caddy redundant (tracked).
+          # NO securityContext: caddy:2-alpine's /usr/bin/caddy is a file-capability
+          # binary (cap_net_bind_service=ep) that cannot exec if that cap is dropped
+          # (capabilities.drop) or under no_new_privs (allowPrivilegeEscalation:false /
+          # any seccompProfile) — Talos baseline PSS also forbids Unconfined. So this
+          # image takes no hardened SC; KSV-0118 is path-scoped-ignored. This chart
+          # uses kserve/huggingfaceserver (IGNORES VLLM_API_KEY) so the Caddy edge-auth
+          # proxy is REQUIRED here (unlike the vllm-openai charts, where it was removed).
           env:
             MODEL_API_KEY:
               secretKeyRef:


### PR DESCRIPTION
## Summary

**Ends the #743–#746 Caddy crashloop saga by removing the redundant sidecar.** The Caddy edge-auth proxy only does "require Bearer `<key>`, else 401, else `reverse_proxy → :8080`". On the vLLM-backed charts this is pure redundancy — the model itself (`vllm-openai` / `lmcache/vllm-openai`) already gates the identical key via `VLLM_API_KEY` on `:8080` (verified live: `/v1/models` → 401 without the key, `/health` stays open). Caddy was only ever load-bearing for `kserve/huggingfaceserver`, which ignores `VLLM_API_KEY`.

It also permanently avoids the fcap/`no_new_privs`/baseline-PSS trap from #743-746: `caddy:2-alpine`'s binary is a file-capability binary that cannot exec under **any** hardened `securityContext` on this Talos (baseline-PSS) cluster — dropping the sidecar removes the problem instead of working around it.

## Intent

Restore + simplify the live model, and close the security-hardening gap that no `securityContext` could actually satisfy. Source of truth: #741/#743/#744/#745/#746 (the crashloop investigation) + live verification that vLLM enforces the key.

## Scope

- **Removed Caddy** from the 3 `vllm-openai` charts — `model-serving-qwen2-vl-2b` (**live**), `model-serving-qwen25-3b-awq`, `model-serving-qwen3-4b`: drop the `proxy` container, `edgeAuth.enabled: false` (gates off the Caddyfile ConfigMap), Service + Ingress repointed from Caddy's `:8090` to the model's `:8080`. Gateway path (Ingress host → Service) is unchanged.
- **Kept Caddy** on the 3 `huggingfaceserver` charts — `model-serving-deepseek-r1-1-5b`, `model-serving-ministral-3b`, `model-serving-qwen3-8b` — where it's still required, reverted to **no securityContext** (the only config the image accepts on this cluster); its KSV-0118 stays path-scoped-ignored with the full fcap/no_new_privs/baseline-PSS rationale.

## Verification

- Live: `curl` against the running `qwen2-vl-2b` model on `:8080` — **401** without `Authorization: Bearer`, **200** on `/health`.
- Rendered `qwen2-vl-2b`/`qwen25-3b-awq`/`qwen3-4b`: StatefulSet has only the `model` container; Service/Ingress target port `8080`; no Caddy ConfigMap.
- Rendered `deepseek-r1-1-5b`/`ministral-3b`/`qwen3-8b`: unchanged shape (`model`+`proxy`), proxy has no securityContext.
- `helm lint --strict` passes for all 6; full-fleet `helm template … --skip-tests | trivy config` is **green**.

## Risk Assessment

Low. The model already validates the same key the gateway sends; removing Caddy removes a hop, not an auth check. **After merge**, the live `qwen2-vl-2b` pod (currently crashlooping in the Caddy container) needs the wedged StatefulSet roll completed once the chart syncs:
`kubectl --context admin@homeos -n converse-poc delete pod qwen2-vl-2b-main-0`
— it should come back **1/1 Ready** immediately (the model container was never the problem).

## AI Usage Declaration

AI (Claude Opus 4.8) identified the redundancy, verified live that vLLM enforces the key, and implemented + verified the removal (render/lint/scan) across all 6 charts, keeping Caddy only where structurally required. Human maintainer accountable for review + merge.

- [x] I reviewed the AI-generated changes and understand them.
- [x] I verified the changes (live curl + render/lint/scan evidence above).
- [x] I take responsibility for this change.

## Reviewer Focus

Confirm no other consumer (dashboards, gateway health checks, docs) references the Caddy `:8090` edge port or the `qwen2-vl-2b-edge-tls` naming on the 3 vLLM charts before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
