### PR TITLE
feat(webank-training): deploy governed GPU workflow

### DIFF
--- a/charts/apps/values.yaml
+++ b/charts/apps/values.yaml
@@ -1432,6 +1432,21 @@ applications:
     destination:
       namespace: mlops
 
+  # --- Webank governed GPU training (webank-models ADR-0034 / ADR-0035) ---
+  # A plain workload Application, not an orchestrator: it installs only the
+  # namespaced WorkflowTemplate. Human submission remains the sole trigger;
+  # the template gates its pinned LakeFS ref and readiness attestation before
+  # requesting one RTX 4000 Ada GPU. Deployment values and the app-scoped
+  # MLflow automation ExternalSecret live in ai-helm-values.
+  - name: webank-training
+    finalizers:
+      - resources-finalizer.argocd.argoproj.io
+    chart: webank-training
+    releaseName: webank-training
+    depsOverlay: environments/prod/deps/webank-training
+    destination:
+      namespace: mlops
+
 extraObjects:
   # ==========================================
   # Upstream namespace quotas & limit ranges

--- a/charts/webank-training/Chart.lock
+++ b/charts/webank-training/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: common
+  repository: file://../common
+  version: 2.31.4
+digest: sha256:46d002d093772b66f3f18b9a60c8ee0e3dcf268a5b03855d7525c003f990f255
+generated: "2026-07-30T13:33:46.086481+02:00"

--- a/charts/webank-training/Chart.yaml
+++ b/charts/webank-training/Chart.yaml
@@ -1,0 +1,25 @@
+apiVersion: v2
+name: webank-training
+description: >-
+  Governed, human-submitted Webank GPU training WorkflowTemplate for the shared
+  MLOps platform. It gates every run on a pinned LakeFS commit and readiness
+  attestation before scheduling the sole GPU task.
+type: application
+version: 0.1.0
+appVersion: "1.1.2"
+keywords:
+  - webank
+  - training
+  - argo-workflows
+  - mlops
+maintainers:
+  - name: ai-helm
+annotations:
+  ai-helm.adorsys-gis.github.io/lint-mode: ci-values
+dependencies:
+  - name: common
+    version: '*'
+    repository: "file://../common"
+    tags:
+      - common
+      - bitnami-common

--- a/charts/webank-training/ci/lint-values.yaml
+++ b/charts/webank-training/ci/lint-values.yaml
@@ -1,0 +1,18 @@
+workflow:
+  serviceAccountName: argo-workflow
+training:
+  image: ghcr.io/adorsys-gis/webank-train-gpu@sha256:c1774729a3bf86c1a1cd231a3d06293bf35c950bfec061726e4aa42ea24cf0e7
+  lakefs:
+    endpoint: http://lakefs.mlops.svc.cluster.local:80
+  mlflow:
+    trackingUri: http://mlflow.mlops.svc.cluster.local:80
+    tokenUrl: https://auth.example.invalid/realms/example/protocol/openid-connect/token
+  otel:
+    endpoint: http://alloy.observability.svc.cluster.local:4318
+  gpu:
+    nodeSelector: { role: gpu }
+    tolerations:
+      - key: role
+        operator: Equal
+        value: gpu
+        effect: NoSchedule

