### PR TITLE
feat(lakefs): oidc_client_secret for native OIDC SSO

### DIFF
--- a/charts/lakefs-secrets/values.yaml
+++ b/charts/lakefs-secrets/values.yaml
@@ -29,6 +29,10 @@ externalSecrets:
     templateData:
       database_connection_string: "postgres://lakefs:{{ .dbPassword | urlquery }}@lightbridge-main-db-rw.converse.svc.cluster.local:5432/lakefs?sslmode=disable"
       auth_encrypt_secret_key: "{{ .encryptSecretKey }}"
+      # OIDC client secret consumed by the chart's secretKeys.oidcClientSecret
+      # (→ auth.oidc.client_secret). Reuses the existing Keycloak confidential
+      # client's secret (ADR-0085 revised: LakeFS OSS native `auth.oidc` SSO).
+      oidc_client_secret: "{{ .oidcClientSecret }}"
     data:
       - secretKey: dbPassword
         key: ai/camer/digital/prod/env
@@ -36,6 +40,9 @@ externalSecrets:
       - secretKey: encryptSecretKey
         key: ai/camer/digital/prod/env
         property: lakefs_encrypt_secret_key
+      - secretKey: oidcClientSecret
+        key: ai/camer/digital/prod/env
+        property: lakefs_proxy_client_secret
 
   # S3 blockstore credentials — the SAME platform S3 material every other
   # Hetzner Object Storage consumer uses (Keycloak/lightbridge CNPG backups,

--- a/charts/lakefs/ci/lakefs-app.yaml
+++ b/charts/lakefs/ci/lakefs-app.yaml
@@ -27,6 +27,9 @@ existingSecret: lakefs-app-secret
 secretKeys:
   authEncryptSecretKey: auth_encrypt_secret_key
   databaseConnectionString: database_connection_string
+  # NB: the chart's `secretKeys.oidcClientSecret` is NOT wired into the pod in
+  # lakefs chart 1.12.13, so the OIDC client secret is injected via
+  # extraEnvVars (LAKEFS_AUTH_OIDC_CLIENT_SECRET) below instead.
 
 lakefsConfig: |
   database:
@@ -39,6 +42,43 @@ lakefsConfig: |
       # Hetzner Object Storage (Ceph-RGW) needs path-style addressing —
       # virtual-hosted-style DNS isn't set up for this endpoint.
       force_path_style: true
+  # ── OIDC SSO (ADR-0085 revised — the maintainer's "OIDC is free in OSS"
+  # ── direction). LakeFS OSS `auth.oidc` is the DEPRECATED-but-free built-in
+  # ── OIDC login (NOT the Enterprise `providers.oidc`/Fluffy path). The
+  # ── client_secret is injected from the existingSecret (secretKeys above),
+  # ── not written here.
+  #
+  # ⚠️ STANDALONE-OIDC TRIAL: LakeFS OSS core removed its authorization layer
+  # ── (ACLs), and with `rbac: none` "no additional users/groups can be
+  # ── created". Whether `auth.oidc` still provisions a login here (likely a
+  # ── shared identity) or needs the external contrib ACL server is being
+  # ── verified LIVE. `login_url_method: select` keeps the native login form
+  # ── available as a fallback so a failed OIDC flow can't lock everyone out.
+  auth:
+    oidc:
+      enabled: true
+      # Reusing the existing Keycloak confidential client (was the oauth2-proxy
+      # client). Its redirect URIs must include
+      # https://lakefs.mlops.ai.camer.digital/oidc/callback.
+      client_id: lakefs_proxy
+      url: https://auth.verif.fyi/realms/camer-digital
+      callback_base_url: https://lakefs.mlops.ai.camer.digital
+      friendly_name_claim_name: name
+      persist_friendly_name: true
+      # Group provisioning only takes effect if an authz service is present
+      # (external ACL server / Enterprise). Harmless under rbac:none.
+      default_initial_groups: ["admins"]
+      initial_groups_claim_name: lakefs_roles
+    ui_config:
+      login_url: /oidc/login
+      # `select` = show BOTH the native login form and the SSO button (safe
+      # during the trial). Switch to the default `redirect` (SSO-only) once
+      # OIDC is confirmed working end-to-end.
+      login_url_method: select
+      logout_url: /logout
+      login_cookie_names:
+        - internal_auth_session
+        - oidc_auth_session
 
 # S3 access key/secret aren't part of the chart's existingSecret/secretKeys
 # mechanism (no such key listed upstream) — the AWS SDK's standard env var
