### PR TITLE
fix(model-serving): openmythos context split + thinking default (load…

### DIFF
--- a/charts/model-serving/values.yaml
+++ b/charts/model-serving/values.yaml
@@ -274,18 +274,35 @@ models:
       include: "OpenMythos-27B-Q4_K.gguf"
       sizeGi: 30
     serving:
-      # Conservative starting point. The load gate walks this up and records
-      # where it stops; do not raise it on a hunch — an over-large KV pool fails
-      # at allocation time, minutes into a load, and looks like a crash.
-      contextSize: 16384
-      # Few slots on purpose: KV is shared across slots, and at ~13 tok/s
+      # ⚠️ `--ctx-size` is the TOTAL KV pool, divided across `--parallel` slots
+      # when kv_unified is false (the default). At 32768 / 2 slots each REQUEST
+      # gets 16384 tokens — that per-slot number, not this one, is what you
+      # advertise as contextLength in charts/ai-models.
+      #
+      # Raised from 16384 after the load gate: at 16384 total the model used
+      # 16748 MiB of 20475 (3.6 GiB headroom) with KV + buffers costing only
+      # ~1 GiB, because Qwen3.6-27B keeps a KV cache on just 16 of its 65 layers.
+      # Doubling should cost ~1 GiB more. Re-measure VRAM after this lands.
+      contextSize: 32768
+      # Few slots on purpose: the pool is split between them, and at ~15 tok/s
       # concurrency is not what this tier is for.
       parallel: 2
-      # Levers to try during the load gate, in this order, one at a time:
+      extraArgs:
+        # Thinking is ON in this model's chat template, and it dominates short
+        # responses: "what is 17 * 23" measured 18.2s / 274 tokens with it on
+        # versus 0.2s / 4 tokens with it off, and a 512-token cap returned an
+        # EMPTY answer because the whole budget went to reasoning. Most clients
+        # will never set this themselves, so the server default is off and a
+        # caller opts back in per request with
+        #   "chat_template_kwargs": {"enable_thinking": true}
+        # ⚠️ `reasoning_budget: 0` as a REQUEST field is ignored by build 10133 —
+        # this is the lever that actually works.
+        - --chat-template-kwargs
+        - '{"enable_thinking": false}'
+      # Further levers if VRAM ever gets tight, one at a time, re-measuring:
       #   --flash-attn                     (check the flag's arity in the build)
       #   --cache-type-k q8_0 --cache-type-v q8_0   (halves KV, needs FA)
       #   --no-mmap                        (if page cache pressures the memory limit)
-      extraArgs: []
     resources:
       cpuRequest: "2"
       cpuLimit: "8"

--- a/docs/patterns/self-hosted-model-serving.md
+++ b/docs/patterns/self-hosted-model-serving.md
@@ -164,6 +164,18 @@ match this page; they are correct for where they run.
   CPU pool.
 - **A context that does not fit fails minutes into loading**, as an allocation
   error that reads like a crash. Measure, don't guess.
+- **⚠️ llama.cpp `--ctx-size` is the TOTAL KV pool, split across `--parallel`
+  slots.** `--ctx-size 16384 --parallel 2` gives each *request* 8192 tokens, not
+  16384. Confirm from the startup log (`n_ctx_slot`) and advertise **that** number
+  as `contextLength` in `charts/ai-models`, or the gateway promises users a window
+  the model will refuse. `--kv-unified` shares one pool across slots instead.
+- **⚠️ A reasoning model's default can dominate the experience.** OpenMythos-27B
+  measured 18.2 s for "what is 17 × 23" with thinking on versus 0.2 s with it off,
+  and a short `max_tokens` returned an *empty* answer because the whole budget went
+  to `reasoning_content`. The fleet default is thinking **off** via
+  `--chat-template-kwargs '{"enable_thinking": false}'`, with clients opting back
+  in per request. `reasoning_budget: 0` as a *request* field was ignored by
+  llama.cpp build 10133 — it is not the lever.
 - **Deploy = brief downtime.** One replica on one card; the StatefulSet recreates
   its single pod. A CrashLooping pod blocks its own rollout — `kubectl delete pod`.
 - **Route timeout defaults to 60 s** and takes precedence over the upstream BTP, so


### PR DESCRIPTION
… gate)

