### PR TITLE
fix(observability-dashboards): calendar-align scoreboard budget-burn queries

### DIFF
--- a/charts/observability-dashboards/files/envoy-ai-gateway/scoreboard.json
+++ b/charts/observability-dashboards/files/envoy-ai-gateway/scoreboard.json
@@ -95,7 +95,7 @@
   "editable": true,
   "graphTooltip": 1,
   "time": {
-    "from": "now-30d",
+    "from": "now/M",
     "to": "now"
   },
   "fiscalYearStartMonth": 0,
@@ -114,7 +114,7 @@
       "repeatDirection": "h",
       "options": {
         "mode": "markdown",
-        "content": "# 🏆 AI Gateway Scoreboard\nWho's using the platform, how much it costs, and how close we are to budget — live from the precomputed Mimir metrics (ADR-0058). Default window is **30 days**; pick a calendar month in the time picker for monthly totals. Filter by client & model up top. ⚡"
+        "content": "# 🏆 AI Gateway Scoreboard\nWho's using the platform, how much it costs, and how close we are to budget — live from the precomputed Mimir metrics (ADR-0058). Default window is **this month so far** (calendar month-to-date, resets on the 1st); pick any other range in the time picker to total a different period. Filter by client & model up top. ⚡"
       }
     },
     {
@@ -134,7 +134,7 @@
       "type": "gauge",
       "targets": [
         {
-          "expr": "100 * (sum(increase(loki_process_custom_gen_ai_usage_cost_micro_usd{service_name=\"envoy-ai-gateway\", azp=~\"$azp\", model=~\"$model\"}[30d])) / 1e6) / $budget",
+          "expr": "100 * (sum(increase(loki_process_custom_gen_ai_usage_cost_micro_usd{service_name=\"envoy-ai-gateway\", azp=~\"$azp\", model=~\"$model\"}[$__range])) / 1e6) / $budget",
           "refId": "A",
           "instant": true,
           "range": false,
@@ -145,8 +145,8 @@
           }
         }
       ],
-      "title": "Monthly budget burn (last 30d)",
-      "description": "Spend over the last 30 days as a % of the $budget variable (default $3000/mo).",
+      "title": "Monthly budget burn (range)",
+      "description": "Spend over the selected time range as a % of the $budget variable (default $3000/mo). Dashboard defaults to This month so far.",
       "transparent": false,
       "datasource": {
         "type": "prometheus",
@@ -204,7 +204,7 @@
       "type": "stat",
       "targets": [
         {
-          "expr": "((sum(increase(loki_process_custom_gen_ai_usage_cost_micro_usd{service_name=\"envoy-ai-gateway\", azp=~\"$azp\", model=~\"$model\"}[30d]))) / 1e6)",
+          "expr": "((sum(increase(loki_process_custom_gen_ai_usage_cost_micro_usd{service_name=\"envoy-ai-gateway\", azp=~\"$azp\", model=~\"$model\"}[$__range]))) / 1e6)",
           "refId": "A",
           "instant": true,
           "range": false,
@@ -215,7 +215,7 @@
           }
         }
       ],
