### PR TITLE
feat(training): expose per-model Argo workflows

### DIFF
--- a/charts/webank-training/Chart.yaml
+++ b/charts/webank-training/Chart.yaml
@@ -1,9 +1,8 @@
 apiVersion: v2
 name: webank-training
 description: >-
-  Governed, human-submitted Webank GPU training WorkflowTemplate for the shared
-  MLOps platform. It gates every run on a pinned LakeFS commit and readiness
-  attestation before scheduling the sole GPU task.
+  Governed, human-submitted Webank dataset-build and GPU candidate-training
+  WorkflowTemplates for the shared MLOps platform.
 type: application
 version: 0.1.1
 appVersion: "1.2.0"

--- a/charts/webank-training/ci/lint-values.yaml
+++ b/charts/webank-training/ci/lint-values.yaml
@@ -14,3 +14,19 @@ training:
         operator: Equal
         value: gpu
         effect: NoSchedule
+models:
+  - id: document-detector
+    datasetMaterializer: materialize-document-detector-descriptor
+    trainer: document-detector
+  - id: document-recognizer
+    datasetMaterializer: materialize-document-recognizer-descriptor
+    trainer: document-recognizer
+  - id: face-detector
+    datasetMaterializer: materialize-face-detector-descriptor
+    trainer: face-detector
+  - id: sface
+    datasetMaterializer: materialize-sface-descriptor
+    trainer: sface
+  - id: pad-liveness
+    datasetMaterializer: materialize-pad-descriptor
+    trainer: pad-liveness-pending

--- a/charts/webank-training/templates/workflowtemplate.yaml
+++ b/charts/webank-training/templates/workflowtemplate.yaml
@@ -8,6 +8,7 @@
 {{- if not $lakefs.candidateBranch }}{{ fail "webank-training: training.lakefs.candidateBranch is required" }}{{- end }}
 {{- if not $training.otel.endpoint }}{{ fail "webank-training: training.otel.endpoint is required" }}{{- end }}
 {{- if not $workflow.serviceAccountName }}{{ fail "webank-training: workflow.serviceAccountName is required" }}{{- end }}
+{{- if eq (len .Values.models) 0 }}{{ fail "webank-training: models must declare the public model workflow catalogue" }}{{- end }}
 {{- $gpuNodeRole := index $training.gpu.nodeSelector "role" | default "" -}}
 {{- if ne $gpuNodeRole "gpu" }}{{ fail "webank-training: GPU-capable templates require training.gpu.nodeSelector.role=gpu" }}{{- end }}
 {{- $gpuLimit := index $training.gpu.resources.limits "nvidia.com/gpu" | default 0 -}}
@@ -17,17 +18,109 @@
 {{- if and (eq (.key | default "") "role") (eq (.operator | default "Equal") "Equal") (eq (.value | default "") "gpu") (eq (.effect | default "") "NoSchedule") }}{{- $toleratesGpu = true }}{{- end }}
 {{- end }}
 {{- if not $toleratesGpu }}{{ fail "webank-training: GPU-capable templates require a role=gpu:NoSchedule toleration" }}{{- end }}
+{{- range $model := .Values.models }}
+{{- $id := required "webank-training: models[].id is required" $model.id -}}
+{{- $materializer := required (printf "webank-training: %s datasetMaterializer is required" $id) $model.datasetMaterializer -}}
+{{- $trainer := required (printf "webank-training: %s trainer is required" $id) $model.trainer -}}
+{{- if not (has $materializer (list "materialize-document-detector-descriptor" "materialize-document-recognizer-descriptor" "materialize-face-detector-descriptor" "materialize-sface-descriptor" "materialize-pad-descriptor")) }}{{ fail (printf "webank-training: %s has an unknown dataset materializer" $id) }}{{- end }}
+{{- if not (has $trainer (list "document-detector" "document-recognizer" "face-detector" "sface" "pad-liveness-pending")) }}{{ fail (printf "webank-training: %s has an unknown trainer" $id) }}{{- end }}
+---
 apiVersion: argoproj.io/v1alpha1
 kind: WorkflowTemplate
 metadata:
-  name: {{ $workflow.name | quote }}
+  name: {{ printf "webank-%s-dataset-build" $id | quote }}
   labels:
-    {{- include "common.labels.standard" . | nindent 4 }}
+    {{- include "common.labels.standard" $ | nindent 4 }}
     app.kubernetes.io/part-of: webank-models
