### PR TITLE
fix(ai-model): convert lint-values-internal plans to ordered-list form

### DIFF
--- a/charts/ai-model/ci/lint-values-internal.yaml
+++ b/charts/ai-model/ci/lint-values-internal.yaml
@@ -57,22 +57,25 @@ pricing:
 
 # Full plan set (budgeted + burst-only) so the BackendTrafficPolicy renders
 # every rule family (burst req/min, burst tokens/min, monthly budget).
+# Ordered list, not a map (ADR-0084/0085/0110) — order matches the sibling
+# lint-values.yaml fixture (alphabetical: free, internal, pro, service).
+# APPEND ONLY.
 plans:
-  free:
+  - id: free
     monthlyBudgetUsd: 50
     burst:
       requestsPerMin: 200
       tokensPerMin: 200000
-  pro:
+  - id: internal
+    burst:
+      requestsPerMin: 1000
+      tokensPerMin: 5000000
+  - id: pro
     monthlyBudgetUsd: 200
     burst:
       requestsPerMin: 400
       tokensPerMin: 400000
-  service:
+  - id: service
     burst:
       requestsPerMin: 600
       tokensPerMin: 2000000
-  internal:
-    burst:
-      requestsPerMin: 1000
-      tokensPerMin: 5000000


### PR DESCRIPTION
## 1. Summary

This PR changes:

- Converts \`plans\` in \`charts/ai-model/ci/lint-values-internal.yaml\` from a map keyed by plan name to the ordered-list form (\`- id: free\`, ...), matching the sibling fixture \`charts/ai-model/ci/lint-values.yaml\`.

It solves:

- The \`lint-values-internal.yaml\` fixture no longer renders — \`helm template x charts/ai-model -f charts/ai-model/ci/lint-values-internal.yaml --dry-run\` fails with \`plans[free]: id is required (plans is an ordered list of {id, monthlyBudgetUsd?, burst}, not a map — see values.yaml)\`, per the guard added in [docs/adr/0110-project-quota-tiers-append-only-and-ai-model-plans-fix.md](https://github.com/ADORSYS-GIS/ai-helm/blob/main/docs/adr/0110-project-quota-tiers-append-only-and-ai-model-plans-fix.md). Confirmed via \`git stash\` that this fixture is already broken on \`main\`/HEAD — not introduced by other in-flight work.

---

## 2. Intent

> \`charts/ai-model\` is a render-only leaf chart (\`ai-helm.adorsys-gis.github.io/lint-mode: ci-values\`), so CI's \`helm-lint\` workflow lints and renders every \`charts/ai-model/ci/*-values.yaml\` fixture in place of the default \`values.yaml\`. ADR-0110 converted \`plans\`/\`tiers\` from a map to an ordered, append-only list (index → Lyft ratelimit \`rule/N\`, ADR-0084) and added an explicit \`fail\` guard for the old map shape. The sibling fixture \`lint-values.yaml\` was updated at the time; this internal-only fixture (covering the \`disableExternal: true\` branch) was missed, so CI has been failing or silently not covering that branch since the ADR-0110 cutover.

---

## 3. Scope

### In Scope

- Convert \`plans\` in \`charts/ai-model/ci/lint-values-internal.yaml\` to the ordered-list shape, preserving the same alphabetical order (free, internal, pro, service) used by \`lint-values.yaml\`.

### Out of Scope

- No template/logic changes to \`charts/ai-model/templates/backendtrafficpolicy.yaml\` — the guard is working as designed; only the stale fixture needed fixing.
- Not adding \`tiers\`/\`projectEnvelope\` to this fixture — those are already covered by the sibling \`lint-values.yaml\` fixture and are optional fields.

---

## 4. Verification

I verified this change by:

- [x] Running automated tests
- [x] Running manual tests

Commands run:

\`\`\`bash
helm dep build charts/ai-model
helm lint charts/ai-model --strict -f charts/ai-model/ci/lint-values-internal.yaml
helm template x charts/ai-model -f charts/ai-model/ci/lint-values-internal.yaml --dry-run
\`\`\`

Results:

\`\`\`text
1 chart(s) linted, 0 chart(s) failed
(helm template rendered with no errors — only the standard --dry-run deprecation notice)
\`\`\`

---

## 5. Screenshots / Evidence

Not applicable — YAML fixture fix, verified via the commands above.

---

## 6. Risk Assessment

Risk level:

* [x] Low

Potential risks:

* None — this only changes a CI lint/render fixture, not any deployed chart logic or values.

Mitigation:

* Verified render output locally before pushing.

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code

Human verification:

* [x] I understand every meaningful change in this PR
* [x] I checked generated code manually
* [x] I removed unsupported AI assumptions
* [x] I accept responsibility for this PR

---

## 8. Reviewer Focus

Please focus your review on:

* [x] Correctness