### PR TITLE
feat(ai-models): federate qwen3-vl-4b-thinking -- load-gated, measured

### DIFF
--- a/charts/ai-models/values.yaml
+++ b/charts/ai-models/values.yaml
@@ -524,6 +524,32 @@ backends:
   # with charts/model-serving/values.yaml (check-model-catalogs.sh).
   # ─────────────────────────────────────────────────────────────────────────
 
+  # Qwen3-VL-4B-Thinking — the fleet's first VISION-LANGUAGE backend (ADR-0094
+  # orchestrator, no KServe/Caddy sidecar — vLLM's own OpenAI server handles
+  # `image_url` content parts natively). `prefix: /v1` is vLLM's own OpenAI
+  # server, same as the other vLLM fleet backends. Same `vllm_local_api_key`
+  # ssegning-aws property every other local vLLM backend uses.
+  #
+  # ⚠️ LOAD-GATED 2026-07-29: sent a real image (a generated PNG, blue square /
+  # red circle) through /v1/chat/completions and read the actual response —
+  # "The image features a blue square with a red circle inside it." — correct,
+  # not just HTTP 200. Peak VRAM 10405 / 20475 MiB (~51%, under the 60%
+  # budget). Reasoning landed in the separate `reasoning_content`/`reasoning`
+  # field, not leaking `<think>` tags into `content`.
+  qwen3-vl-4b-thinking-local:
+    schema: OpenAI
+    prefix: "/v1"
+    fqdn:
+      hostname: qwen3-vl-4b-thinking.inference.svc.cluster.local
+      port: 8080
+    securityType: APIKey
+    resourceName: qwen3-vl-4b-thinking-local-svc
+    secretRef:
+      name: qwen3-vl-4b-thinking-api-key
+    externalSecret:
+      key: ai/camer/digital/prod/env
+      property: vllm_local_api_key
+
 # Models — each entry becomes one child Application using the `ai-model`
 # leaf chart. Setting `enabled: false` on a model skips its Application
 # (the AppSet controller will delete a previously-generated child).
@@ -630,6 +656,52 @@ models:
         ref: qwen3-8b-fast-local
         priority: 0
         modelNameOverride: "qwen3-8b-fast"   # = --served-model-name
+
+  # ─────────────────────────────────────────────────────────────────────────
+  # Qwen3-VL-4B-Thinking — VISION-LANGUAGE, on the second GPU fleet card.
+  #
+  # First multimodal model on the new orchestrator (ADR-0094) — accepts
+  # `image_url` content parts alongside text in `/v1/chat/completions`, same
+  # shape every other chat model here uses (no separate endpoint, unlike
+  # Z-Image-Turbo's `/v1/images/generations`).
+  #
+  # Reasons by default ("Thinking" variant) — the reasoning trace arrives in
+  # `reasoning_content`/`reasoning`, not inline in `content` (verified at the
+  # load gate). `contextLength: 8192` is what actually fits this model's VRAM
+  # budget on this card (see charts/model-serving/values.yaml for the KV-cache
+  # math) — well under the model's native 256K, and a real constraint, not a
+  # rounding choice.
+  #
+  # ⚠️ PRICING IS PROVISIONAL. Derived from exactly ONE load-gate request
+  # (96 completion tokens incl. reasoning in 3.564s ⇒ ~26.9 tok/s blended
+  # prefill+decode — not a dedicated throughput benchmark), using the same
+  # method as qwen3-8b-fast-local: €0.2968/h (ADR-0104) ÷ (tok/s × 3600) ×
+  # 3.45 duty-cycle uplift, split 1 : 0.15 : 0.03 output/input/cached per
+  # ADR-0028. Re-derive from a proper multi-run benchmark before trusting this
+  # for real cost recovery — this is an honest ceiling from one data point,
+  # not a settled number.
+  qwen3-vl-4b-thinking-local:
+    enabled: true
+    kind: text
+    minBackends: 1                   # one GPU, one backend, by design
+    timeout:
+      requestTimeout: 600s
+      connectionIdleTimeout: 1h
+    info:
+      displayName: "Qwen3-VL-4B-Thinking (self-hosted, vision-language)"
+      contextLength: 8192
+      maxOutputTokens: 4096
+    pricing:
+      strategy: weighted
+      standard:
+        inputPer1M: 1.72
+        cachedInputPer1M: 0.34
+        outputPer1M: 11.44
+    backends:
+      qwen3-vl-4b-thinking-local:
+        ref: qwen3-vl-4b-thinking-local
+        priority: 0
+        modelNameOverride: "qwen3-vl-4b-thinking"   # = --served-model-name
 
   # ─────────────────────────────────────────────────────────────────────────
   # Z-Image-Turbo — IMAGE GENERATION, on the GPU fleet (ADR-0100).


