### PR TITLE
feat(webank-training): add detector run template

### DIFF
--- a/charts/webank-training/ci/lint-values.yaml
+++ b/charts/webank-training/ci/lint-values.yaml
@@ -4,9 +4,7 @@ training:
   image: ghcr.io/adorsys-gis/webank-train-gpu@sha256:c1774729a3bf86c1a1cd231a3d06293bf35c950bfec061726e4aa42ea24cf0e7
   lakefs:
     endpoint: http://lakefs.mlops.svc.cluster.local:80
-  mlflow:
-    trackingUri: http://mlflow.mlops.svc.cluster.local:80
-    tokenUrl: https://auth.example.invalid/realms/example/protocol/openid-connect/token
+    candidateBranch: candidates
   otel:
     endpoint: http://alloy.observability.svc.cluster.local:4318
   gpu:

--- a/charts/webank-training/templates/workflowtemplate.yaml
+++ b/charts/webank-training/templates/workflowtemplate.yaml
@@ -1,12 +1,11 @@
 {{- $workflow := .Values.workflow -}}
 {{- $training := .Values.training -}}
 {{- $lakefs := $training.lakefs -}}
-{{- $mlflow := $training.mlflow -}}
+{{- $detector := $training.documentDetector -}}
 {{- if not $training.image }}{{ fail "webank-training: training.image must be an immutable image digest" }}{{- end }}
 {{- if not (contains "@sha256:" $training.image) }}{{ fail "webank-training: training.image must be digest-pinned" }}{{- end }}
 {{- if not $lakefs.endpoint }}{{ fail "webank-training: training.lakefs.endpoint is required" }}{{- end }}
-{{- if not $mlflow.trackingUri }}{{ fail "webank-training: training.mlflow.trackingUri is required" }}{{- end }}
-{{- if not $mlflow.tokenUrl }}{{ fail "webank-training: training.mlflow.tokenUrl is required" }}{{- end }}
+{{- if not $lakefs.candidateBranch }}{{ fail "webank-training: training.lakefs.candidateBranch is required" }}{{- end }}
 {{- if not $training.otel.endpoint }}{{ fail "webank-training: training.otel.endpoint is required" }}{{- end }}
 {{- if not $workflow.serviceAccountName }}{{ fail "webank-training: workflow.serviceAccountName is required" }}{{- end }}
 apiVersion: argoproj.io/v1alpha1
@@ -16,7 +15,7 @@ metadata:
   labels:
     {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: webank-models
-    app.kubernetes.io/component: training-orchestration
+    app.kubernetes.io/component: document-detector-training
   annotations:
     webank.io/adr: "0034"
     webank.io/observability-adr: "0035"
@@ -32,71 +31,42 @@ spec:
   {{- end }}
   arguments:
     parameters:
-      - name: model
-      - name: lakefs_ref
+      - name: dataset_uri
       - name: run_name
-      - name: readiness_manifest
-      - name: readiness_attestation
-      - name: training_command
-      - name: output_path
-      - name: training_image
-        value: {{ $training.image | quote }}
   templates:
     - name: train
       dag:
         tasks:
-          - name: validate-lakefs-ref
-            template: validate-lakefs-ref
           - name: readiness-gate
-            dependencies: [validate-lakefs-ref]
             template: readiness-gate
-          - name: gpu-train
+          - name: gpu-train-and-publish-candidate
             dependencies: [readiness-gate]
-            template: gpu-train
-          - name: push-candidate
-            dependencies: [gpu-train]
-            template: push-candidate
+            template: gpu-train-and-publish-candidate
 
-    - name: validate-lakefs-ref
-      container:
-        image: "{{`{{workflow.parameters.training_image}}`}}"
-        command: ["sh", "-c"]
-        args:
-          - |
-            case "$LAKEFS_REF" in
-              [0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]) exit 0 ;;
-              *) echo "lakefs_ref must be a pinned 64-character lowercase-hex commit id" >&2; exit 1 ;;
-            esac
-        env:
-          - name: LAKEFS_REF
-            value: "{{`{{workflow.parameters.lakefs_ref}}`}}"
-          - name: TRAINING_RUN_ID
-            value: "{{`{{workflow.parameters.run_name}}`}}"
-          - name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: {{ $training.otel.endpoint | quote }}
-          - name: OTEL_SERVICE_NAME
-            value: webank-training-validate-lakefs-ref
-        resources:
-          requests: { cpu: 100m, memory: 64Mi }
-          limits: { cpu: 200m, memory: 128Mi }
-
+    # Checkout verifies that `dataset_uri` names a pinned LakeFS commit,
+    # allowlists the archive shape, and executes the embedded readiness gate.
+    # It runs before the GPU task, so non-eligible data never consumes a GPU.
     - name: readiness-gate
       container:
