### PR TITLE
fix(lightbridge-code-intelligence): nest review tiers under presets

### DIFF
--- a/charts/lightbridge-code-intelligence/templates/config.yaml
+++ b/charts/lightbridge-code-intelligence/templates/config.yaml
@@ -123,18 +123,23 @@ data:
 {{- if $cfg.model.extra }}{{- $_ := set $rev "extra" $cfg.model.extra }}{{- end }}
 {{- /* NB: review.fallback_model is intentionally NOT mapped — the review failover model was removed
        (lightbridge-ci ADR-0053 / #208); a single model + retry/backoff + circuit breaker replaces it. */}}
-{{- /* Two-tier review (lightbridge-ci ADR-0062) → agent.json review.fast / review.deep. Each tier is a
-       COMPLETE, independent block: it shares the gateway (env) + system prompt (mounted file), and carries
-       its OWN model + generation/budget knobs. Set per tier in ai-helm-values (config.model.fast.* /
-       config.model.deep.*); `fast` is the automatic PR-opened pass (cheap model, single diff-only turn —
-       the runner enforces 1 turn + no retrieval regardless of maxTurns), `deep` is the `@mention` run
-       (strong model, long timeout). When a tier is unset the runner falls back to the flat review.* above.
-       ⚠️ REQUIRES a runner image carrying review.fast/review.deep (lightbridge-ci #233) before these are
-       set, else deny_unknown_fields fails every Job (ship the runner first). */}}
+{{- /* Named review presets (lightbridge-code-intelligence ADR-0103) → agent.json review.presets.<name>.
+       Each preset is a COMPLETE, independent block: it shares the gateway (env) + system prompt (mounted
+       file), and carries its OWN model + generation/budget knobs. Set per tier in ai-helm-values
+       (config.model.fast.* / config.model.deep.*) — the values key names are unchanged by ADR-0103,
+       only the rendered JSON's nesting moved under `presets`. `fast` is the automatic PR-opened pass
+       (cheap model, single diff-only turn — the runner enforces 1 turn + no retrieval regardless of
+       maxTurns), `deep` is the `@mention` run (strong model, long timeout). A preset absent from
+       `presets` falls back to the flat review.* above.
+       ⚠️ REQUIRES a runner image carrying review.presets (lightbridge-code-intelligence #527) before
+       this is set, else deny_unknown_fields fails every Job — a runner older than #527 instead expects
+       these nested directly under review.fast/review.deep (ship the runner first when bumping either
+       shape). */}}
 {{- /* Truthiness guards (NOT `ne (toString …) ""`): an unset key in a `{}` tier block is nil, and
        `toString nil` is "<nil>" (≠ ""), which would emit a JSON `null` the runner rejects. Truthiness
        skips nil / "" / 0 / false cleanly. The whole tier is gated on a non-empty `model` so the default
        (empty `fast: {}` / `deep: {}`) emits nothing → the runner uses the flat review.* (back-compat). */}}
+{{- $presets := dict }}
 {{- range $tier := list "fast" "deep" }}
 {{- $tv := index $cfg.model $tier }}
 {{- if and $tv $tv.model }}
