### PR TITLE
ci: update GitHub Actions runners to ubuntu-latest

### DIFF
--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -26,7 +26,7 @@ concurrency:
 
 jobs:
   commit-lint:
-    runs-on: adorsys-gis-runner
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout (full history for the PR commit range)
         uses: actions/checkout@v7

--- a/.github/workflows/dashboards-drift.yml
+++ b/.github/workflows/dashboards-drift.yml
@@ -26,7 +26,7 @@ permissions:
 
 jobs:
   check:
-    runs-on: adorsys-gis-runner
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
 

--- a/.github/workflows/helm-lint.yaml
+++ b/.github/workflows/helm-lint.yaml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   lint:
-    runs-on: adorsys-gis-runner
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
 

--- a/.github/workflows/publish-charts-oci.yml
+++ b/.github/workflows/publish-charts-oci.yml
@@ -46,7 +46,7 @@ env:
 
 jobs:
   publish:
-    runs-on: adorsys-gis-runner
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v7

--- a/.github/workflows/release-helm-charts.yml
+++ b/.github/workflows/release-helm-charts.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   release:
-    runs-on: adorsys-gis-runner
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v7

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -44,7 +44,7 @@ concurrency:
 
 jobs:
   release-please:
-    runs-on: adorsys-gis-runner
+    runs-on: ubuntu-latest
     steps:
       - uses: googleapis/release-please-action@v5
         with:


### PR DESCRIPTION
## 1. Summary

This PR changes:

- Updates GitHub Actions runner labels to `ubuntu-latest` in workflows.

It solves:

- Sunsets the use of old private runners and standardizes on `ubuntu-latest`.

---

## 2. Intent

The intent of this PR is:

> To align with current infrastructure standards by using standard runners (`ubuntu-latest`), avoiding failures related to missing or deprecated self-hosted runners.

---

## 3. Scope

### In Scope

- Workflow files in `.github/workflows/`

### Out of Scope

- Changes to actual pipeline steps or commands.

---

## 4. Verification

I verified this change by:

- [x] Checking logs (by verifying workflow triggers on PR creation)

---

## 5. Screenshots / Evidence

Add evidence here:

* N/A

---

## 6. Risk Assessment

Risk level:

* [x] Low
* [ ] Medium
* [ ] High

---

## 7. AI Usage Declaration

AI was used for:

* [x] Refactoring

Human verification:

* [x] I accept responsibility for this PR

---

## 8. Reviewer Focus

Please focus your review on:

* [x] Correctness