### PR TITLE
fix(model-serving): size qwen3-vl-4b-thinking's weights PVC for the real download

### DIFF
--- a/charts/model-serving/values.yaml
+++ b/charts/model-serving/values.yaml
@@ -539,13 +539,18 @@ models:
        # No `include`: vLLM needs the whole repo (safetensors shards + tokenizer
        # + processor config), not a single file.
        #
-       # ~2.2x the measured ~8.9 GB repo — matches the qwen3-8b-fast precedent
-       # (also sizeGi: 20 for a similarly-sized whole-repo vLLM download) and
-       # comfortably survives the "hf download stages the whole repo twice"
-       # peak (charts/model-serving/templates/_helpers.tpl already reclaims the
-       # `.cache` staging directory after a successful download — the fix from
-       # the Z-Image-Turbo disk-space incident, #802).
-       sizeGi: 20
+       # ⚠️ CORRECTED 2026-07-29, live: 20Gi (the qwen3-8b-fast precedent) was too
+       # tight. `hf download --local-dir` stages the WHOLE repo into `.cache`
+       # before materialising it (peak ~2x the ~8.9 GB repo = ~17.8 GB), which
+       # already left only ~2.2 GB margin in a 20Gi volume — and every OOM-killed
+       # attempt (see seedMaxWorkers below) staged its own partial copy in
+       # `.cache` without reaching the post-success cleanup, so the volume hit
+       # 100% full / 0 bytes free purely from crash debris, before a single
+       # complete download. Same mechanism as the Z-Image-Turbo incident (#802),
+       # just at 1/4 the scale. 30Gi ~= 2x the repo plus real margin. Longhorn
+       # grows a PVC in place but never shrinks one, so this errs high rather
+       # than resize twice.
+       sizeGi: 30
        # ⚠️ CORRECTED 2026-07-29, live: this DID OOM (exit 137) at the
        # fleet-default 6Gi seed limit with the default 8-way `hf download`
        # fan-out, at 12/14 files. The earlier assumption here — "largest shard


### PR DESCRIPTION
## Summary
- Resizes `qwen3-vl-4b-thinking`'s weights PVC from 20Gi to 30Gi in `charts/model-serving/values.yaml`, fixing "Not enough free disk space" observed live immediately after #806's OOM fix landed.

## Intent
Source of truth: live cluster observation. After #806 fixed the seed OOM, the very next sync attempt hit `df -h /models` = 100% used, 0 bytes free — entirely `.cache` debris from the earlier OOM-killed attempts (each one stages a partial download and only cleans up on success). Independent of the debris, 20Gi was already too tight: peak disk during a clean run is ~2x the ~8.9GB repo (~17.8GB), leaving only ~2.2GB margin — the same "must fit the download twice" mechanism as the Z-Image-Turbo incident (#802), just smaller and easier to underestimate.

## Scope
Single field change: `sizeGi: 20 -> 30` on the existing `qwen3-vl-4b-thinking` entry. No template changes.

## Verification
- `helm lint charts/model-serving/` — 0 chart(s) failed
- `helm template x charts/model-serving/ --dry-run` — confirmed `size: "30Gi"` renders on the `qwen3-vl-4b-thinking-weights` PVC.
- Not yet re-verified live from this session — next step post-merge is confirming Longhorn grows the existing PVC in place and the seed Job completes cleanly this time (two fixes deep on this model now: OOM in #806, disk space here).

## Screenshots/Evidence
```
$ kubectl -n inference exec qwen3-vl-4b-thinking-seed-cntqg -- df -h /models
Filesystem      Size  Used Avail Use% Mounted on
...             20G   20G     0 100% /models
$ ... du -sh /models/Qwen3-VL-4B-Thinking/.cache
20G   (all of it — the actual model files total ~11KB, nothing real seeded yet)
```

## Risk Assessment
Low. Longhorn PVC expansion is in-place and non-destructive (same operation already proven safe for Z-Image-Turbo in #802). Only affects a one-shot seed Job for a still-unfederated model.

## AI Usage Declaration
- [x] AI (Claude Code) diagnosed the disk-space failure from live `df`/`du` output (not guessed), traced it to the same staging-doubling mechanism already documented for Z-Image-Turbo, and authored this fix.
- [x] A human (via chat) asked to "ensure the others are live," which is what prompted iterating through each failure this model hit on its first real rollout.
- [x] `helm lint` + `helm template --dry-run` were run and their output inspected.
- [x] No secrets or federation changes.

## Reviewer Focus
This is the third small PR against this one model's entry in quick succession (#805 catalog entry, #806 OOM fix, this PVC fix) — each fix was driven by an actual live failure, not speculation, but it's worth a reviewer's eye on whether 30Gi has enough margin or whether to just match Z-Image-Turbo's playbook and go straight to a rounder, more generous number.
