### PR TITLE
fix(lakefs): ci reference copies - oauth2-proxy reverse-proxy mode

### DIFF
--- a/charts/lakefs/ci/lakefs-app.yaml
+++ b/charts/lakefs/ci/lakefs-app.yaml
@@ -95,23 +95,14 @@ service:
   type: ClusterIP
   port: 80
 
+# The LakeFS chart does NOT own an ingress. All external traffic enters
+# through the lakefs-auth oauth2-proxy (reverse-proxy mode) via the ingress
+# shipped in the depsOverlay (environments/base/deps/lakefs/ingress.yaml),
+# which routes `/` → the oauth2-proxy Service; oauth2-proxy then proxies to
+# this chart's in-cluster `lakefs` Service. Exposing the chart's own ingress
+# too would bypass the SSO gate. (Previously this chart owned the ingress
+# with a ForwardAuth + `errors` middleware chain that rewrote LakeFS's own
+# API 401s to redirects → "Failed to fetch"; replaced by reverse-proxy mode,
+# ADR-0085.)
 ingress:
-  enabled: true
-  ingressClassName: traefik
-  annotations:
-    # Middleware chain shipped by the depsOverlay (ADR-0085). ORDER MATTERS:
-    # Traefik applies middlewares left-to-right on the request, so the
-    # FIRST one listed is outermost and sees the response LAST — it must be
-    # errors-first so it can catch/rewrite the 401 that forwardauth
-    # produces for unauthenticated requests. forwardauth alone (no errors
-    # middleware) returns a bare 401 with no redirect to login — found live
-    # during ADR-0085 verification.
-    traefik.ingress.kubernetes.io/router.middlewares: mlops-lakefs-oauth-errors@kubernetescrd,mlops-lakefs-forwardauth@kubernetescrd
-  hosts:
-    - host: lakefs.mlops.ai.camer.digital
-      paths:
-        - /
-  tls:
-    - secretName: lakefs-tls
-      hosts:
-        - lakefs.mlops.ai.camer.digital
+  enabled: false

--- a/charts/lakefs/ci/lakefs-auth.yaml
+++ b/charts/lakefs/ci/lakefs-auth.yaml
@@ -10,10 +10,14 @@
 #    upstream/redirect via extraArgs, no chart-owned ingress).
 #
 # A DEDICATED instance for LakeFS (own Keycloak client `lakefs-proxy`, own
-# cookie secret) — NOT shared with any other app (ADR-0085). Gates ALL of
-# LakeFS via Traefik ForwardAuth (Middleware CR + oauth2 callback Ingress
-# shipped in the lakefs-app depsOverlay, pointing at THIS release's Service
-# `lakefs-auth-oauth2-proxy:80`).
+# cookie secret) — NOT shared with any other app (ADR-0085). Runs in full
+# REVERSE-PROXY mode: the depsOverlay ingress routes ALL of the LakeFS
+# hostname (`/`) to this release's Service `lakefs-auth-oauth2-proxy:80`, and
+# oauth2-proxy proxies authenticated traffic to `upstream` (the in-cluster
+# LakeFS Service) while redirecting unauthenticated document requests to
+# Keycloak. This replaced the earlier Traefik ForwardAuth + `errors`
+# middleware chain, which rewrote LakeFS's own API 401s into redirects and
+# broke the LakeFS login form with "Failed to fetch" (ADR-0085).
 
 config:
   existingSecret: lakefs-proxy-secret


### PR DESCRIPTION
## Summary
Switch LakeFS auth from Traefik ForwardAuth + `errors` middleware to oauth2-proxy **reverse-proxy mode**. Fixes the LakeFS login form failing with "Failed to fetch". (Maintainer's Option 2: keep the SSO gate.)

## Intent
ADR-0085 live-verification follow-up.

## Scope
- `environments/prod/values/lakefs-app.yaml` — `ingress.enabled: false` (chart no longer owns an ingress).
- `environments/base/deps/lakefs/` — `ingress-oauth2.yaml` → `ingress.yaml` (routes `/` → oauth2-proxy); removed `middleware.yaml` + `middleware-errors.yaml`; updated kustomization.
- `environments/prod/deps/lakefs/ciliumnetworkpolicy.yaml` — add `lakefs-auth → lakefs:8000` egress (reverse-proxy now dials the upstream).
- `environments/prod/values/lakefs-auth.yaml` — doc comment.

## Verification
- Live root cause: the `errors` middleware rewrote ANY 401/403 (status 401-403 → 302 `/oauth2/start`) — including LakeFS's own `/api/v1/auth/login` 401 — so the UI's fetch() got an opaque cross-origin redirect → "Failed to fetch" for correct and incorrect keys alike.
- `kubectl kustomize environments/prod/deps/lakefs` builds clean: Certificate, both CiliumNetworkPolicies, one Ingress (`/` → `lakefs-auth-oauth2-proxy:80`), no middleware annotations.
- `helm template lakefs/lakefs -f lakefs-app.yaml` now renders **0** Ingress (chart ingress disabled).
- Cilium egress rule targets the pod's container port 8000 (Service port is 80→targetPort http); verified pod label `app.kubernetes.io/instance=lakefs`, containerPort 8000.

## Risk
Medium — front-door routing change. All LakeFS traffic now flows through oauth2-proxy; the new egress rule is required or the proxy 502s under the default-deny baseline. Rollback = revert.

## AI Usage Declaration
- [x] AI diagnosed the middleware-hijack root cause and authored the reverse-proxy switch + egress rule.
- [x] Human (maintainer) chose Option 2 and reviews this diff.

## Reviewer Focus
The added `lakefs-auth → lakefs:8000` Cilium egress (reverse-proxy dependency), and that disabling the chart ingress + routing `/` through oauth2-proxy leaves no unauthenticated path to LakeFS.