-    app.kubernetes.io/component: document-detector-training
+    app.kubernetes.io/component: dataset-build
+    webank.io/model: {{ $id | quote }}
+  annotations:
+    webank.io/adr: "0034"
+    webank.io/dataset-contract: "0006"
+    webank.io/materialization: "metadata-descriptor"
+spec:
+  entrypoint: build
+  activeDeadlineSeconds: {{ $workflow.activeDeadlineSeconds }}
+  ttlStrategy:
+    secondsAfterCompletion: {{ $workflow.ttlSecondsAfterCompletion }}
+  serviceAccountName: {{ $workflow.serviceAccountName | quote }}
+  {{- with $workflow.imagePullSecrets }}
+  imagePullSecrets:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  arguments:
+    parameters:
+      - name: lakefs_ref
+        description: >-
+          Required immutable 64-character LakeFS commit named by the governed
+          manifest and readiness attestation. Branches and moving tags fail closed.
+    artifacts:
+      - name: source
+      - name: manifest
+      - name: readiness
+  templates:
+    - name: build
+      inputs:
+        artifacts:
+          - name: source
+            path: /workspace/input/source.json
+          - name: manifest
+            path: /workspace/input/source-manifest.json
+          - name: readiness
+            path: /workspace/input/readiness.json
+      container:
+        image: {{ $training.image | quote }}
+        command: ["sh", "-ceu"]
+        args:
+          - |
+            cargo xtask training-data {{ $materializer }} \
+              --source /workspace/input/source.json \
+              --manifest /workspace/input/source-manifest.json \
+              --lakefs-ref "$LAKEFS_REF" \
+              --readiness /workspace/input/readiness.json \
+              --output /workspace/output/{{ $id }}-descriptor.json
+            cargo xtask training-data push \
+              --destination training-data-lake \
+              --path /workspace/output/{{ $id }}-descriptor.json \
+              --manifest /workspace/input/source-manifest.json \
+              --lakefs-ref "$LAKEFS_REF" \
+              --readiness /workspace/input/readiness.json \
+              --lakefs-branch "$WEBANK_LAKEFS_CANDIDATE_BRANCH" \
+              --lakefs-endpoint "$WEBANK_LAKEFS_ENDPOINT"
+        env:
+          - name: LAKEFS_REF
+            value: "{{`{{workflow.parameters.lakefs_ref}}`}}"
+          - name: WEBANK_LAKEFS_ENDPOINT
+            value: {{ $lakefs.endpoint | quote }}
+          - name: WEBANK_LAKEFS_CANDIDATE_BRANCH
+            value: {{ $lakefs.candidateBranch | quote }}
+          - name: LAKEFS_ACCESS_KEY_ID
+            valueFrom: { secretKeyRef: { name: {{ $lakefs.secretName | quote }}, key: {{ $lakefs.accessKey | quote }} } }
+          - name: LAKEFS_SECRET_ACCESS_KEY
+            valueFrom: { secretKeyRef: { name: {{ $lakefs.secretName | quote }}, key: {{ $lakefs.secretKey | quote }} } }
+          - name: OTEL_EXPORTER_OTLP_ENDPOINT
+            value: {{ $training.otel.endpoint | quote }}
+          - name: OTEL_SERVICE_NAME
+            value: {{ printf "webank-%s-dataset-build" $id | quote }}
+        resources:
+          requests: { cpu: 250m, memory: 512Mi }
+          limits: { cpu: "1", memory: 1Gi }
+---
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: {{ printf "webank-%s-train" $id | quote }}
+  labels:
+    {{- include "common.labels.standard" $ | nindent 4 }}
+    app.kubernetes.io/part-of: webank-models
+    app.kubernetes.io/component: candidate-training
+    webank.io/model: {{ $id | quote }}
   annotations:
     webank.io/adr: "0034"
     webank.io/observability-adr: "0035"
+{{- if eq $trainer "pad-liveness-pending" }}
+    webank.io/execution-state: "blocked-by-pad-training-harness"
+{{- end }}
 spec:
   entrypoint: train
   activeDeadlineSeconds: {{ $workflow.activeDeadlineSeconds }}
@@ -40,55 +133,36 @@ spec:
   {{- end }}
   arguments:
     parameters:
+{{- if eq $trainer "document-detector" }}
       - name: dataset_uri
         description: >-
-          Required pinned LakeFS dataset location in the form
-          lakefs://repository/64-character-commit/dataset-version. The training
-          container enforces the URI shape and embedded governance checks before
-          training.
+          Required pinned document-detector LakeFS location:
+          lakefs://repository/64-character-commit/dataset-version.
+{{- else if ne $trainer "pad-liveness-pending" }}
+      - name: lakefs_ref
+        description: Required immutable 64-character LakeFS commit for the dataset artifacts.
+{{- end }}
       - name: run_name
