### PR TITLE
fix(model-serving): the weights PVC must fit the download twice over

### DIFF
--- a/charts/model-serving/templates/_helpers.tpl
+++ b/charts/model-serving/templates/_helpers.tpl
@@ -107,6 +107,13 @@ echo "Linked $GGUF -> $MODEL_DIR/model.gguf"
 hf download {{ $w.hfRepo }} --revision {{ $rev }}{{ if $workers }} --max-workers {{ $workers }}{{ end }} --local-dir "$MODEL_DIR"
 {{- end }}
 printf '%s' "$STAMP" > "$MODEL_DIR/.seeded"
+# ⚠️ Reclaim the staging area. `hf download --local-dir` writes the whole repo
+# into <dir>/.cache/huggingface first and then materialises the real files, so
+# PEAK disk is roughly TWICE the repo size — and the staging copy is kept
+# afterwards, doubling the volume forever. Removing it only after the stamp is
+# written keeps a failed or interrupted run resumable (which matters at 33 GB)
+# while making the steady state just the weights.
+rm -rf "$MODEL_DIR/.cache"
 echo "Seed complete."
 {{- end -}}
 

--- a/charts/model-serving/values.yaml
+++ b/charts/model-serving/values.yaml
@@ -428,7 +428,17 @@ models:
       # text_encoder/ (3 shards each for the first two) plus tokenizer/ and the
       # per-component config.json files it reads at load. A glob here would seed
       # a directory that fails validation at start-up.
-      sizeGi: 45
+      # ⚠️ ~2× the repo, MEASURED the hard way. `hf download --local-dir` stages
+      # the entire download into `<dir>/.cache/huggingface` and only then
+      # materialises the real files, so peak disk is repo + staging copy, not
+      # repo. At 45Gi this volume hit 100% full with 44 GB sitting in `.cache`
+      # and the model directories still empty. The seed now deletes the staging
+      # area once the stamp is written, so the steady state is ~33 GB — but the
+      # volume still has to survive the peak, and Longhorn can grow a PVC but
+      # never shrink one.
+      #
+      # Every other model on the fleet is small enough that 2× never mattered.
+      sizeGi: 100
       # ~33 GB over a cold Hub connection. The 2h fleet default is uncomfortably
       # close; 3h costs nothing when the stamp makes re-runs a no-op.
       seedDeadlineSeconds: 10800

