### PR TITLE
fix(librechat-opencode-wellknown): bump @vymalo plugins to 0.11.0, drop modelsInfoHideTextOnly

### DIFF
--- a/charts/librechat-opencode-wellknown/values.yaml
+++ b/charts/librechat-opencode-wellknown/values.yaml
@@ -191,7 +191,7 @@ wellKnown:
             # catalogs:
             # modelsInfoTtlSeconds: 3600
             # ⚠️ Deliberately NOT setting modelsInfoHideTextOnly (#800,
-            # reverted here). It was turned on as a plugin-side "second belt"
+            # reverted #848). It was turned on as a plugin-side "second belt"
             # for hiding internal-only models from the picker, but it filters
             # on MODALITY (text-in/text-out), not on internal status — the
             # two aren't the same thing. It hid every text-only model, internal or not,

--- a/charts/librechat-opencode-wellknown/values.yaml
+++ b/charts/librechat-opencode-wellknown/values.yaml
@@ -47,17 +47,17 @@ wellKnown:
     # subagents, so no primary carries the 27 browser_* schemas every turn.
     default_agent: assistant
     plugin:
-      - "@vymalo/opencode-oauth2@0.10.0"
+      - "@vymalo/opencode-oauth2@0.11.0"
       # Enriches the model catalog with context length, pricing,
       # modalities, capability flags. See ADR-0015.
-      - "@vymalo/opencode-models-info@0.10.0"
+      - "@vymalo/opencode-models-info@0.11.0"
       # Reads the IETF draft-03 `x-ratelimit-*` response headers our
       # Envoy AI Gateway emits (the per-model BackendTrafficPolicy,
       # ADR-0021) and makes opencode rate-limit-aware: on a short burst
       # reset it waits the quota out, and on a days-away monthly-budget
       # reset it fails fast — see the per-model-scoped `rateLimit.tiers`
       # under the provider options below.
-      - "@vymalo/opencode-ratelimit@0.10.0"
+      - "@vymalo/opencode-ratelimit@0.11.0"
       # Gives an agent a real browser: registers `browser_*` tools (open
       # tabs, click, type, scroll, screenshot — in named tab groups) backed
       # by a localhost WebSocket bridge a companion browser EXTENSION dials
@@ -72,7 +72,7 @@ wellKnown:
       # in the plugin TUPLE's second arg — this plugin reads its options from
       # there (NOT from provider.options.meta like the others), i.e.
       # opencode's `[name, {opts}]` install form, which toJson renders as a
-      # JSON 2-tuple. Part of the 0.8.0 vymalo line — pin matches the three
+      # JSON 2-tuple. Part of the 0.11.0 vymalo line — pin matches the three
       # above.
       #
       # TWO independent token levers, at different scopes:
@@ -114,7 +114,7 @@ wellKnown:
       # right form here: it's local-only (bridge + extension on the user's box,
       # so it can't ride the remote gateway /mcp/* routes anyway) and its opencode
       # adapter saves screenshots to disk for the model to read. One source only.
-      - - "@vymalo/opencode-browser@0.10.0"
+      - - "@vymalo/opencode-browser@0.11.0"
         - port: 4517
           groups:
             - page
@@ -190,20 +190,27 @@ wellKnown:
             # TTL (24h default upstream); override if you want fresher
             # catalogs:
             # modelsInfoTtlSeconds: 3600
-            # Makes /v1/models/info authoritative for which models even show
-            # up in the opencode picker (models-info plugin ≥ 0.10.0,
-            # vymalo/opencode-oauth2@802ce44..cc8fce1). A model is hard-deleted
-            # from provider.models (not just left un-enriched) when the
-            # catalog reports it as exactly text-in/text-out, OR when the
-            # catalog has no entry for it at all — the latter also acts as a
-            # second, plugin-side belt for the `disableExternal`/`-internal`
-            # exclusion charts/ai-model + charts/ai-models-info already apply
-            # server-side (AIGatewayRoute hostnames + the catalog helper).
-            # ⚠️ Broad blast radius: this hides every plain-text chat model
-            # from oauth2's /v1/models discovery, not just the internal ones —
-            # only multimodal/image models (+ any the catalog explicitly
-            # reports non-text-only) survive in the opencode picker.
-            modelsInfoHideTextOnly: true
+            # ⚠️ Deliberately NOT setting modelsInfoHideTextOnly (#800,
+            # reverted here). It was turned on as a plugin-side "second belt"
+            # for hiding internal-only models from the picker, but it filters
+            # on MODALITY (text-in/text-out), not on internal status — the
+            # two aren't the same thing. It hid every text-only model, internal or not,
+            # including legitimate external ones (glm-4.7-flash) and our own
+            # adorsys-coder/researcher/reviewer coding agents. The actual
+            # internal-model leak this was meant to guard against is already
+            # fully closed server-side (AIGatewayRoute `hostnames` scoping,
+            # charts/ai-model + charts/ai-models-info's catalog helper, #797) —
+            # `disableExternal: true` models are excluded outright from both
+            # /v1/models and /v1/models/info, so there's nothing left for a
+            # plugin-side belt to catch. If a future model genuinely needs
+            # hiding from the opencode picker without being modality-hidden,
+            # reach for @vymalo/opencode-models-info's `modelsInfoHideInternal`
+            # (≥ 0.11.0) — but it needs the catalog to actually emit
+            # `internal: true` on a model entry, which charts/ai-models-info
+            # deliberately does not do today (it excludes disableExternal
+            # models rather than flagging them — re-including them, even
+            # flagged, would reintroduce the "advertised model that 404s"
+            # problem #797 fixed). Don't set either flag until that changes.
             # Force our endpoint's `name` to win over the normalized label
             # the oauth2 plugin pre-stamps (vymalo/opencode-models-info#38,
             # needs plugin ≥ 0.7.1 — pinned 0.8.0 above). models-info merges