@@ -191,9 +196,10 @@ data:
        plugin dropped). REQUIRES a runner image carrying review.<tier>.opencode
        (lightbridge-code-intelligence #464) before this is set, else deny_unknown_fields fails every Job. */}}
 {{- if $tv.opencode }}{{- $_ := set $t "opencode" $tv.opencode }}{{- end }}
-{{- $_ := set $rev $tier $t }}
+{{- $_ := set $presets $tier $t }}
 {{- end }}
 {{- end }}
+{{- if $presets }}{{- $_ := set $rev "presets" $presets }}{{- end }}
 {{- $_ := set $ag "review" $rev }}
 {{- /* Deterministic SAST pass (lightbridge-ci ADR-0061) → agent.json `sast`. opengrep scans the PR's
        changed files in the runner; findings ride the EXISTING review buffer (no second poster) and the


### PR DESCRIPTION
## 1. Summary

This PR changes:

- `charts/lightbridge-code-intelligence/templates/config.yaml`: the review tier-rendering
  loop now nests the `fast`/`deep` blocks under `review.presets.<tier>` in the rendered
  `agent.json`, instead of setting them directly as `review.fast`/`review.deep`.

It solves:

- A live production incident: every review Job has been crash-looping since
  `vymalo/lightbridge-code-intelligence#527` merged, with:
  ```json
  {"level":"ERROR","fields":{"message":"invalid agent config file","detail":"deserializing /etc/lightbridge/agent.json"}}
  ```

---

## 2. Intent

> `lightbridge-code-intelligence#527` (ADR-0103) replaced the runner's
> `ReviewFile.fast`/`ReviewFile.deep` fields with a generic, operator-extensible
> `ReviewFile.presets: HashMap<String, ReviewFile>` map. `ReviewFile` uses
> `#[serde(deny_unknown_fields)]`, so once #527 shipped, this chart's still-`review.fast`/
> `review.deep` output became two unrecognized fields on every rendered `agent.json`,
> failing deserialization for every review Job. This PR updates the chart to match the
> runner's current schema.

---

## 3. Scope

### In Scope

- Nest the tier loop's output dict under a `presets` key on `review` instead of setting
  it directly.
- Update the surrounding doc comments (this template documents its own hazards inline,
  per this chart's convention) to describe the current `review.presets.<name>` shape
  instead of the pre-#527 `review.fast`/`review.deep` shape.

### Out of Scope

- No `ai-helm-values` change: the values key names (`config.model.fast.*`/
  `config.model.deep.*`) are untouched — only the *rendered JSON's* nesting moved. Verified
  by rendering the chart against the actual prod values file (see Verification).
- No new preset support beyond `fast`/`deep` — the runner's `presets` map is
  operator-extensible, but this PR only fixes the existing two-tier rendering to match the
  new schema; adding a third named preset (e.g. `ultra`, tracked in
  `lightbridge-code-intelligence#496`) is separate follow-up work.

---

## 4. Verification

I verified this change by:

- [x] Running manual tests
- [x] Checking logs

Commands run:

```bash
helm dependency build charts/lightbridge-code-intelligence
helm template test charts/lightbridge-code-intelligence \
  -f ../ai-helm-values/environments/prod/values/lightbridge-code-intelligence.yaml \
  --show-only templates/config.yaml > /tmp/rendered.yaml
python3 -c "
import yaml, json
docs = list(yaml.safe_load_all(open('/tmp/rendered.yaml')))
for d in docs:
    if d and 'agent.json' in (d.get('data') or {}):
        r = json.loads(d['data']['agent.json'])['review']
        print('flat keys:', sorted(r.keys()))
        print('presets keys:', sorted(r.get('presets', {}).keys()))
"
```

Results:

```text
flat keys: ['api_key', 'base_url', 'model', 'presets', 'system_prompt_file']
presets keys: ['deep', 'fast']
```

`review.fast`/`review.deep` no longer appear as top-level unknown fields; the full tier
block (model, prompt, tool allowlist, opencode overlay, etc.) renders under
`review.presets.deep`/`review.presets.fast` as expected by the current `ReviewFile` shape.

---

## 5. Screenshots / Evidence

* Prod error log that prompted this fix:
  ```json
  {"timestamp":"2026-07-28T15:20:32.221022Z","level":"ERROR","fields":{"message":"invalid agent config file","detail":"deserializing /etc/lightbridge/agent.json"},"target":"agent_runner::run"}
  ```

---

## 6. Risk Assessment

Risk level:

* [ ] Low
* [x] Medium
* [ ] High

Potential risks:

* This is a chart change that goes live on merge to `main` (GitOps/ArgoCD). Every review Job
  in every environment using this chart is currently already broken (crash-looping) without
  this fix, so the risk is asymmetric: not merging keeps review entirely down; merging
  restores it to the #527 schema this repo's runner image already expects.
* If any environment's values file still relies on an even OLDER runner image (pre-#527,
  expecting flat `review.fast`/`review.deep`), this fix would break it. Checked: the deployed
  runner image already ships #527/#528/#529, so this is not a concern for the environments
  this chart currently targets.

Mitigation:

* Verified via `helm template` against the actual checked-in prod values file, not a
  synthetic one — the rendered JSON's shape was inspected directly, not merely
  template-syntax-checked.

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [ ] Refactoring
* [ ] Generating tests
* [ ] Drafting documentation
* [ ] Reviewing the diff
* [ ] Not used

Human verification:

* [ ] I understand every meaningful change in this PR
* [ ] I checked generated code manually
* [ ] I checked generated tests manually
* [ ] I removed unsupported AI assumptions
* [ ] I accept responsibility for this PR

_AI-drafted (Claude) for @stephane-segning's review — human-verification checkboxes
intentionally left unticked; only the accountable owner can truthfully check them._

---

## 8. Reviewer Focus

Please focus your review on:

* [x] Correctness
* [ ] Architecture
* [ ] Security
* [ ] Performance
* [ ] Tests
* [ ] Maintainability
* [x] Product intent
* [ ] Edge cases

Source of truth: [vymalo/lightbridge-code-intelligence#527](https://github.com/vymalo/lightbridge-code-intelligence/pull/527)
(the schema change that broke this chart), traced from a live prod error log.
