### PR TITLE
fix(mlflow): ci reference copy - point oidc-auth user DB at Postgres

### DIFF
--- a/charts/mlflow/ci/mlflow-app.yaml
+++ b/charts/mlflow/ci/mlflow-app.yaml
@@ -80,6 +80,27 @@ oidcAuth:
     - admin
   defaultPermission: "READ"
   sessionCookieSecure: true
+  # The mlflow-oidc-auth plugin keeps its OWN users/groups/permissions DB,
+  # SEPARATE from the tracking backendStore. Left unset it defaults to
+  # `sqlite:///auth.db` on the pod's (read-only) filesystem → every OIDC
+  # callback fails with `sqlite3.OperationalError: unable to open database
+  # file` → "Failed to update user/groups" (the Keycloak claim is correct;
+  # the plugin just can't persist the user). Found live during ADR-0085
+  # verification. Point it at the SAME lightbridge-main-db `mlflow` Postgres
+  # the tracking store already uses (the plugin creates its own tables there;
+  # the mlflow CNPG role owns the DB so it has DDL). No new egress needed —
+  # same host:port the backendStore already reaches.
+  database:
+    postgres:
+      enabled: true
+      host: "lightbridge-main-db-rw.converse.svc.cluster.local"
+      port: 5432
+      database: "mlflow"
+      driver: "psycopg2"
+      existingSecret:
+        name: mlflow-db-secret
+        usernameKey: username
+        passwordKey: password
 
 replicaCount: 1
 


### PR DESCRIPTION
## Summary
Reference-copy sync of ai-helm-values fix: point the mlflow-oidc-auth plugin DB at Postgres.

## Intent
ADR-0085 follow-up; mirrors the private ai-helm-values change. The live deploy reads the private file; this keeps the ci reference in sync per repo convention.

## Verification
`helm template mlflow community-charts/mlflow -f <this file>` renders `OIDC_USERS_DB_URI=postgresql+psycopg2://…/mlflow` (was defaulting to read-only SQLite → "Failed to update user/groups").

## Risk
None — reference copy only.

## AI Usage Declaration
- [x] AI authored the mirror.
- [x] Human reviewed.

## Reviewer Focus
Consistency with the ai-helm-values PR.