### PR TITLE
fix(librechat-opencode-wellknown): bump @vymalo plugins to 0.12.0, enable modelsInfoHideUnmatched

### DIFF
--- a/charts/librechat-opencode-wellknown/values.yaml
+++ b/charts/librechat-opencode-wellknown/values.yaml
@@ -47,17 +47,17 @@ wellKnown:
     # subagents, so no primary carries the 27 browser_* schemas every turn.
     default_agent: assistant
     plugin:
-      - "@vymalo/opencode-oauth2@0.11.0"
+      - "@vymalo/opencode-oauth2@0.12.0"
       # Enriches the model catalog with context length, pricing,
       # modalities, capability flags. See ADR-0015.
-      - "@vymalo/opencode-models-info@0.11.0"
+      - "@vymalo/opencode-models-info@0.12.0"
       # Reads the IETF draft-03 `x-ratelimit-*` response headers our
       # Envoy AI Gateway emits (the per-model BackendTrafficPolicy,
       # ADR-0021) and makes opencode rate-limit-aware: on a short burst
       # reset it waits the quota out, and on a days-away monthly-budget
       # reset it fails fast — see the per-model-scoped `rateLimit.tiers`
       # under the provider options below.
-      - "@vymalo/opencode-ratelimit@0.11.0"
+      - "@vymalo/opencode-ratelimit@0.12.0"
       # Gives an agent a real browser: registers `browser_*` tools (open
       # tabs, click, type, scroll, screenshot — in named tab groups) backed
       # by a localhost WebSocket bridge a companion browser EXTENSION dials
@@ -72,7 +72,7 @@ wellKnown:
       # in the plugin TUPLE's second arg — this plugin reads its options from
       # there (NOT from provider.options.meta like the others), i.e.
       # opencode's `[name, {opts}]` install form, which toJson renders as a
-      # JSON 2-tuple. Part of the 0.11.0 vymalo line — pin matches the three
+      # JSON 2-tuple. Part of the 0.12.0 vymalo line — pin matches the three
       # above.
       #
       # TWO independent token levers, at different scopes:
@@ -114,7 +114,7 @@ wellKnown:
       # right form here: it's local-only (bridge + extension on the user's box,
       # so it can't ride the remote gateway /mcp/* routes anyway) and its opencode
       # adapter saves screenshots to disk for the model to read. One source only.
-      - - "@vymalo/opencode-browser@0.11.0"
+      - - "@vymalo/opencode-browser@0.12.0"
         - port: 4517
           groups:
             - page
@@ -196,21 +196,35 @@ wellKnown:
             # on MODALITY (text-in/text-out), not on internal status — the
             # two aren't the same thing. It hid every text-only model, internal or not,
             # including legitimate external ones (glm-4.7-flash) and our own
