### PR TITLE
feat(lightbridge-code-intelligence): enable debug logging for control…

### DIFF
--- a/charts/lightbridge-code-intelligence/values.yaml
+++ b/charts/lightbridge-code-intelligence/values.yaml
@@ -379,7 +379,7 @@ lci:
             pullPolicy: IfNotPresent
           env:
             BIND_ADDR: "0.0.0.0:8080"
-            RUST_LOG: "info"
+            RUST_LOG: "info,opentelemetry_sdk=debug,opentelemetry_otlp=debug,reqwest=debug"
             # File config (ADR-0021): read control-plane.json from the mounted ConfigMap (review
             # labels/reactions + the embedding-dimension guard). Absent the file the binary uses env.
             CONTROL_PLANE_CONFIG: "/etc/lightbridge/control-plane.json"
@@ -678,7 +678,7 @@ lci:
             pullPolicy: IfNotPresent
           env:
             CONTROL_PLANE_ROLE: "dispatcher"
-            RUST_LOG: "info"
+            RUST_LOG: "info,opentelemetry_sdk=debug,opentelemetry_otlp=debug,reqwest=debug"
             METRICS_ADDR: "0.0.0.0:9090"
             # File config (ADR-0021): control-plane.json drives the runner Job resources + dispatcher
             # tuning; the binary falls back to the AGENT_*/defaults below when a field is absent.


### PR DESCRIPTION
## 1. Summary

This PR changes:

-  Updated RUST_LOG for control-plane role to enable debug logging
- Updated RUST_LOG for dispatcher role to enable debug logging

It solves:

- [Problem / ticket / story link]

---

## 2. Intent

The intent of this PR is:

> Enable detailed debug logging for OpenTelemetry SDK, OTLP exporter, and reqwest HTTP client
> across the control-plane and dispatcher roles to improve observability and troubleshooting
> capabilities for TLS validation issues and OTLP telemetry flow in production environments.

---

## 3. Scope

### In Scope

- Updated `RUST_LOG` for control-plane role
- Updated `RUST_LOG` for dispatcher role
- Both roles now use: `"info,opentelemetry_sdk=debug,opentelemetry_otlp=debug,reqwest=debug"`

### Out of Scope

- Reconciler role (unchanged)
- A2A role (unchanged)
- Web console role (unchanged)
- Neo4j role (unchanged)
- Other chart configurations

---

## 4. Verification

I verified this change by:

- [x] Running automated tests (helm lint)
- [ ] Running manual tests
- [ ] Checking logs
- [ ] Checking metrics
- [ ] Testing error cases
- [ ] Testing permissions/security behavior
- [ ] Testing rollback or failure behavior, if relevant

Commands run:

```bash
helm lint ./charts/lightbridge-code-intelligence
```

Results:

```
==> Linting ./charts/lightbridge-code-intelligence
[INFO] Chart.yaml: icon is recommended

1 chart(s) linted, 0 chart(s) failed
```

---

## 5. Screenshots / Evidence

Add evidence here:

* Screenshot: [link]
* Logs: [link]
* Metrics: [link]
* Recording: [link]

---

## 6. Risk Assessment

Risk level:

* [ ] Low
* [x] Medium

Potential risks:

- Increased log volume in production environments
- Potential performance impact from debug logging
- Possible exposure of sensitive information in logs (though RUST_LOG is configured to only expose debug for specific modules)

Mitigation:

- Monitor log volume and performance impact after deployment
- Adjust RUST_LOG levels if needed based on production observations
- Ensure log aggregation and retention policies are in place

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [ ] Refactoring
* [ ] Generating tests
* [ ] Drafting documentation
* [x] Reviewing the diff
* [ ] Not used

Human verification:

* [x] I understand every meaningful change in this PR
* [x] I checked generated code manually
* [ ] I checked generated tests manually
* [ ] I removed unsupported AI assumptions
* [x] I accept responsibility for this PR

---

## 8. Reviewer Focus

Please focus your review on:

* [x] Correctness
* [ ] Architecture
* [ ] Security
* [ ] Performance
* [ ] Tests
* [ ] Maintainability
* [ ] Product intent
* [ ] Edge cases