### PR TITLE
fix(observability-dashboards): correct extractFields format id on ratelimit quota board

### DIFF
--- a/charts/observability-dashboards/files/envoy-ai-gateway/ratelimit-quota.json
+++ b/charts/observability-dashboards/files/envoy-ai-gateway/ratelimit-quota.json
@@ -687,7 +687,7 @@
           "id": "extractFields",
           "options": {
             "source": "key",
-            "format": "regex",
+            "format": "regexp",
             "regExp": "^(?:.*/converse/(?<Model>[^/]+)/)?.*_rule-\\d+-match-0_(?<Account>.+?)_rule-\\d+-match-1",
             "keepFields": true
           }

--- a/tools/dashboards/src/dashboards/envoy_ai_gateway/ratelimit_quota.py
+++ b/tools/dashboards/src/dashboards/envoy_ai_gateway/ratelimit_quota.py
@@ -255,7 +255,7 @@ def _panel_live_census() -> table.Panel:
                 id_val="extractFields",
                 options={
                     "source": "key",
-                    "format": "regex",
+                    "format": "regexp",
                     "regExp": (
                         r"^(?:.*/converse/(?<Model>[^/]+)/)?"
                         r".*_rule-\d+-match-0_(?<Account>.+?)_rule-\d+-match-1"


### PR DESCRIPTION
## 1. Summary

This PR changes:

- Fixes the `extractFields` transform's `format` id on the "Live limiter counters — direct from Redis" panel of the **AI Gateway — rate-limit quota** dashboard, from `"regex"` to `"regexp"`.
- Regenerates `charts/observability-dashboards/files/envoy-ai-gateway/ratelimit-quota.json` from the corrected source (`uv run dashboards build`).

It solves:

- Every load of that panel failed client-side with **"Error transforming data: unknown extractor"**, so the Account/Model columns were never carved out of the raw Redis `tmscan` key. Found live while visually verifying the ADR-0111 `billing_period` fix in #862.

---

## 2. Intent

> Grafana's `extractFields` transformer only registers extractors under `json` / `kvp` / `auto` / `delimiter` / `regexp` (verified against Grafana core's [`fieldExtractors/types.ts`](https://github.com/grafana/grafana/blob/main/public/app/features/transformers/extractFields/types.ts) — `RegExp = 'regexp'`). There is no `regex` extractor, so a panel configured with `"format": "regex"` finds nothing in the registry and fails outright. This is a plain typo fix, one character (`regex` → `regexp`), no behavior change intended beyond making the transform actually run.

---

## 3. Scope

### In Scope

- `tools/dashboards/src/dashboards/envoy_ai_gateway/ratelimit_quota.py` — the `format` value on the panel's `extractFields` transform.
- Regenerated `charts/observability-dashboards/files/envoy-ai-gateway/ratelimit-quota.json`.

### Out of Scope

- The separate, already-fixed issue of the `redis-datasource` Grafana plugin not being installed (that's an `ai-helm-values` values change — `environments/prod/values/grafana.yaml` — already merged directly, since chart logic vs. deployed config are split repos per ADR-0055/0056).
- Any other dashboard's transforms — `extractFields` is used exactly once in this whole dashboards codebase (grepped), so no other panel carries the same typo.

---

## 4. Verification

I verified this change by:

- [x] Running automated tests
- [x] Running manual tests
- [x] Checking logs
- [ ] Checking metrics
- [ ] Testing error cases
- [ ] Testing permissions/security behavior
- [ ] Testing rollback or failure behavior, if relevant

Commands run:

```bash
cd tools/dashboards
uv run dashboards build   # regenerates the JSON from the corrected source
uv run dashboards check   # CI drift guard
uv run ruff format --check . && uv run ruff check .
helm lint charts/observability-dashboards --strict
helm template x charts/observability-dashboards --dry-run | grep -A3 '"format": "regexp"'
```

Results:

```text
ok — every dashboard matches its generator
21 files already formatted / All checks passed!
1 chart(s) linted, 0 chart(s) failed
"format": "regexp",
"regExp": "^(?:.*/converse/(?<Model>[^/]+)/)?.*_rule-\\d+-match-0_(?<Account>.+?)_rule-\\d+-match-1",
"keepFields": true
```

Additionally verified LIVE against the actual cluster (Hetzner `home-remote`, ns `observability`) before this fix was authored: reproduced the exact `level=error msg="Could not find plugin definition for data source"` (the separate, already-fixed plugin bug) and then, after that fix synced, the `Error transforming data: unknown extractor` banner in the browser (Grafana 12.3.1) on this panel specifically — confirmed via Grafana's own Inspect view.

---

## 5. Screenshots / Evidence

* Browser confirmation of the "unknown extractor" error on the live dashboard (session transcript, not re-hosted here — happy to attach a screenshot on request).
* Grafana core source confirming the valid extractor ids: https://github.com/grafana/grafana/blob/main/public/app/features/transformers/extractFields/types.ts

---

## 6. Risk Assessment

Risk level:

* [x] Low
* [ ] Medium
* [ ] High

Potential risks:

* None expected — single-character string value fix inside one panel's transform config, JSON output is otherwise byte-identical (diff is a 1-line change in the generated file).

Mitigation:

* `dashboards check` (the drift-guard CI gate) confirms the generator and committed JSON stay in lockstep.
* `helm lint --strict` + `helm template --dry-run` confirm the chart still renders.

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [ ] Refactoring
* [ ] Generating tests
* [ ] Drafting documentation
* [x] Reviewing the diff
* [ ] Not used

Human verification:

* [x] I understand every meaningful change in this PR
* [x] I checked generated code manually
* [ ] I checked generated tests manually
* [x] I removed unsupported AI assumptions
* [x] I accept responsibility for this PR

---

## 8. Reviewer Focus

Please focus your review on:

* [x] Correctness
* [ ] Architecture
* [ ] Security
* [ ] Performance
* [ ] Tests
* [ ] Maintainability
* [ ] Product intent
* [ ] Edge cases
