### PR TITLE
feat(ai-models): add adorsys-tiny -- free (zsh) alias for qwen3-vl-4b-thinking

### DIFF
--- a/charts/ai-models/values.yaml
+++ b/charts/ai-models/values.yaml
@@ -1722,7 +1722,9 @@ models:
   # pattern as `adorsys-planner` / `-pro`. The opencode role subagents
   # (charts/librechat-opencode-wellknown, ADR-0044) reference THESE brands,
   # never the raw model ids, so a backing swap is invisible to users.
-  # (Backings deliberately avoid qwen3-local and gemma-4 per maintainer pref.)
+  # (Backings avoided qwen3-local and gemma-4 per maintainer pref, until
+  # adorsys-tiny below — 2026-07-29, once self-hosted vision-language was
+  # load-gated and measured on the GPU fleet.)
   adorsys-researcher:
     kind: text
     # Backing: DeepInfra · deepseek-ai/DeepSeek-V4-Flash (cheap/fast research).
@@ -1899,3 +1901,36 @@ models:
       deepinfra-02:
         <<: *deepinfraBackendSecondary
         modelNameOverride: "moonshotai/Kimi-K2.7-Code"
+
+  # adorsys-tiny — the first "Adorsys" alias backed by the GPU FLEET rather
+  # than a SaaS provider, breaking the prior "avoid qwen3-local" preference
+  # noted above (deliberate, 2026-07-29 — self-hosted vision-language is now
+  # load-gated and measured, see qwen3-vl-4b-thinking-local above).
+  #
+  # Backing: self-hosted Qwen3-VL-4B-Thinking on hetzner-k8s-gpu-1. Same alias
+  # mechanism as every other adorsys-* brand: a stable id over a swappable
+  # backing, here pointing at the SAME backend ref `qwen3-vl-4b-thinking-local`
+  # rather than a second Backend/route — one physical model, two gateway ids.
+  #
+  # Price: $0 — owned hardware, no cost-recovery pricing applied (explicit
+  # choice, not ADR-0028's usual cost-recovery default). Per-plan burst
+  # req/min + tokens/min limits still apply; there is simply no per-token
+  # charge or monthly-budget deduction for this id.
+  adorsys-tiny:
+    kind: multimodal
+    info:
+      displayName: "Adorsys Tiny (Qwen3-VL-4B-Thinking, self-hosted)"
+      contextLength: 8192
+      maxOutputTokens: 4096
+      supportedParameters: *spReasoning
+    pricing:
+      strategy: weighted
+      standard:
+        inputPer1M: 0
+        cachedInputPer1M: 0
+        outputPer1M: 0
+    backends:
+      qwen3-vl-4b-thinking-local:
+        ref: qwen3-vl-4b-thinking-local
+        priority: 0
+        modelNameOverride: "qwen3-vl-4b-thinking"   # = --served-model-name


### PR DESCRIPTION
## Summary
- Adds `adorsys-tiny` to `charts/ai-models/values.yaml` — a $0-priced "Adorsys" brand alias for the self-hosted `qwen3-vl-4b-thinking-local` model, the first such alias backed by the GPU fleet rather than a SaaS provider.

## Intent
Requested in chat, following the alias/pricing pattern already established for `adorsys-coder`/`adorsys-researcher`/etc: a stable, user-facing id (`adorsys-tiny`) whose backing model can change later without changing the id users select. Points at the SAME backend ref as `qwen3-vl-4b-thinking-local` (one physical model, two gateway ids) rather than creating a second Backend/route.

## Scope
Single file, one new `models:` entry in `charts/ai-models/values.yaml`, plus a comment update noting the change to the alias section's prior "avoid qwen3-local/gemma-4" preference. No template changes, no changes to the underlying `qwen3-vl-4b-thinking-local` model or its backend.

## Verification
- `helm lint charts/ai-models/` — 0 chart(s) failed
- `helm template x charts/ai-models/ --dry-run` — confirmed the alias renders as its own child (`x-adorsys-tiny`) with `modelName: adorsys-tiny`, backend ref `qwen3-vl-4b-thinking-local`.
- `sh tools/check-model-catalogs.sh` — still reports "1 served on the GPU fleet, 1 federated cluster-local" (correctly treats this as an alias sharing the existing backend, not a second independent federation).

## Screenshots/Evidence
N/A — Helm values change; render output quoted above.

## Risk Assessment
Low. No new Backend/AIGatewayRoute infrastructure — this reuses the already-load-gated `qwen3-vl-4b-thinking-local` backend. Pricing is explicitly $0 by design (owned hardware), not a placeholder.

## AI Usage Declaration
- [x] AI (Claude Code) authored this entry following the exact existing `adorsys-*` alias pattern, verified via render + the catalog-consistency guard script.
- [x] A human (via chat) explicitly requested this alias, its name, and the $0 price.
- [x] `helm lint` + `helm template --dry-run` + `tools/check-model-catalogs.sh` were run and their output inspected.
- [x] No secrets, no new backend/route infrastructure.

## Reviewer Focus
Companion change in the private `ai-helm-values` repo (PR #160) adds this id to LibreChat's model list and bumps the config-rollout generation counter — both need to land for the alias to actually be user-reachable end to end.
