### PR TITLE
fix(keycloak-baseline): rename longhorn client scope to longhorn_groups

### DIFF
--- a/charts/keycloak-baseline/values.yaml
+++ b/charts/keycloak-baseline/values.yaml
@@ -192,7 +192,7 @@ keycloak-config:
     # volume/node management (including delete) and has no native auth of
     # its own.
     longhornProxy:
-      name: "longhorn-proxy"
+      name: "longhorn_groups"
       description: "Longhorn oauth2-proxy roles scope"
       protocol: "openid-connect"
       attributes:
@@ -442,7 +442,7 @@ keycloak-config:
       defaultClientScopes:
         - web-origins
         - acr
-        - longhorn-proxy
+        - longhorn_groups
         - profile
         - roles
         - basic

--- a/charts/longhorn-auth/ci/longhorn-auth.yaml
+++ b/charts/longhorn-auth/ci/longhorn-auth.yaml
@@ -46,11 +46,19 @@ extraArgs:
   skip-provider-button: "true"
   set-xauthrequest: "true"
   silence-ping-logging: "true"
-  # Role restriction (ADR-0093): the longhorn-proxy Keycloak client scope is
+  # Role restriction (ADR-0093): the longhorn_groups Keycloak client scope is
   # a DEFAULT client scope (charts/keycloak-baseline), so the longhorn_roles
-  # claim is present in every token issued to this client without needing an
-  # explicit --scope flag here. A user with no `admin` client role gets an
+  # claim is present in every token issued to this client regardless of what
+  # scope is requested. A user with no `admin` client role gets an
   # empty/absent claim and --allowed-group rejects the login.
+  #
+  # --scope is set explicitly (openid/email/profile are oauth2-proxy's own
+  # defaults for this provider, restated here because --scope REPLACES the
+  # whole list rather than adding to it) so the auth request carries the
+  # real, named longhorn_groups scope instead of oauth2-proxy's own implicit
+  # "groups" scope (auto-added only when --scope is unset AND allowed_group
+  # is set — a generic value unrelated to this client's actual scope).
+  scope: "openid email profile longhorn_groups"
   oidc-groups-claim: "longhorn_roles"
   allowed-group: "admin"
 


### PR DESCRIPTION
## Summary

Renames the Longhorn oauth2-proxy's Keycloak client scope from
`longhorn-proxy` to `longhorn_groups` in `charts/keycloak-baseline`
(documentation of the desired realm state), and updates the human
reference values file to match the companion `ai-helm-values` PR (which
makes oauth2-proxy explicitly request this scope by name instead of its
own implicit `groups` default).

⚠️ Merge alongside [`ai-helm-values#156`](https://github.com/ADORSYS-GIS/ai-helm-values/pull/156)
— order matters less than usual here (the rename is cosmetic to the
request URL, not functionality), but keep them together.

## Intent

Requested directly: change the OAuth scope Longhorn's oauth2-proxy
requests from the generic, dangling `groups` (oauth2-proxy's own
auto-added default) to a real, named `longhorn_groups` scope that matches
this client's actual Keycloak configuration. Only the **scope** name
changes — the **claim** it delivers (`longhorn_roles`, read via
`--oidc-groups-claim`) and the client's own `clientId` (`longhorn-proxy`)
are both unchanged; those are different Keycloak concepts and weren't
part of this request.

## ⚠️ Required manual step (rename, not create this time)

`charts/keycloak-baseline` is not reconciled by anything — the live realm
needs the equivalent manual change:

1. In the Keycloak admin console, find the client scope currently named
   `longhorn-proxy` (description "Longhorn oauth2-proxy roles scope") and
   rename it to `longhorn_groups`. Its protocol mapper (claim name
   `longhorn_roles`) needs no change.
2. On the `longhorn-proxy` client's "Client scopes" tab, the renamed
   scope should still show as assigned — Keycloak renames in place, so
   this is usually automatic, but verify it's still listed as **Default**
   (not Optional) after the rename.

No new client, no new role, no new secret needed — this is a rename of an
already-live object.

## Scope

- **In:** `charts/keycloak-baseline/values.yaml` (scope `name:` +
  `defaultClientScopes` entry), `charts/longhorn-auth/ci/longhorn-auth.yaml`
  (reference copy, matches the real `ai-helm-values` file).
- **Out:** the claim name, the client's clientId, the client's redirect
  URIs/role — all unchanged.

## Verification

- `helm lint --strict` + `helm template` pass clean for
  `charts/keycloak-baseline`.
- Parsed the rendered realm ConfigMap (YAML) directly: confirmed the
  `longhorn-proxy` client's `defaultClientScopes` now lists
  `longhorn_groups`, a scope named `longhorn_groups` exists with
  `claim.name: longhorn_roles` unchanged, and no stale `longhorn-proxy`
  scope entry remains.

## Risk Assessment

Low — a documentation-only rename in a chart nothing reconciles; the
actual live-realm risk is the manual step above, which is a straightforward
in-place rename with no new object creation.

## AI Usage Declaration

AI (Claude Code) made this change per explicit user request, verified the
full rename by parsing the actual rendered realm-export YAML (not
assumed).

- [x] Verified against the actual rendered realm structure.
- [x] No secrets included.

## Reviewer Focus

The manual Keycloak rename step above — small, but required for the two
sides (Keycloak realm state and this chart's documentation of it) to stay
in sync.
