### PR TITLE
fix(homepage): send the real Host header on liveness/readiness probes

### DIFF
--- a/charts/homepage-app/values.yaml
+++ b/charts/homepage-app/values.yaml
@@ -146,6 +146,14 @@ homepage:
             readOnlyRootFilesystem: true
             capabilities:
               drop: [ALL]
+          # kubelet's httpGet probe connects to the pod IP directly and (with
+          # no explicit httpHeaders) sends that IP as the Host header — which
+          # HOMEPAGE_ALLOWED_HOSTS doesn't list, so Homepage's own host-header
+          # validation 400s the probe ("Host validation failed for:
+          # <pod-ip>:3000"), found live. Real browser traffic is unaffected
+          # (oauth2-proxy's reverse-proxy mode forwards the original
+          # hub.ai.camer.digital Host header) — this only fixes the probes,
+          # not a real request path.
           probes:
             liveness:
               enabled: true
@@ -154,6 +162,9 @@ homepage:
                 httpGet:
                   path: /api/healthcheck
                   port: 3000
+                  httpHeaders:
+                    - name: Host
+                      value: "hub.ai.camer.digital"
                 initialDelaySeconds: 10
                 periodSeconds: 30
                 timeoutSeconds: 5
@@ -164,6 +175,9 @@ homepage:
                 httpGet:
                   path: /api/healthcheck
                   port: 3000
+                  httpHeaders:
+                    - name: Host
+                      value: "hub.ai.camer.digital"
                 periodSeconds: 10
                 timeoutSeconds: 3
           resources:


### PR DESCRIPTION
## 1. Summary

Adds `httpHeaders: [{name: Host, value: hub.ai.camer.digital}]` to both the liveness and readiness `httpGet` probes on `charts/homepage-app`.

It solves:

- Live sync of `homepage-app` (after #760) is failing readiness with:
  \`\`\`
  Readiness probe failed: HTTP probe failed with statuscode: 400
  \`\`\`
  and the pod's own log shows why:
  \`\`\`
  Host validation failed for: 10.42.4.161:3000. Hint: Set the HOMEPAGE_ALLOWED_HOSTS environment variable to allow requests from this host / port.
  \`\`\`

## 2. Intent

> kubelet's `httpGet` probe connects to the pod IP directly and, with no `httpHeaders` override, sends that IP as the `Host` header. `HOMEPAGE_ALLOWED_HOSTS` only lists `hub.ai.camer.digital`, so Homepage's own host-header validation (a real security feature, not a bug) rejects the probe request with a 400. Real browser traffic through `homepage-auth` (oauth2-proxy, reverse-proxy mode) is unaffected — it forwards the client's original `Host: hub.ai.camer.digital`, which already matches. Only the probe's synthetic request needed the explicit header.

## 3. Scope

### In Scope
- `charts/homepage-app/values.yaml` — `probes.liveness`/`probes.readiness` `httpGet.httpHeaders` only.

### Out of Scope
- Anything else — targeted fix for the specific reported failure.

## 4. Verification

Commands run:

\`\`\`bash
helm dep build charts/homepage-app
helm lint charts/homepage-app
helm template x charts/homepage-app --dry-run=client
\`\`\`

Results: 0 chart(s) failed; both probes now render with the explicit `Host` header.

Not yet verified: live re-sync on the cluster (this is a direct follow-up to a live-observed failure, so should be watched after merge).

## 6. Risk Assessment

Risk level: Low — one-field addition to an already-passing-elsewhere probe spec.

## 7. AI Usage Declaration

AI was used for understanding the reported error, confirming the root cause (kubelet probe Host header vs HOMEPAGE_ALLOWED_HOSTS), and generating the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)