### PR TITLE
fix(model-serving-zimage-turbo): size the seed PVC and worker fan-out for the real download

### DIFF
--- a/charts/model-serving-zimage-turbo/values.yaml
+++ b/charts/model-serving-zimage-turbo/values.yaml
@@ -29,7 +29,17 @@ pvc:
   name: zimage-models
   storageClassName: longhorn
   accessMode: ReadWriteMany
-  size: 20Gi
+  # ⚠️ Tongyi-MAI/Z-Image-Turbo publishes FP32 weights (~33 GB: transformer
+  # 24.62 + text_encoder 8.05 + VAE 0.17), not the "FP8, ~8 GB" the model card
+  # implies. `hf download --local-dir` also stages the whole repo into
+  # `.cache/huggingface` before materialising the real files, so peak disk is
+  # ~2× the repo — a 20Gi PVC filled solid with the model directories still
+  # near-empty. 100Gi is 2x the repo plus margin (this is exactly the sizing
+  # ai-helm's own charts/model-serving orchestrator converged on for this same
+  # download — see docs/adr/0100-image-generation-on-the-gpu-fleet.md and
+  # docs/migrations/2026-07-27-gpu-fleet-followups.md). Longhorn can grow a PVC
+  # in place but never shrink one, so err high rather than resize twice.
+  size: 100Gi
 
 seedJob:
   enabled: true
@@ -172,7 +182,22 @@ modelServing:
               mkdir -p "$MODEL_DIR"
               echo "Seeding Tongyi-MAI/Z-Image-Turbo -> $MODEL_DIR (skips files already present)"
               pip install --no-cache-dir -q --root-user-action=ignore "huggingface_hub[hf_xet]>=1.0"
-              hf download Tongyi-MAI/Z-Image-Turbo --local-dir "$MODEL_DIR"
+              # --max-workers 2: `hf download` fans out over 8 workers by
+              # default and hf_xet buffers per file, so peak seed memory tracks
+              # the LARGEST SHARD (this repo has three ~10 GB safetensors
+              # shards) × concurrent workers, not the repo total. 8 workers on
+              # 10 GB shards OOM-killed this exact download at a 6-10Gi limit
+              # elsewhere in the fleet; capping fan-out is the real fix (Hub
+              # bandwidth, not concurrency, is the bottleneck here anyway).
+              hf download Tongyi-MAI/Z-Image-Turbo --max-workers 2 --local-dir "$MODEL_DIR"
+              # Reclaim the staging area. `hf download --local-dir` stages the
+              # whole repo into $MODEL_DIR/.cache/huggingface before
+              # materialising the real files, so it doubles steady-state disk
+              # usage forever unless removed. Only after a successful download
+              # (this script is `sh -ec`, so an earlier failure exits before
+              # reaching this line) — an interrupted run keeps its staging area
+              # and stays resumable rather than re-fetching 33 GB from scratch.
+              rm -rf "$MODEL_DIR/.cache"
               echo "Seed complete."
           env:
             HF_TOKEN:
@@ -181,7 +206,9 @@ modelServing:
                 key: token
           resources:
             requests: { cpu: "4", memory: 6Gi }
-            limits:   { cpu: "8", memory: 10Gi }
+            # 16Gi, not the fleet-typical 6-10Gi: sized for the largest-shard ×
+            # worker-count math above, not the repo total.
+            limits:   { cpu: "8", memory: 16Gi }
           securityContext:
             allowPrivilegeEscalation: false
             runAsNonRoot: false


