### PR TITLE
fix(observability-dashboards): fix extractFields format + delimiters on ratelimit census

### DIFF
--- a/charts/observability-dashboards/files/envoy-ai-gateway/ratelimit-quota.json
+++ b/charts/observability-dashboards/files/envoy-ai-gateway/ratelimit-quota.json
@@ -687,8 +687,8 @@
           "id": "extractFields",
           "options": {
             "source": "key",
-            "format": "regex",
-            "regExp": "^(?:.*/converse/(?<Model>[^/]+)/)?.*_rule-\\d+-match-0_(?<Account>.+?)_rule-\\d+-match-1(?:_rule-\\d+-match-1)?(?:_rule-\\d+-match-2_(?<BillingPeriod>\\d{4}-\\d{2}))?",
+            "format": "regexp",
+            "regExp": "/^(?:.*\\/converse\\/(?<Model>[^/]+)\\/)?.*_rule-\\d+-match-0_(?<Account>.+?)_rule-\\d+-match-1(?:_rule-\\d+-match-1)?(?:_rule-\\d+-match-2_(?<BillingPeriod>\\d{4}-\\d{2}))?/",
             "keepFields": true
           }
         },

--- a/tools/dashboards/src/dashboards/envoy_ai_gateway/ratelimit_quota.py
+++ b/tools/dashboards/src/dashboards/envoy_ai_gateway/ratelimit_quota.py
@@ -260,6 +260,25 @@ def _panel_live_census() -> table.Panel:
     # useful for watching the rollout finish. The $billing_period Mimir filter
     # above can't show this: it only ever sees keys the exporter has already
     # scraped and relabeled, not the raw-key rotation state.