-        image: "{{`{{workflow.parameters.training_image}}`}}"
+        image: {{ $training.image | quote }}
         command: ["cargo"]
-        args: [xtask, training-data, readiness-gate, --manifest, "{{`{{workflow.parameters.readiness_manifest}}`}}", --lakefs-ref, "{{`{{workflow.parameters.lakefs_ref}}`}}", --readiness, "{{`{{workflow.parameters.readiness_attestation}}`}}"]
+        args: [xtask, training-data, checkout-document-detector, --dataset-uri, "{{`{{workflow.parameters.dataset_uri}}`}}", --lakefs-endpoint, {{ $lakefs.endpoint | quote }}, --output, /tmp/document-detector-gate]
         env:
           - name: TRAINING_RUN_ID
             value: "{{`{{workflow.parameters.run_name}}`}}"
+          - name: LAKEFS_ACCESS_KEY_ID
+            valueFrom: { secretKeyRef: { name: {{ $lakefs.secretName | quote }}, key: {{ $lakefs.accessKey | quote }} } }
+          - name: LAKEFS_SECRET_ACCESS_KEY
+            valueFrom: { secretKeyRef: { name: {{ $lakefs.secretName | quote }}, key: {{ $lakefs.secretKey | quote }} } }
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
             value: {{ $training.otel.endpoint | quote }}
           - name: OTEL_SERVICE_NAME
-            value: webank-training-readiness-gate
+            value: webank-document-detector-readiness-gate
         resources:
-          requests: { cpu: 250m, memory: 256Mi }
-          limits: { cpu: 500m, memory: 512Mi }
+          requests: { cpu: 250m, memory: 512Mi }
+          limits: { cpu: "1", memory: 1Gi }
 
-    - name: gpu-train
+    - name: gpu-train-and-publish-candidate
       nodeSelector:
         {{- toYaml $training.gpu.nodeSelector | nindent 8 }}
       {{- with $training.gpu.tolerations }}
@@ -104,53 +74,47 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       container:
-        image: "{{`{{workflow.parameters.training_image}}`}}"
-        command: ["sh", "-c"]
-        args: ["{{`{{workflow.parameters.training_command}}`}}"]
+        image: {{ $training.image | quote }}
+        command: ["sh", "-ceu"]
+        args:
+          - |
+            cargo xtask training-data checkout-document-detector \
+              --dataset-uri "$DATASET_URI" \
+              --lakefs-endpoint "$WEBANK_LAKEFS_ENDPOINT" \
+              --output /tmp/document-detector
+            cargo xtask document-detector-train \
+              --data /tmp/document-detector/dataset \
+              --output "/tmp/candidate-{{`{{workflow.name}}`}}.safetensors" \
+              --stem-channels {{ $detector.stemChannels }} \
+              --epochs {{ $detector.epochs }} \
+              --batch-size {{ $detector.batchSize }} \
+              --learning-rate {{ $detector.learningRate }} \
+              --shrink-ratio {{ $detector.shrinkRatio }}
+            . /tmp/document-detector/governance/lineage.env
+            cargo xtask training-data push \
+              --destination training-data-lake \
+              --path "/tmp/candidate-{{`{{workflow.name}}`}}.safetensors" \
+              --manifest /tmp/document-detector/governance/source-manifest.json \
+              --lakefs-ref "$LAKEFS_SOURCE_REF" \
+              --readiness /tmp/document-detector/governance/readiness.json \
+              --lakefs-branch "$WEBANK_LAKEFS_CANDIDATE_BRANCH" \
+              --lakefs-endpoint "$WEBANK_LAKEFS_ENDPOINT"
         env:
+          - name: DATASET_URI
+            value: "{{`{{workflow.parameters.dataset_uri}}`}}"
           - name: TRAINING_RUN_ID
             value: "{{`{{workflow.parameters.run_name}}`}}"
-          - name: WEBANK_LAKEFS_REF
-            value: "{{`{{workflow.parameters.lakefs_ref}}`}}"
-          - name: LAKEFS_ENDPOINT
+          - name: WEBANK_LAKEFS_ENDPOINT
             value: {{ $lakefs.endpoint | quote }}
+          - name: WEBANK_LAKEFS_CANDIDATE_BRANCH
+            value: {{ $lakefs.candidateBranch | quote }}
           - name: LAKEFS_ACCESS_KEY_ID
             valueFrom: { secretKeyRef: { name: {{ $lakefs.secretName | quote }}, key: {{ $lakefs.accessKey | quote }} } }
           - name: LAKEFS_SECRET_ACCESS_KEY
             valueFrom: { secretKeyRef: { name: {{ $lakefs.secretName | quote }}, key: {{ $lakefs.secretKey | quote }} } }
