### PR TITLE
fix(model-serving): cap qwen3-vl-4b-thinking seed worker fan-out, raise memory limit

### DIFF
--- a/charts/model-serving/values.yaml
+++ b/charts/model-serving/values.yaml
@@ -546,9 +546,17 @@ models:
        # `.cache` staging directory after a successful download — the fix from
        # the Z-Image-Turbo disk-space incident, #802).
        sizeGi: 20
-       # Largest shard here is ~5 GB, well under the ~10 GB threshold that
-       # OOM-killed the Z-Image-Turbo seed at the fleet-default 6Gi limit — no
-       # seedMaxWorkers/seedMemoryLimit override needed.
+       # ⚠️ CORRECTED 2026-07-29, live: this DID OOM (exit 137) at the
+       # fleet-default 6Gi seed limit with the default 8-way `hf download`
+       # fan-out, at 12/14 files. The earlier assumption here — "largest shard
+       # ~5 GB, under the ~10 GB threshold, no override needed" — missed that
+       # the repo's two big shards (4.97 + 3.91 GB) can be fetched
+       # CONCURRENTLY under 8-way fan-out, buffering both at once, which is
+       # what actually decides peak memory, not the single largest file.
+       # Same fix as the Z-Image-Turbo incident (#802): cap the fan-out and
+       # raise the margin.
+       seedMaxWorkers: 2
+       seedMemoryLimit: 10Gi
      serving:
        contextSize: 32768
        parallel: 2


### PR DESCRIPTION
## Summary
- Caps `hf download`'s worker fan-out (`weights.seedMaxWorkers: 2`) and raises the seed container's memory limit (`weights.seedMemoryLimit: 10Gi`) for `qwen3-vl-4b-thinking`, fixing an `OOMKilled` seed Job observed live on the first sync after #805.

## Intent
Source of truth: live cluster observation right after #805 merged and synced — the seed Job (`qwen3-vl-4b-thinking-seed`, ns `inference`) was `OOMKilled` (exit 137) at 12/14 files under the fleet-default 6Gi limit. This is the same failure class already fixed for Z-Image-Turbo in #802; #805's in-line reasoning that this model's ~5GB largest shard was safely under the ~10GB OOM threshold didn't account for the two big shards being fetched concurrently under the default 8-way fan-out.

## Scope
Single file, two new fields on the existing `qwen3-vl-4b-thinking` entry in `charts/model-serving/values.yaml`. No template changes.

## Verification
- `helm lint charts/model-serving/` — 0 chart(s) failed
- `helm template x charts/model-serving/ --dry-run` — confirmed `--max-workers 2` on the rendered `hf download` command and `memory: "10Gi"` on the seed container's limit.
- Not yet re-verified live from this session (queued behind the same chart-publish/runner backlog as the last few merges) — next step post-merge is confirming the seed Job actually completes and the model Deployment reaches Ready.

## Screenshots/Evidence
```
$ kubectl -n inference get pod qwen3-vl-4b-thinking-seed-vzt7t -o jsonpath='{.status.containerStatuses[0].lastState}'
{"terminated":{"exitCode":137,"reason":"OOMKilled", ...}}
```

## Risk Assessment
Low. This only affects a one-shot Sync-hook seed Job for a model that isn't federated yet (no user-facing traffic). Worst case if 10Gi is still insufficient: the Job retries (`backoffLimit`) with no impact elsewhere.

## AI Usage Declaration
- [x] AI (Claude Code) diagnosed the OOM from the pod's `lastState` (not guessed), identified the same root cause pattern already documented for Z-Image-Turbo, and authored this fix.
- [x] A human (via chat) asked to "ensure the others are live," which is what prompted checking this model's actual rollout status rather than assuming #805 was sufficient.
- [x] `helm lint` + `helm template --dry-run` were run and their output inspected.
- [x] No secrets or federation changes.

## Reviewer Focus
This corrects an incorrect assumption made in #805's own comments — flagging in case the reviewer wants to sanity-check whether 10Gi is enough margin, or would prefer a more conservative number given this is still an unmeasured model.