--- a/docs/patterns/self-hosted-model-serving.md
+++ b/docs/patterns/self-hosted-model-serving.md
@@ -297,6 +297,16 @@ do not "fix" them to match this page; they are correct for where they ran.
       | python3 -c 'import sys,json;print(sum((f.get("lfs") or {}).get("size",f.get("size",0)) for f in json.load(sys.stdin))/1e9,"GB")'
   done
   ```
+- **⚠️ The weights PVC must fit ~2× the repo, not 1×.** `hf download --local-dir`
+  stages the entire download into `<dir>/.cache/huggingface` and only then
+  materialises the real files, so peak disk is repo **plus** staging copy — and
+  the staging copy is kept afterwards unless something removes it. A 45 GiB
+  volume for a 33 GB repo hit **100% full with 44 GB in `.cache` and the model
+  directories still empty**, which reads like a much bigger download than it is.
+  The seed script now `rm -rf`s the staging area *after* writing the `.seeded`
+  stamp (after, so an interrupted run stays resumable), but the volume still has
+  to survive the peak. Size for 2× + margin. Longhorn can grow a PVC and can
+  never shrink one, so err high.
 - **⚠️ Seed-Job memory is sized by the LARGEST SHARD × workers, not by repo size.**
   `hf download` fans out over **8 workers by default** and hf_xet buffers per
   file, so a repo of three ~10 GB safetensors shards needs several times what a


### PR DESCRIPTION
## 1. Summary

This PR changes:

- The seed script **removes `$MODEL_DIR/.cache` after writing the `.seeded` stamp** — after, so an interrupted run stays resumable.
- **`z-image-turbo` PVC 45Gi → 100Gi.**
- Records the rule in the pattern doc's gotcha list.

It solves:

- The Z-Image-Turbo seed filling its volume to **100% (44 GB in `.cache`)** with the model directories still empty, stalling with `Not enough free disk space`. Follow-on from #791/#792.

---

## 2. Intent

> Size the weights volume for what the download actually occupies at peak, and stop the staging copy living there forever.

`hf download --local-dir` stages the entire repo into `<dir>/.cache/huggingface` and only then materialises the real files. Peak disk is **repo + staging copy**, and the staging copy is *kept*. The failure is misleading in a specific way: the bytes are real, but they are not where you look for them — `du` on `transformer/` showed **56K** while the volume was full.

---

## 3. Scope

### In Scope

- `charts/model-serving/templates/_helpers.tpl` — the post-stamp cleanup.
- `charts/model-serving/values.yaml` — the PVC size.
- `docs/patterns/self-hosted-model-serving.md` — the gotcha.

### Out of Scope

- Every other model: all are small enough that 2× never mattered, and none changes here.
- Avoiding the staging copy altogether (e.g. `HF_HUB_DISABLE_XET`) — the double-space is inherent to the staged approach; reclaiming it is the cheaper fix.

---

## 4. Verification

I verified this change by:

- [x] Running automated tests
- [x] Running manual tests
- [x] Checking logs
- [ ] Checking metrics
- [x] Testing error cases
- [ ] Testing permissions/security behavior
- [ ] Testing rollback or failure behavior, if relevant

Commands run:

```bash
kubectl -n inference exec z-image-turbo-seed-lnkr8 -- sh -c 'df -h /models; du -sh …'
kubectl get sc longhorn -o jsonpath='{.allowVolumeExpansion}'
helm template ms charts/model-serving | grep -E 'size: "100Gi"|rm -rf .*\.cache'
helm lint charts/model-serving --strict && ./tools/check-model-catalogs.sh
```

Results:

```text
# the failure, measured in the running pod
/models  44G  44G  0  100%
44G   /models/Z-Image-Turbo/.cache      <-- all of it
56K   /models/Z-Image-Turbo/transformer <-- nothing materialised
96M   /models/Z-Image-Turbo/text_encoder
160M  /models/Z-Image-Turbo/vae

allowVolumeExpansion: true          # Longhorn will grow the PVC in place
Longhorn free: 1601Gi / 1617Gi      # room to spare

# render
size: "100Gi"   (z-image-turbo)     size: "20Gi" (qwen3-8b-fast, unchanged)
rm -rf "$MODEL_DIR/.cache"          on both models, after the stamp
lint OK
check-model-catalogs: OK (2 served on the GPU fleet, 2 federated cluster-local)
```

---

## 5. Screenshots / Evidence

* `df`/`du` above, taken inside the live seed pod — the diagnosis is measurement, not inference.
* Longhorn expansion support and free capacity confirmed before choosing 100Gi.

---

## 6. Risk Assessment

Risk level:

* [x] Low
* [ ] Medium
* [ ] High

Potential risks:

* PVC expansion is one-way — Longhorn grows but never shrinks. 100Gi against ~33 GB of steady-state weights is deliberate slack, on a node with ~1.6 TiB free.
* `rm -rf` on a path derived from the model's `storagePath`; it runs only after a successful download and only on the `.cache` subdirectory.

Mitigation:

* Cleanup is post-stamp, so a crashed run keeps its resumable staging area.
* Both changes are plain values/script lines — reverting is mechanical.

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [ ] Refactoring
* [ ] Generating tests
* [x] Drafting documentation
* [x] Reviewing the diff
* [ ] Not used

Human verification:

* [x] I understand every meaningful change in this PR
* [x] I checked generated code manually
* [ ] I checked generated tests manually
* [x] I removed unsupported AI assumptions
* [x] I accept responsibility for this PR

---

## 8. Reviewer Focus

Please focus your review on:

* [x] Correctness
* [ ] Architecture
* [ ] Security
* [ ] Performance
* [x] Maintainability
* [ ] Product intent
* [x] Edge cases

Specifically: whether the cleanup should be unconditional (always `rm -rf .cache` on entry when the stamp does not match) rather than post-success. That would bound disk harder but throw away resumability on a 33 GB download — I chose resumability.