### PR TITLE
fix(ai-models): adorsys-tiny needs minBackends: 1

### DIFF
--- a/charts/ai-models/values.yaml
+++ b/charts/ai-models/values.yaml
@@ -1918,6 +1918,7 @@ models:
   # charge or monthly-budget deduction for this id.
   adorsys-tiny:
     kind: multimodal
+    minBackends: 1                   # one GPU, one backend, by design
     info:
       displayName: "Adorsys Tiny (Qwen3-VL-4B-Thinking, self-hosted)"
       contextLength: 8192


### PR DESCRIPTION
## Summary
Fixes a live ArgoCD ComparisonError on the \`models-adorsys-tiny\` child Application: the leaf \`ai-model\` chart requires \`minBackends: 1\` be set explicitly for any single-backend model, and #812 missed it.

## Verification
- Extracted the leaf chart's value contract from \`charts/ai-model/ci/lint-values.yaml\` and rendered \`charts/ai-model\` directly against a fixture matching adorsys-tiny's real shape (with the fix) -- renders clean. Previously only the orchestrator was rendered locally, which doesn't exercise this leaf-chart fail-guard.
- \`helm lint charts/ai-models/\` -- 0 failed
- \`tools/check-model-catalogs.sh\` -- OK

## Risk
Low -- one-field fix, matches the exact pattern every other single-GPU-backed model already uses.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>