### PR TITLE
fix(homepage): mount a writable emptyDir at /app/config/logs

### DIFF
--- a/charts/homepage-app/values.yaml
+++ b/charts/homepage-app/values.yaml
@@ -223,3 +223,17 @@ homepage:
         main:
           main:
             - path: /tmp
+    # Homepage's own app code (not just docker-entrypoint.sh) tries to
+    # `mkdir /app/config/logs` at runtime and crashes with ENOENT if it
+    # can't — found live. /app/config itself is the read-only ConfigMap
+    # mount above, so a plain writable emptyDir nested at this more
+    # specific subpath shadows just that one subdirectory (a standard k8s
+    # nested-mount pattern); the rest of /app/config stays the read-only
+    # projected content.
+    configLogs:
+      enabled: true
+      type: emptyDir
+      advancedMounts:
+        main:
+          main:
+            - path: /app/config/logs


### PR DESCRIPTION
## 1. Summary

Adds a writable `emptyDir` mounted at `/app/config/logs`, nested inside the existing read-only ConfigMap mount at `/app/config`.

It solves:

- Live crash, after the auth-proxy fix landed:
  \`\`\`
  Error: ENOENT: no such file or directory, mkdir '/app/config/logs'
  \`\`\`
  Homepage's own app code (not just its `docker-entrypoint.sh`) tries to `mkdir /app/config/logs` at request time and throws when it can't, since `/app/config` is the read-only ConfigMap mount.

## 2. Intent

> A standard Kubernetes nested-mount: `/app/config` stays the read-only projected ConfigMap content (services/bookmarks/widgets/settings/kubernetes.yaml), while a plain `emptyDir` mounted at the more specific subpath `/app/config/logs` shadows just that one subdirectory with a writable volume. No change to what's actually served as config content.

## 4. Verification

\`\`\`bash
helm dep build charts/homepage-app
helm lint charts/homepage-app
helm template x charts/homepage-app --dry-run=client
trivy config <rendered manifest> --severity HIGH,CRITICAL
\`\`\`

Results: 0 chart(s) failed, 0 Trivy misconfigurations at HIGH/CRITICAL. Both `/app/config` (readOnly) and `/app/config/logs` (writable emptyDir) volumeMounts render as expected.

Not yet verified: live re-sync (this is a direct follow-up to a live-observed crash).

## 6. Risk Assessment

Risk level: Low — additive volume mount only.

## 7. AI Usage Declaration

AI was used for diagnosing the live error and generating the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)