-            # adorsys-coder/researcher/reviewer coding agents. The actual
-            # internal-model leak this was meant to guard against is already
-            # fully closed server-side (AIGatewayRoute `hostnames` scoping,
-            # charts/ai-model + charts/ai-models-info's catalog helper, #797) —
-            # `disableExternal: true` models are excluded outright from both
-            # /v1/models and /v1/models/info, so there's nothing left for a
-            # plugin-side belt to catch. If a future model genuinely needs
-            # hiding from the opencode picker without being modality-hidden,
-            # reach for @vymalo/opencode-models-info's `modelsInfoHideInternal`
-            # (≥ 0.11.0) — but it needs the catalog to actually emit
-            # `internal: true` on a model entry, which charts/ai-models-info
-            # deliberately does not do today (it excludes disableExternal
-            # models rather than flagging them — re-including them, even
-            # flagged, would reintroduce the "advertised model that 404s"
-            # problem #797 fixed). Don't set either flag until that changes.
+            # adorsys-coder/researcher/reviewer coding agents.
+            #
+            # Also NOT setting modelsInfoHideInternal (≥ 0.11.0) — it needs
+            # the catalog to actually emit `internal: true` on a model entry,
+            # which charts/ai-models-info deliberately does not do (it
+            # excludes disableExternal models outright rather than flagging
+            # them — re-including them, even flagged, would reintroduce the
+            # "advertised model that 404s" problem #797 fixed). Nothing in
+            # the catalog ever carries `internal: true`, so this flag would
+            # have zero entries to act on today.
+            #
+            # ⚠️ modelsInfoHideUnmatched IS set (≥ 0.12.0,
+            # vymalo/opencode-oauth2#79/#80). Removing modelsInfoHideTextOnly
+            # in #848 also silently removed the OTHER thing it did: making
+            # /v1/models/info authoritative for catalog MEMBERSHIP, not just
+            # modality — a model in a client's discovered `provider.models`
+            # that later drops out of the catalog (renamed, removed,
+            # access-scoped) used to get pruned; after #848 it never was.
+            # Real consequence, not theoretical: end users started seeing
+            # stale/dead model ids (pre-`-internal`-suffix names, fully
+            # retired models) in their opencode picker that the catalog
+            # hasn't listed in a while, and selecting one either 404s or
+            # errors. modelsInfoHideUnmatched reaches the exact same
+            # membership-pruning deletion path modelsInfoHideTextOnly used
+            # to, but WITHOUT its modality filtering — the correct fix,
+            # since disableExternal exclusion (#797) already makes the
+            # catalog itself the intersection point: shown = /v1/models ∩
+            # /v1/models/info.
+            modelsInfoHideUnmatched: true
             # Force our endpoint's `name` to win over the normalized label
             # the oauth2 plugin pre-stamps (vymalo/opencode-models-info#38,
             # needs plugin ≥ 0.7.1 — pinned 0.8.0 above). models-info merges

--- a/docs/integrations/opencode-well-known.md
+++ b/docs/integrations/opencode-well-known.md
@@ -394,7 +394,24 @@ but it needs the catalog to actually emit `internal: true` on a model entry.
 `charts/ai-models-info` deliberately does not do that today (it *excludes*
 `disableExternal` models rather than flagging them); re-including them, even
 flagged, would reintroduce the "advertised model that 404s" problem #797
