### PR TITLE
fix(argo-workflows): ci reference copy - disable chart CRD install

### DIFF
--- a/charts/argo-workflows/ci/argo-workflows-app.yaml
+++ b/charts/argo-workflows/ci/argo-workflows-app.yaml
@@ -27,6 +27,25 @@
 # workflows.argoproj.io/rbac-rule) is a follow-up once real usage patterns
 # emerge — do not over-build this now.
 
+# CRDs are managed OUT-OF-BAND, not by this chart. The chart's default
+# `crds.install: true` + `crds.full: true` ships the (very large) full CRDs
+# via a pre-install/pre-upgrade **hook Job** that `kubectl apply`s them
+# straight from raw.githubusercontent.com at EVERY sync. Under this cluster's
+# default-deny-egress Cilium baseline that Job is unworkable — it races
+# Cilium's FQDN-policy programming and timed out on `dial tcp
+# 185.199.x.x:443` for hours, failing the whole Application sync (found live
+# during ADR-0085 verification). The 8 argoproj.io CRDs are already installed
+# cluster-wide as full CRDs (and `keep: true` means an uninstall never
+# removes them), so the chart doesn't need to fetch them.
+#
+# ⚠️ Trade-off: a future argo-workflows chart-version bump that changes the
+# CRD schemas will NOT auto-apply them. When bumping the chart, manually
+# apply the new CRDs first from a host that has egress, e.g.:
+#   kubectl apply --server-side -f \
+#     https://raw.githubusercontent.com/argoproj/argo-helm/argo-workflows-<VER>/charts/argo-workflows/files/crds/full/
+crds:
+  install: false
+
 server:
   authModes:
     - sso


### PR DESCRIPTION
## Summary
Reference-copy sync: add `crds.install: false` to `charts/argo-workflows/ci/argo-workflows-app.yaml`, mirroring the live fix in ai-helm-values PR #140.

## Intent
Source of truth: ADR-0085 + ai-helm-values#140. The ci `*-app.yaml` files are human/CI reference copies of the private workload values; repo convention keeps them in sync.

## Scope
`charts/argo-workflows/ci/argo-workflows-app.yaml` only (documentation/reference; the live deploy reads the private ai-helm-values file).

## Verification
- `helm template awf argo/argo-workflows --version 1.0.20 -f <this file>` renders 0 `kind: Job` and 0 `kind: CustomResourceDefinition`, with server + controller Deployments intact.
- Rationale is the live root cause: the chart's `crds.full: true` hook Job downloads CRDs from raw.githubusercontent.com every sync and times out under the default-deny-egress Cilium baseline; the 8 argoproj.io CRDs are already installed cluster-wide (`keep: true`), so out-of-band management is safe.

## Risk Assessment
None functional — reference copy only.

## AI Usage Declaration
- [x] AI (Claude) authored this mirror to match the diagnosed live fix.
- [x] I (the human) reviewed the diff.

## Reviewer Focus
Consistency with ai-helm-values#140.