### PR DESCRIPTION
## Summary
- Federates `qwen3-vl-4b-thinking` into `charts/ai-models/values.yaml` — a cluster-local backend (`qwen3-vl-4b-thinking-local`, ClusterIP, `prefix: /v1`) and the model entry, following the existing `qwen3-8b-fast-local` shape exactly.
- This wires the model into Envoy AI Gateway for the first time — until this PR it was running on the GPU (#805-#810) but had zero presence in EAIG (no route, no backend, no routable id).

## Intent
Per ADR-0101 ("the load gate has no exceptions"), federating only because the model has actually been measured on this hardware:
- Sent a real image (generated PNG: blue square, red circle) through `/v1/chat/completions`, read the actual response: *"The image features a blue square with a red circle inside it."* — correct.
- Reasoning landed in the separate `reasoning`/`reasoning_content` field, not leaking `<think>` tags into `content`.
- Peak VRAM: 10405 / 20475 MiB (~51%), under the 60% budget this deployment was scoped to.

## Scope
Single file: `charts/ai-models/values.yaml` — one new `backends:` entry, one new `models:` entry. No template changes, no other model's config touched.

## Verification
- `helm lint charts/ai-models/` — 0 chart(s) failed
- `helm template x charts/ai-models/ --dry-run` — the new backend/model render correctly and the model gets its own child Application (`x-qwen3-vl-4b-thinking-local`).
- `sh tools/check-model-catalogs.sh` — `check-model-catalogs: OK (1 served on the GPU fleet, 1 federated cluster-local)`.
- Live load gate (port-forward + real request), evidence below.

## Screenshots/Evidence
```
$ curl .../v1/chat/completions (image_url content part, generated test PNG)
"content": "\n\nThe image features a blue square with a red circle inside it."

$ kubectl exec <pod> -- nvidia-smi --query-gpu=memory.used,memory.total --format=csv
10405 MiB, 20475 MiB
```

## Risk Assessment
Low-medium — this is the first time a request can reach this model through the real gateway path (JWT auth, rate limiting, `x-account-id` budget tracking), which hasn't been exercised yet (only a direct port-forward was tested). Pricing is explicitly flagged provisional (one data point, not a benchmark) so it doesn't misrepresent cost recovery as settled.

## AI Usage Declaration
- [x] AI (Claude Code) ran the load gate (port-forward, real image request, VRAM check) and authored this federation entry from the actual results.
- [x] A human (via chat) explicitly asked to wire this into EAIG after reviewing the load-gate proposal.
- [x] `helm lint` + `helm template --dry-run` + `tools/check-model-catalogs.sh` were run and their output inspected.
- [x] No secrets were created directly — `secretRef`/`externalSecret` reuse the existing, already-proven `vllm_local_api_key` property.

## Reviewer Focus
- Pricing is provisional by design — flag if that's not acceptable to merge as-is versus blocking on a proper benchmark first.
- Not yet exercised through the actual gateway (JWT/rate-limit path) — only a direct port-forward. Worth a real end-to-end request through `api.ai.camer.digital` post-merge.
- Unrelated but adjacent: while editing this file I noticed `z-image-turbo-local` (a separate, already-disabled-elsewhere model) is still `enabled: true` here and points at a legacy public-edge backend from the #790 regression — not touched in this PR, already tracked as a separate follow-up.