+    #
+    # ⚠️ Two Grafana-model gotchas here, both pre-dating this file (verified
+    # against Grafana's own source, packages/grafana-data/src/text/string.ts
+    # + public/app/features/transformers/extractFields/{types,fieldExtractors}.ts,
+    # v12.3.1 — the pinned chart version, charts/observability/values.yaml):
+    #   1. `format` must be the literal `FieldExtractorID` enum value
+    #      `"regexp"`, not `"regex"` — an unrecognized format id fails the
+    #      WHOLE transform with "Error transforming data: unknown extractor"
+    #      (the registry has no `"regex"` entry: json|kvp|auto|regexp|delimiter).
+    #   2. The pattern must be wrapped in `/…/` delimiters, like a JS regex
+    #      literal. `stringToJsRegex` special-cases this: `stringStartsAsRegEx`
+    #      only checks the FIRST character is `/`; without both delimiters the
+    #      whole option is silently discarded and Grafana falls back to its own
+    #      built-in default `/(?<NewField>.*)/` — which is exactly why the
+    #      table used to render one big "NewField" column holding the whole raw
+    #      key instead of Account/Model/Billing period, with no error at all.
+    #      (The trailing `/` before `stringToJsRegex`'s own non-greedy `.*?`
+    #      still finds the TRUE closing delimiter correctly across our
+    #      pattern's internal `/`s — verified live, not just reasoned about.)
     return (
         table.Panel()
         .title("Live limiter counters — direct from Redis (zero scrape-lag)")
@@ -272,12 +291,12 @@ def _panel_live_census() -> table.Panel:
                 id_val="extractFields",
                 options={
                     "source": "key",
-                    "format": "regex",
+                    "format": "regexp",
                     "regExp": (
-                        r"^(?:.*/converse/(?<Model>[^/]+)/)?"
+                        r"/^(?:.*\/converse\/(?<Model>[^/]+)\/)?"
                         r".*_rule-\d+-match-0_(?<Account>.+?)_rule-\d+-match-1"
                         r"(?:_rule-\d+-match-1)?"
-                        r"(?:_rule-\d+-match-2_(?<BillingPeriod>\d{4}-\d{2}))?"
+                        r"(?:_rule-\d+-match-2_(?<BillingPeriod>\d{4}-\d{2}))?/"
                     ),
                     "keepFields": True,
                 },


### PR DESCRIPTION
## 1. Summary

This PR changes:

- `tools/dashboards/src/dashboards/envoy_ai_gateway/ratelimit_quota.py`: the "Live limiter counters" panel's `extractFields` transform now uses `"format": "regexp"` (was `"regex"`) and wraps the pattern in `/…/` delimiters as Grafana's `stringToJsRegex` requires.
- Regenerated `charts/observability-dashboards/files/envoy-ai-gateway/ratelimit-quota.json` via `uv run dashboards build`.

It solves:

- The panel's field extraction has been non-functional since before #862/#865 — verified against Grafana v12.3.1 source (the pinned chart version in `charts/observability/values.yaml`): `public/app/features/transformers/extractFields/types.ts` defines `FieldExtractorID` as `json|kvp|auto|regexp|delimiter` (no `"regex"`), and `packages/grafana-data/src/text/string.ts`'s `stringToJsRegex` silently falls back to Grafana's own default `/(?<NewField>.*)/` unless the pattern starts and ends with `/`. This was invisible until now because a separate, unrelated bug (the `redis-datasource` Grafana plugin was never installed — fixed in `ai-helm-values` commit `c4c4330`, found and fixed live while verifying #865) meant the whole panel errored with "Datasource not found" before the transform pipeline ever ran far enough to hit it.

---

## 2. Intent

> Make the census table's Account/Model/Billing-period columns actually populate from live Redis data, instead of either erroring ("unknown extractor") or silently collapsing into one "NewField" column holding the raw unparsed key. Both are Grafana-model-schema bugs, not logic bugs — the regex content itself was already correct (verified independently in Python and in a live browser JS console against real keys before touching source).

---

## 3. Scope

### In Scope

- `format` and `regExp` option values on the one `extractFields` transform in `_panel_live_census`.
- Explanatory comments citing the exact Grafana source files/lines that document this behavior.

### Out of Scope

- The `redis-datasource` plugin-install fix — already applied directly (`ai-helm-values` commit `c4c4330`, not a PR in that private repo per its own file-header convention: "Edit here; ArgoCD auto-syncs on commit to main").
- Any other panel/query logic — untouched.

---

## 4. Verification

I verified this change by:

- [x] Running automated tests
- [x] Running manual tests
- [x] Checking logs
- [ ] Checking metrics
- [ ] Testing error cases
- [ ] Testing permissions/security behavior
- [ ] Testing rollback or failure behavior, if relevant

Commands run:

```bash
cd tools/dashboards
uv run dashboards build
uv run dashboards check
uv run ruff format . && uv run ruff check .
```

Results:

```text
wrote charts/observability-dashboards/files/envoy-ai-gateway/ratelimit-quota.json
ok — every dashboard matches its generator
21 files left unchanged
All checks passed!
```

`git diff --stat` after build confirms only `ratelimit-quota.json` changed.

**Manual/live verification** (the substantive check here): opened the live
`AI Gateway — rate-limit quota` dashboard in Grafana after the plugin fix
landed, confirmed the panel errored with "Error transforming data: unknown
extractor" using the pre-existing `"format": "regex"`. Used the panel's own
Transformations tab to change `Format` to `RegExp` in the UI (confirming
Grafana's own dropdown only recognizes that spelling) and, via the browser's
JS console (`javascript_tool`), set the `regExp` field's value directly to
test both a minimal single-group pattern and the full three-group pattern
wrapped in `/…/` — both correctly split into separate `Account`/`Model`/
`BillingPeriod` columns against real Redis keys (including one real key with
a `billing_period` segment and several without, correctly leaving that
column blank on the latter). Cross-checked the mechanism against Grafana's
own pinned-version source (`fieldExtractors.ts`, `string.ts`) rather than
just trusting the empirical result. Discarded the exploratory panel edits
(never saved to Grafana) and applied the equivalent fix here in source.

---

## 5. Screenshots / Evidence

* Logs: build/check/lint output above; Grafana source excerpts quoted in code comments.

---

## 6. Risk Assessment

Risk level:

* [x] Low

Potential risks:

* None to enforcement or data — dashboard JSON only (a client-side, read-only transform), no chart templates, no rate-limit config, no auth.
* If the Grafana version is ever bumped past 12.3.1, re-verify this transform's option schema hasn't changed again (same class of risk as any other panel referencing internal Grafana schema shapes).

Mitigation:

* n/a — dashboard-only change, revertible by `git revert` (dashboard JSON is regenerated from source, no stateful migration).

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [x] Drafting documentation
* [x] Reviewing the diff
* [ ] Refactoring
* [ ] Generating tests

Human verification:

* [x] I understand every meaningful change in this PR
* [x] I checked generated code manually
* [x] I removed unsupported AI assumptions
* [x] I accept responsibility for this PR

---

## 8. Reviewer Focus

Please focus your review on:

* [x] Correctness
* [ ] Architecture
* [ ] Security
* [ ] Performance
* [ ] Tests
* [ ] Maintainability
* [ ] Product intent
* [ ] Edge cases
