### PR TITLE
fix(webank-training): clarify document detector submission

### DIFF
--- a/charts/webank-training/Chart.yaml
+++ b/charts/webank-training/Chart.yaml
@@ -6,7 +6,7 @@ description: >-
   attestation before scheduling the sole GPU task.
 type: application
 version: 0.1.0
-appVersion: "1.1.2"
+appVersion: "1.2.0"
 keywords:
   - webank
   - training

--- a/charts/webank-training/templates/workflowtemplate.yaml
+++ b/charts/webank-training/templates/workflowtemplate.yaml
@@ -41,7 +41,15 @@ spec:
   arguments:
     parameters:
       - name: dataset_uri
+        description: >-
+          Required pinned LakeFS dataset location in the form
+          lakefs://repository/64-character-commit/dataset-version. A branch,
+          local path, or raw source-data URL is rejected before training.
       - name: run_name
+        value: "document-detector-{{`{{workflow.name}}`}}"
+        description: >-
+          Optional human-readable run identity. Defaults to the unique Argo
+          workflow name and may be overridden for a deliberately named experiment.
   templates:
     - name: train
       dag:

--- a/charts/webank-training/templates/workflowtemplate.yaml
+++ b/charts/webank-training/templates/workflowtemplate.yaml
@@ -43,8 +43,9 @@ spec:
       - name: dataset_uri
         description: >-
           Required pinned LakeFS dataset location in the form
-          lakefs://repository/64-character-commit/dataset-version. A branch,
-          local path, or raw source-data URL is rejected before training.
+          lakefs://repository/64-character-commit/dataset-version. The training
+          container enforces the URI shape and embedded governance checks before
+          training.
       - name: run_name
         value: "document-detector-{{`{{workflow.name}}`}}"
         description: >-

--- a/docs/integrations/webank-training-deployment.md
+++ b/docs/integrations/webank-training-deployment.md
@@ -1,63 +1,73 @@
-# Webank governed training deployment
+# Document-detector governed training deployment
 
