### PR TITLE
fix(observability): rate-limit quota dashboard filters by calendar billing_period

### DIFF
--- a/charts/observability-dashboards/files/envoy-ai-gateway/ratelimit-quota.json
+++ b/charts/observability-dashboards/files/envoy-ai-gateway/ratelimit-quota.json
@@ -4,10 +4,10 @@
     "list": [
       {
         "type": "query",
-        "name": "window",
-        "label": "Budget window (30-day bucket)",
+        "name": "billing_period",
+        "label": "Billing period (calendar month)",
         "skipUrlSync": false,
-        "query": "label_values(gateway_ratelimit_spend_micro_usd, window)",
+        "query": "label_values(gateway_ratelimit_spend_micro_usd, billing_period)",
         "datasource": {
           "type": "prometheus",
           "uid": "mimir"
@@ -15,7 +15,7 @@
         "multi": false,
         "allowCustomValue": true,
         "refresh": 2,
-        "sort": 4,
+        "sort": 2,
         "includeAll": false,
         "auto": false,
         "auto_min": "10s",
@@ -84,7 +84,7 @@
   "annotations": {},
   "uid": "envoy-ai-gateway-ratelimit-quota",
   "title": "AI Gateway — rate-limit quota",
-  "description": "WHO is consuming the Envoy AI Gateway and HOW MUCH of their budget, read from the rate-limit service's LIVE counters in redis-ha (ADR-0070) — the only place that current-window state exists. Mimir panels rank spend per account/plan for the selected 30-day budget window (prometheus-redis-exporter → gateway_ratelimit_spend_micro_usd, ÷1e6 → USD); the bottom table is a direct redis-datasource census (zero scrape-lag). RAW consumption only — budget limits are static Helm config (ADR-0021/0035), not derivable per-user here. NO per-model breakdown: since the #532 shared-budget cutover the budget is one counter per (account, plan) spanning ALL models and both planes, so the keys carry no model label — see the Mimir/Loki cost dashboards for per-model spend. $window defaults to the current bucket. Filters: plan, account. GENERATED — source: tools/dashboards/envoy_ai_gateway/ratelimit_quota.py.",
+  "description": "WHO is consuming the Envoy AI Gateway and HOW MUCH of their budget, read from the rate-limit service's LIVE counters in redis-ha (ADR-0070) — the only place that current-window state exists. Mimir panels rank spend per account/plan for the selected calendar billing period (prometheus-redis-exporter → gateway_ratelimit_spend_micro_usd, ÷1e6 → USD); the bottom table is a direct redis-datasource census (zero scrape-lag). RAW consumption only — budget limits are static Helm config (ADR-0021/0035), not derivable per-user here. NO per-model breakdown: since the #532 shared-budget cutover the budget is one counter per (account, plan) spanning ALL models and both planes, so the keys carry no model label — see the Mimir/Loki cost dashboards for per-model spend. $billing_period (ai-helm ADR-0111) defaults to the current calendar month — the correct temporal filter, replacing the old 30-day-epoch `window` label. Filters: plan, account. GENERATED — source: tools/dashboards/envoy_ai_gateway/ratelimit_quota.py.",
   "tags": [
     "ai-gateway",
     "rate-limit",
@@ -106,7 +106,7 @@
       "collapsed": false,
       "id": 0,
       "panels": [],
-      "title": "Live budget consumption — selected window",
+      "title": "Live budget consumption — selected billing period",
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -118,7 +118,7 @@
       "type": "stat",
       "targets": [
         {
-          "expr": "((sum(gateway_ratelimit_spend_micro_usd{window=~\"$window\", plan=~\"$plan\", account_id=~\"$account\"})) / 1e6)",
+          "expr": "((sum(gateway_ratelimit_spend_micro_usd{billing_period=~\"$billing_period\", plan=~\"$plan\", account_id=~\"$account\"})) / 1e6)",
           "refId": "A",
           "instant": true,
           "range": false,
@@ -129,7 +129,7 @@
           }
         }
       ],
-      "title": "Total spend — this window",
+      "title": "Total spend — this period",
       "transparent": false,
       "datasource": {
         "type": "prometheus",
@@ -179,7 +179,7 @@
       "type": "stat",
       "targets": [
         {
-          "expr": "count(count by (account_id) (gateway_ratelimit_spend_micro_usd{window=~\"$window\", plan=~\"$plan\", account_id=~\"$account\"}))",
+          "expr": "count(count by (account_id) (gateway_ratelimit_spend_micro_usd{billing_period=~\"$billing_period\", plan=~\"$plan\", account_id=~\"$account\"}))",
           "refId": "A",
           "instant": true,
           "range": false,
@@ -240,7 +240,7 @@
       "type": "stat",
       "targets": [
         {
-          "expr": "count(gateway_ratelimit_spend_micro_usd{window=~\"$window\", plan=~\"$plan\", account_id=~\"$account\"})",
+          "expr": "count(gateway_ratelimit_spend_micro_usd{billing_period=~\"$billing_period\", plan=~\"$plan\", account_id=~\"$account\"})",
           "refId": "A",
           "instant": true,
           "range": false,
@@ -301,7 +301,7 @@
       "type": "stat",
       "targets": [
         {
-          "expr": "count(count by (plan) (gateway_ratelimit_spend_micro_usd{window=~\"$window\", plan=~\"$plan\", account_id=~\"$account\"}))",
+          "expr": "count(count by (plan) (gateway_ratelimit_spend_micro_usd{billing_period=~\"$billing_period\", plan=~\"$plan\", account_id=~\"$account\"}))",
           "refId": "A",
           "instant": true,
           "range": false,
@@ -362,7 +362,7 @@
       "type": "bargauge",
       "targets": [
         {
-          "expr": "((topk(20, sum by (account_id) (gateway_ratelimit_spend_micro_usd{window=~\"$window\", plan=~\"$plan\", account_id=~\"$account\"}))) / 1e6)",
+          "expr": "((topk(20, sum by (account_id) (gateway_ratelimit_spend_micro_usd{billing_period=~\"$billing_period\", plan=~\"$plan\", account_id=~\"$account\"}))) / 1e6)",
           "refId": "A",
           "instant": true,
           "range": false,
@@ -374,7 +374,7 @@
           }
         }
       ],
-      "title": "Top accounts by spend — this window",
+      "title": "Top accounts by spend — this period",
       "transparent": false,
       "datasource": {
         "type": "prometheus",
@@ -431,7 +431,7 @@
       "type": "piechart",
       "targets": [
         {
-          "expr": "((sum by (plan) (gateway_ratelimit_spend_micro_usd{window=~\"$window\", plan=~\"$plan\", account_id=~\"$account\"})) / 1e6)",
+          "expr": "((sum by (plan) (gateway_ratelimit_spend_micro_usd{billing_period=~\"$billing_period\", plan=~\"$plan\", account_id=~\"$account\"})) / 1e6)",
           "refId": "A",
           "instant": true,
           "range": false,
@@ -443,7 +443,7 @@
           }
         }
       ],
-      "title": "Spend share by plan — this window",
+      "title": "Spend share by plan — this period",
       "transparent": false,
       "datasource": {
         "type": "prometheus",
@@ -482,7 +482,7 @@
       "type": "table",
       "targets": [
         {
-          "expr": "((sum by (account_id, plan) (gateway_ratelimit_spend_micro_usd{window=~\"$window\", plan=~\"$plan\", account_id=~\"$account\"})) / 1e6)",
+          "expr": "((sum by (account_id, plan) (gateway_ratelimit_spend_micro_usd{billing_period=~\"$billing_period\", plan=~\"$plan\", account_id=~\"$account\"})) / 1e6)",
           "refId": "A",
           "instant": true,
           "range": false,
@@ -493,7 +493,7 @@
           }
         }
       ],
-      "title": "Consumption by account x plan — this window",
+      "title": "Consumption by account x plan — this period",
       "transparent": false,
       "datasource": {
         "type": "prometheus",
@@ -516,8 +516,7 @@
               "Value #A": "Spend ($)"
             },
             "excludeByName": {
-              "Time": true,
-              "window": true
+              "Time": true
             },
             "indexByName": {
               "account_id": 0,
@@ -584,7 +583,7 @@
       "type": "timeseries",
       "targets": [
         {
-          "expr": "((topk(10, sum by (account_id) (gateway_ratelimit_spend_micro_usd{window=~\"$window\", plan=~\"$plan\", account_id=~\"$account\"}))) / 1e6)",
+          "expr": "((topk(10, sum by (account_id) (gateway_ratelimit_spend_micro_usd{billing_period=~\"$billing_period\", plan=~\"$plan\", account_id=~\"$account\"}))) / 1e6)",
           "refId": "A",
           "instant": false,
           "range": true,

--- a/tools/dashboards/src/dashboards/_common.py
+++ b/tools/dashboards/src/dashboards/_common.py
@@ -97,11 +97,11 @@ METRIC_REQUESTS = _METRIC_PREFIX + "gen_ai_requests"
 # LIVE rate-limit quota gauge in Mimir (ADR-0070). prometheus-redis-exporter
 # SCANs the Lyft ratelimit service's monthly-budget keys in redis-ha and exports
 # each key's value; the ServiceMonitor metricRelabelings rename redis_key_value →
-# this metric and parse account_id / model / plan / plane / window out of the
-# 200-char key (see ai-helm-values environments/prod/values/
-# prometheus-redis-exporter.yaml). Value = micro-USD spent in the current 30-day
-# budget window — a GAUGE (current cumulative spend, not a counter; ÷1e6 → USD).
-# This is the limiter's own current-window state, which Mimir's historical cost
+# this metric and parse account_id / model / plan / plane / window / billing_period
+# out of the 200-char key (see ai-helm-values environments/prod/values/
+# prometheus-redis-exporter.yaml). Value = micro-USD spent in the current budget
+# period — a GAUGE (current cumulative spend, not a counter; ÷1e6 → USD). This
+# is the limiter's own current-window state, which Mimir's historical cost
 # metrics above do NOT hold.
 # ---------------------------------------------------------------------------
 METRIC_RATELIMIT_SPEND_MICRO_USD = "gateway_ratelimit_spend_micro_usd"
@@ -112,6 +112,13 @@ RL_LABEL_MODEL = "model"
 RL_LABEL_PLAN = "plan"
 RL_LABEL_PLANE = "plane"
 RL_LABEL_WINDOW = "window"
+# The calendar "YYYY-MM" marker (ai-helm ADR-0111) stamped on every request as
+# `x-billing-period` and carved out of the key alongside the legacy `window`
+# epoch bucket above. This is the semantically correct temporal filter — the
+# rate-limit key rotates on it at the real calendar month boundary, unlike
+# `window`, which drifts on a fixed 30-day cycle. See docs/adr/0111-calendar-
+# aligned-billing-period.md.
+RL_LABEL_BILLING_PERIOD = "billing_period"
 
 
 # ---------------------------------------------------------------------------

--- a/tools/dashboards/src/dashboards/envoy_ai_gateway/ratelimit_quota.py
+++ b/tools/dashboards/src/dashboards/envoy_ai_gateway/ratelimit_quota.py
@@ -7,25 +7,28 @@ budget; ADR-0070). Two read paths over the SAME Redis keys:
 
   1. Mimir leaderboard (the numbers). prometheus-redis-exporter SCANs the
      monthly-budget keys and exports `gateway_ratelimit_spend_micro_usd` with
-     parsed account_id / model / plan / plane / window labels. These panels rank
-     spend per account and per model for the selected 30-day budget window.
+     parsed account_id / plan / plane / window / billing_period labels. These
+     panels rank spend per account and per plan for the selected calendar
+     billing period.
   2. Redis census (the live "who's active right now"). A `redis-datasource`
      tmscan straight against redis-ha — zero scrape-lag, the limiter's own view.
 
 RAW consumption only (no quota/% overlay): the budget LIMITS live in static Helm
 config (free $50/mo, pro $200, per-model overrides — charts/ai-models) and a
 user's plan isn't on the key, so a precise "% of quota" can't be derived here.
-The value shown is micro-USD spent this window (÷1e6 → USD).
+The value shown is micro-USD spent this billing period (÷1e6 → USD).
 
-`window` is the 30-day budget bucket start (Unix epoch, a multiple of 2592000s).
-The $window picker defaults to the newest (current) bucket; the previous bucket
-lingers until its TTL, so pick it to see last period.
+`billing_period` is the calendar "YYYY-MM" marker (ai-helm ADR-0111) and is the
+primary temporal filter — it rotates on the real 1st-of-the-month, unlike the
+legacy `window` label (a fixed 30-day Unix-epoch bucket that drifts off the
+calendar and is no longer surfaced here). The $billing_period picker defaults
+to the newest (current) month; pick an older one to see a past period.
 
 The JSON file is regenerated from this module — do **not** hand-edit it::
 
     uv run dashboards build
 
-ADR: docs/adr/0070-ratelimit-quota-observability.md (+ ADR-0008).
+ADR: docs/adr/0070-ratelimit-quota-observability.md (+ ADR-0008, ADR-0111).
 """
 
 from __future__ import annotations
@@ -42,8 +45,8 @@ from dashboards._common import (
     METRIC_RATELIMIT_SPEND_MICRO_USD,
     REDIS_RATELIMIT_UID,
     RL_LABEL_ACCOUNT,
+    RL_LABEL_BILLING_PERIOD,
     RL_LABEL_PLAN,
-    RL_LABEL_WINDOW,
 )
 from dashboards.envoy_ai_gateway import _shared as sh
 
@@ -52,6 +55,7 @@ OUTPUT_PATH: str = "charts/observability-dashboards/files/envoy-ai-gateway/ratel
 _M = METRIC_RATELIMIT_SPEND_MICRO_USD
 _A = RL_LABEL_ACCOUNT
 _PL = RL_LABEL_PLAN
+_BP = RL_LABEL_BILLING_PERIOD
 
 # ⚠️ NO `model` / `plane` dimension here, by design. Since the #532 shared-budget
 # cutover the monthly budget is ONE counter per (account, plan) on the gateway-wide
@@ -61,9 +65,14 @@ _PL = RL_LABEL_PLAN
 # a `$model` variable here would blank the whole board, not just its own panels.
 # Per-model spend still lives in the Mimir/Loki cost dashboards (ADR-0058/0046).
 #
-# All filters refine the same metric. $window is single-select (default newest)
-# so totals are for ONE budget period; the rest are multi (default All → .+).
-_SEL = f'{{{RL_LABEL_WINDOW}=~"$window", {_PL}=~"$plan", {_A}=~"$account"}}'
+# All filters refine the same metric. $billing_period is single-select (default
+# newest) so totals are for ONE calendar month; the rest are multi (default All →
+# .+). The legacy `window` label still exists on the metric (kept by the exporter
+# for the lingering pre-rollover bucket) but is deliberately NOT selected on here
+# — it's a vestigial 30-day epoch artifact, not something a user should filter by
+# directly; summing across it within one billing_period gives the correct total
+# even if the underlying window happened to roll over mid-month.
+_SEL = f'{{{_BP}=~"$billing_period", {_PL}=~"$plan", {_A}=~"$account"}}'
 _MSEL = f"{_M}{_SEL}"
 
 _LEGEND_ACCOUNT = "{{" + _A + "}}"
@@ -100,7 +109,7 @@ class _RedisTmscanTarget:
 # ── Mimir leaderboard (the numbers) ────────────────────────────────────────────
 def _panel_total_spend() -> object:
     return sh.stat_panel(
-        title="Total spend — this window",
+        title="Total spend — this period",
         expr=sh.usd(f"sum({_MSEL})"),
         unit="currencyUSD",
         color="orange",
@@ -142,7 +151,7 @@ def _panel_plans() -> object:
 
 def _panel_top_accounts() -> object:
     return sh.bargauge_panel(
-        title="Top accounts by spend — this window",
+        title="Top accounts by spend — this period",
         expr=sh.usd(f"topk(20, sum by ({_A}) ({_MSEL}))"),
         legend=_LEGEND_ACCOUNT,
         unit="currencyUSD",
@@ -155,7 +164,7 @@ def _panel_spend_by_plan() -> object:
     # Was "Spend share by model". Same grid slot; billing tier is the dimension
     # the shared budget actually has.
     return sh.pie_panel(
-        title="Spend share by plan — this window",
+        title="Spend share by plan — this period",
         expr=sh.usd(f"sum by ({_PL}) ({_MSEL})"),
         legend_label=_LEGEND_PLAN,
         grid=(12, 12, 12, 5),
@@ -167,7 +176,7 @@ def _panel_breakdown_table() -> table.Panel:
     expr = sh.usd(f"sum by ({_A}, {_PL}) ({_MSEL})")
     panel = (
         table.Panel()
-        .title("Consumption by account x plan — this window")
+        .title("Consumption by account x plan — this period")
         .datasource(sh.MIMIR_DS)
         .grid_pos(dm.GridPos(h=12, w=24, x=0, y=17))
         .filterable(True)
@@ -181,7 +190,7 @@ def _panel_breakdown_table() -> table.Panel:
                         _PL: "Plan",
                         "Value #A": "Spend ($)",
                     },
-                    "excludeByName": {"Time": True, RL_LABEL_WINDOW: True},
+                    "excludeByName": {"Time": True},
                     "indexByName": {
                         _A: 0,
                         _PL: 1,
@@ -207,7 +216,7 @@ def _panel_breakdown_table() -> table.Panel:
 
 
 def _panel_spend_over_time() -> object:
-    # The gauge over time — accumulation within the window, per top account.
+    # The gauge over time — accumulation within the billing period, per top account.
     expr = sh.usd(f"topk(10, sum by ({_A}) ({_MSEL}))")
     return sh.daily_bars_panel(
         title="Spend over time — top accounts",
@@ -272,28 +281,32 @@ _DESCRIPTION = (
     "WHO is consuming the Envoy AI Gateway and HOW MUCH of their budget, read from "
     "the rate-limit service's LIVE counters in redis-ha (ADR-0070) — the only place "
     "that current-window state exists. Mimir panels rank spend per account/plan "
-    "for the selected 30-day budget window (prometheus-redis-exporter → "
+    "for the selected calendar billing period (prometheus-redis-exporter → "
     "gateway_ratelimit_spend_micro_usd, ÷1e6 → USD); the bottom table is a direct "
     "redis-datasource census (zero scrape-lag). RAW consumption only — budget "
     "limits are static Helm config (ADR-0021/0035), not derivable per-user here. "
     "NO per-model breakdown: since the #532 shared-budget cutover the budget is one "
     "counter per (account, plan) spanning ALL models and both planes, so the keys "
     "carry no model label — see the Mimir/Loki cost dashboards for per-model spend. "
-    "$window defaults to the current bucket. Filters: plan, account. "
+    "$billing_period (ai-helm ADR-0111) defaults to the current calendar month — "
+    "the correct temporal filter, replacing the old 30-day-epoch `window` label. "
+    "Filters: plan, account. "
     "GENERATED — source: tools/dashboards/envoy_ai_gateway/ratelimit_quota.py."
 )
 
 
-def _window_var() -> db.QueryVariable:
-    # Single-select, newest-first (NUMERICAL_DESC) so the current 30-day bucket is
-    # the default. No "All" — totals must be for ONE budget period.
+def _billing_period_var() -> db.QueryVariable:
+    # Single-select, newest-first so the current calendar month is the default.
+    # No "All" — totals must be for ONE budget period. ALPHABETICAL_DESC sorts
+    # a "YYYY-MM" string newest-first identically to a numerical sort, since the
+    # format is zero-padded and lexicographic order matches chronological order.
     return (
-        db.QueryVariable("window")
-        .label("Budget window (30-day bucket)")
+        db.QueryVariable("billing_period")
+        .label("Billing period (calendar month)")
         .datasource(sh.MIMIR_DS)
-        .query(sh.label_values(_M, RL_LABEL_WINDOW))
+        .query(sh.label_values(_M, _BP))
         .refresh(dm.VariableRefresh.ON_TIME_RANGE_CHANGED)
-        .sort(dm.VariableSort.NUMERICAL_DESC)
+        .sort(dm.VariableSort.ALPHABETICAL_DESC)
         .multi(False)
         .include_all(False)
     )
@@ -310,14 +323,14 @@ def _dashboard() -> db.Dashboard:
         .tooltip(dm.DashboardCursorSync.CROSSHAIR)
         .refresh("1m")
         .time("now-30d", "now")
-        .with_variable(_window_var())
+        .with_variable(_billing_period_var())
         .with_variable(sh.multi_var(name="plan", label="Plan", definition=sh.label_values(_M, _PL)))
         # NB: no `$model` variable — the shared-budget counters carry no `model`
         # label, and the multi-var default `.+` would match nothing at all.
         .with_variable(
             sh.multi_var(name="account", label="Account", definition=sh.label_values(_M, _A))
         )
-        .with_panel(sh.row("Live budget consumption — selected window", y=0))
+        .with_panel(sh.row("Live budget consumption — selected billing period", y=0))
         .with_panel(_panel_total_spend())
         .with_panel(_panel_active_accounts())
         .with_panel(_panel_counters())


### PR DESCRIPTION
## 1. Summary

This PR changes:

- Replaces the \`AI Gateway — rate-limit quota\` Grafana dashboard's only temporal filter, \`\$window\` (keyed on the old fixed 30-day rolling epoch bucket), with a new single-select \`\$billing_period\` variable keyed on the calendar \`YYYY-MM\` marker.
- Adds \`RL_LABEL_BILLING_PERIOD\` to \`tools/dashboards/src/dashboards/_common.py\` alongside the existing \`RL_LABEL_*\` constants.
- Regenerates \`charts/observability-dashboards/files/envoy-ai-gateway/ratelimit-quota.json\` via \`uv run dashboards build\` (generated source, not hand-edited).

It solves:

- ADR-0111 (#859) added the calendar-correct \`x-billing-period\` descriptor to the shared monthly-budget rate-limit rule so the *enforcement* side resets on the real 1st of the month, but left this dashboard filtering on the old drifting 30-day \`window\` epoch — exactly the imprecise concept the ADR fixed everywhere else.

---

## 2. Intent

> Give operators a dashboard filter that actually means \"this calendar month\", matching what ADR-0111 already did for rate-limit enforcement, instead of the old 30-day rolling bucket that drifts off the calendar by ~5 days/year.

Source of truth: #859 (ADR-0111 merge), \`docs/adr/0111-calendar-aligned-billing-period.md\`.

---

## 3. Scope

### In Scope

- \`tools/dashboards/src/dashboards/_common.py\` — new \`RL_LABEL_BILLING_PERIOD\` constant.
- \`tools/dashboards/src/dashboards/envoy_ai_gateway/ratelimit_quota.py\` — \`\$billing_period\` variable (replaces \`\$window\`), updated selector, panel titles, docstrings, description.
- Regenerated \`charts/observability-dashboards/files/envoy-ai-gateway/ratelimit-quota.json\`.

### Out of Scope

- The \`prometheus-redis-exporter\` regex change that actually parses \`billing_period\` out of the Redis key and exports it as a label on \`gateway_ratelimit_spend_micro_usd\`. That lives in the private \`ai-helm-values\` repo and is a separate, in-flight cross-repo change — **it has not merged/deployed yet**. Until it does, this dashboard's \`\$billing_period\` picker will show no options (the label doesn't exist in Mimir yet).
- The legacy \`window\` label stays on the metric (still needed by the exporter to avoid colliding pre/post-rollover buckets into one series) — it's just no longer surfaced as a dashboard filter (hard cutover, no dual-filter transition period, per repo convention).

---

## 4. Verification

I verified this change by:

- [x] Running automated tests
- [ ] Running manual tests
- [ ] Checking logs
- [ ] Checking metrics
- [ ] Testing error cases
- [ ] Testing permissions/security behavior
- [ ] Testing rollback or failure behavior, if relevant

Commands run:

\`\`\`bash
cd tools/dashboards
uv run dashboards build
uv run dashboards check
uv run ruff format . && uv run ruff check .
\`\`\`

Results:

\`\`\`text
wrote charts/observability-dashboards/files/envoy-ai-gateway/ratelimit-quota.json
(+ all other dashboards unchanged)
ok — every dashboard matches its generator
21 files left unchanged
All checks passed!
\`\`\`

⚠️ **Live Grafana verification is NOT possible yet** and is intentionally unchecked above — it depends on the \`ai-helm-values\` exporter change (see Scope) merging and deploying first, and on real gateway traffic occurring in the new billing period after that. Follow-up: once that lands, confirm \`label_values(gateway_ratelimit_spend_micro_usd, billing_period)\` returns real \`YYYY-MM\` values and that selecting the current month shows non-empty panels.

---

## 5. Screenshots / Evidence

Add evidence here:

* Screenshot: N/A — no live Grafana instance reachable from this change's environment; see Verification note above.
* Logs: N/A
* Metrics: N/A
* Recording: N/A

---

## 6. Risk Assessment

Risk level:

* [ ] Low
* [x] Medium
* [ ] High

Potential risks:

* Until the \`ai-helm-values\` exporter change lands, the \`\$billing_period\` picker on the live dashboard will show zero options (empty dropdown), making the dashboard temporarily less useful than before for anyone who opens it in that window.
* Historical spend recorded before the exporter change ships won't carry a \`billing_period\` label and won't show up under any billing-period selection (ages out on the existing Redis key TTL — no migration needed, same handling the exporter already gives the \`window\` label across monthly rollovers).

Mitigation:

* This PR should merge and deploy in the same rollout window as (or after) the \`ai-helm-values\` exporter change, not before — both halves of this dependency are now visible and explicit for whoever coordinates that.
* No other dashboards or metrics are affected — this is an isolated single-dashboard change with an automated drift check (\`dashboards check\`) protecting the generated JSON.

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [x] Refactoring
* [ ] Generating tests
* [x] Drafting documentation
* [ ] Reviewing the diff
* [ ] Not used

Human verification:

* [x] I understand every meaningful change in this PR
* [x] I checked generated code manually
* [ ] I checked generated tests manually
* [x] I removed unsupported AI assumptions
* [x] I accept responsibility for this PR

---

## 8. Reviewer Focus

Please focus your review on:

* [x] Correctness
* [ ] Architecture
* [ ] Security
* [ ] Performance
* [ ] Tests
* [x] Maintainability
* [ ] Product intent
* [x] Edge cases