-        value: "document-detector-{{`{{workflow.name}}`}}"
-        description: >-
-          Optional human-readable run identity. Defaults to the unique Argo
-          workflow name and may be overridden for a deliberately named experiment.
+        value: {{ printf "%s-{{workflow.name}}" $id | quote }}
+        description: Optional operator label; defaults to the unique Argo workflow name.
+{{- if and (ne $trainer "document-detector") (ne $trainer "pad-liveness-pending") }}
+    artifacts:
+      - name: dataset
+      - name: manifest
+      - name: readiness
+{{- end }}
   templates:
     - name: train
-      dag:
-        tasks:
-          - name: readiness-gate
-            template: readiness-gate
-          - name: gpu-train-and-publish-candidate
-            dependencies: [readiness-gate]
-            template: gpu-train-and-publish-candidate
-
-    # Checkout verifies that `dataset_uri` names a pinned LakeFS commit,
-    # allowlists the archive shape, and executes the embedded readiness gate.
-    # It runs before the GPU task, so non-eligible data never consumes a GPU.
-    - name: readiness-gate
-      container:
-        image: {{ $training.image | quote }}
-        command: ["cargo"]
-        args: [xtask, training-data, checkout-document-detector, --dataset-uri, "{{`{{workflow.parameters.dataset_uri}}`}}", --lakefs-endpoint, {{ $lakefs.endpoint | quote }}, --output, /tmp/document-detector-gate]
-        env:
-          - name: TRAINING_RUN_ID
-            value: "{{`{{workflow.parameters.run_name}}`}}"
-          - name: LAKEFS_ACCESS_KEY_ID
-            valueFrom: { secretKeyRef: { name: {{ $lakefs.secretName | quote }}, key: {{ $lakefs.accessKey | quote }} } }
-          - name: LAKEFS_SECRET_ACCESS_KEY
-            valueFrom: { secretKeyRef: { name: {{ $lakefs.secretName | quote }}, key: {{ $lakefs.secretKey | quote }} } }
-          - name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: {{ $training.otel.endpoint | quote }}
-          - name: OTEL_SERVICE_NAME
-            value: webank-document-detector-readiness-gate
-        resources:
-          requests: { cpu: 250m, memory: 512Mi }
-          limits: { cpu: "1", memory: 1Gi }
-
-    # The only GPU-capable task carries an enforced `role=gpu` selector,
-    # matching NoSchedule toleration, and an extended-resource GPU request.
-    # Kubernetes therefore cannot place it on a non-GPU node. The preceding
-    # readiness gate is deliberately CPU-only.
-    - name: gpu-train-and-publish-candidate
+{{- if and (ne $trainer "document-detector") (ne $trainer "pad-liveness-pending") }}
+      inputs:
+        artifacts:
+          - name: dataset
+            path: /workspace/dataset
+          - name: manifest
+            path: /workspace/governance/source-manifest.json
+          - name: readiness
+            path: /workspace/governance/readiness.json
+{{- end }}
       nodeSelector:
         {{- toYaml $training.gpu.nodeSelector | nindent 8 }}
       {{- with $training.gpu.tolerations }}
@@ -100,30 +174,93 @@ spec:
         command: ["sh", "-ceu"]
         args:
           - |
+{{- if eq $trainer "document-detector" }}
             cargo xtask training-data checkout-document-detector \
               --dataset-uri "$DATASET_URI" \
               --lakefs-endpoint "$WEBANK_LAKEFS_ENDPOINT" \
-              --output /tmp/document-detector
+              --output /workspace/document-detector
             cargo xtask document-detector-train \
-              --data /tmp/document-detector/dataset \
-              --output "/tmp/candidate-{{`{{workflow.name}}`}}.safetensors" \
+              --data /workspace/document-detector/dataset \
+              --output "$CANDIDATE_PATH" \
               --stem-channels {{ $detector.stemChannels }} \
               --epochs {{ $detector.epochs }} \
               --batch-size {{ $detector.batchSize }} \
               --learning-rate {{ $detector.learningRate }} \
               --shrink-ratio {{ $detector.shrinkRatio }}
-            . /tmp/document-detector/governance/lineage.env
+            . /workspace/document-detector/governance/lineage.env
             cargo xtask training-data push \
               --destination training-data-lake \
-              --path "/tmp/candidate-{{`{{workflow.name}}`}}.safetensors" \
-              --manifest /tmp/document-detector/governance/source-manifest.json \
+              --path "$CANDIDATE_PATH" \
+              --manifest /workspace/document-detector/governance/source-manifest.json \
               --lakefs-ref "$LAKEFS_SOURCE_REF" \
