### PR TITLE
fix(model-serving): qwen3-vl-4b-thinking's contextSize did not fit its own VRAM budget

### DIFF
--- a/charts/model-serving/values.yaml
+++ b/charts/model-serving/values.yaml
@@ -554,11 +554,12 @@ models:
    # ⚠️ `gpuMemoryUtilization: 0.60` is a deliberate ceiling, not vLLM's 0.90
    # fleet default: this model is going on a shared 20 GiB card and the budget
    # for it is 60% (~12 GiB) for weights + KV cache, leaving the rest for
-   # overhead and whatever runs alongside it. At ~8.9 GB of BF16 weights that
-   # leaves ~3 GiB of KV cache in-budget — likely tight for a VISION model
-   # (image tokens are expensive), so `contextSize`/`parallel` below are
-   # deliberately conservative starting points, to be tuned at the load gate
-   # rather than assumed.
+   # overhead and whatever runs alongside it. MEASURED live: 8.6 GiB of that
+   # goes to weights (matches the ~8.9 GB on-disk estimate), leaving only
+   # ~1.14 GiB of actual usable KV-cache memory after CUDA context/activation/
+   # vision-encoder-cache overhead — vLLM's own admission check rejected the
+   # first `contextSize` attempt (32768) outright. See `serving.contextSize`
+   # below for the corrected, measured number.
    #
    # ⚠️ The "Thinking" variant reasons by default and vLLM emits the trace as
    # raw `<think>` tags in `content` unless a reasoning parser is set — hence
@@ -599,7 +600,21 @@ models:
        seedMaxWorkers: 2
        seedMemoryLimit: 10Gi
      serving:
-       contextSize: 32768
+       # ⚠️ CORRECTED 2026-07-29, live: 32768 didn't fit. vLLM's own KV-cache
+       # admission check rejected it at boot:
+       #     To serve at least one request with the models's max seq len
+       #     (32768), (4.5 GiB KV cache is needed, which is larger than the
+       #     available KV cache memory (1.14 GiB). ... the estimated maximum
+       #     model length is 8288.
+       # Weights loaded exactly as predicted (8.6 GiB), but at the deliberate
+       # `gpuMemoryUtilization: 0.60` ceiling there's only ~1.14 GiB left for
+       # KV cache once CUDA context, activation buffers and the vision encoder
+       # cache are accounted for — nowhere near enough for a full 32768-token
+       # sequence. 8192 is comfortably under vLLM's own reported ceiling
+       # (8288) and keeps this within the 60% VRAM budget rather than relaxing
+       # it — raising `gpuMemoryUtilization` instead was the other option
+       # vLLM suggested, deliberately not taken here.
+       contextSize: 8192
        parallel: 2
        dtype: bfloat16
        toolCallParser: hermes


### PR DESCRIPTION
## Summary
- Lowers `qwen3-vl-4b-thinking`'s `serving.contextSize` from 32768 to 8192, fixing a KV-cache admission failure at engine boot observed live after #809 synced.

## Intent
Source of truth: live boot log. This time the engine got much further than any prior attempt — weights loaded correctly (8.6GiB, matching the ~8.9GB on-disk estimate), architecture resolved, FlashAttention active — and failed only at vLLM's own KV-cache admission check: `estimated maximum model length is 8288` against the requested 32768. This is exactly the tension flagged as a risk when the catalog entry was first drafted (`gpuMemoryUtilization: 0.60` leaves little room for a vision model's KV cache) — this is that tuning, done from a measured error.

## Scope
Single field: `serving.contextSize` on the existing `qwen3-vl-4b-thinking` entry, plus updated comments reflecting the measured numbers. No template changes. Deliberately does NOT raise `gpuMemoryUtilization` past 0.60 — vLLM's error offered that as the alternative fix, but the 60% VRAM ceiling was an explicit policy, not a default to relax.

## Verification
- `helm lint charts/model-serving/` — 0 chart(s) failed
- `helm template x charts/model-serving/ --dry-run` — confirmed `--max-model-len 8192` renders.
- Not yet re-verified against the live Deployment — next step post-merge.

## Screenshots/Evidence
```
$ kubectl -n inference logs qwen3-vl-4b-thinking-main-... (crash, before this fix)
INFO ... gpu_model_runner.py:4917] Model loading took 8.6 GiB memory and 2.255171 seconds
...
ValueError: To serve at least one request with the models's max seq len (32768),
(4.5 GiB KV cache is needed, which is larger than the available KV cache memory
(1.14 GiB). ... the estimated maximum model length is 8288.
```

## Risk Assessment
Low. Only affects this one model's own serving parameters — no shared engine/image changes this time, no federation, no user traffic.

## AI Usage Declaration
- [x] AI (Claude Code) diagnosed the exact KV-cache shortfall from the live boot log (vLLM's own numbers, not a guess) and picked a contextSize under its reported ceiling.
- [x] A human (via chat) merged the prior two fixes and asked to keep chasing this to a working pod, which is what surfaced this measurement.
- [x] `helm lint` + `helm template --dry-run` were run and their output inspected.
- [x] No secrets, federation, or shared-engine-default changes.

## Reviewer Focus
This is the fourth PR against this one model's rollout (catalog entry, seed OOM, PVC size, two CUDA image fixes, now this) — each driven by a real, sequential failure on the actual hardware, not speculation. Worth confirming 8192 is an acceptable context window for the intended use case, since it's well under this model's native 256K.