The load gate found two things the pre-deployment estimate could not, both recorded in inference-ops docs/benchmarks/2026-07-26-openmythos-27b-q4k-rtx4000-ada.md.

1. `--ctx-size` is the TOTAL KV pool and llama.cpp divides it across the `--parallel` slots. Configured 16384 with 2 slots gave each REQUEST 8192 tokens, half the intended window (`n_ctx_slot = 8192` in the startup log). Raised to 32768 so a request gets 16384, which is the number that will be advertised as contextLength when this federates. Measured headroom supports it: at 16384 total the model sat at 16748 MiB of 20475 with KV + buffers costing only ~1 GiB, because Qwen3.6-27B keeps a KV cache on just 16 of its 65 layers.

2. Thinking mode is on in the model's chat template and dominates short responses. Same question, "what is 17 * 23":
       thinking on   274 tokens   18.2 s   answer after 542 chars of reasoning
       thinking off    4 tokens    0.2 s   answer
   Worse, a 512-token cap returned an EMPTY content with reasoning_content
   populated — the whole budget went to thinking and the user would see a long
   pause and nothing. Most clients will never set this themselves, so the
   server default is now off via --chat-template-kwargs, and a caller opts back
   in per request with chat_template_kwargs.enable_thinking=true.
   `reasoning_budget: 0` as a request field is ignored by build 10133 and is
   not the lever.

Throughput itself passed comfortably and needed no change: 15.05 tok/s decode (~89% of the 280 GB/s ÷ 15.4 GiB ceiling, top of the predicted 12-15 band), 625 tok/s prefill on a 3502-token prompt, tool calling verified working.

Both traps are now documented in docs/patterns/self-hosted-model-serving.md §8 rather than left for the next person to rediscover.

Still deliberately unfederated — charts/ai-models comes after this restarts and the new VRAM figure is confirmed.

## 1. Summary

This PR changes:

- [Change 1]
- [Change 2]
- [Change 3]

It solves:

- [Problem / ticket / story link]

---

## 2. Intent

The intent of this PR is:

> [Explain why this change exists.]

---

## 3. Scope

### In Scope

- [Included change 1]
- [Included change 2]

### Out of Scope

- [Excluded change 1]
- [Excluded change 2]

---

## 4. Verification

I verified this change by:

- [ ] Running automated tests
- [ ] Running manual tests
- [ ] Checking logs
- [ ] Checking metrics
- [ ] Testing error cases
- [ ] Testing permissions/security behavior
- [ ] Testing rollback or failure behavior, if relevant

Commands run:

```bash
[command 1]
[command 2]
```

Results:

```text
[paste result or link]
```

---

## 5. Screenshots / Evidence

Add evidence here:

* Screenshot: [link]
* Logs: [link]
* Metrics: [link]
* Recording: [link]

---

## 6. Risk Assessment

Risk level:

* [ ] Low
* [ ] Medium
* [ ] High

Potential risks:

* [Risk 1]
* [Risk 2]

Mitigation:

* [Mitigation 1]
* [Mitigation 2]

---

## 7. AI Usage Declaration

AI was used for:

* [ ] Understanding existing code
* [ ] Generating code
* [ ] Refactoring
* [ ] Generating tests
* [ ] Drafting documentation
* [ ] Reviewing the diff
* [ ] Not used

Human verification:

* [x] I understand every meaningful change in this PR
* [ ] I checked generated code manually
* [ ] I checked generated tests manually
* [ ] I removed unsupported AI assumptions
* [x] I accept responsibility for this PR

---

## 8. Reviewer Focus

Please focus your review on:

* [ ] Correctness
* [ ] Architecture
* [ ] Security
* [ ] Performance
* [ ] Tests
* [ ] Maintainability
* [ ] Product intent
* [ ] Edge cases