### PR DESCRIPTION
## Summary
- The `z-image-turbo-seed` Job was crash-looping with \"Not enough free disk space\" — the PVC was sized 20Gi from the model card's advertised \"FP8, ~8GB\", but the published repo is FP32 (~33GB), and \`hf download --local-dir\` stages the whole repo into \`.cache\` before materializing it, so peak disk during the download is ~2x the repo size.
- Bumps \`pvc.size\` 20Gi → 100Gi, caps \`hf download\` fan-out to 2 workers (uncapped defaults to 8, which OOMs against this repo's ~10GB shards), bumps the seed container's memory limit 10Gi → 16Gi, and reclaims the \`.cache\` staging directory after a successful download.

## Intent
Fixes the crash-looping pod \`z-image-turbo-seed-ws6l9\` in ns \`inference\` on the Hetzner GPU fleet. Source of truth: this repo's own [docs/adr/0100-image-generation-on-the-gpu-fleet.md](https://github.com/ADORSYS-GIS/ai-helm/blob/main/docs/adr/0100-image-generation-on-the-gpu-fleet.md) and [docs/migrations/2026-07-27-gpu-fleet-followups.md](https://github.com/ADORSYS-GIS/ai-helm/blob/main/docs/migrations/2026-07-27-gpu-fleet-followups.md) already document this exact repo needing this exact sizing (100Gi PVC, capped worker fan-out, raised seed memory) — applied here to \`charts/model-serving-zimage-turbo\`, the chart actually live today.

## Scope
Single file: \`charts/model-serving-zimage-turbo/values.yaml\` (PVC size + seed Job args/resources). No template changes, no other charts touched. This is a targeted disk-space/OOM fix, not a redesign — see Reviewer Focus below for a related but out-of-scope finding.

## Verification
- \`helm lint charts/model-serving-zimage-turbo/\` — 0 chart(s) failed
- \`helm template x charts/model-serving-zimage-turbo/ --dry-run\` — renders clean; confirmed PVC renders at \`storage: 100Gi\`, seed container resources render at \`memory: 16Gi\` limit, and the seed script body carries \`--max-workers 2\` and the \`rm -rf \"\$MODEL_DIR/.cache\"\` cleanup line.
- Not yet verified live (no cluster access from this session) — next step is deleting the stuck \`z-image-turbo-seed\` Job in ns \`inference\` post-merge so it re-runs against the resized PVC, then confirming the seed completes and the model Deployment goes Ready.

## Screenshots/Evidence
N/A — Helm chart change, no UI. \`helm template\` output for the changed resources is quoted above.

## Risk Assessment
Low. Increasing a Longhorn PVC size is a safe, in-place, non-shrinking expansion (confirmed by \`docs/migrations/2026-07-27-gpu-fleet-followups.md\`, which documents the same PVC growing 45Gi→100Gi for this same download without incident). The seed Job change only affects a one-shot ArgoCD Sync-hook Job, not the running model server. Worst case if this is insufficient: the seed Job fails again and is retried (\`backoffLimit: 6\`) with no impact on other workloads.

## AI Usage Declaration
- [x] AI (Claude Code) diagnosed the failing pod's log output, investigated the repo's own git history and ADRs to find the exact sizing this repo's model-serving orchestrator already converged on for this same HF repo, and authored this diff.
- [x] A human (via chat) reviewed the diagnosis, explicitly chose the minimal-patch approach over a larger revert (see Reviewer Focus), and reviewed this PR body before it was opened.
- [x] \`helm lint\` + \`helm template --dry-run\` were run and their output inspected, not merely assumed to pass.
- [x] No secrets, credentials, or generated code beyond this Helm values change were introduced.

## Reviewer Focus
⚠️ **This is a stopgap, not the full fix, by explicit user choice.** While diagnosing this, I found that PR #790 (merged as 15a9c6b) accidentally reverted ~15 commits of already-completed, measured work (ADR-0100 through ADR-0105) that had replaced this same custom Rust/Candle server with a LocalAI-based deployment, measured live at 32.4s/image, and had already disabled \`model-serving-zimage-turbo\` (this chart's app entry) for exactly this reason (FP32-vs-marketing sizing, an unbuildable Dockerfile, wrong CUDA compute capability, a lazy-load/readiness deadlock). That regression is tracked separately and is NOT addressed by this PR — this PR only makes the currently-live (regressed) chart survive its seed. Please review with that context: this fix is correct for the chart as it exists today, but the chart itself is one the team had already decided to retire.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>