### PR TITLE
fix(apps): disable model-serving-zimage-turbo -- its image does not exist

### DIFF
--- a/charts/apps/values.yaml
+++ b/charts/apps/values.yaml
@@ -1285,11 +1285,30 @@ applications:
         selfHeal: true
 
   # Self-hosted Tongyi-MAI Z-Image-Turbo FP8 on the Hetzner GPU fleet (ADR-0094/0095).
-  # 6B params, FP8 quantized (~8 GB VRAM), 1024×1024, 8-step distilled DiT.
+  #
+  # ⚠️ DISABLED 2026-07-29 — the image this chart deploys does not exist.
+  # `ghcr.io/adorsys-gis/z-image-turbo-server:v0.1.0` 403s on pull (verified live:
+  # kubelet `failed to authorize: ... 403 Forbidden`, no imagePullSecret configured
+  # anywhere in this namespace). ADR-0102 already recorded why: the source for
+  # this image (`images/z-image-turbo-server/`) was deleted the day after this
+  # chart's original deployment (PR #704), when the team replaced this whole
+  # custom-Rust-server approach with LocalAI, measured live at 32.4s/image
+  # (ADR-0100 through ADR-0105). [PR #790](https://github.com/ADORSYS-GIS/ai-helm/pull/790)
+  # then merged a stale branch that resurrected this chart (re-enabling it here)
+  # without noticing the LocalAI work — see the disk-space fix in
+  # [PR #802](https://github.com/ADORSYS-GIS/ai-helm/pull/802) for the seed-side
+  # half of that regression, and #803 for the full writeup and the ask to
+  # either finish this custom server properly or restore LocalAI instead.
+  #
+  # The "FP8, ~8 GB VRAM" claim below is the model card's, not measured: the
+  # published HF repo is FP32 (~33 GB on disk: transformer 24.62 + text_encoder
+  # 8.05 + VAE 0.17), and how that fits a 20 GB-VRAM card was never demonstrated
+  # end to end — the model Deployment never got past ImagePullBackOff to find out.
+  # 6B params, 1024×1024, 8-step distilled DiT.
   # Served by a custom Rust/Actix server (ghcr.io/adorsys-gis/z-image-turbo-server).
   # Deployed on the Hetzner GPU nodes via the model-serving orchestrator pattern.
   - name: model-serving-zimage-turbo
-    enabled: true
+    enabled: false                 # DISABLED — image does not exist (see comment above). Do not re-enable without fixing the image first.
     finalizers:
       - resources-finalizer.argocd.argoproj.io
     source:


### PR DESCRIPTION
## Summary
- Disables `model-serving-zimage-turbo` (`enabled: false`) in `charts/apps/values.yaml`. Its model Deployment is stuck `ImagePullBackOff` — `ghcr.io/adorsys-gis/z-image-turbo-server:v0.1.0` returns 403 Forbidden and does not appear to exist (per ADR-0102, its source was deleted three days after it was published).
- Documents, in-place, why: the app was re-enabled by [PR #790](https://github.com/ADORSYS-GIS/ai-helm/pull/790), which silently reverted the already-measured LocalAI replacement (ADR-0100–0105) for this exact model.

## Intent
Fixes the ArgoCD health/sync noise from a Deployment that structurally cannot come up. Source of truth: [#803](https://github.com/ADORSYS-GIS/ai-helm/issues/803) (filed alongside this PR, assigned to @benie-joy-possi) has the full writeup of both blockers found (missing image, unvalidated VRAM fit) and the ask to either finish the custom server properly or restore LocalAI.

## Scope
Single file, one app entry: `charts/apps/values.yaml` (`model-serving-zimage-turbo`, `enabled: true` → `false`, plus a comment explaining why). No chart templates touched. Does not delete the chart itself or attempt to fix the image/VRAM problem — that's explicitly out of scope, tracked in #803.

## Verification
- `helm lint charts/apps/` — 0 chart(s) failed
- `helm template x charts/apps/ --dry-run` — confirmed the `model-serving-zimage-turbo` Application is no longer rendered (`grep -c "name: model-serving-zimage-turbo"` → 0)
- Not verified against a live sync from this session — next step after merge is confirming ArgoCD prunes the Application CR (it carries `resources-finalizer.argocd.argoproj.io`, so pruning cascades to delete the Deployment, PVC, and ExternalSecrets it owns) and that no other app depends on the `inference`-namespace resources it created.

## Screenshots/Evidence
```
$ kubectl -n inference get pods -l job-name!=z-image-turbo-seed
NAME                                  READY   STATUS             RESTARTS   AGE
z-image-turbo-main-6f6cf5c6d9-44r99   0/1     ImagePullBackOff   0          90s

Events:
  Warning  Failed  kubelet  Failed to pull image "ghcr.io/adorsys-gis/z-image-turbo-server:v0.1.0":
  failed to authorize: ... 403 Forbidden
```

## Risk Assessment
Low, and it reduces risk: disabling a crash-looping/never-Ready app stops ArgoCD from reporting misleading health and stops the fleet GPU node from being reserved (nodeSelector/toleration) by a pod that can never run. The one thing to watch post-merge: the app's finalizer means pruning deletes its PVC (`zimage-models`, now 100Gi with the fully-seeded weights from #802) — acceptable, since those weights are simply re-downloadable and this deployment was never functional.

## AI Usage Declaration
- [x] AI (Claude Code) diagnosed the `ImagePullBackOff` from pod logs/events, traced it to ADR-0102's image deletion, and authored this diff plus the companion issue.
- [x] A human (via chat) explicitly requested this action ("disable it") after reviewing the diagnosis.
- [x] `helm lint` + `helm template --dry-run` were run and their output inspected.
- [x] No secrets, credentials, or image-registry changes were made or attempted.

## Reviewer Focus
This is a narrow "stop the bleeding" change. The real decision (rebuild the custom server vs. restore LocalAI) is deliberately left to #803 / @benie-joy-possi rather than made here.