-              --readiness /tmp/document-detector/governance/readiness.json \
+              --readiness /workspace/document-detector/governance/readiness.json \
               --lakefs-branch "$WEBANK_LAKEFS_CANDIDATE_BRANCH" \
               --lakefs-endpoint "$WEBANK_LAKEFS_ENDPOINT"
+{{- else if eq $trainer "document-recognizer" }}
+            cargo xtask training-data readiness-gate \
+              --manifest /workspace/governance/source-manifest.json \
+              --lakefs-ref "$LAKEFS_REF" \
+              --readiness /workspace/governance/readiness.json
+            cargo xtask distill-recognizer \
+              --data /workspace/dataset \
+              --output "$CANDIDATE_PATH" \
+              --epochs 10
+            cargo xtask training-data push \
+              --destination training-data-lake \
+              --path "$CANDIDATE_PATH" \
+              --manifest /workspace/governance/source-manifest.json \
+              --lakefs-ref "$LAKEFS_REF" \
+              --readiness /workspace/governance/readiness.json \
+              --lakefs-branch "$WEBANK_LAKEFS_CANDIDATE_BRANCH" \
+              --lakefs-endpoint "$WEBANK_LAKEFS_ENDPOINT"
+{{- else if eq $trainer "face-detector" }}
+            cargo xtask training-data readiness-gate \
+              --manifest /workspace/governance/source-manifest.json \
+              --lakefs-ref "$LAKEFS_REF" \
+              --readiness /workspace/governance/readiness.json
+            cargo xtask face-detector-train \
+              --data /workspace/dataset \
+              --output "$CANDIDATE_PATH" \
+              --epochs 10
+            cargo xtask training-data push \
+              --destination training-data-lake \
+              --path "$CANDIDATE_PATH" \
+              --manifest /workspace/governance/source-manifest.json \
+              --lakefs-ref "$LAKEFS_REF" \
+              --readiness /workspace/governance/readiness.json \
+              --lakefs-branch "$WEBANK_LAKEFS_CANDIDATE_BRANCH" \
+              --lakefs-endpoint "$WEBANK_LAKEFS_ENDPOINT"
+{{- else if eq $trainer "sface" }}
+            cargo xtask training-data readiness-gate \
+              --manifest /workspace/governance/source-manifest.json \
+              --lakefs-ref "$LAKEFS_REF" \
+              --readiness /workspace/governance/readiness.json
+            cargo xtask sface-train \
+              --data /workspace/dataset \
+              --output "$CANDIDATE_PATH" \
+              --epochs 10
+            cargo xtask training-data push \
+              --destination training-data-lake \
+              --path "$CANDIDATE_PATH" \
+              --manifest /workspace/governance/source-manifest.json \
+              --lakefs-ref "$LAKEFS_REF" \
+              --readiness /workspace/governance/readiness.json \
+              --lakefs-branch "$WEBANK_LAKEFS_CANDIDATE_BRANCH" \
+              --lakefs-endpoint "$WEBANK_LAKEFS_ENDPOINT"
+{{- else }}
+            echo "PAD liveness candidate training is unavailable: the governed PAD dataset descriptor exists, but no PAD optimizer/trainer has landed. Refusing to fabricate a candidate." >&2
+            exit 2
+{{- end }}
         env:
+{{- if eq $trainer "document-detector" }}
           - name: DATASET_URI
             value: "{{`{{workflow.parameters.dataset_uri}}`}}"
+{{- else if ne $trainer "pad-liveness-pending" }}
+          - name: LAKEFS_REF
+            value: "{{`{{workflow.parameters.lakefs_ref}}`}}"
+{{- end }}
+          - name: CANDIDATE_PATH
+            value: {{ printf "/workspace/candidate-%s-{{workflow.name}}.safetensors" $id | quote }}
           - name: TRAINING_RUN_ID
             value: "{{`{{workflow.parameters.run_name}}`}}"
           - name: WEBANK_LAKEFS_ENDPOINT
@@ -137,6 +274,7 @@ spec:
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
             value: {{ $training.otel.endpoint | quote }}
           - name: OTEL_SERVICE_NAME
-            value: webank-document-detector-train
+            value: {{ printf "webank-%s-train" $id | quote }}
         resources:
           {{- toYaml $training.gpu.resources | nindent 10 }}
+{{- end }}

