### PR TITLE
fix(webank-training): enforce GPU placement

### DIFF
--- a/charts/apps/values.yaml
+++ b/charts/apps/values.yaml
@@ -1436,8 +1436,8 @@ applications:
   # A plain workload Application, not an orchestrator: it installs only the
   # namespaced WorkflowTemplate. Human submission remains the sole trigger;
   # the template gates its pinned LakeFS ref and readiness attestation before
-  # requesting one RTX 4000 Ada GPU. Deployment values and the app-scoped
-  # MLflow automation ExternalSecret live in ai-helm-values.
+  # requesting one RTX 4000 Ada GPU. Deployment values, including the
+  # enforced GPU-pool selector, live in ai-helm-values.
   - name: webank-training
     finalizers:
       - resources-finalizer.argocd.argoproj.io

--- a/charts/webank-training/templates/workflowtemplate.yaml
+++ b/charts/webank-training/templates/workflowtemplate.yaml
@@ -8,6 +8,15 @@
 {{- if not $lakefs.candidateBranch }}{{ fail "webank-training: training.lakefs.candidateBranch is required" }}{{- end }}
 {{- if not $training.otel.endpoint }}{{ fail "webank-training: training.otel.endpoint is required" }}{{- end }}
 {{- if not $workflow.serviceAccountName }}{{ fail "webank-training: workflow.serviceAccountName is required" }}{{- end }}
+{{- $gpuNodeRole := index $training.gpu.nodeSelector "role" | default "" -}}
+{{- if ne $gpuNodeRole "gpu" }}{{ fail "webank-training: GPU-capable templates require training.gpu.nodeSelector.role=gpu" }}{{- end }}
+{{- $gpuLimit := index $training.gpu.resources.limits "nvidia.com/gpu" | default 0 -}}
+{{- if lt (int $gpuLimit) 1 }}{{ fail "webank-training: GPU-capable templates require limits.nvidia.com/gpu >= 1" }}{{- end }}
+{{- $toleratesGpu := false -}}
+{{- range $training.gpu.tolerations }}
+{{- if and (eq (.key | default "") "role") (eq (.operator | default "Equal") "Equal") (eq (.value | default "") "gpu") (eq (.effect | default "") "NoSchedule") }}{{- $toleratesGpu = true }}{{- end }}
+{{- end }}
+{{- if not $toleratesGpu }}{{ fail "webank-training: GPU-capable templates require a role=gpu:NoSchedule toleration" }}{{- end }}
 apiVersion: argoproj.io/v1alpha1
 kind: WorkflowTemplate
 metadata:
@@ -66,6 +75,10 @@ spec:
           requests: { cpu: 250m, memory: 512Mi }
           limits: { cpu: "1", memory: 1Gi }
 
+    # The only GPU-capable task carries an enforced `role=gpu` selector,
+    # matching NoSchedule toleration, and an extended-resource GPU request.
+    # Kubernetes therefore cannot place it on a non-GPU node. The preceding
+    # readiness gate is deliberately CPU-only.
     - name: gpu-train-and-publish-candidate
       nodeSelector:
         {{- toYaml $training.gpu.nodeSelector | nindent 8 }}

--- a/charts/webank-training/values.yaml
+++ b/charts/webank-training/values.yaml
@@ -18,6 +18,9 @@ training:
     candidateBranch: candidates
   otel:
     endpoint: ""
+  # Every GPU-capable template is rendered only when these placement
+  # invariants are present: `role: gpu`, a matching NoSchedule toleration,
+  # and a positive nvidia.com/gpu limit. The readiness gate remains CPU-only.
   gpu:
     nodeSelector: {}
     tolerations: []


### PR DESCRIPTION
## 1. Summary

This PR changes:

- Enforces the GPU-node selector, matching NoSchedule toleration, and positive `nvidia.com/gpu` limit whenever the document-detector GPU template renders.
- Documents the deliberate CPU-only readiness gate and removes a stale MLflow deployment comment.

It solves:

- Ensuring the GPU-capable training step cannot be scheduled onto a non-GPU node after the document-detector workflow introduced in [webank-models #339](https://github.com/ADORSYS-GIS/webank-models/pull/339).

---

## 2. Intent

The intent is to fail Helm rendering before deployment when the required GPU placement contract is incomplete, while allowing the data-readiness gate to remain CPU-only.

---

## 3. Scope

### In Scope

- Webank training chart validation and documentation.
- Existing `role=gpu` workload-pool convention.

### Out of Scope

- Starting a workflow or creating LakeFS data.
- Changing node labels, taints, credentials, or the training image release policy.

---

## 4. Verification

I verified this change by:

- [x] Running automated tests
- [x] Testing error cases
- [x] Testing permissions/security behavior
- [x] Testing rollback or failure behavior, if relevant

Commands run:

```bash
helm dependency build charts/webank-training
helm lint charts/webank-training --strict -f charts/webank-training/ci/lint-values.yaml
helm template webank-training charts/webank-training -f charts/webank-training/ci/lint-values.yaml --dry-run
helm template webank-training charts/webank-training -f charts/webank-training/ci/lint-values.yaml --set training.gpu.nodeSelector.role=cpu
```

Results:

```text
The valid render contains role: gpu, the matching NoSchedule toleration, and nvidia.com/gpu: 1.
The invalid render fails: GPU-capable templates require training.gpu.nodeSelector.role=gpu.
```

---

## 5. Screenshots / Evidence

Rendered Helm output was inspected locally; no cluster resources or data were changed.

---

## 6. Risk Assessment

Risk level:

* [x] Low

Potential risks:

* A future environment with a different GPU-pool label or taint will fail rendering until its values conform to this deployment contract.

Mitigation:

* The error identifies the missing invariant before ArgoCD applies anything. Reverting this commit restores the prior chart behavior.

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [x] Drafting documentation
* [x] Reviewing the diff

Human verification:

* [x] I understand every meaningful change in this PR
* [x] I checked generated code manually
* [x] I checked generated tests manually
* [x] I removed unsupported AI assumptions
* [x] I accept responsibility for this PR

---

## 8. Reviewer Focus

Please focus your review on:

* [x] Correctness
* [x] Architecture
* [x] Security
* [x] Tests
* [x] Maintainability
* [x] Edge cases
