### PR TITLE
fix(model-serving): the vllm engine's "safe" image tag was actually CUDA 13

### DIFF
--- a/charts/model-serving/values.yaml
+++ b/charts/model-serving/values.yaml
@@ -251,13 +251,35 @@ defaults:
       # the tags by DATE, never by version string:
       #     curl -s 'https://hub.docker.com/v2/repositories/lmcache/vllm-openai/tags?ordering=last_updated'
       #
-      # ⚠️ Use the plain tag, NOT `-cu129`: these nodes run driver 550.163.01 /
-      # CUDA 12.4. Same class of trap as llama.cpp's `server-cuda13`.
+      # ⚠️⚠️ CORRECTED 2026-07-29, live and the hard way: this guidance used to
+      # say "use the plain tag, NOT `-cu129`" — that is now BACKWARDS.
+      # LMCache moved the plain/`latest` tag's CUDA toolkit to **13.0.1** at
+      # some point after that note was written (confirmed by pulling the image
+      # config, not assumed from the tag name: `CUDA_VERSION=13.0.1.012` in
+      # `v0.5.2`'s env). CUDA 13 is a MAJOR version bump past this fleet's
+      # driver (550.163.01, CUDA 12.4 max) — no minor-version-compatibility
+      # applies across a major boundary, and the pod crash-loops at engine
+      # start:
+      #     RuntimeError: The NVIDIA driver on your system is too old
+      #     (found version 12040). ...
+      # `v0.5.2-cu129` (CUDA 12.9 — still within the 12.x family) is what
+      # actually initializes on this hardware — verified with a throwaway pod
+      # on `hetzner-k8s-gpu-1` running this exact image:
+      #     CUDA_OK 2.11.0+cu129 12.9 NVIDIA RTX 4000 SFF Ada Generation
+      # Same LMCache version (v0.5.2) underneath both tags — this is a CUDA
+      # toolkit swap only, not a vLLM/LMCache version change, so nothing about
+      # model support changes.
+      #
+      # ⚠️ Re-verify this against the config's `CUDA_VERSION` env (not the tag
+      # name) on every bump — the "plain tag = safe" assumption already
+      # inverted once and will again once the fleet's driver is upgraded past
+      # 550, or once LMCache moves the `-cu129` tag itself. Same class of trap
+      # as llama.cpp's `server-cuda13`.
       #
       # ⚠️ vLLM↔LMCache compatibility is pinned by this image — test before bumping.
       image:
         repository: lmcache/vllm-openai
-        tag: v0.5.2
+        tag: v0.5.2-cu129
         pullPolicy: IfNotPresent
       healthPath: /health
       # vLLM's own OpenAI server reads the Bearer from the environment.


### PR DESCRIPTION
## Summary
- Fixes the fleet's shared `vllm` engine image (`defaults.engines.vllm.image.tag`): `v0.5.2` (plain) → `v0.5.2-cu129`. The plain tag is CUDA 13.0.1 — a major-version bump past the fleet's driver (550.163.01, CUDA 12.4 max) — and crash-loops any vLLM model at engine start. `-cu129` (CUDA 12.9, still within the 12.x family) is what actually initializes on this hardware.

## Intent
Source of truth: live crash-loop on `qwen3-vl-4b-thinking-main` right after #807 synced — `RuntimeError: The NVIDIA driver on your system is too old (found version 12040)`. This is a fleet-wide defect in the shared engine image, not specific to that model: `qwen3-8b-fast` uses the same pinned tag and was disabled before ever being measured, so this is likely the first real exercise of the `vllm` engine on this hardware.

The chart's existing comment said the opposite (`use the plain tag, NOT -cu129`) — that was true when written, but LMCache has since moved their plain/`latest` tag from CUDA 12.x to CUDA 13.x. Confirmed via the Docker Hub registry API (image config `Env: CUDA_VERSION=13.0.1.012`), not assumed from the tag name.

## Scope
Single field + comment rewrite in `charts/model-serving/values.yaml` (`defaults.engines.vllm.image.tag`). No template changes. Affects every current and future model using the `vllm` engine profile (only `qwen3-vl-4b-thinking` is currently enabled).

## Verification
- Pulled both tags' image config via the Docker Hub registry v2 API (no local image pull needed) and confirmed `CUDA_VERSION` directly: `v0.5.2` → `13.0.1.012`, `v0.5.2-cu129` → `12.9.0.043`.
- Ran a throwaway pod on `hetzner-k8s-gpu-1` with `lmcache/vllm-openai:v0.5.2-cu129` executing `python3 -c "import torch; torch.cuda.init(); print(...)"` under the real `nvidia` RuntimeClass — succeeded: `CUDA_OK 2.11.0+cu129 12.9 NVIDIA RTX 4000 SFF Ada Generation`. Pod deleted after the check.
- `helm lint charts/model-serving/` — 0 chart(s) failed
- `helm template x charts/model-serving/ --dry-run` — confirmed `tag: "v0.5.2-cu129"` renders.
- Not yet verified that `qwen3-vl-4b-thinking-main` itself reaches Ready with this image — that's the next live step post-merge.

## Screenshots/Evidence
```
$ kubectl -n inference logs qwen3-vl-4b-thinking-main-... (crash, before this fix)
RuntimeError: The NVIDIA driver on your system is too old (found version 12040). ...

$ kubectl -n inference logs cuda-probe-cu129 (verification pod, this fix's candidate)
CUDA_OK 2.11.0+cu129 12.9 NVIDIA RTX 4000 SFF Ada Generation
```

## Risk Assessment
Low-medium. This changes a shared engine default, but only one model currently uses it (unfederated, no user traffic). The empirical verification (actually running torch.cuda.init() on the target hardware) is exactly the load-gate discipline this repo already requires before trusting a CUDA/driver pairing — this isn't a guess.

## AI Usage Declaration
- [x] AI (Claude Code) diagnosed the crash from live pod logs, pulled image manifests/configs via the registry API to get ground truth (not tag-name assumptions), and empirically verified the fix with a real pod on the target GPU node before writing any config.
- [x] A human (via chat) explicitly asked for empirical investigation over trial-and-error guessing, given this exact class of mistake cost real time previously in this repo.
- [x] `helm lint` + `helm template --dry-run` were run and their output inspected.
- [x] No secrets or federation changes.

## Reviewer Focus
This corrects the chart's own prior guidance, which was correct when written but has since inverted as the upstream image's tagging drifted — worth a second pair of eyes given it affects a shared engine profile, and worth re-verifying with the same registry-API technique before the next bump (documented in the updated comment).