-The `webank-training` chart installs a single namespaced Argo
-`WorkflowTemplate`, `webank-weak-training-pass`, in `mlops`. It is the live,
-manual GPU-training route for `ADORSYS-GIS/webank-models` — not a scheduler and
-not a model-serving deployment. It implements Webank
-[ADR-0034](https://github.com/ADORSYS-GIS/webank-models/blob/main/docs/adr/0034-training-job-orchestration-argo-workflows.md)
-and [ADR-0035](https://github.com/ADORSYS-GIS/webank-models/blob/main/docs/adr/0035-training-observability-on-mlflow.md).
+The `webank-training` chart installs the namespaced Argo
+`WorkflowTemplate` `webank-document-detector-train` in `mlops`. It is a
+manual candidate-training route for the document detector, not a scheduler,
+dataset builder, or model-serving deployment.
 
-## Deployment shape
+It implements Webank
+[ADR-0034](https://github.com/ADORSYS-GIS/webank-models/blob/main/docs/adr/0034-training-job-orchestration-argo-workflows.md).
+The deployment values, including the immutable GPU-training image digest, live
+in the private `ai-helm-values` repository.
 
-`charts/apps` creates `aii-webank-training` as a normal OCI Application. Its
-deployment values are read from the private `ai-helm-values` repository and its
-one dependency overlay materialises `mlops/mlflow-automation` from the existing
-AWS Secrets Manager property. This order is intentional: merge the values-repo
-change before the chart Application so `ignoreMissingValueFiles` can never
-install an incomplete template.
+## Dashboard submission
 
-The template runs as the existing `argo-workflow` ServiceAccount. That identity
-has Argo executor permissions only; it does not grant data or experiment access.
-The GPU and candidate-push steps receive the minimum extra credentials they
-need:
+In the Argo UI, select the `webank-document-detector-train` WorkflowTemplate
+and leave **Entrypoint** set to `train`.
 
-| Boundary | Mechanism |
-|---|---|
-| LakeFS data plane | Existing `mlops/lakefs-proxy-admin` Secret, mounted only into GPU/push steps; direct in-cluster Service endpoint |
-| MLflow experiment plane | `mlops/mlflow-automation` client secret; the Webank command must exchange it for an `aud=mlflow` bearer token |
-| Operational telemetry | OTLP/HTTP to `alloy.observability.svc.cluster.local:4318` |
-| GPU placement | `role=gpu` selector + `role=gpu:NoSchedule` toleration + exactly `nvidia.com/gpu: 1` |
+The UI also lists `readiness-gate` and `gpu-train-and-publish-candidate` because
+they are Argo implementation templates. They are not alternate public
+workflows. `train` is the only supported entrypoint and fixes the ordering:
 
-No credential material is held in either Git repository. The LakeFS key is the
-platform's single root credential and must not be duplicated; the MLflow client
-secret is synchronised by ESO from
-`ai/camer/digital/prod/env#mlflow_automation_client_secret`. The MLflow identity
-`service-account-mlflow-automation` needs `EDIT` on the intended experiment.
+```text
+train
+  -> readiness-gate (CPU only)
+  -> gpu-train-and-publish-candidate (one GPU)
+```
 
-## Submitting a candidate run
+The submission fields are:
 
-The chart deliberately creates no `Workflow`, `CronWorkflow`, `EventSource`, or
-`Sensor`. A model owner submits a reviewed run against the template, supplying:
+| Field | Value |
+| --- | --- |
+| `dataset_uri` | Required immutable URI: `lakefs://repository/64-character-commit/dataset-version`. It must name an approved, published document-detector training archive. Branches, local paths, raw source data, and moving refs are rejected. |
+| `run_name` | Optional correlation name. It defaults to `document-detector-<Argo workflow name>` so every submission has a unique identity. Override it only for a deliberately named experiment; never include personal or source-record data. |
 
-- one of the five model names;
-- a pinned 64-character lowercase-hex LakeFS commit;
-- a governed readiness manifest and attestation;
-- the model-specific `cargo xtask ...` training command; and
-- a candidate output path in the training-data plane.
+Do not submit this template while LakeFS has no approved document-detector
+dataset. A missing `dataset_uri` is intentionally rejected by Argo before a
+Workflow is created; it must not be replaced with a fake or blank default.
 
-The DAG is fixed: pinned-ref validation → readiness gate → GPU training →
-candidate push. A failed validation or readiness gate cannot claim a GPU. The
-template defaults to the published immutable training image
-`webank-train-gpu@sha256:c177…`, has a six-hour active deadline, and retains
-completed workflow records for three days.
+## Producing the required dataset URI
 
-The template supplies `MLFLOW_TOKEN_URL`, `MLFLOW_AUTOMATION_CLIENT_ID`, and
-`MLFLOW_AUTOMATION_CLIENT_SECRET` to the GPU command but does not put a bearer
-token into a Workflow parameter or status field. The current training image
-does not mint that token itself yet, so this makes the credential boundary
-available without claiming an end-to-end MLflow write. The Webank command must
-exchange the secret at runtime, keep the token in process memory, and never log
-it or write it as an Argo output/artifact.
+Dataset publication is a distinct, restricted-plane operation. The Python
+builder in
+[webank-models](https://github.com/ADORSYS-GIS/webank-models/tree/main/tools/document-detector-dataset)
+creates the typed archive from approved source records. A governed LakeFS push
+then returns the immutable commit used in `dataset_uri`.
 
-The source-of-truth request is
-[webank-models#48](https://github.com/ADORSYS-GIS/webank-models/issues/48).
+1. Build and review the archive, source manifest, and readiness attestation in
+   the restricted plane.
+2. Push the reviewed archive through `cargo xtask training-data push` to the
+   repository named by the governed manifest.
+3. Record the returned LakeFS commit and the manifest `dataset_version`.
+4. Submit `train` with
+   `lakefs://<repository>/<returned-commit>/<dataset-version>`.
+
+The workflow downloads that exact archive, verifies its embedded governance
+files on CPU, and only then requests the GPU. A successful run publishes a
+candidate; it is not production promotion evidence.
+
+## Model-specific workflow surface
+
+Each model gets its own public WorkflowTemplate when its dataset contract and
+trainer exist. The document detector is the first deployed template. Do not add
+new model behaviour as an extra entrypoint or optional parameter to this
+template: that obscures the governed data contract and makes the dashboard form
+unsafe.
+
+## Placement and credentials
+
+The GPU task is constrained to `role=gpu`, tolerates the matching
+`role=gpu:NoSchedule` taint, and requests exactly `nvidia.com/gpu: 1`. The
+readiness gate is CPU-only. LakeFS credentials are mounted from the
+platform-managed `mlops` Secret only inside workflow pods and are never passed
+through dashboard parameters or committed to Git.


### PR DESCRIPTION
## Summary

- keeps `dataset_uri` deliberately required and documents its immutable LakeFS format
- defaults `run_name` to `document-detector-{{workflow.name}}`, while preserving manual override
- replaces the stale generic weak-training guide with the live document-detector dashboard contract
- clarifies that `readiness-gate` and `gpu-train-and-publish-candidate` are internal DAG stages; `train` is the supported entrypoint

## Root cause

The first deployed document-detector template exposed unnamed arguments in the Argo UI. A blank required `dataset_uri` therefore reached the API as an invalid Workflow submission, while `run_name` also required needless manual input. The prior deployment guide described a retired generic template rather than the deployed model-specific route.

## Source of truth

- https://github.com/ADORSYS-GIS/webank-models/pull/339
- https://github.com/ADORSYS-GIS/ai-helm/pull/847
- https://github.com/ADORSYS-GIS/ai-helm/pull/849
- https://github.com/ADORSYS-GIS/webank-models/blob/main/tools/document-detector-dataset/README.md

## Verification evidence

- [x] `helm dependency build charts/webank-training`
- [x] `helm lint charts/webank-training --strict -f charts/webank-training/ci/lint-values.yaml`
- [x] `helm template webank-training charts/webank-training -n mlops -f charts/webank-training/ci/lint-values.yaml --dry-run`
- [x] Render confirms the immutable `dataset_uri` guidance and automatic `run_name` value.
- [x] A render with `training.gpu.nodeSelector.role=cpu` fails at the enforced GPU-placement guard.

## AI Usage Declaration

- [x] AI assisted with the focused Helm and documentation change. The rendered WorkflowTemplate, existing deployment state, and dataset contract were inspected. No dataset, LakeFS credential, model artifact, or Workflow was created.
