### PR TITLE
fix(homepage): rename configLogs persistence identifier to config-logs

### DIFF
--- a/charts/homepage-app/values.yaml
+++ b/charts/homepage-app/values.yaml
@@ -230,7 +230,7 @@ homepage:
     # specific subpath shadows just that one subdirectory (a standard k8s
     # nested-mount pattern); the rest of /app/config stays the read-only
     # projected content.
-    configLogs:
+    config-logs:
       enabled: true
       type: emptyDir
       advancedMounts:


### PR DESCRIPTION
## 1. Summary

Renames the `configLogs` persistence identifier (added in #762) to `config-logs`.

It solves:

- ArgoCD's server-side diff for `homepage-app` sat in a `ComparisonError` after #762 published:
  \`\`\`
  spec.template.spec.volumes[1].name: Invalid value: "configLogs": a lowercase RFC 1123 label
  must consist of lower case alphanumeric characters or '-' ...
  \`\`\`
  bjw-template derives the rendered volume/mount name directly from the persistence key, and camelCase isn't a valid Kubernetes object name.

## 2. Intent

> Client-side `helm template` doesn't validate object names against the Kubernetes API schema, so this got past my earlier local checks and CI's render-only gate. ArgoCD's server-side apply dry-run caught it correctly. Going forward for this chart I'm also checking `kubectl apply --dry-run=server` against the live cluster before pushing, not just `helm template`.

## 4. Verification

\`\`\`bash
helm dep build charts/homepage-app
helm lint charts/homepage-app
helm template x charts/homepage-app -n homepage --dry-run=client > /tmp/render.yaml
trivy config /tmp/render.yaml --severity HIGH,CRITICAL
kubectl --context hetzner-prod apply --dry-run=server -f /tmp/render.yaml
\`\`\`

Results: 0 chart(s) failed, 0 Trivy misconfigurations, and this time **all 6 objects pass server-side dry-run** against the actual target cluster (ServiceAccount, ConfigMap, ClusterRole, ClusterRoleBinding, Service, Deployment) — the same check that caught the bug.

## 6. Risk Assessment

Risk level: Low — identifier rename only, same object shape.

## 7. AI Usage Declaration

AI diagnosed the ArgoCD ComparisonError directly from cluster state and generated the fix, this time verified server-side before pushing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)