### PR TITLE
fix(longhorn-auth): actually wire the deps overlay to the auth child

### DIFF
--- a/charts/longhorn-auth/templates/applications.yaml
+++ b/charts/longhorn-auth/templates/applications.yaml
@@ -67,7 +67,17 @@ spec:
         valueFiles:
           - $values/environments/{{ $a.env | default "prod" }}/values/longhorn-auth.yaml
         ignoreMissingValueFiles: true
-    # Source B — $values ref: the workload values file (ai-helm-values, ADR-0056).
+    {{- if .Values.auth.depsOverlay }}
+    # Source B — app-scoped deps (ingress Certificate) via the per-env
+    # kustomize overlay in ai-helm-values; issuer patched per environment.
+    # There is no "app" child in this orchestrator (unlike homepage) — the
+    # Longhorn workload is the separate aii-longhorn Application (ADR-0092),
+    # so the deps that route to THIS release's Service live here instead.
+    - repoURL: {{ $a.repoURL | quote }}
+      targetRevision: {{ $a.targetRevision | quote }}
+      path: {{ .Values.auth.depsOverlay | quote }}
+    {{- end }}
+    # Source C — $values ref: the workload values file (ai-helm-values, ADR-0056).
     - repoURL: {{ $a.repoURL | quote }}
       targetRevision: {{ $a.targetRevision | quote }}
       ref: values

--- a/charts/longhorn-auth/values.yaml
+++ b/charts/longhorn-auth/values.yaml
@@ -61,3 +61,7 @@ auth:
     repoURL: https://oauth2-proxy.github.io/manifests
     name: oauth2-proxy
     targetRevision: "10.7.0"
+  # App-scoped deps (ingress Certificate) for the Longhorn UI front door —
+  # routes longhorn.ai.camer.digital to THIS release's Service. No "app"
+  # child exists in this orchestrator (unlike homepage) to carry it instead.
+  depsOverlay: environments/prod/deps/longhorn-auth


### PR DESCRIPTION
## Summary

Fixes a real bug in the just-merged ADR-0093 Longhorn-UI-auth change: the
`longhorn-auth` orchestrator (`#771`) never actually attached the
Ingress/Certificate deps overlay to either of its two children, so nothing
routes external traffic to the (correctly running, correctly gated)
oauth2-proxy pod.

## Intent

Verified live on the cluster: `aii-longhorn-auth`/`longhorn-secrets`/
`longhorn-auth` are all `Synced`/`Healthy`, the `longhorn-proxy-secret`
resolved (3/3 keys — the manual Keycloak step was completed), and the
`longhorn-auth-oauth2-proxy` pod is `Running`. But `kubectl -n
longhorn-system get ingress,certificate` returns nothing at all. Root
cause: unlike `homepage`, this orchestrator has no `app` child to carry a
`depsOverlay` (the Longhorn workload is the separate `aii-longhorn`
Application, ADR-0092) — I built the overlay files in `ai-helm-values` but
never wired a `depsOverlay` reference onto the `auth` child that should
carry it instead. My mistake in the original PR; this fixes it.

## Scope

- **In:** `charts/longhorn-auth/values.yaml` (`auth.depsOverlay`),
  `charts/longhorn-auth/templates/applications.yaml` (conditional
  `depsSource` on the `auth` child, mirroring the general `charts/apps`
  template's `{{- if .depsOverlay }}` pattern).
- **Out:** no change to the deps overlay files themselves
  (`ai-helm-values`, already merged) — they were correct, just unreferenced.

## Verification

- `helm dep build && helm lint --strict` (via the `ci/ci-values.yaml`
  fixture) passes clean for `charts/longhorn-auth` and `charts/apps`.
- `helm template` on the fixed chart shows the `longhorn-auth` child's
  `sources:` now has three entries: the oauth2-proxy chart, the deps
  overlay (`path: "environments/prod/deps/longhorn-auth"`), and the
  `$values` ref — matches the intended design exactly.
- **Not yet verified live** (needs this PR merged first): that the
  Certificate issues and the Ingress actually routes
  `longhorn.ai.camer.digital` to the oauth2-proxy Service end-to-end.

## Risk Assessment

Low — this only adds a missing source to one already-deployed Application;
ArgoCD will add the Ingress/Certificate resources on next sync, nothing
existing is removed or altered.

## AI Usage Declaration

AI (Claude Code) found and fixed this by checking live cluster state after
the prior PR merged (not assuming success from the merge alone), diagnosed
the exact gap by re-reading its own template against the `homepage`
precedent, and verified the fix's render before pushing.

- [x] Verified against live cluster state and a local render, not assumed.
- [x] No secrets included.

## Reviewer Focus

None beyond the usual — this is a straightforward, verified fix for a gap
in the just-merged PR.
