### PR TITLE
fix(ci): repin security.yml to ai-ops security-gates.yml@v1.2.1

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -22,7 +22,7 @@ permissions:
 # workflow. See PR / .trivyignore.yaml header.
 jobs:
   scan:
-    uses: ADORSYS-GIS/ai-ops/.github/workflows/security-gates.yml@v1.2.0
+    uses: ADORSYS-GIS/ai-ops/.github/workflows/security-gates.yml@v1.2.1
     secrets: inherit
     with:
       trivy-scan-type: 'config'

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -22,7 +22,7 @@ permissions:
 # workflow. See PR / .trivyignore.yaml header.
 jobs:
   scan:
-    uses: ADORSYS-GIS/ai-ops/.github/workflows/security-gates.yml@v1.2.1
+    uses: ADORSYS-GIS/ai-ops/.github/workflows/security-gates.yml@v1.2.2
     secrets: inherit
     with:
       trivy-scan-type: 'config'

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -9,7 +9,7 @@ permissions:
   contents: read
   pull-requests: write
 
-# NOTE on chart coverage: this gate delegates to the org-shared ai-ops
+# NOTE on chart coverage: this gate delegates to the org-shared ai-governance
 # security-gates workflow, which does a bare `actions/checkout` and runs
 # `trivy config charts/` with NO `helm dependency build`. Every chart in this
 # repo that has a subchart dependency (all the model-serving/llm-d/librechat/…
@@ -20,9 +20,14 @@ permissions:
 # release-helm-charts.yml. We keep delegating here (org alignment); closing this
 # gap would mean forking an inline dep-build+render job away from the shared
 # workflow. See PR / .trivyignore.yaml header.
+#
+# Hosted in ai-governance (public), not ai-ops (private) — ai-ops's Actions
+# "Access" setting blocks all external callers outright, independent of the
+# workflow file's content. Pinned to an immutable commit SHA, not @main or a
+# movable tag, so a future push to ai-governance cannot change what runs here.
 jobs:
   scan:
-    uses: ADORSYS-GIS/ai-ops/.github/workflows/security-gates.yml@v1.2.2
+    uses: ADORSYS-GIS/ai-governance/.github/workflows/security-gates.yml@b0798a3b7218a21bd807405551fc6c73b63693b4
     secrets: inherit
     with:
       trivy-scan-type: 'config'


### PR DESCRIPTION
## 1. Summary

This PR changes:

- Repins \`.github/workflows/security.yml\` from \`ADORSYS-GIS/ai-ops/.github/workflows/security-gates.yml@v1.2.0\` to \`@v1.2.1\`.

It solves:

- Every push to this repo has been failing the "Security Audit" workflow instantly (0s, no jobs run) with GitHub's generic "This run likely failed because of a workflow file issue" — e.g. [run #30665060111](https://github.com/ADORSYS-GIS/ai-helm/actions/runs/30665060111) and every prior push to \`main\` today. Root-caused (in a separate investigation) to a duplicate \`runs-on:\` key in the \`gitleaks\` job of the pinned \`v1.2.0\` tag of the shared reusable workflow — GitHub Actions rejects duplicate mapping keys outright. Fixed upstream in [ADORSYS-GIS/ai-ops#155](https://github.com/ADORSYS-GIS/ai-ops/pull/155), tagged \`v1.2.1\`.

---

## 2. Intent

> This repo delegates its Trivy/Gitleaks security scanning to the org-shared \`ai-ops\` reusable workflow (documented rationale in the comment block above the \`scan\` job). That gate has been a complete no-op since \`v1.2.0\` was cut — not a partial/soft failure, every run fails before any job starts. Repin to the corrected tag so the actual security scan runs again.

---

## 3. Scope

### In Scope

- Bump the \`@v1.2.0\` → \`@v1.2.1\` pin in \`.github/workflows/security.yml\`.

### Out of Scope

- The upstream fix itself (already merged + tagged in \`ai-ops\`).
- \`release-please\`'s failure to auto-cut the tag (org-level GitHub Actions billing issue in \`ai-ops\`, unrelated to this repo) — \`v1.2.1\` was tagged manually at the merged fix commit as a result.

---

## 4. Verification

I verified this change by:

- [x] Checking logs

Commands run:

\`\`\`bash
# Confirmed the referenced tag content is syntactically valid before repinning
curl -s "https://api.github.com/repos/ADORSYS-GIS/ai-ops/contents/.github/workflows/security-gates.yml?ref=v1.2.1" | jq -r .content | base64 -d > /tmp/security-gates.yml
actionlint /tmp/security-gates.yml
\`\`\`

Results:

\`\`\`text
(no duplicate-key error; only a pre-existing, unrelated style warning on
an unused default remains — same as the last known-good v1.1.0 tag)
\`\`\`

Live confirmation: this PR's own CI run of \`.github/workflows/security.yml\` (against \`@v1.2.1\`) is the real end-to-end test — see the Checks tab on this PR.

---

## 5. Screenshots / Evidence

* Root-cause upstream PR: https://github.com/ADORSYS-GIS/ai-ops/pull/155
* Failing run before fix: https://github.com/ADORSYS-GIS/ai-helm/actions/runs/30665060111

---

## 6. Risk Assessment

Risk level:

* [x] Low

Potential risks:

* \`v1.2.1\` was tagged manually rather than via \`ai-ops\`'s automated release-please flow (blocked by that repo's GitHub Actions billing issue), so it carries no auto-generated changelog entry until that's reconciled.

Mitigation:

* Verified the tag's content directly (points at the merged, actionlint-clean commit) rather than relying on the release automation.

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code

Human verification:

* [x] I understand every meaningful change in this PR
* [x] I checked generated code manually
* [x] I removed unsupported AI assumptions
* [x] I accept responsibility for this PR

---

## 8. Reviewer Focus

Please focus your review on:

* [x] Correctness