-fixed. Don't set either flag until that changes.
+fixed. Don't set this flag until that changes.
+
+⚠️ **`meta.modelsInfoHideUnmatched: true` IS set** (`@vymalo/opencode-models-info`
+≥ 0.12.0, [ADORSYS-GIS/lightbridge-opencode-toolbeit#79](https://github.com/ADORSYS-GIS/lightbridge-opencode-toolbeit/issues/79)/[#80](https://github.com/ADORSYS-GIS/lightbridge-opencode-toolbeit/pull/80)).
+Removing `modelsInfoHideTextOnly` in #848 turned off *two* things it did, not
+one: modality filtering (the intended fix) AND making the catalog authoritative
+for *membership* — a model a client's `provider.models` picked up at some
+point (upstream discovery, or accumulated local state) that later drops out
+of the catalog (renamed, removed, access-scoped) used to get pruned on the
+next sync; after #848 it never was again. Real consequence, confirmed live:
+end users started seeing stale/dead model ids in their opencode picker —
+pre-`-internal`-suffix names, fully retired models — that the catalog hadn't
+listed in a while, and picking one either 404s or errors.
+`modelsInfoHideUnmatched` reaches the exact same deletion path
+`modelsInfoHideTextOnly` used to, without its modality filtering — since
+`disableExternal` exclusion (#797) already makes the catalog the correct
+intersection point, the opencode picker now shows exactly `/v1/models` ∩
+`/v1/models/info`, nothing stale, nothing modality-filtered.
 
 ## Prerequisites the cluster must satisfy
 


### PR DESCRIPTION
## 1. Summary

This PR changes:

- Bumps `@vymalo/opencode-oauth2` / `opencode-models-info` / `opencode-ratelimit` / `opencode-browser` from `0.11.0` → `0.12.0` in `charts/librechat-opencode-wellknown/values.yaml`.
- Sets `meta.modelsInfoHideUnmatched: true` on the `camer-digital` provider.

It solves:

- End users seeing stale/dead model ids (pre-`-internal`-suffix names, fully retired models) in the opencode picker, reported as a live client complaint. Selecting one either 404s or errors.

---

## 2. Intent

[#848](https://github.com/ADORSYS-GIS/ai-helm/pull/848) removed `modelsInfoHideTextOnly` to fix a real modality false-positive (it was hiding legitimate text-only external models like `glm-4.7-flash`). What wasn't obvious at the time: that flag was doing two unrelated things, and removing it threw both out. The second thing — making `/v1/models/info` authoritative for catalog *membership*, pruning any model a client's `provider.models` had picked up that the catalog no longer lists — silently stopped working. Confirmed live: clients accumulate model ids over time (via `@vymalo/opencode-oauth2` discovery, or local state) that later drop out of the catalog (renamed, access-scoped, removed), and without membership pruning those ids just sit there forever, visible and selectable, but broken.

[`ADORSYS-GIS/lightbridge-opencode-toolbeit#79`](https://github.com/ADORSYS-GIS/lightbridge-opencode-toolbeit/issues/79) / [`#80`](https://github.com/ADORSYS-GIS/lightbridge-opencode-toolbeit/pull/80) (published as `0.12.0`) adds `modelsInfoHideUnmatched` — the membership-pruning half of the old flag's behavior, decoupled from modality. This PR wires it in.

---

## 3. Scope

### In Scope

- Plugin version pins (4 lines) in `charts/librechat-opencode-wellknown/values.yaml`.
- Adding `modelsInfoHideUnmatched: true` + updating the inline comment explaining all three related flags' state.
- `docs/integrations/opencode-well-known.md` — updated to match.

### Out of Scope

- `modelsInfoHideTextOnly` stays unset (still correct — the modality false-positive is still not wanted).
- `modelsInfoHideInternal` stays unset (still correct — `charts/ai-models-info` excludes `disableExternal` models outright rather than flagging them `internal: true`, so this flag would have zero entries to act on).

---

## 4. Verification

I verified this change by:

- [x] Running automated tests
- [x] Checking logs

Commands run:

```bash
helm dep build charts/librechat-opencode-wellknown
helm lint charts/librechat-opencode-wellknown --strict
helm template x charts/librechat-opencode-wellknown --dry-run
```

Results:

```text
1 chart(s) linted, 0 chart(s) failed

Rendered config.plugin:
["@vymalo/opencode-oauth2@0.12.0","@vymalo/opencode-models-info@0.12.0",
 "@vymalo/opencode-ratelimit@0.12.0",["@vymalo/opencode-browser@0.12.0",{...}]]

Rendered provider.options.meta.modelsInfoHideUnmatched: true (confirmed via grep).
Rendered provider.options.meta: modelsInfoHideTextOnly / modelsInfoHideInternal both absent
(confirmed via grep).
```

Upstream package verified live on npm before opening this PR: all 7 `@vymalo/opencode-*`
packages show `0.12.0` (`npm view @vymalo/<pkg> version`).

---

## 6. Risk Assessment

Risk level:

* [x] Low

Potential risks:

* A model id that's genuinely still valid but the catalog momentarily fails to report (transient fetch error, cache miss) could get pruned incorrectly.

Mitigation:

* The plugin's "known before we assert" rule applies: a model is only deleted when the catalog fetch actually succeeded and the id is confirmed absent, not on a fetch failure (which serves stale cache instead per the plugin's own fallback behavior, verified in its test suite). Reversible in one line if it ever over-prunes — this is a config flip, not a one-way migration.

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [x] Drafting documentation

Human verification:

* [ ] I understand every meaningful change in this PR
* [ ] I checked generated code manually
* [ ] I removed unsupported AI assumptions
* [ ] I accept responsibility for this PR

---

## 8. Reviewer Focus

Please focus your review on:

* [x] Correctness
* [x] Product intent

This closes the client-facing complaint that prompted `lightbridge-opencode-toolbeit#79`/`#80` — worth confirming the fix actually clears the stale ids once opencode clients next sync their catalog (the plugin's background refresh scheduler runs on the `modelsInfoTtlSeconds` cadence, default 24h, or immediately on a fresh `opencode` process start).