--- a/charts/webank-training/values.yaml
+++ b/charts/webank-training/values.yaml
@@ -1,8 +1,9 @@
-# Environment-neutral structure for the Webank training WorkflowTemplate.
+# Environment-neutral structure for Webank's public dataset-build and training
+# WorkflowTemplates. Environment literals belong in ai-helm-values; this chart
+# fails closed when they are absent.
 # Deployment literals belong in ai-helm-values; this chart fails closed when
 # they are absent, so ArgoCD cannot silently install an unsafe default.
 workflow:
-  name: webank-document-detector-train
   activeDeadlineSeconds: 21600
   ttlSecondsAfterCompletion: 259200
   serviceAccountName: argo-workflow
@@ -33,3 +34,8 @@ training:
     batchSize: 1
     learningRate: 0.001
     shrinkRatio: 0.6
+
+# One entry produces exactly two public WorkflowTemplates: `<id>-dataset-build`
+# and `<id>-train`. Keep model-specific commands in the chart, selected by the
+# closed `trainer` enum below; values never provide executable shell text.
+models: []

--- a/docs/README.md
+++ b/docs/README.md
@@ -69,6 +69,7 @@ Step-by-step runbooks, setup guides, and break-glass recipes.
 | [`gateway-api-usage.md`](playbooks/gateway-api-usage.md) | **Command reference for calling the models from outside the cluster** — `/v1/models`, image generation, chat completions, streaming, vision, embeddings, and the failure table. ⚠️ Image responses default to an in-pod `127.0.0.1` URL; always pass `response_format: b64_json`. Verified live |
 | [`lakefs-sso.md`](playbooks/lakefs-sso.md) | **LakeFS Keycloak SSO** via the `lakefs-proxy` session shim (ADR-0090): why LakeFS OSS 1.83 has no OIDC and is single-user, the securecookie relay, the admin-credential runbook, symptom→fix table |
 | [`mlops-app-auth.md`](playbooks/mlops-app-auth.md) | **Argo Workflows SSO/RBAC + MLflow OIDC** (ADR-0085, ADR-0091): the three independent Argo identities (SSO delegate / workflow pod / API client), `code:7` vs `code:5`, the `<sa>.service-account-token` name, Argo Events CRD stubs, `--auth-mode=client` for CI, the `mlflow-oidc-auth` plugin's dedicated DB + the `OIDC_AUDIENCE` bearer gate, mounting the LakeFS key in a workflow step |
+| [`webank-model-workflows.md`](playbooks/webank-model-workflows.md) | **Webank dataset and training workflow submission** — choose each model's explicit Argo template, provide governed inputs, verify GPU placement, and handle the PAD fail-closed path |
 
 ---
 
@@ -149,7 +150,7 @@ Operational subsystems with several files keep their own directory + local index
 | [`solutions-team/`](./solutions-team/) | Solutions-team runbooks (e.g. graphify setup) |
 | [`mlops-access-model.md`](patterns/mlops-access-model.md) | **MLOps access model** (ADR-0085/0090/0091): who can reach LakeFS / Argo Workflows / MLflow and as what — humans vs in-cluster workloads vs external scripts, the credential inventory, the end-to-end training-job path, and the known limitations |
 | [`mlops-platform-consumer-guide.md`](integrations/mlops-platform-consumer-guide.md) | **Consuming the MLOps platform from another team/repo** (ADR-0085/0090/0091): endpoints, machine auth per app, the training-job recipe, and what to request from the maintainer |
-| [`webank-training-deployment.md`](integrations/webank-training-deployment.md) | **Webank governed training deployment** — the chart-owned Argo WorkflowTemplate, GPU placement, credential boundaries, and candidate-run submission contract |
+| [`webank-training-deployment.md`](integrations/webank-training-deployment.md) | **Webank governed dataset and training deployment** — ten explicit Argo templates, model-specific input contracts, GPU placement, and credential boundaries |
 
 ---
 

--- a/docs/integrations/README.md
+++ b/docs/integrations/README.md
@@ -17,4 +17,4 @@ other categories.
 | [keycloak-identity-datasource.md](keycloak-identity-datasource.md) | Resolving `user_id` → person, sessions & grants (ADR-0063/0064) |
 | [homepage.md](homepage.md) | Homepage central hub — the `gethomepage.dev/*` discovery-annotation convention for adding new apps (ADR-0089) |
 | [mlops-platform-consumer-guide.md](mlops-platform-consumer-guide.md) | **Using the MLOps platform from another repo/team** — endpoints, how a script or training job authenticates to LakeFS/MLflow/Argo, and the end-to-end training recipe |
