### PR TITLE
fix(argo-workflows): ci reference copy - single-namespace mode

### DIFF
--- a/charts/argo-workflows/ci/argo-workflows-app.yaml
+++ b/charts/argo-workflows/ci/argo-workflows-app.yaml
@@ -46,6 +46,21 @@
 crds:
   install: false
 
+# Run Argo in single-namespace mode (adds `--namespaced` to the server and
+# controller; they operate only in the install namespace `mlops`). WITHOUT
+# this the server runs cluster-scoped and the UI lists workflows across ALL
+# namespaces (namespace=""), which requires cluster-wide list permission —
+# but our SSO RBAC ServiceAccounts (environments/base/deps/argo-workflows/
+# rbac.yaml) are bound via *namespaced* RoleBindings (mlops only), so the UI
+# failed with `code:7 Permission denied, not allowed to list workflows in
+# namespace ""`. In namespaced mode the UI queries `mlops`, which the SSO
+# SAs are allowed. Verified live: the admin/viewer SAs CAN list workflows in
+# mlops but NOT --all-namespaces. The chart's admin/edit/view aggregate
+# ClusterRoles stay ClusterRoles under singleNamespace, so the rbac.yaml
+# RoleBindings (roleRef ClusterRole/argo-workflows-{admin,view}) are
+# unaffected. Found live during ADR-0085 verification.
+singleNamespace: true
+
 server:
   authModes:
     - sso


### PR DESCRIPTION
## Summary
Set `singleNamespace: true` on Argo Workflows so the server/controller run `--namespaced` (confined to `mlops`).

## Intent
ADR-0085 live-verification follow-up. Fixes the UI failing right after SSO login with `code:7 Permission denied, not allowed to list workflows in namespace ""`.

## Verification
- Live root cause: the server ran cluster-scoped, so the UI lists workflows across ALL namespaces (namespace=""), needing cluster-wide list permission. Our SSO RBAC SAs are bound via namespaced RoleBindings (mlops only).
- `kubectl auth can-i list workflows.argoproj.io -n mlops --as=system:serviceaccount:mlops:argo-workflows-admin` = yes; `--all-namespaces` = no. So namespaced mode resolves it.
- `helm template ... --set/-f` renders `--namespaced` on both server and controller (2x); the admin/edit/view aggregate roles stay ClusterRole, so the custom rbac.yaml RoleBindings are unaffected.

## Risk
Low. Confines Argo to `mlops` (the only namespace we run workflows in). Custom SSO RBAC unchanged.

## AI Usage Declaration
- [x] AI diagnosed from live server error + `kubectl auth can-i` and authored the fix.
- [x] Human reviewed diagnosis and diff.

## Reviewer Focus
Confirm single-namespace (`mlops`-only) operation is acceptable — we don't run workflows elsewhere.