-          - name: MLFLOW_TRACKING_URI
-            value: {{ $mlflow.trackingUri | quote }}
-          - name: MLFLOW_TOKEN_URL
-            value: {{ $mlflow.tokenUrl | quote }}
-          - name: MLFLOW_AUTOMATION_CLIENT_ID
-            value: {{ $mlflow.clientId | quote }}
-          - name: MLFLOW_AUTOMATION_CLIENT_SECRET
-            valueFrom: { secretKeyRef: { name: {{ $mlflow.secretName | quote }}, key: {{ $mlflow.clientSecretKey | quote }} } }
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
             value: {{ $training.otel.endpoint | quote }}
           - name: OTEL_SERVICE_NAME
-            value: "webank-training-{{`{{workflow.parameters.model}}`}}"
+            value: webank-document-detector-train
         resources:
           {{- toYaml $training.gpu.resources | nindent 10 }}
-
-    - name: push-candidate
-      container:
-        image: "{{`{{workflow.parameters.training_image}}`}}"
-        command: ["cargo"]
-        args: [xtask, training-data, push, --destination, training-data-lake, --path, "{{`{{workflow.parameters.output_path}}`}}", --manifest, "{{`{{workflow.parameters.readiness_manifest}}`}}", --lakefs-ref, "{{`{{workflow.parameters.lakefs_ref}}`}}", --readiness, "{{`{{workflow.parameters.readiness_attestation}}`}}"]
-        env:
-          - name: TRAINING_RUN_ID
-            value: "{{`{{workflow.parameters.run_name}}`}}"
-          - name: LAKEFS_ENDPOINT
-            value: {{ $lakefs.endpoint | quote }}
-          - name: LAKEFS_ACCESS_KEY_ID
-            valueFrom: { secretKeyRef: { name: {{ $lakefs.secretName | quote }}, key: {{ $lakefs.accessKey | quote }} } }
-          - name: LAKEFS_SECRET_ACCESS_KEY
-            valueFrom: { secretKeyRef: { name: {{ $lakefs.secretName | quote }}, key: {{ $lakefs.secretKey | quote }} } }
-          - name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: {{ $training.otel.endpoint | quote }}
-          - name: OTEL_SERVICE_NAME
-            value: webank-training-push-candidate
-        resources:
-          requests: { cpu: 250m, memory: 256Mi }
-          limits: { cpu: 500m, memory: 512Mi }

--- a/charts/webank-training/values.yaml
+++ b/charts/webank-training/values.yaml
@@ -2,7 +2,7 @@
 # Deployment literals belong in ai-helm-values; this chart fails closed when
 # they are absent, so ArgoCD cannot silently install an unsafe default.
 workflow:
-  name: webank-weak-training-pass
+  name: webank-document-detector-train
   activeDeadlineSeconds: 21600
   ttlSecondsAfterCompletion: 259200
   serviceAccountName: argo-workflow
@@ -15,12 +15,7 @@ training:
     secretName: lakefs-proxy-admin
     accessKey: access-key-id
     secretKey: secret-access-key
-  mlflow:
-    trackingUri: ""
-    tokenUrl: ""
-    clientId: mlflow-automation
-    secretName: mlflow-automation
-    clientSecretKey: client-secret
+    candidateBranch: candidates
   otel:
     endpoint: ""
   gpu:
@@ -29,3 +24,9 @@ training:
     resources:
       requests: { cpu: "4", memory: 16Gi }
       limits: { cpu: "8", memory: 16Gi, nvidia.com/gpu: 1 }
+  documentDetector:
+    stemChannels: 32
+    epochs: 10
+    batchSize: 1
+    learningRate: 0.001
+    shrinkRatio: 0.6


### PR DESCRIPTION
## Summary

- replace the generic workflow form with a document-detector-specific training route
- gate a pinned LakeFS training bundle before GPU allocation
- run the fixed Rust trainer and publish only a LakeFS candidate

## Source of truth

- https://github.com/ADORSYS-GIS/webank-models/issues/328
- ADR-0034

## Verification

- [x] `helm lint charts/webank-training --strict -f charts/webank-training/ci/lint-values.yaml`
- [x] `helm template webank-training charts/webank-training -f charts/webank-training/ci/lint-values.yaml --dry-run`

## AI Usage Declaration

AI was used for:

- [x] Implementation and documentation drafting
- [ ] Not used

Human verification:

- [x] I reviewed the rendered WorkflowTemplate, gate-before-GPU ordering, secret references, and verification evidence.
- [x] I understand and accept responsibility for the change.