-| [webank-training-deployment.md](webank-training-deployment.md) | **Webank governed training deployment** — the Argo WorkflowTemplate, Hetzner RTX 4000 Ada placement, LakeFS/MLflow credential boundaries, and manual submission contract |
+| [webank-training-deployment.md](webank-training-deployment.md) | **Webank governed dataset and training deployment** — the ten public Argo templates, GPU placement, LakeFS credential boundary, and model-specific contracts |

--- a/docs/integrations/webank-training-deployment.md
+++ b/docs/integrations/webank-training-deployment.md
@@ -1,73 +1,74 @@
-# Document-detector governed training deployment
+# Webank governed dataset and training deployment
 
-The `webank-training` chart installs the namespaced Argo
-`WorkflowTemplate` `webank-document-detector-train` in `mlops`. It is a
-manual candidate-training route for the document detector, not a scheduler,
-dataset builder, or model-serving deployment.
+The `webank-training` chart installs a deliberately small, public Argo
+WorkflowTemplate catalogue in `mlops`. Each governed model has two separate
+templates in the dashboard: one for restricted dataset materialization and one
+for GPU candidate training. This is the deployment boundary for
+[Webank ADR-0034](https://github.com/ADORSYS-GIS/webank-models/blob/main/docs/adr/0034-training-job-orchestration-argo-workflows.md);
+it is neither a scheduler nor a model-serving deployment.
 
-It implements Webank
-[ADR-0034](https://github.com/ADORSYS-GIS/webank-models/blob/main/docs/adr/0034-training-job-orchestration-argo-workflows.md).
-The deployment values, including the immutable GPU-training image digest, live
-in the private `ai-helm-values` repository.
+| Model | Dataset template | Training template |
+| --- | --- | --- |
+| Document detector | `webank-document-detector-dataset-build` | `webank-document-detector-train` |
+| Document recognizer | `webank-document-recognizer-dataset-build` | `webank-document-recognizer-train` |
+| Face detector | `webank-face-detector-dataset-build` | `webank-face-detector-train` |
+| SFace | `webank-sface-dataset-build` | `webank-sface-train` |
+| PAD liveness | `webank-pad-liveness-dataset-build` | `webank-pad-liveness-train` |
 
-## Dashboard submission
+Each object has exactly one named template and fixes its own `entrypoint`
+(`build` or `train`). The Argo UI therefore cannot turn an implementation
+stage into an alternative public operation.
 
-In the Argo UI, select the `webank-document-detector-train` WorkflowTemplate
-and leave **Entrypoint** set to `train`.
+## Dataset-build templates
 
-The UI also lists `readiness-gate` and `gpu-train-and-publish-candidate` because
-they are Argo implementation templates. They are not alternate public
-workflows. `train` is the only supported entrypoint and fixes the ordering:
+`*-dataset-build` templates are CPU-only restricted-plane operations. The
+Argo submission form requires three governed artifacts:
 
-```text
-train
-  -> readiness-gate (CPU only)
-  -> gpu-train-and-publish-candidate (one GPU)
-```
+- `source` — the model-specific source metadata;
+- `manifest` — the RFC-0006 source manifest; and
+- `readiness` — the matching attestation.
 
-The submission fields are:
+It also requires `lakefs_ref`, the immutable commit declared by those two
+governance documents. The container materializes the model-specific descriptor
+and calls the narrow `training-data push` LakeFS boundary. It never accepts a
+dataset path or arbitrary shell command from the dashboard.
 
-| Field | Value |
-| --- | --- |
-| `dataset_uri` | Required immutable URI: `lakefs://repository/64-character-commit/dataset-version`. It must name an approved, published document-detector training archive. Branches, local paths, raw source data, and moving refs are rejected. |
-| `run_name` | Optional correlation name. It defaults to `document-detector-<Argo workflow name>` so every submission has a unique identity. Override it only for a deliberately named experiment; never include personal or source-record data. |
+The current materializers deliberately produce metadata descriptors. They do
+not invent document, biometric, identity, or PAD bytes. A data repository must
+provide an approved model-specific source and its governed artifact contract
+before an operator starts one of these templates.
 
-Do not submit this template while LakeFS has no approved document-detector
-dataset. A missing `dataset_uri` is intentionally rejected by Argo before a
-Workflow is created; it must not be replaced with a fake or blank default.
+## Training templates
 
-## Producing the required dataset URI
+All `*-train` templates select `role=gpu`, tolerate
+`role=gpu:NoSchedule`, and request one `nvidia.com/gpu`. A submitted training
+workflow therefore cannot land on a CPU-only node.
 
-Dataset publication is a distinct, restricted-plane operation. The Python
-builder in
-[webank-models](https://github.com/ADORSYS-GIS/webank-models/tree/main/tools/document-detector-dataset)
-creates the typed archive from approved source records. A governed LakeFS push
-then returns the immutable commit used in `dataset_uri`.
+The document detector accepts one `dataset_uri` in the immutable form
+`lakefs://repository/64-character-commit/dataset-version`; its runtime checks
+out and gates the archive itself. The recognizer, face-detector, and SFace
+templates take a governed `dataset`, `manifest`, and `readiness` artifact plus
+the matching `lakefs_ref`; they run their closed, model-specific Rust trainer
+only after the readiness gate passes. All successful trainers write candidates
+back only through `training-data push`, never to the model registry.
 
-1. Build and review the archive, source manifest, and readiness attestation in
-   the restricted plane.
-2. Push the reviewed archive through `cargo xtask training-data push` to the
-   repository named by the governed manifest.
-3. Record the returned LakeFS commit and the manifest `dataset_version`.
-4. Submit `train` with
-   `lakefs://<repository>/<returned-commit>/<dataset-version>`.
+`run_name` is optional on every training template. Its default includes the
+generated Argo workflow name, so it is unique even when the operator leaves
+the form untouched. Use an override only for an intentional experiment and
+never include source-record or personal data.
 
-The workflow downloads that exact archive, verifies its embedded governance
-files on CPU, and only then requests the GPU. A successful run publishes a
-candidate; it is not production promotion evidence.
+The PAD liveness template is visible intentionally but **fails closed**: PAD
+has a governed descriptor materializer, while a PAD optimizer/trainer has not
+landed. It emits no checkpoint and cannot fabricate a candidate. That gap must
+be closed in `webank-models` before a real PAD training submission is possible.
 
-## Model-specific workflow surface
+Use the [model workflow playbook](../playbooks/webank-model-workflows.md) for
+the dashboard submission sequence and failure handling.
 
-Each model gets its own public WorkflowTemplate when its dataset contract and
-trainer exist. The document detector is the first deployed template. Do not add
-new model behaviour as an extra entrypoint or optional parameter to this
-template: that obscures the governed data contract and makes the dashboard form
-unsafe.
+## Credentials and delivery
 
-## Placement and credentials
-
-The GPU task is constrained to `role=gpu`, tolerates the matching
-`role=gpu:NoSchedule` taint, and requests exactly `nvidia.com/gpu: 1`. The
-readiness gate is CPU-only. LakeFS credentials are mounted from the
-platform-managed `mlops` Secret only inside workflow pods and are never passed
-through dashboard parameters or committed to Git.
+LakeFS credentials are mounted only into the restricted workflow pods from the
+platform-managed `mlops` Secret. They are never dashboard parameters or Git
+values. The immutable GPU training image and all endpoint/placement literals
+live in the private `ai-helm-values` repository. Argo CD renders the public
+catalogue from the OCI chart plus those values.

--- a/docs/playbooks/README.md
+++ b/docs/playbooks/README.md
@@ -22,3 +22,4 @@ to **do** something. See the [docs index](../README.md) for the other categories
 | [cnpg-reconcile-stall.md](cnpg-reconcile-stall.md) | CNPG Managed role password not reconciled after secret change |
 | [lakefs-sso.md](lakefs-sso.md) | LakeFS Keycloak SSO via the `lakefs-proxy` session shim (ADR-0090): flow, config, admin-credential runbook, troubleshooting |
 | [mlops-app-auth.md](mlops-app-auth.md) | Argo Workflows SSO/RBAC (`code:7` vs `code:5`, the impersonation-token name), the workflow-pod SA + `--auth-mode=client` programmatic path, MLflow OIDC (the plugin's own DB + the `OIDC_AUDIENCE` bearer gate), and reaching LakeFS from a workflow step |
+| [webank-model-workflows.md](webank-model-workflows.md) | Start model-specific governed dataset-build and training templates in Argo; inputs, GPU placement, and fail-closed paths |

--- a/docs/playbooks/webank-model-workflows.md
+++ b/docs/playbooks/webank-model-workflows.md
@@ -1,0 +1,66 @@
+# Webank model workflows
+
+Use this playbook when preparing a governed dataset or starting a candidate
+training run from the Argo Workflows dashboard. Do not use it to upload source
+records, bypass the readiness gate, or promote a candidate.
+
+## Choose the right template
+
+Start with the model-specific operation you actually need:
+
+| Need | Template pattern | Compute |
+| --- | --- | --- |
+| Materialize and publish a governed descriptor | `webank-<model>-dataset-build` | CPU |
+| Train a governed candidate | `webank-<model>-train` | one GPU |
+
+There is one template of each kind for document detector, document recognizer,
+face detector, SFace, and PAD liveness. Do not choose a different entrypoint:
+the displayed `build` or `train` entrypoint is fixed by the selected template.
+
+## Build a dataset descriptor
+
+1. In Argo, open the model's `*-dataset-build` template and select **Submit**.
+2. Set `lakefs_ref` to the 64-character immutable commit recorded by the
+   approved source manifest. A branch name is rejected.
+3. Provide the three restricted artifacts: `source`, `manifest`, and
+   `readiness`. They must be the model-specific source metadata, RFC-0006
+   manifest, and matching readiness attestation from the data repository.
+4. Submit and inspect the `build` pod. A successful run writes only the
+   generated descriptor through the LakeFS training-data boundary.
+
+If LakeFS is empty, this operation still cannot begin without an approved
+source artifact and its manifest/attestation. Do not use fixtures or a blank
+reference as a substitute.
+
+## Start candidate training
+
+1. Confirm the dataset and its governance evidence are already approved.
+2. Select the model's `*-train` template.
+3. For document detector, enter
+   `lakefs://<repository>/<64-character-commit>/<dataset-version>` as
+   `dataset_uri`. For document recognizer, face detector, and SFace, provide
+   the governed `dataset`, `manifest`, and `readiness` artifacts and the
+   matching `lakefs_ref`.
+4. Leave `run_name` empty unless a named experiment is needed. Its default is
+   `<model>-<Argo workflow name>` and is the preferred unique correlation key.
+5. Submit. The pod must show `role=gpu`, the `role=gpu:NoSchedule` toleration,
+   and a one-GPU request before it begins candidate training.
+
+The run can only publish a candidate. Evaluation and governed promotion remain
+separate procedures.
+
+## Known blocked path
+
+`webank-pad-liveness-train` is intentionally fail-closed. The PAD data
+descriptor exists but the Rust PAD optimizer/trainer does not. Record the
+missing trainer as implementation work; do not treat a parity or smoke command
+as PAD training and do not create a candidate manually.
+
+## Troubleshooting
+
+| Symptom | Meaning | Action |
+| --- | --- | --- |
+| Argo rejects a missing dataset field | The data contract is intentionally required. | Supply the approved URI/artifacts; never fake a value. |
+| `readiness-gate` fails | Source manifest, readiness attestation, and pinned commit disagree or are not eligible. | Repair/reapprove data in its source repository. |
+| Pod remains Pending | GPU placement requirements cannot currently be met. | Check a `role=gpu` node and its allocatable GPU; do not remove placement constraints. |
+| PAD train exits immediately | There is no PAD trainer. | Keep it blocked until a model-specific trainer lands. |


### PR DESCRIPTION
## Summary

Render ten public Webank WorkflowTemplates: a dedicated dataset-build and a dedicated candidate-training template for document detector, document recognizer, face detector, SFace, and PAD liveness. Each template has exactly one visible entrypoint; the dashboard no longer exposes internal DAG stages as alternate operations.

## Root cause

The chart rendered one document-detector WorkflowTemplate whose internal DAG templates appeared in Argo’s Entrypoint selector. The other four models had no dataset or training WorkflowTemplate at all.

## Source of truth

- https://github.com/ADORSYS-GIS/webank-models/blob/main/docs/adr/0034-training-job-orchestration-argo-workflows.md
- https://github.com/ADORSYS-GIS/webank-models/blob/main/docs/rfc/0006-training-data-governance-gate-contract.md
- https://github.com/ADORSYS-GIS/webank-models/blob/main/docs/rfc/0007-governed-dataset-materialization-and-local-weak-training.md

## Verification evidence

- [x] `helm lint charts/webank-training --strict -f charts/webank-training/ci/lint-values.yaml`
- [x] `helm template` renders ten WorkflowTemplates, each with one template and its fixed public entrypoint.
- [x] `kubectl apply --dry-run=server -n mlops -f /tmp/webank-workflows-ci.yaml` accepted all ten rendered WorkflowTemplates against the live CRD.
- [x] Every training template has `role=gpu`, matching `role=gpu:NoSchedule` toleration, and `nvidia.com/gpu: 1`.
- [x] Documentation and dashboard playbook added.

## Known limitation

The PAD dataset descriptor template is real, but `webank-pad-liveness-train` fails closed because no PAD optimizer/trainer exists yet. It cannot emit a fabricated candidate.

## AI Usage Declaration

- [x] AI assisted with implementation and documentation.
- [x] I reviewed rendered manifests, GPU placement, and server-side CRD validation output.