### PR TITLE
feat(apps): deploy NVIDIA k8s-device-plugin to Hetzner GPU nodes via ArgoCD

### DIFF
--- a/charts/apps/values.yaml
+++ b/charts/apps/values.yaml
@@ -313,6 +313,66 @@ applications:
   # point at `redis-ha-redis.redis-system.svc.cluster.local:6379`.
   # Do not re-add a redis Application here.
 
+  # --- GPU device plugin (Hetzner Robot GPU workers) ---
+  # NVIDIA k8s-device-plugin — advertises the `nvidia.com/gpu` extended
+  # resource to the kubelet on the hand-joined Hetzner Robot GPU workers
+  # (hetzner-k8s-gpu-*, RTX 4000 SFF Ada, Debian 13), so GPU workloads can be
+  # scheduled onto them. Lands on home-remote (the default destination) — this
+  # is the Hetzner cluster, NOT the home GPU that the `model-serving-*` apps
+  # target via `homeCluster` (ADR-0022).
+  #
+  # Replaces a manual `kubectl apply` DaemonSet (kube-system/nvidia-device-plugin)
+  # that predated GitOps — SAME name, so it MUST be deleted at cutover (see the
+  # PR's cutover note); the default syncPolicy's `Replace=true` is only a
+  # fallback for the adoption conflict.
+  #
+  # Pinned to the GPU workers via nodeSelector + a matching single-term
+  # affinity (the chart's default NFD/Tegra affinity is replaced — we run
+  # neither NFD nor GFD here), tolerates the taint, and runs under the
+  # k3s-autodetected `nvidia` RuntimeClass. The upstream chart also emits an
+  # idle `nvidia-device-plugin-mps-control-daemon` DaemonSet (gated only on
+  # devicePlugin.enabled); with no MPS config selected its init container just
+  # waits — no crash-loop, no GPU claimed.
+  - name: nvidia-device-plugin
+    finalizers:
+      - resources-finalizer.argocd.argoproj.io
+    source:
+      repoURL: https://nvidia.github.io/k8s-device-plugin
+      # 0.17.1 == appVersion 0.17.1 → image nvcr.io/nvidia/k8s-device-plugin:v0.17.1
+      # (matches the manual DaemonSet being replaced). Verify before bumping:
+      # `helm show chart nvidia-device-plugin --repo https://nvidia.github.io/k8s-device-plugin --version <v>`
+      targetRevision: 0.17.1
+      chart: nvidia-device-plugin
+      helm:
+        releaseName: nvidia-device-plugin
+        values: |
+          runtimeClassName: nvidia
+          # FAIL_ON_INIT_ERROR="false" — don't wedge the pod on a transient
+          # driver/init hiccup (matches the manual DaemonSet).
+          failOnInitError: false
+          priorityClassName: system-node-critical
+          nodeSelector:
+            nvidia.com/gpu.present: "true"
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                  - matchExpressions:
+                      - key: nvidia.com/gpu.present
+                        operator: In
+                        values: ["true"]
+          tolerations:
+            - key: nvidia.com/gpu
+              operator: Exists
+              effect: NoSchedule
+          # Privileged host access for the plugin socket at
+          # /var/lib/kubelet/device-plugins (matches the manual DaemonSet;
+          # overrides the chart's default drop-ALL context).
+          securityContext:
+            privileged: true
+    destination:
+      namespace: kube-system
+
   - name: aieg-crd
     finalizers:
       - resources-finalizer.argocd.argoproj.io


### PR DESCRIPTION
## 1. Summary

This PR changes:

- Adds an ArgoCD `Application` (`aii-nvidia-device-plugin`) to the `charts/apps` umbrella that installs the **official NVIDIA `nvidia-device-plugin` Helm chart** (`0.17.1`, image `nvcr.io/nvidia/k8s-device-plugin:v0.17.1`) onto the cluster's GPU workers.
- The plugin advertises the `nvidia.com/gpu` extended resource to the kubelet so GPU workloads can be scheduled on the hand-joined Hetzner Robot GPU boxes (`hetzner-k8s-gpu-*`, RTX 4000 SFF Ada, Debian 13).

It solves:

- Removes the last hand-rolled `kubectl apply` on this cluster: a manual `kube-system/nvidia-device-plugin` DaemonSet that predated GitOps. Source of truth for the deployment shape: the upstream chart at https://nvidia.github.io/k8s-device-plugin (repo https://github.com/NVIDIA/k8s-device-plugin), and the GPU-node facts (labels/taint/`nvidia` RuntimeClass) established during the manual enrollment in `hetzner-k8s`.

---

## 2. Intent

The intent of this PR is:

> Bring the NVIDIA device plugin under GitOps like every other platform workload, instead of a manual DaemonSet nobody reconciles. Using the **official Helm chart via a pinned ArgoCD Application** gives us versioned, self-healing, prune-on-drift management, and keeps the GPU-targeting rules (nodeSelector, taint toleration, `nvidia` RuntimeClass) declared in one reviewed place.

---