--- a/charts/webank-training/templates/workflowtemplate.yaml
+++ b/charts/webank-training/templates/workflowtemplate.yaml
@@ -1,0 +1,156 @@
+{{- $workflow := .Values.workflow -}}
+{{- $training := .Values.training -}}
+{{- $lakefs := $training.lakefs -}}
+{{- $mlflow := $training.mlflow -}}
+{{- if not $training.image }}{{ fail "webank-training: training.image must be an immutable image digest" }}{{- end }}
+{{- if not (contains "@sha256:" $training.image) }}{{ fail "webank-training: training.image must be digest-pinned" }}{{- end }}
+{{- if not $lakefs.endpoint }}{{ fail "webank-training: training.lakefs.endpoint is required" }}{{- end }}
+{{- if not $mlflow.trackingUri }}{{ fail "webank-training: training.mlflow.trackingUri is required" }}{{- end }}
+{{- if not $mlflow.tokenUrl }}{{ fail "webank-training: training.mlflow.tokenUrl is required" }}{{- end }}
+{{- if not $training.otel.endpoint }}{{ fail "webank-training: training.otel.endpoint is required" }}{{- end }}
+{{- if not $workflow.serviceAccountName }}{{ fail "webank-training: workflow.serviceAccountName is required" }}{{- end }}
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: {{ $workflow.name | quote }}
+  labels:
+    {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/part-of: webank-models
+    app.kubernetes.io/component: training-orchestration
+  annotations:
+    webank.io/adr: "0034"
+    webank.io/observability-adr: "0035"
+spec:
+  entrypoint: train
+  activeDeadlineSeconds: {{ $workflow.activeDeadlineSeconds }}
+  ttlStrategy:
+    secondsAfterCompletion: {{ $workflow.ttlSecondsAfterCompletion }}
+  serviceAccountName: {{ $workflow.serviceAccountName | quote }}
+  {{- with $workflow.imagePullSecrets }}
+  imagePullSecrets:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  arguments:
+    parameters:
+      - name: model
+      - name: lakefs_ref
+      - name: run_name
+      - name: readiness_manifest
+      - name: readiness_attestation
+      - name: training_command
+      - name: output_path
+      - name: training_image
+        value: {{ $training.image | quote }}
+  templates:
+    - name: train
+      dag:
+        tasks:
+          - name: validate-lakefs-ref
+            template: validate-lakefs-ref
+          - name: readiness-gate
+            dependencies: [validate-lakefs-ref]
+            template: readiness-gate
+          - name: gpu-train
+            dependencies: [readiness-gate]
+            template: gpu-train
+          - name: push-candidate
+            dependencies: [gpu-train]
+            template: push-candidate
+
+    - name: validate-lakefs-ref
+      container:
+        image: "{{`{{workflow.parameters.training_image}}`}}"
+        command: ["sh", "-c"]
+        args:
+          - |
+            case "$LAKEFS_REF" in
+              [0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]) exit 0 ;;
+              *) echo "lakefs_ref must be a pinned 64-character lowercase-hex commit id" >&2; exit 1 ;;
+            esac
+        env:
+          - name: LAKEFS_REF
+            value: "{{`{{workflow.parameters.lakefs_ref}}`}}"
+          - name: TRAINING_RUN_ID
+            value: "{{`{{workflow.parameters.run_name}}`}}"
+          - name: OTEL_EXPORTER_OTLP_ENDPOINT
+            value: {{ $training.otel.endpoint | quote }}
+          - name: OTEL_SERVICE_NAME
+            value: webank-training-validate-lakefs-ref
+        resources:
+          requests: { cpu: 100m, memory: 64Mi }
+          limits: { cpu: 200m, memory: 128Mi }
+
+    - name: readiness-gate
+      container:
+        image: "{{`{{workflow.parameters.training_image}}`}}"
+        command: ["cargo"]
+        args: [xtask, training-data, readiness-gate, --manifest, "{{`{{workflow.parameters.readiness_manifest}}`}}", --lakefs-ref, "{{`{{workflow.parameters.lakefs_ref}}`}}", --readiness, "{{`{{workflow.parameters.readiness_attestation}}`}}"]
+        env:
+          - name: TRAINING_RUN_ID
+            value: "{{`{{workflow.parameters.run_name}}`}}"
+          - name: OTEL_EXPORTER_OTLP_ENDPOINT
+            value: {{ $training.otel.endpoint | quote }}
+          - name: OTEL_SERVICE_NAME
+            value: webank-training-readiness-gate
+        resources:
+          requests: { cpu: 250m, memory: 256Mi }
+          limits: { cpu: 500m, memory: 512Mi }
+
+    - name: gpu-train
+      nodeSelector:
+        {{- toYaml $training.gpu.nodeSelector | nindent 8 }}
+      {{- with $training.gpu.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      container:
+        image: "{{`{{workflow.parameters.training_image}}`}}"
+        command: ["sh", "-c"]
+        args: ["{{`{{workflow.parameters.training_command}}`}}"]
+        env:
+          - name: TRAINING_RUN_ID
+            value: "{{`{{workflow.parameters.run_name}}`}}"
+          - name: WEBANK_LAKEFS_REF
+            value: "{{`{{workflow.parameters.lakefs_ref}}`}}"
+          - name: LAKEFS_ENDPOINT
+            value: {{ $lakefs.endpoint | quote }}
+          - name: LAKEFS_ACCESS_KEY_ID
+            valueFrom: { secretKeyRef: { name: {{ $lakefs.secretName | quote }}, key: {{ $lakefs.accessKey | quote }} } }
+          - name: LAKEFS_SECRET_ACCESS_KEY
+            valueFrom: { secretKeyRef: { name: {{ $lakefs.secretName | quote }}, key: {{ $lakefs.secretKey | quote }} } }
+          - name: MLFLOW_TRACKING_URI
+            value: {{ $mlflow.trackingUri | quote }}
+          - name: MLFLOW_TOKEN_URL
+            value: {{ $mlflow.tokenUrl | quote }}
+          - name: MLFLOW_AUTOMATION_CLIENT_ID
+            value: {{ $mlflow.clientId | quote }}
+          - name: MLFLOW_AUTOMATION_CLIENT_SECRET
+            valueFrom: { secretKeyRef: { name: {{ $mlflow.secretName | quote }}, key: {{ $mlflow.clientSecretKey | quote }} } }
+          - name: OTEL_EXPORTER_OTLP_ENDPOINT
+            value: {{ $training.otel.endpoint | quote }}
+          - name: OTEL_SERVICE_NAME
+            value: "webank-training-{{`{{workflow.parameters.model}}`}}"
+        resources:
+          {{- toYaml $training.gpu.resources | nindent 10 }}
+
+    - name: push-candidate
+      container:
+        image: "{{`{{workflow.parameters.training_image}}`}}"
+        command: ["cargo"]
+        args: [xtask, training-data, push, --destination, training-data-lake, --path, "{{`{{workflow.parameters.output_path}}`}}", --manifest, "{{`{{workflow.parameters.readiness_manifest}}`}}", --lakefs-ref, "{{`{{workflow.parameters.lakefs_ref}}`}}", --readiness, "{{`{{workflow.parameters.readiness_attestation}}`}}"]
+        env:
+          - name: TRAINING_RUN_ID
+            value: "{{`{{workflow.parameters.run_name}}`}}"
+          - name: LAKEFS_ENDPOINT
+            value: {{ $lakefs.endpoint | quote }}
+          - name: LAKEFS_ACCESS_KEY_ID
+            valueFrom: { secretKeyRef: { name: {{ $lakefs.secretName | quote }}, key: {{ $lakefs.accessKey | quote }} } }
+          - name: LAKEFS_SECRET_ACCESS_KEY
+            valueFrom: { secretKeyRef: { name: {{ $lakefs.secretName | quote }}, key: {{ $lakefs.secretKey | quote }} } }
+          - name: OTEL_EXPORTER_OTLP_ENDPOINT
+            value: {{ $training.otel.endpoint | quote }}
+          - name: OTEL_SERVICE_NAME
+            value: webank-training-push-candidate
+        resources:
+          requests: { cpu: 250m, memory: 256Mi }
+          limits: { cpu: 500m, memory: 512Mi }

--- a/charts/webank-training/values.yaml
+++ b/charts/webank-training/values.yaml
@@ -1,0 +1,31 @@
+# Environment-neutral structure for the Webank training WorkflowTemplate.
+# Deployment literals belong in ai-helm-values; this chart fails closed when
+# they are absent, so ArgoCD cannot silently install an unsafe default.
+workflow:
+  name: webank-weak-training-pass
+  activeDeadlineSeconds: 21600
+  ttlSecondsAfterCompletion: 259200
+  serviceAccountName: argo-workflow
+  imagePullSecrets: []
+
+training:
+  image: ""
+  lakefs:
+    endpoint: ""
+    secretName: lakefs-proxy-admin
+    accessKey: access-key-id
+    secretKey: secret-access-key
+  mlflow:
+    trackingUri: ""
+    tokenUrl: ""
+    clientId: mlflow-automation
+    secretName: mlflow-automation
+    clientSecretKey: client-secret
+  otel:
+    endpoint: ""
+  gpu:
+    nodeSelector: {}
+    tolerations: []
+    resources:
+      requests: { cpu: "4", memory: 16Gi }
+      limits: { cpu: "8", memory: 16Gi, nvidia.com/gpu: 1 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -149,6 +149,7 @@ Operational subsystems with several files keep their own directory + local index
 | [`solutions-team/`](./solutions-team/) | Solutions-team runbooks (e.g. graphify setup) |
 | [`mlops-access-model.md`](patterns/mlops-access-model.md) | **MLOps access model** (ADR-0085/0090/0091): who can reach LakeFS / Argo Workflows / MLflow and as what — humans vs in-cluster workloads vs external scripts, the credential inventory, the end-to-end training-job path, and the known limitations |
 | [`mlops-platform-consumer-guide.md`](integrations/mlops-platform-consumer-guide.md) | **Consuming the MLOps platform from another team/repo** (ADR-0085/0090/0091): endpoints, machine auth per app, the training-job recipe, and what to request from the maintainer |
+| [`webank-training-deployment.md`](integrations/webank-training-deployment.md) | **Webank governed training deployment** — the chart-owned Argo WorkflowTemplate, GPU placement, credential boundaries, and candidate-run submission contract |
 
 ---
 

--- a/docs/integrations/README.md
+++ b/docs/integrations/README.md
@@ -17,3 +17,4 @@ other categories.
 | [keycloak-identity-datasource.md](keycloak-identity-datasource.md) | Resolving `user_id` → person, sessions & grants (ADR-0063/0064) |
 | [homepage.md](homepage.md) | Homepage central hub — the `gethomepage.dev/*` discovery-annotation convention for adding new apps (ADR-0089) |
 | [mlops-platform-consumer-guide.md](mlops-platform-consumer-guide.md) | **Using the MLOps platform from another repo/team** — endpoints, how a script or training job authenticates to LakeFS/MLflow/Argo, and the end-to-end training recipe |
+| [webank-training-deployment.md](webank-training-deployment.md) | **Webank governed training deployment** — the Argo WorkflowTemplate, Hetzner RTX 4000 Ada placement, LakeFS/MLflow credential boundaries, and manual submission contract |

--- a/docs/integrations/webank-training-deployment.md
+++ b/docs/integrations/webank-training-deployment.md
@@ -1,0 +1,63 @@
+# Webank governed training deployment
+
+The `webank-training` chart installs a single namespaced Argo
+`WorkflowTemplate`, `webank-weak-training-pass`, in `mlops`. It is the live,
+manual GPU-training route for `ADORSYS-GIS/webank-models` — not a scheduler and
+not a model-serving deployment. It implements Webank
+[ADR-0034](https://github.com/ADORSYS-GIS/webank-models/blob/main/docs/adr/0034-training-job-orchestration-argo-workflows.md)
+and [ADR-0035](https://github.com/ADORSYS-GIS/webank-models/blob/main/docs/adr/0035-training-observability-on-mlflow.md).
+
+## Deployment shape
+
+`charts/apps` creates `aii-webank-training` as a normal OCI Application. Its
+deployment values are read from the private `ai-helm-values` repository and its
+one dependency overlay materialises `mlops/mlflow-automation` from the existing
+AWS Secrets Manager property. This order is intentional: merge the values-repo
+change before the chart Application so `ignoreMissingValueFiles` can never
+install an incomplete template.
+
+The template runs as the existing `argo-workflow` ServiceAccount. That identity
+has Argo executor permissions only; it does not grant data or experiment access.
+The GPU and candidate-push steps receive the minimum extra credentials they
+need:
+
+| Boundary | Mechanism |
+|---|---|
+| LakeFS data plane | Existing `mlops/lakefs-proxy-admin` Secret, mounted only into GPU/push steps; direct in-cluster Service endpoint |
+| MLflow experiment plane | `mlops/mlflow-automation` client secret; the Webank command must exchange it for an `aud=mlflow` bearer token |
+| Operational telemetry | OTLP/HTTP to `alloy.observability.svc.cluster.local:4318` |
+| GPU placement | `role=gpu` selector + `role=gpu:NoSchedule` toleration + exactly `nvidia.com/gpu: 1` |
+
+No credential material is held in either Git repository. The LakeFS key is the
+platform's single root credential and must not be duplicated; the MLflow client
+secret is synchronised by ESO from
+`ai/camer/digital/prod/env#mlflow_automation_client_secret`. The MLflow identity
+`service-account-mlflow-automation` needs `EDIT` on the intended experiment.
+
+## Submitting a candidate run
+
+The chart deliberately creates no `Workflow`, `CronWorkflow`, `EventSource`, or
+`Sensor`. A model owner submits a reviewed run against the template, supplying:
+
+- one of the five model names;
+- a pinned 64-character lowercase-hex LakeFS commit;
+- a governed readiness manifest and attestation;
+- the model-specific `cargo xtask ...` training command; and
+- a candidate output path in the training-data plane.
+
+The DAG is fixed: pinned-ref validation → readiness gate → GPU training →
+candidate push. A failed validation or readiness gate cannot claim a GPU. The
+template defaults to the published immutable training image
+`webank-train-gpu@sha256:c177…`, has a six-hour active deadline, and retains
+completed workflow records for three days.
+
+The template supplies `MLFLOW_TOKEN_URL`, `MLFLOW_AUTOMATION_CLIENT_ID`, and
+`MLFLOW_AUTOMATION_CLIENT_SECRET` to the GPU command but does not put a bearer
+token into a Workflow parameter or status field. The current training image
+does not mint that token itself yet, so this makes the credential boundary
+available without claiming an end-to-end MLflow write. The Webank command must
+exchange the secret at runtime, keep the token in process memory, and never log
+it or write it as an Argo output/artifact.
+
+The source-of-truth request is
+[webank-models#48](https://github.com/ADORSYS-GIS/webank-models/issues/48).


### PR DESCRIPTION
## 1. Summary

This PR changes:

- [x] Adds the `webank-training` chart and ArgoCD Application.
- [x] Renders a manual, gate-first Webank `WorkflowTemplate` in `mlops`.
- [x] Pins the CUDA image and configures the Hetzner GPU, LakeFS, MLflow, and OTLP boundaries.

It solves: [webank-models #48](https://github.com/ADORSYS-GIS/webank-models/issues/48).

## 2. Intent

The intent is to provide the cluster deployment path for webank-models ADR-0034 (manual candidate-only GPU orchestration) and ADR-0035 (MLflow training plane plus OTLP operational telemetry). This chart consumes the deployment values in [ai-helm-values #162](https://github.com/ADORSYS-GIS/ai-helm-values/pull/162), which merged first under the values-repo-first rule.

## 3. Scope

### In Scope

- [x] One namespaced `WorkflowTemplate`, with pinned-ref validation → readiness gate → one-GPU training → candidate push.
- [x] Digest-pinned `webank-train-gpu` image and the existing `role=gpu` scheduling contract.
- [x] Secret references scoped to LakeFS data steps and the MLflow-capable GPU command.

### Out of Scope

- [x] Creating a Workflow, CronWorkflow, Sensor, EventSource, dataset, model artifact, or registry promotion.
- [x] End-to-end MLflow writes: the current training image receives the client secret but does not mint a bearer token yet.

## 4. Verification

I verified this change by:

- [x] Running Helm lint and templates.
- [x] Rendering the real production values from ai-helm-values.
- [x] Rendering the parent ArgoCD Application.
- [x] Checking credential scope and immutable image configuration.

Commands run:

```text
helm dependency build charts/webank-training
helm lint --strict charts/webank-training -f charts/webank-training/ci/lint-values.yaml
helm template webank-training charts/webank-training -n mlops -f ../ai-helm-values-webank-training/environments/prod/values/webank-training.yaml
helm dependency build charts/apps && helm template apps charts/apps --dry-run
```

Results:

```text
Helm lint passed. The rendered WorkflowTemplate preserves Argo parameters, uses the immutable training-image digest, requests nvidia.com/gpu: 1, and references only lakefs-proxy-admin and mlflow-automation. The rendered Application has OCI chart, values, and dependency-overlay sources.
```

## 5. Risk Assessment

Risk level: Medium. Once this OCI chart is published, ArgoCD can reconcile it using the already-merged values. The template fails closed for missing endpoints or a non-digest image. Secrets remain in ESO/AWS Secrets Manager, never Git.

## 6. AI Usage Declaration

AI was used for:

- [x] Understanding existing code and the MLOps access model.
- [x] Generating the chart and deployment documentation.
- [x] Reviewing rendered manifests.

Human verification:

- [x] I understand every meaningful change in this PR.
- [x] I checked generated code and manifests manually.
- [x] I removed unsupported AI assumptions, including any claim that MLflow token minting already exists.
- [x] I accept responsibility for this PR.

## 7. Reviewer Focus

Please focus your review on:

- [x] LakeFS and MLflow credential scoping.
- [x] The values-repo-first deployment ordering.
- [x] GPU placement and gate-first DAG semantics.