--- a/docs/integrations/opencode-well-known.md
+++ b/docs/integrations/opencode-well-known.md
@@ -373,7 +373,9 @@ provides one.
 
 `meta.modelsInfoHideTextOnly` was turned on in #800 as a plugin-side "second
 belt" meant to hide internal-only models from the opencode picker, then turned
-back off (this change). It filters on **modality** (text-in/text-out), not on
+back off in
+[#848](https://github.com/ADORSYS-GIS/ai-helm/pull/848). It filters on
+**modality** (text-in/text-out), not on
 internal status — those aren't the same axis, and the correlation broke as
 soon as a legitimate text-only *external* model existed: it hid 12 models, not
 just the 6 actually-internal ones, including `glm-4.7-flash` and our own

--- a/docs/integrations/opencode-well-known.md
+++ b/docs/integrations/opencode-well-known.md
@@ -371,19 +371,28 @@ landed and the UI showed the plain normalized label. Listing `name` lets the
 endpoint value replace it; a field only changes when the endpoint actually
 provides one.
 
-`meta.modelsInfoHideTextOnly: true` (models-info plugin ≥ 0.10.0,
-[vymalo/opencode-oauth2@802ce44..cc8fce1](https://github.com/vymalo/opencode-oauth2/commit/cc8fce1eaa62383ac6b6692b37061972e6a77a19))
-makes `/v1/models/info` authoritative for which models the opencode picker
-even offers, not just their metadata: a model is hard-deleted from
-`provider.models` when the catalog reports it as exactly text-in/text-out, or
-when the catalog has no matching entry at all. We turn this on so oauth2's
-`/v1/models` discovery gets a second, plugin-side check that a model actually
-belongs in the picker — on top of the server-side `disableExternal`/`-internal`
-exclusion `charts/ai-model` (AIGatewayRoute `hostnames`) and
-`charts/ai-models-info` (the catalog helper) already apply. ⚠️ Broad blast
-radius: this hides every plain-text chat model, not just the internal ones —
-only multimodal/image models (and any the catalog explicitly reports as
-non-text-only) survive in the picker.
+`meta.modelsInfoHideTextOnly` was turned on in #800 as a plugin-side "second
+belt" meant to hide internal-only models from the opencode picker, then turned
+back off (this change). It filters on **modality** (text-in/text-out), not on
+internal status — those aren't the same axis, and the correlation broke as
+soon as a legitimate text-only *external* model existed: it hid 12 models, not
+just the 6 actually-internal ones, including `glm-4.7-flash` and our own
+`adorsys-coder`/`adorsys-researcher`/`adorsys-reviewer` coding agents. The
+internal-model leak it was guarding against is already fully closed
+server-side — `disableExternal: true` models are excluded outright from both
+`/v1/models` and `/v1/models/info` via AIGatewayRoute `hostnames` scoping
+(`charts/ai-model`) and the catalog helper (`charts/ai-models-info`, #797) —
+so there was nothing left for a plugin-side belt to catch.
+
+If a future model genuinely needs hiding from the opencode picker without
+being modality-hidden, `@vymalo/opencode-models-info` ≥ 0.11.0 ships
+`meta.modelsInfoHideInternal` for exactly that
+([vymalo/opencode-oauth2#73](https://github.com/vymalo/opencode-oauth2/pull/73)) —
+but it needs the catalog to actually emit `internal: true` on a model entry.
+`charts/ai-models-info` deliberately does not do that today (it *excludes*
+`disableExternal` models rather than flagging them); re-including them, even
+flagged, would reintroduce the "advertised model that 404s" problem #797
+fixed. Don't set either flag until that changes.
 
 ## Prerequisites the cluster must satisfy
 


### PR DESCRIPTION
## 1. Summary

This PR changes:

- Bumps `@vymalo/opencode-oauth2` / `opencode-models-info` / `opencode-ratelimit` / `opencode-browser` from `0.10.0` → `0.11.0` in `charts/librechat-opencode-wellknown/values.yaml`.
- Removes `meta.modelsInfoHideTextOnly: true` from the `camer-digital` provider config.

It solves:

- Picks up the newly released `0.11.0` line (vymalo/opencode-oauth2#73, ADORSYS-GIS/lightbridge-opencode-toolbeit#74).
- `glm-4.7-flash` (and 11 other legitimate text models, including our own `adorsys-coder`/`adorsys-researcher`/`adorsys-reviewer`) missing from the opencode picker.

---

## 2. Intent

`modelsInfoHideTextOnly` (#800) was turned on as a plugin-side "second belt" to hide internal-only models from the opencode picker. It actually filters on **modality** (text-in/text-out), not internal status — those aren't the same axis. It hid every text-only model regardless of whether it was actually internal, catching 12 models instead of the 6 real `disableExternal` ones.

The internal-model leak it was meant to guard against is already fully closed **server-side**: `disableExternal: true` models are excluded outright from both `/v1/models` and `/v1/models/info` via `AIGatewayRoute.spec.hostnames` scoping (#797, verified live #801). So the plugin-side belt had nothing left to catch, and its only remaining effect was hiding legitimate text models.

I investigated whether the new `modelsInfoHideInternal` flag (the plugin capability shipped in 0.11.0 for exactly this kind of decoupling) should replace it here, but `charts/ai-models-info`'s catalog helper **excludes** `disableExternal` models from the emitted catalog rather than flagging them `internal: true` — so `modelsInfoHideInternal` would have zero entries to act on. Re-including them in the catalog, even flagged, would reintroduce the "advertised model that 404s" problem #797 fixed. So the correct fix here is simply dropping the flag, not swapping it for another one.

---

## 3. Scope

### In Scope

- Plugin version pins (4 lines) in `charts/librechat-opencode-wellknown/values.yaml`.
- Removing `modelsInfoHideTextOnly` + updating its inline comment.
- `docs/integrations/opencode-well-known.md` — updated the section documenting this flag.

### Out of Scope

- Stamping `internal: true` in the `charts/ai-models-info` catalog output — deliberately not done; would regress #797. Tracked as a non-issue unless a future need for `modelsInfoHideInternal` arises here.
- Any change to `charts/ai-models`/`charts/ai-models-info`'s `disableExternal` exclusion mechanism.

---

## 4. Verification

I verified this change by:

- [x] Running automated tests
- [x] Checking logs

Commands run:

```bash
helm dep build charts/librechat-opencode-wellknown
helm lint charts/librechat-opencode-wellknown --strict
helm template x charts/librechat-opencode-wellknown --dry-run
```

Results:

```text
1 chart(s) linted, 0 chart(s) failed

Rendered config.plugin:
["@vymalo/opencode-oauth2@0.11.0","@vymalo/opencode-models-info@0.11.0",
 "@vymalo/opencode-ratelimit@0.11.0",["@vymalo/opencode-browser@0.11.0",{...}]]

Rendered provider.options.meta: modelsInfoHideTextOnly absent (confirmed via grep).
```

---

## 6. Risk Assessment

Risk level:

* [x] Low

Potential risks:

* Text-only models (12, listed in PR discussion) become selectable in the opencode picker again — this is the intended outcome (restoring legitimate models), not a side effect to guard against.
* A genuinely-internal model could theoretically leak into the picker if the server-side `disableExternal` exclusion ever regresses, since the plugin-side belt is now gone.

Mitigation:

* Server-side exclusion (#797) is the correct, verified-live enforcement point and covers both `/v1/models` and `/v1/models/info` — the plugin-side check was redundant with it when working, and actively harmful when it over-matched.
* If a future model needs opencode-picker-only hiding independent of `disableExternal`, `modelsInfoHideInternal` is available (0.11.0) once the catalog is changed to flag rather than exclude — documented inline in `values.yaml` and in `docs/integrations/opencode-well-known.md`.

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [x] Drafting documentation

Human verification:

* [ ] I understand every meaningful change in this PR
* [ ] I checked generated code manually
* [ ] I removed unsupported AI assumptions
* [ ] I accept responsibility for this PR

---

## 8. Reviewer Focus

Please focus your review on:

* [x] Correctness
* [x] Product intent

The specific thing worth a second look: whether the 12 now-unhidden text models (full list in the linked investigation) should really all be selectable in opencode, or whether some deserve a different, more targeted curation mechanism going forward.