@@ -62,6 +102,17 @@ extraEnvVars:
   # setting).
   - name: LAKEFS_BLOCKSTORE_DEFAULT_NAMESPACE_PREFIX
     value: "s3://ssegning-k8s-state/lakefs"
+  # OIDC client secret → auth.oidc.client_secret. The lakefs chart 1.12.13
+  # does NOT wire `secretKeys.oidcClientSecret` into the pod, so inject it
+  # directly via LakeFS's env-override of any config key
+  # (LAKEFS_AUTH_OIDC_CLIENT_SECRET). Key `oidc_client_secret` is provisioned
+  # into lakefs-app-secret by charts/lakefs-secrets (from ASM
+  # `lakefs_proxy_client_secret`). Kept out of lakefsConfig/this repo.
+  - name: LAKEFS_AUTH_OIDC_CLIENT_SECRET
+    valueFrom:
+      secretKeyRef:
+        name: lakefs-app-secret
+        key: oidc_client_secret
 
 replicaCount: 1
 


### PR DESCRIPTION
## Summary
LakeFS OSS native OIDC SSO via the (deprecated-but-free) `auth.oidc` — maintainer-directed. **Standalone trial** (no external ACL server yet), pending live verification.

## Intent
LakeFS OSS `auth.oidc` is free (not the Enterprise `providers.oidc`/Fluffy path). Goal: one Keycloak login into LakeFS.

## Scope
- **ai-helm-values**: `lakefs-app.yaml` — `auth.oidc` (client_id `lakefs_proxy`, camer-digital realm, callback_base_url) + `auth.ui_config.login_url:/oidc/login`, `login_url_method: select` (keeps native form as fallback); client secret via `extraEnvVars` `LAKEFS_AUTH_OIDC_CLIENT_SECRET`.
- **ai-helm**: `lakefs-secrets` adds `oidc_client_secret` (from ASM `lakefs_proxy_client_secret`); ci mirror.

## Verification (render only — live pending)
- `helm template lakefs/lakefs -f lakefs-app.yaml` renders the `auth.oidc` config block and injects `LAKEFS_AUTH_OIDC_CLIENT_SECRET` from `lakefs-app-secret`.
- `helm template charts/lakefs-secrets` renders the `oidc_client_secret` key; chart lints clean.
- ⚠️ NOT yet verified live: whether OSS `auth.oidc` provisions a login under `rbac: none` (ACLs removed from core) or needs the external contrib ACL server. `login_url_method: select` prevents lockout.

## PREREQUISITE (manual, before this can work)
The Keycloak `lakefs_proxy` client's **redirect URIs must include** `https://lakefs.mlops.ai.camer.digital/oidc/callback`. (The client secret is already in ASM — reused.)

## Risk
Medium — untested auth config. Mitigated by `select` mode (native form stays). LakeFS is fresh (no real data); rollback = revert.

## AI Usage Declaration
- [x] AI researched OSS `auth.oidc` (correcting an earlier wrong "OSS can't do OIDC" conclusion) and authored the config.
- [x] Human (maintainer) chose the standalone-OIDC-first approach and reviews.

## Reviewer Focus
The `rbac:none` + `auth.oidc` interplay is the open question — this PR is a live trial; if OIDC won't provision users we add the contrib ACL server or revert to native login.
