### PR TITLE
feat(lightbridge): add /api/v2 to CONTROL_PLANE_INTERNAL_URL and AUTH_BACKEND_URL

### DIFF
--- a/charts/lightbridge-code-intelligence/values.yaml
+++ b/charts/lightbridge-code-intelligence/values.yaml
@@ -532,7 +532,7 @@ lci:
             # the OIDC web image is live — see chart bump notes): the chart config (Source A, ai-helm
             # release) and the image tag (Source B, image-updater) sync independently, so this chart must
             # work with BOTH the old better-auth image AND the new OIDC image. The new image ignores these.
-            AUTH_BACKEND_URL: "http://{{ .Release.Name }}-control-plane:8080"
+            AUTH_BACKEND_URL: "http://{{ .Release.Name }}-control-plane:8080/api/v2"
             BETTER_AUTH_URL: ""
             BETTER_AUTH_SECRET:
               valueFrom:
@@ -729,7 +729,7 @@ lci:
             # FQDN, not the bare Service name: the runner Jobs run in the lightbridge-agents
             # namespace, so a same-namespace short name would not resolve to the control-plane
             # Service in `converse`.
-            CONTROL_PLANE_INTERNAL_URL: "http://{{ .Release.Name }}-control-plane.{{ .Release.Namespace }}.svc.cluster.local:8080"
+            CONTROL_PLANE_INTERNAL_URL: "http://{{ .Release.Name }}-control-plane.{{ .Release.Namespace }}.svc.cluster.local:8080/api/v2"
           probes:
             liveness:
               enabled: true


### PR DESCRIPTION
## 1. Summary

Adds `/api/v2` to `AUTH_BACKEND_URL` and `CONTROL_PLANE_INTERNAL_URL` in the chart's default values.

After [lightbridge-code-intelligence#534](https://github.com/vymalo/lightbridge-code-intelligence/pull/534), the `ControlPlaneClient` (Rust — used by agent-runner, review-agent, open-agent, review-mcp) and `ApiClient` (lci CLI) no longer append `/api/v2` automatically. The env var must carry the full versioned base URL. Similarly, `apps/web` reads `AUTH_BACKEND_URL` via `controlPlaneUrl()` which uses the value as-is (no automatic append).

Changes — one file, two lines:
- `AUTH_BACKEND_URL`: `…:8080` → `…:8080/api/v2`
- `CONTROL_PLANE_INTERNAL_URL`: `…:8080` → `…:8080/api/v2`

It solves:

- Companion to [lightbridge-code-intelligence#534](https://github.com/vymalo/lightbridge-code-intelligence/pull/534) (story #506, Epic #492)

---

## 2. Verification

- [x] Diff reviewed — 1 file, 2 lines changed, nothing else.

**Deploy order:** merge and deploy `lightbridge-code-intelligence#534` first, then merge and deploy this PR.

---

## 3. Risk Assessment

* [x] Low — URL value change only; the chart image is unchanged.

If deployed before `lightbridge-code-intelligence#534`, the agent-runner and web app would 404 on every control-plane call. Deploy order matters.

---

## 4. AI Usage Declaration

AI was used for:
* [x] Understanding existing code
* [x] Generating code

Human verification:
* [x] I understand every meaningful change in this PR
* [x] I accept responsibility for this PR