## 3. Scope

### In Scope

- One new entry in `charts/apps/values.yaml` (`nvidia-device-plugin`) under **Core Infrastructure**, following the existing upstream-Helm-chart umbrella pattern (cf. `reloader`, `authorino-operator`).
- Values that reproduce the manual DaemonSet's behaviour on the chart: `runtimeClassName: nvidia`, `nodeSelector` + single-term `affinity` on `nvidia.com/gpu.present=true`, toleration for `nvidia.com/gpu=true:NoSchedule`, `failOnInitError: false`, `priorityClassName: system-node-critical`, privileged securityContext.

### Out of Scope

- **Deleting the manual DaemonSet** — that is an operator cutover step (see below), not part of this GitOps change.
- MPS / time-slicing / GFD / NFD configuration. The upstream chart also emits an idle `nvidia-device-plugin-mps-control-daemon` DaemonSet (gated only on `devicePlugin.enabled`); with no MPS config it just waits in init — no crash-loop, no GPU claimed. Left at chart default.
- Any change to the home-cluster GPU / `model-serving-*` apps — those target `homeCluster` (ADR-0022); this lands on the default `home-remote` (Hetzner) destination.

### 🔀 Cutover step (operator, after sync)

The chart's DaemonSet name (`nvidia-device-plugin`, release name in `kube-system`) is **identical** to the manual one. After the app syncs, delete the pre-GitOps DaemonSet so Argo owns the reconciled copy:

```bash
kubectl -n kube-system delete daemonset nvidia-device-plugin
```

The default syncPolicy carries `Replace=true` as a fallback for the adoption conflict, but an explicit delete is the clean path.

---

## 4. Verification

I verified this change by:

- [x] Running automated tests
- [ ] Running manual tests
- [ ] Checking logs
- [ ] Checking metrics
- [ ] Testing error cases
- [ ] Testing permissions/security behavior
- [ ] Testing rollback or failure behavior, if relevant

Commands run:

```bash
# chart/version ↔ image mapping (chart 0.17.1 → appVersion 0.17.1 → image v0.17.1)
helm show chart nvidia-device-plugin --repo https://nvidia.github.io/k8s-device-plugin --version 0.17.1

# rendered the umbrella Application + the upstream chart with the exact values
helm lint charts/apps --strict
helm template x charts/apps --dry-run
helm template nvidia-device-plugin ./nvidia-device-plugin -n kube-system -f ndp-values.yaml

# commit convention
zsh tools/commit-lint.sh --message "feat(apps): deploy NVIDIA k8s-device-plugin to Hetzner GPU nodes via ArgoCD"
```

Results:

```text
charts/apps: 1 chart(s) linted, 0 chart(s) failed   (--strict)
helm template x charts/apps --dry-run → OK
rendered DaemonSet: image nvcr.io/nvidia/k8s-device-plugin:v0.17.1, runtimeClassName: nvidia,
  nodeSelector nvidia.com/gpu.present="true", toleration nvidia.com/gpu:NoSchedule (Exists),
  privileged: true, FAIL_ON_INIT_ERROR="false", priorityClassName system-node-critical
Application aii-nvidia-device-plugin → project ai, destination home-remote/kube-system,
  automated prune+selfHeal
commit-lint → exit 0
```

---

## 5. Screenshots / Evidence

Add evidence here:

* Rendered Application + DaemonSet verified locally (see §4). Post-sync, `kubectl -n kube-system get ds nvidia-device-plugin` and `kubectl describe node <gpu-node> | grep nvidia.com/gpu` confirm the resource is advertised.

---

## 6. Risk Assessment

Risk level:

* [x] Low
* [ ] Medium
* [ ] High

Potential risks:

* Adoption conflict at cutover (same DaemonSet name as the manual one).
* Privileged pod in `kube-system` — same posture as the manual DaemonSet it replaces.

Mitigation:

* Cutover step deletes the manual DaemonSet; `Replace=true` is a fallback.
* Pinned chart + image version (`0.17.1`); scheduling confined to `nvidia.com/gpu.present=true` nodes via nodeSelector + affinity + taint toleration, so no non-GPU node is touched. Rollback = revert this commit (Argo prunes the app) and re-apply the manual manifest if needed.

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [ ] Refactoring
* [ ] Generating tests
* [x] Drafting documentation
* [x] Reviewing the diff
* [ ] Not used

Human verification:

* [x] I understand every meaningful change in this PR
* [x] I checked generated code manually
* [ ] I checked generated tests manually
* [x] I removed unsupported AI assumptions
* [x] I accept responsibility for this PR

---

## 8. Reviewer Focus

Please focus your review on:

* [x] Correctness
* [x] Architecture
* [ ] Security
* [ ] Performance
* [ ] Tests
* [ ] Maintainability
* [x] Product intent
* [ ] Edge cases

Specifically: the chart-version ↔ image-version pin, the GPU-node targeting (nodeSelector + affinity + toleration), and whether the idle upstream MPS control daemon should be explicitly suppressed rather than left at chart default.
