### PR TITLE
fix(webank-training): publish submission contract update

### DIFF
--- a/charts/webank-training/Chart.yaml
+++ b/charts/webank-training/Chart.yaml
@@ -5,7 +5,7 @@ description: >-
   MLOps platform. It gates every run on a pinned LakeFS commit and readiness
   attestation before scheduling the sole GPU task.
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: "1.2.0"
 keywords:
   - webank


### PR DESCRIPTION
## Summary

- releases `webank-training` chart version `0.1.1`
- makes the merged document-detector submission-contract fix publishable to OCI

## Root cause

PR #851 changed the chart but did not change `Chart.yaml`'s chart version. The
OCI publisher correctly detected no new chart package, leaving ArgoCD on the
previous `0.1.0` package digest.

## Source of truth

- https://github.com/ADORSYS-GIS/ai-helm/pull/851

## Verification evidence

- [x] `helm dependency build charts/webank-training`
- [x] `helm lint charts/webank-training --strict -f charts/webank-training/ci/lint-values.yaml`
- [x] `helm template webank-training charts/webank-training -n mlops -f charts/webank-training/ci/lint-values.yaml --dry-run`
- [x] `helm package charts/webank-training --destination /tmp/webank-training-package` produced `webank-training-0.1.1.tgz`

## AI Usage Declaration

- [x] AI assisted with the focused chart-release fix and Helm verification. The rendered chart version and submission fields were inspected; no Workflow, LakeFS data, credential, or model artifact was created.
