### PR TITLE
feat(librechart): hide internal models from opencode picker via modelsInfoHideTextOnly

### DIFF
--- a/charts/librechat-opencode-wellknown/values.yaml
+++ b/charts/librechat-opencode-wellknown/values.yaml
@@ -190,6 +190,20 @@ wellKnown:
             # TTL (24h default upstream); override if you want fresher
             # catalogs:
             # modelsInfoTtlSeconds: 3600
+            # Makes /v1/models/info authoritative for which models even show
+            # up in the opencode picker (models-info plugin ≥ 0.10.0,
+            # vymalo/opencode-oauth2@802ce44..cc8fce1). A model is hard-deleted
+            # from provider.models (not just left un-enriched) when the
+            # catalog reports it as exactly text-in/text-out, OR when the
+            # catalog has no entry for it at all — the latter also acts as a
+            # second, plugin-side belt for the `disableExternal`/`-internal`
+            # exclusion charts/ai-model + charts/ai-models-info already apply
+            # server-side (AIGatewayRoute hostnames + the catalog helper).
+            # ⚠️ Broad blast radius: this hides every plain-text chat model
+            # from oauth2's /v1/models discovery, not just the internal ones —
+            # only multimodal/image models (+ any the catalog explicitly
+            # reports non-text-only) survive in the opencode picker.
+            modelsInfoHideTextOnly: true
             # Force our endpoint's `name` to win over the normalized label
             # the oauth2 plugin pre-stamps (vymalo/opencode-models-info#38,
             # needs plugin ≥ 0.7.1 — pinned 0.8.0 above). models-info merges

--- a/docs/integrations/opencode-well-known.md
+++ b/docs/integrations/opencode-well-known.md
@@ -371,6 +371,20 @@ landed and the UI showed the plain normalized label. Listing `name` lets the
 endpoint value replace it; a field only changes when the endpoint actually
 provides one.
 
+`meta.modelsInfoHideTextOnly: true` (models-info plugin ≥ 0.10.0,
+[vymalo/opencode-oauth2@802ce44..cc8fce1](https://github.com/vymalo/opencode-oauth2/commit/cc8fce1eaa62383ac6b6692b37061972e6a77a19))
+makes `/v1/models/info` authoritative for which models the opencode picker
+even offers, not just their metadata: a model is hard-deleted from
+`provider.models` when the catalog reports it as exactly text-in/text-out, or
+when the catalog has no matching entry at all. We turn this on so oauth2's
+`/v1/models` discovery gets a second, plugin-side check that a model actually
+belongs in the picker — on top of the server-side `disableExternal`/`-internal`
+exclusion `charts/ai-model` (AIGatewayRoute `hostnames`) and
+`charts/ai-models-info` (the catalog helper) already apply. ⚠️ Broad blast
+radius: this hides every plain-text chat model, not just the internal ones —
+only multimodal/image models (and any the catalog explicitly reports as
+non-text-only) survive in the picker.
+
 ## Prerequisites the cluster must satisfy
 
 The chart deploys the endpoint, but two things must exist in Keycloak


### PR DESCRIPTION
## 1. Summary

This PR changes:

- Turns on `meta.modelsInfoHideTextOnly: true` for the `camer-digital` provider in `charts/librechat-opencode-wellknown/values.yaml`
- Documents the new option in `docs/integrations/opencode-well-known.md`

It solves:

- `@vymalo/opencode-models-info` shipped a new opt-in flag in 0.10.0 (already pinned in this repo by a prior commit) that makes its `/v1/models/info` catalog authoritative for *which models exist* in the opencode picker, not just their metadata. This PR turns that flag on, giving a second, plugin-side check that a model belongs in the picker — on top of the server-side `disableExternal`/`-internal` exclusion already applied in `charts/ai-model` (AIGatewayRoute `hostnames`, #797) and `charts/ai-models-info` (the catalog helper).

---

## 2. Intent

> Close the loop on hiding internal-only models from the opencode CLI's model picker. The AIGatewayRoute/catalog-side fix (#797, same day) scopes `disableExternal` models out of `/v1/models` and `/v1/models/info` server-side, but was flagged in its own commit message as not yet verified live. Enabling `modelsInfoHideTextOnly` adds a belt-and-suspenders check inside the opencode-models-info plugin itself: any model discovery surfaces that our catalog doesn't vouch for gets pruned client-side too.

---

## 3. Scope

### In Scope

- One provider-config flag (`meta.modelsInfoHideTextOnly: true`) in the opencode well-known descriptor
- Doc update explaining the option and its blast radius

### Out of Scope

- The server-side AIGatewayRoute hostname scoping (already shipped in #797)
- Any change to which models are marked `disableExternal`/`kind`

---

## 4. Verification

I verified this change by:

- [x] Running automated tests
- [ ] Running manual tests
- [ ] Checking logs
- [ ] Checking metrics
- [ ] Testing error cases
- [ ] Testing permissions/security behavior
- [ ] Testing rollback or failure behavior, if relevant

Commands run:

```bash
helm lint charts/librechat-opencode-wellknown/ --strict
helm template x charts/librechat-opencode-wellknown/ --dry-run | grep -o '"modelsInfoHideTextOnly":[a-z]*'
```

Results:

```text
1 chart(s) linted, 0 chart(s) failed
"modelsInfoHideTextOnly":true
```

---

## 5. Screenshots / Evidence

* Upstream diff reviewed: https://github.com/vymalo/opencode-oauth2/compare/802ce44f9ce50b14b036ca53eb3887c6ac4d7e9d...cc8fce1eaa62383ac6b6692b37061972e6a77a19
* Related server-side fix: #797 (fix(ai-model): scope disableExternal models out of /v1/models via AIGatewayRoute hostnames)

---

## 6. Risk Assessment

Risk level:

* [ ] Low
* [x] Medium
* [ ] High

Potential risks:

* `modelsInfoHideTextOnly` hides by *modality*, not by our `internal` concept: 18 of ~31 catalog models are `kind: text` and will disappear from the opencode picker entirely (only the 10 `multimodal` + 1 `image` models remain selectable), not just the 6 `disableExternal`/`-internal` ones.
* This is a live-deploy repo (ADR-0055) — merging to main takes effect immediately, no staged rollout.

Mitigation:

* Confirmed as the intended behavior with the maintainer before implementing (the broad blast radius was surfaced and explicitly accepted).
* Rollback is a one-line revert of the flag (or `git revert`), same as any other continuous-delivery change.

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [ ] Refactoring
* [ ] Generating tests
* [x] Drafting documentation
* [x] Reviewing the diff
* [ ] Not used

Human verification:

* [x] I understand every meaningful change in this PR
* [ ] I checked generated code manually
* [ ] I checked generated tests manually
* [x] I removed unsupported AI assumptions
* [x] I accept responsibility for this PR

---

## 8. Reviewer Focus

Please focus your review on:

* [ ] Correctness
* [ ] Architecture
* [ ] Security
* [ ] Performance
* [ ] Tests
* [x] Product intent
* [ ] Edge cases
