### PR TITLE
feat(lightbridge): add /api/v2 to CONTROL_PLANE_INTERNAL_URL and AUTH_BACKEND_URL

### DIFF
--- a/charts/lightbridge-code-intelligence/values.yaml
+++ b/charts/lightbridge-code-intelligence/values.yaml
@@ -379,7 +379,7 @@ lci:
             pullPolicy: IfNotPresent
           env:
             BIND_ADDR: "0.0.0.0:8080"
-            RUST_LOG: "info"
+            RUST_LOG: "info,opentelemetry_sdk=debug,opentelemetry_otlp=debug,reqwest=debug"
             # File config (ADR-0021): read control-plane.json from the mounted ConfigMap (review
             # labels/reactions + the embedding-dimension guard). Absent the file the binary uses env.
             CONTROL_PLANE_CONFIG: "/etc/lightbridge/control-plane.json"
@@ -678,7 +678,7 @@ lci:
             pullPolicy: IfNotPresent
           env:
             CONTROL_PLANE_ROLE: "dispatcher"
-            RUST_LOG: "info"
+            RUST_LOG: "info,opentelemetry_sdk=debug,opentelemetry_otlp=debug,reqwest=debug"
             METRICS_ADDR: "0.0.0.0:9090"
             # File config (ADR-0021): control-plane.json drives the runner Job resources + dispatcher
             # tuning; the binary falls back to the AGENT_*/defaults below when a field is absent.

--- a/charts/lightbridge-code-intelligence/values.yaml
+++ b/charts/lightbridge-code-intelligence/values.yaml
@@ -532,7 +532,7 @@ lci:
             # the OIDC web image is live — see chart bump notes): the chart config (Source A, ai-helm
             # release) and the image tag (Source B, image-updater) sync independently, so this chart must
             # work with BOTH the old better-auth image AND the new OIDC image. The new image ignores these.
-            AUTH_BACKEND_URL: "http://{{ .Release.Name }}-control-plane:8080"
+            AUTH_BACKEND_URL: "http://{{ .Release.Name }}-control-plane:8080/api/v2"
             BETTER_AUTH_URL: ""
             BETTER_AUTH_SECRET:
               valueFrom:
@@ -729,7 +729,7 @@ lci:
             # FQDN, not the bare Service name: the runner Jobs run in the lightbridge-agents
             # namespace, so a same-namespace short name would not resolve to the control-plane
             # Service in `converse`.
-            CONTROL_PLANE_INTERNAL_URL: "http://{{ .Release.Name }}-control-plane.{{ .Release.Namespace }}.svc.cluster.local:8080"
+            CONTROL_PLANE_INTERNAL_URL: "http://{{ .Release.Name }}-control-plane.{{ .Release.Namespace }}.svc.cluster.local:8080/api/v2"
           probes:
             liveness:
               enabled: true


### PR DESCRIPTION
Superseded by a clean branch from origin/main — see the new PR.