-      "title": "Spend (last 30d)",
+      "title": "Spend (range)",
       "transparent": false,
       "datasource": {
         "type": "prometheus",
@@ -265,7 +265,7 @@
       "type": "stat",
       "targets": [
         {
-          "expr": "$budget - (sum(increase(loki_process_custom_gen_ai_usage_cost_micro_usd{service_name=\"envoy-ai-gateway\", azp=~\"$azp\", model=~\"$model\"}[30d])) / 1e6)",
+          "expr": "$budget - (sum(increase(loki_process_custom_gen_ai_usage_cost_micro_usd{service_name=\"envoy-ai-gateway\", azp=~\"$azp\", model=~\"$model\"}[$__range])) / 1e6)",
           "refId": "A",
           "instant": true,
           "range": false,

--- a/tools/dashboards/src/dashboards/envoy_ai_gateway/scoreboard.py
+++ b/tools/dashboards/src/dashboards/envoy_ai_gateway/scoreboard.py
@@ -65,8 +65,15 @@ OUTPUT_PATH: str = "charts/observability-dashboards/files/envoy-ai-gateway/score
 
 TEMPO_DS = dm.DataSourceRef(type_val="tempo", uid=TEMPO_UID)
 
-# Filters apply to every metric panel; the budget burn uses a fixed 30d window
-# (monthly budget) regardless of the dashboard range.
+# Filters apply to every metric panel. The budget-burn gauge and the two spend
+# stats use [$__range] (not a hardcoded duration) so they total whatever the
+# dashboard time picker has selected, same as every other panel here — the
+# dashboard defaults to "This month so far" (now/M .. now) so out of the box
+# they read as calendar month-to-date spend, mirroring the calendar-aligned
+# rate-limit windows fixed in ADR-0111. A fixed `[30d]` duration cannot express
+# "since the 1st of the month" (PromQL range-vector durations have no
+# since-month-start syntax); relying on the picker's own relative-time
+# resolution is the correct fix, not a synthetic duration computation.
 _SEL = sh.selector('azp=~"$azp"', 'model=~"$model"')
 
 _LEGEND_USER = "{{" + LABEL_DISPLAY_NAME + "}}"
@@ -96,14 +103,16 @@ def _budget_thresholds() -> db.ThresholdsConfig:
 
 
 def _gauge_budget() -> gauge.Panel:
-    # Percent of the editable monthly budget spent in the last 30 days. PromQL
-    # substitutes $budget as a literal number, so dividing by it is valid.
-    expr = f"100 * (sum(increase({METRIC_COST_MICRO_USD}{_SEL}[30d])) / 1e6) / $budget"
+    # Percent of the editable monthly budget spent over the dashboard's own
+    # time range (defaults to calendar month-to-date). PromQL substitutes
+    # $budget as a literal number, so dividing by it is valid.
+    expr = f"100 * (sum(increase({METRIC_COST_MICRO_USD}{_SEL}[$__range])) / 1e6) / $budget"
     return (
         gauge.Panel()
-        .title("Monthly budget burn (last 30d)")
+        .title("Monthly budget burn (range)")
         .description(
-            "Spend over the last 30 days as a % of the $budget variable (default $3000/mo)."
+            "Spend over the selected time range as a % of the $budget variable "
+            "(default $3000/mo). Dashboard defaults to This month so far."
         )
         .datasource(sh.MIMIR_DS)
         .grid_pos(dm.GridPos(h=8, w=8, x=0, y=4))
@@ -265,8 +274,9 @@ _HERO_MD = (
     "# 🏆 AI Gateway Scoreboard\n"
     "Who's using the platform, how much it costs, and how close we are to budget — "
     "live from the precomputed Mimir metrics (ADR-0058). "
-    "Default window is **30 days**; pick a calendar month in the time picker for "
-    "monthly totals. Filter by client & model up top. ⚡"
+    "Default window is **this month so far** (calendar month-to-date, resets on the "
+    "1st); pick any other range in the time picker to total a different period. "
+    "Filter by client & model up top. ⚡"
 )
 
 
@@ -286,10 +296,10 @@ def _hero() -> text.Panel:
 # ---------------------------------------------------------------------------
 
 
-def _stat_spend_30d() -> object:
+def _stat_spend_range() -> object:
     return sh.stat_panel(
-        title="Spend (last 30d)",
-        expr=sh.usd(f"sum(increase({METRIC_COST_MICRO_USD}{_SEL}[30d]))"),
+        title="Spend (range)",
+        expr=sh.usd(f"sum(increase({METRIC_COST_MICRO_USD}{_SEL}[$__range]))"),
         unit="currencyUSD",
         color="orange",
         grid=(4, 8, 8, 4),
@@ -297,7 +307,7 @@ def _stat_spend_30d() -> object:
 
 
 def _stat_budget_remaining() -> object:
-    expr = f"$budget - (sum(increase({METRIC_COST_MICRO_USD}{_SEL}[30d])) / 1e6)"
+    expr = f"$budget - (sum(increase({METRIC_COST_MICRO_USD}{_SEL}[$__range])) / 1e6)"
     return sh.stat_panel(
         title="Budget remaining (of $budget)",
         expr=expr,
@@ -412,7 +422,7 @@ def _dashboard() -> db.Dashboard:
         .editable()
         .tooltip(dm.DashboardCursorSync.CROSSHAIR)
         .refresh("5m")
-        .time("now-30d", "now")
+        .time("now/M", "now")
         .with_variable(_budget_var())
         .with_variable(
             sh.multi_var(
@@ -432,7 +442,7 @@ def _dashboard() -> db.Dashboard:
         .with_panel(_hero())
         .with_panel(sh.row("Headline", y=3))
         .with_panel(_gauge_budget())
-        .with_panel(_stat_spend_30d())
+        .with_panel(_stat_spend_range())
         .with_panel(_stat_budget_remaining())
         .with_panel(_stat_requests_range())
         .with_panel(_stat_active_actors())


### PR DESCRIPTION
## 1. Summary

This PR changes:

- `tools/dashboards/src/dashboards/envoy_ai_gateway/scoreboard.py`: the budget-burn gauge and the two spend stats (`_gauge_budget`, `_stat_spend_range` renamed from `_stat_spend_30d`, `_stat_budget_remaining`) now query `[$__range]` instead of a hardcoded `[30d]`.
- Dashboard default time range changed from `now-30d .. now` to `now/M .. now` ("this month so far").
- Regenerated `charts/observability-dashboards/files/envoy-ai-gateway/scoreboard.json` via `uv run dashboards build`.

It solves:

- The scoreboard's "Monthly budget burn" gauge and spend stats used a fixed 30-day rolling window, the same conceptual bug ADR-0111 fixed on the rate-limit enforcement side in #859 — a 30-day window is not a calendar month and drifts ~5 days/year off the real month boundary. Found while investigating ADR-0111.

---

## 2. Intent

> Make "monthly budget burn" on the App Scoreboard actually reset on the 1st of the calendar month instead of showing a rolling blend of the trailing 30 days (part last month, part this month). PromQL has no native "since start of month" range-vector duration, so the fix relies on the Grafana time picker's own relative-time resolution (`now/M`) driving `$__range`, matching the pattern every other panel in this file (and every other dashboard in `envoy_ai_gateway/`) already uses.

---

## 3. Scope

### In Scope

- The three `[30d]`-hardcoded PromQL queries in `scoreboard.py`.
- The dashboard's default time range.
- Updated docstring/comments that documented the old fixed-30d behavior as intentional.

### Out of Scope

- The Redis-derived `gateway_ratelimit_spend_micro_usd` quota dashboard (`ratelimit_quota.py`) — separate, already-filed follow-up (cross-repo, `ai-helm-values` `prometheus-redis-exporter` regex + a `$billing_period` variable). Unrelated data path (Redis live quota vs. Mimir historical cost).
- ADR-0111's gateway rate-limit enforcement fix — already merged, see #859.

---

## 4. Verification

I verified this change by:

- [x] Running automated tests
- [x] Checking logs
- [ ] Running manual tests
- [ ] Checking metrics
- [ ] Testing error cases
- [ ] Testing permissions/security behavior
- [ ] Testing rollback or failure behavior, if relevant

Commands run:

```bash
cd tools/dashboards
uv run dashboards build
uv run dashboards check
uv run ruff format . && uv run ruff check .
```

Results:

```text
wrote charts/observability-dashboards/files/envoy-ai-gateway/scoreboard.json
(+ 15 other unchanged dashboards re-serialized identically)
ok — every dashboard matches its generator
21 files left unchanged
All checks passed!
```

`git diff --stat` after build confirms only `scoreboard.json` changed.
Inspected the regenerated JSON directly: `time` is now `{"from": "now/M", "to": "now"}`
and all three panels' `targets[].expr` now end in `[$__range]` instead of `[30d]`.

Live confirmation that the gauge/stats actually read as calendar
month-to-date in the running Grafana (e.g. value drops near-zero right
after a month boundary) is **pending this PR's merge and ArgoCD sync**
— this repo's dashboards deploy via the `observability-dashboards`
chart reconciled by ArgoCD (continuous delivery, ADR-0055), so there is
no live dashboard to check against before merge. Will verify against
the live Grafana scoreboard after sync and report back.

---

## 5. Screenshots / Evidence

* Logs: build/check/lint output above.

---

## 6. Risk Assessment

Risk level:

* [x] Low

Potential risks:

* None to enforcement or data — this only changes a Grafana dashboard JSON (read-only visualization), no chart templates, no rate-limit config, no auth.
* Panel titles changed ("Spend (last 30d)" → "Spend (range)", "Monthly budget burn (last 30d)" → "Monthly budget burn (range)") — cosmetic only.

Mitigation:

* n/a — dashboard-only change, revertible by `git revert` (dashboard JSON is regenerated from source, no stateful migration).

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [x] Drafting documentation
* [x] Reviewing the diff
* [ ] Refactoring
* [ ] Generating tests

Human verification:

* [x] I understand every meaningful change in this PR
* [x] I checked generated code manually
* [x] I removed unsupported AI assumptions
* [x] I accept responsibility for this PR

---

## 8. Reviewer Focus

Please focus your review on:

* [x] Correctness
* [ ] Architecture
* [ ] Security
* [ ] Performance
* [ ] Tests
* [ ] Maintainability
* [ ] Product intent
* [ ] Edge cases
