### PR TITLE
feat(homepage): discovery annotations for LibreChat + opencode well-known

### DIFF
--- a/charts/librechat-app/values.yaml
+++ b/charts/librechat-app/values.yaml
@@ -133,6 +133,10 @@ librechat:
       enabled: true
       annotations:
         cert-manager.io/cluster-issuer: cert-home-cert-http
+        gethomepage.dev/enabled: "true"
+        gethomepage.dev/name: "LibreChat"
+        gethomepage.dev/group: "Chat"
+        gethomepage.dev/icon: "librechat.png"
       className: traefik
       hosts:
         - host: ai.camer.digital
@@ -182,6 +186,10 @@ librechat:
       annotations:
         cert-manager.io/cluster-issuer: cert-home-cert-http
         traefik.ingress.kubernetes.io/router.middlewares: '{{ .Release.Namespace }}-kivoyo-redirect@kubernetescrd'
+        gethomepage.dev/enabled: "true"
+        gethomepage.dev/name: "LibreChat (kivoyo redirect)"
+        gethomepage.dev/group: "Chat"
+        gethomepage.dev/icon: "librechat.png"
       spec:
         spec:
           ingressClassName: traefik

--- a/charts/librechat-opencode-wellknown/values.yaml
+++ b/charts/librechat-opencode-wellknown/values.yaml
@@ -2043,6 +2043,10 @@ opencode-wellknown:
       className: traefik
       annotations:
         cert-manager.io/cluster-issuer: cert-home-cert-http
+        gethomepage.dev/enabled: "true"
+        gethomepage.dev/name: "opencode well-known"
+        gethomepage.dev/group: "Dev Tools"
+        gethomepage.dev/icon: "opencode.png"
       hosts:
         - host: ai.camer.digital
           paths:


### PR DESCRIPTION
## 1. Summary

This PR changes:

- Adds `gethomepage.dev/*` annotations to `librechat-app`, the `ai.kivoyo.com` redirect Ingress, and `librechat-opencode-wellknown` so they show up on the new Homepage central hub (ADR-0089).

It solves:

- ADR-0089 shipped a starter set (Grafana/MLflow/Argo Workflows/Coder). This is one of a batch of follow-up PRs (across ai-helm, ai-helm-values, and home-os) extending that to the rest of the platform's Ingresses, per the maintainer's explicit "annotate literally everything" direction in chat.

---

## 2. Intent

The intent of this PR is:

> One-line annotation additions, documented convention in `docs/integrations/homepage.md` — no chart logic changes.

---

## 3. Scope

### In Scope

- `charts/librechat-app/values.yaml`, `charts/librechat-opencode-wellknown/values.yaml` — annotations only

### Out of Scope

- Any chart logic or behavior change

---

## 4. Verification

I verified this change by:

- [x] Running automated tests
- [x] Running manual tests

Commands run:

```bash
helm dep build charts/librechat-app charts/librechat-opencode-wellknown
helm lint charts/librechat-app charts/librechat-opencode-wellknown
helm template x charts/librechat-app -n converse --dry-run=client | kubectl --context hetzner-prod apply --dry-run=server -f -
helm template x charts/librechat-opencode-wellknown -n converse --dry-run=client | kubectl --context hetzner-prod apply --dry-run=server -f -
```

Results:

```text
1 chart(s) linted, 0 chart(s) failed (x2)
ingress.networking.k8s.io/x created (server dry run)
ingress.networking.k8s.io/librechat-kivoyo-redirect created (server dry run)
ingress.networking.k8s.io/x created (server dry run)
```

Both rendered Ingress objects pass server-side dry-run against the live cluster.

---

## 5. Screenshots / Evidence

* Logs: see Verification section above (server dry-run output)

---

## 6. Risk Assessment

Risk level:

* [x] Low

Potential risks:

* None beyond the change itself — additive metadata annotations only.

Mitigation:

* Verified server-side against the actual target cluster before opening this PR.

---

## 7. AI Usage Declaration

AI was used for:

* [x] Generating code
* [x] Understanding existing code

Human verification:

* [ ] I understand every meaningful change in this PR
* [ ] I checked generated code manually
* [ ] I checked generated tests manually
* [ ] I removed unsupported AI assumptions
* [ ] I accept responsibility for this PR

> Human verification checkboxes intentionally left unchecked by the AI — the maintainer should check these after their own review, not have the agent self-attest to them.

---

## 8. Reviewer Focus

Please focus your review on:

* [x] Correctness

🤖 Generated with [Claude Code](https://claude.com/claude-code)
