### PR TITLE
fix(mlflow): dedicated mlflow_oidc database for oidc-auth plugin

### DIFF
--- a/charts/lightbridge-db/values.yaml
+++ b/charts/lightbridge-db/values.yaml
@@ -468,6 +468,33 @@ resources:
       name: mlflow
       owner: mlflow
       ensure: present
+  # ────────────────────────────────────────────────────────────────────
+  # MLflow OIDC auth DB (ADR-0085): a SECOND `mlflow_oidc` Database owned by
+  # the same `mlflow` role. The mlflow-oidc-auth plugin keeps its own
+  # users/groups/permissions store and auto-migrates it (Alembic → head) on
+  # first login. It MUST NOT share the tracking store's `mlflow` DB: both use
+  # a default `alembic_version` table, so the plugin reads MLflow's tracking
+  # revision, can't resolve it against its own migration chain, aborts before
+  # any DDL, and never creates its tables → every login fails
+  # "Failed to update user/groups". A dedicated DB (empty alembic_version)
+  # lets the plugin migrate from base cleanly. Found live during ADR-0085
+  # verification. No extra Secret — reuses the `mlflow` role/password.
+  # ────────────────────────────────────────────────────────────────────
+  - |
+    apiVersion: postgresql.cnpg.io/v1
+    kind: Database
+    metadata:
+      name: mlflow-oidc
+      namespace: converse
+      annotations:
+        argocd.argoproj.io/sync-wave: "3"
+        argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    spec:
+      cluster:
+        name: lightbridge-main-db
+      name: mlflow_oidc
+      owner: mlflow
+      ensure: present
   - |
     apiVersion: external-secrets.io/v1
     kind: ExternalSecret

--- a/charts/mlflow/ci/mlflow-app.yaml
+++ b/charts/mlflow/ci/mlflow-app.yaml
@@ -81,21 +81,27 @@ oidcAuth:
   defaultPermission: "READ"
   sessionCookieSecure: true
   # The mlflow-oidc-auth plugin keeps its OWN users/groups/permissions DB,
-  # SEPARATE from the tracking backendStore. Left unset it defaults to
-  # `sqlite:///auth.db` on the pod's (read-only) filesystem → every OIDC
-  # callback fails with `sqlite3.OperationalError: unable to open database
-  # file` → "Failed to update user/groups" (the Keycloak claim is correct;
-  # the plugin just can't persist the user). Found live during ADR-0085
-  # verification. Point it at the SAME lightbridge-main-db `mlflow` Postgres
-  # the tracking store already uses (the plugin creates its own tables there;
-  # the mlflow CNPG role owns the DB so it has DDL). No new egress needed —
-  # same host:port the backendStore already reaches.
+  # SEPARATE from the tracking backendStore, and auto-migrates it (Alembic →
+  # head) on first login. It MUST have a DEDICATED database — NOT the tracking
+  # store's `mlflow` DB. Both use a default `alembic_version` table, so if the
+  # plugin shares `mlflow` it reads the TRACKING store's revision, can't
+  # resolve it against its own migration chain, aborts before any DDL, and
+  # never creates its tables → every login fails "Failed to update
+  # user/groups" (traced through the plugin's `migrate_if_needed`, ADR-0085
+  # verification). Two earlier wrong states, same class of bug: default
+  # `sqlite:///auth.db` (read-only fs → "unable to open database file"), then
+  # the shared `mlflow` DB (alembic revision collision above).
+  # Point it at a DEDICATED `mlflow_oidc` DB on the same lightbridge-main-db
+  # server (owned by the same `mlflow` role — charts/lightbridge-db Database
+  # CR); the plugin then finds an empty alembic_version and migrates from
+  # base. No new egress / no new Secret — same host:port + role as the
+  # tracking store.
   database:
     postgres:
       enabled: true
       host: "lightbridge-main-db-rw.converse.svc.cluster.local"
       port: 5432
-      database: "mlflow"
+      database: "mlflow_oidc"
       driver: "psycopg2"
       existingSecret:
         name: mlflow-db-secret


### PR DESCRIPTION
## Summary
Add a dedicated `mlflow_oidc` CNPG Database (owned by the existing `mlflow` role) for the mlflow-oidc-auth plugin, and update the mlflow ci reference copy to point at it. Paired with ai-helm-values PR (mlflow-app.yaml + argo RBAC).

## Intent
Fixes MLflow "Failed to update user/groups": the plugin auto-migrates its auth schema on first login but cannot share the tracking store's `mlflow` DB (default `alembic_version` collision), so it needs its own DB.

## Verification
- Root cause traced through the plugin's `migrate_if_needed` (reads default `alembic_version`; the shared DB carries MLflow's tracking revision → resolution error → abort before DDL → no tables).
- `helm template charts/lightbridge-db` renders both `mlflow` and `mlflow-oidc` Database CRs (`spec.name: mlflow_oidc`, owner `mlflow`).
- Same server/role/password as the tracking DB — no new Secret, no new egress.

## Risk
Low — one additional CNPG Database on the shared cluster, owned by an existing managed role.

## AI Usage Declaration
- [x] AI researched the plugin's DB-migration behavior and authored the fix.
- [x] Human reviews the diff.

## Reviewer Focus
Merge this BEFORE the ai-helm-values mlflow-app change so `mlflow_oidc` exists when MLflow connects.
