### PR TITLE
feat(webank-training): pin LakeFS routes per model

### DIFF
--- a/charts/webank-training/ci/lint-values.yaml
+++ b/charts/webank-training/ci/lint-values.yaml
@@ -4,7 +4,6 @@ training:
   image: ghcr.io/adorsys-gis/webank-train-gpu@sha256:c1774729a3bf86c1a1cd231a3d06293bf35c950bfec061726e4aa42ea24cf0e7
   lakefs:
     endpoint: http://lakefs.mlops.svc.cluster.local:80
-    candidateBranch: candidates
   otel:
     endpoint: http://alloy.observability.svc.cluster.local:4318
   gpu:
@@ -18,15 +17,30 @@ models:
   - id: document-detector
     datasetMaterializer: materialize-document-detector-descriptor
     trainer: document-detector
+    lakefs:
+      dataset: { repository: ds-document-detector, branch: main }
+      model: { repository: model-document-detector, branch: main }
   - id: document-recognizer
     datasetMaterializer: materialize-document-recognizer-descriptor
     trainer: document-recognizer
+    lakefs:
+      dataset: { repository: ds-document-recognizer, branch: main }
+      model: { repository: model-document-recognizer, branch: main }
   - id: face-detector
     datasetMaterializer: materialize-face-detector-descriptor
     trainer: face-detector
+    lakefs:
+      dataset: { repository: ds-face-detector, branch: main }
+      model: { repository: model-face-detector, branch: main }
   - id: sface
     datasetMaterializer: materialize-sface-descriptor
     trainer: sface
+    lakefs:
+      dataset: { repository: ds-sface, branch: main }
+      model: { repository: model-sface, branch: main }
   - id: pad-liveness
     datasetMaterializer: materialize-pad-descriptor
     trainer: pad-liveness-pending
+    lakefs:
+      dataset: { repository: ds-pad-liveness, branch: main }
+      model: { repository: model-pad-liveness, branch: main }

--- a/charts/webank-training/templates/workflowtemplate.yaml
+++ b/charts/webank-training/templates/workflowtemplate.yaml
@@ -5,7 +5,6 @@
 {{- if not $training.image }}{{ fail "webank-training: training.image must be an immutable image digest" }}{{- end }}
 {{- if not (contains "@sha256:" $training.image) }}{{ fail "webank-training: training.image must be digest-pinned" }}{{- end }}
 {{- if not $lakefs.endpoint }}{{ fail "webank-training: training.lakefs.endpoint is required" }}{{- end }}
-{{- if not $lakefs.candidateBranch }}{{ fail "webank-training: training.lakefs.candidateBranch is required" }}{{- end }}
 {{- if not $training.otel.endpoint }}{{ fail "webank-training: training.otel.endpoint is required" }}{{- end }}
 {{- if not $workflow.serviceAccountName }}{{ fail "webank-training: workflow.serviceAccountName is required" }}{{- end }}
 {{- if eq (len .Values.models) 0 }}{{ fail "webank-training: models must declare the public model workflow catalogue" }}{{- end }}
@@ -22,6 +21,17 @@
 {{- $id := required "webank-training: models[].id is required" $model.id -}}
 {{- $materializer := required (printf "webank-training: %s datasetMaterializer is required" $id) $model.datasetMaterializer -}}
 {{- $trainer := required (printf "webank-training: %s trainer is required" $id) $model.trainer -}}
+{{- $modelLakefs := required (printf "webank-training: %s lakefs is required" $id) $model.lakefs -}}
+{{- $datasetLakefs := required (printf "webank-training: %s lakefs.dataset is required" $id) $modelLakefs.dataset -}}
+{{- $candidateLakefs := required (printf "webank-training: %s lakefs.model is required" $id) $modelLakefs.model -}}
+{{- $datasetRepository := required (printf "webank-training: %s lakefs.dataset.repository is required" $id) $datasetLakefs.repository -}}
+{{- $datasetBranch := required (printf "webank-training: %s lakefs.dataset.branch is required" $id) $datasetLakefs.branch -}}
+{{- $candidateRepository := required (printf "webank-training: %s lakefs.model.repository is required" $id) $candidateLakefs.repository -}}
+{{- $candidateBranch := required (printf "webank-training: %s lakefs.model.branch is required" $id) $candidateLakefs.branch -}}
+{{- if ne $datasetRepository (printf "ds-%s" $id) }}{{ fail (printf "webank-training: %s dataset repository must be ds-%s" $id $id) }}{{- end }}
+{{- if ne $candidateRepository (printf "model-%s" $id) }}{{ fail (printf "webank-training: %s model repository must be model-%s" $id $id) }}{{- end }}
+{{- if ne $datasetBranch "main" }}{{ fail (printf "webank-training: %s dataset branch must be main" $id) }}{{- end }}
+{{- if ne $candidateBranch "main" }}{{ fail (printf "webank-training: %s model branch must be main" $id) }}{{- end }}
 {{- if not (has $materializer (list "materialize-document-detector-descriptor" "materialize-document-recognizer-descriptor" "materialize-face-detector-descriptor" "materialize-sface-descriptor" "materialize-pad-descriptor")) }}{{ fail (printf "webank-training: %s has an unknown dataset materializer" $id) }}{{- end }}
 {{- if not (has $trainer (list "document-detector" "document-recognizer" "face-detector" "sface" "pad-liveness-pending")) }}{{ fail (printf "webank-training: %s has an unknown trainer" $id) }}{{- end }}
 ---
@@ -38,6 +48,8 @@ metadata:
     webank.io/adr: "0034"
     webank.io/dataset-contract: "0006"
     webank.io/materialization: "metadata-descriptor"
+    webank.io/dataset-lakefs-repository: {{ $datasetRepository | quote }}
+    webank.io/dataset-lakefs-branch: {{ $datasetBranch | quote }}
 spec:
   entrypoint: build
   activeDeadlineSeconds: {{ $workflow.activeDeadlineSeconds }}
@@ -85,15 +97,18 @@ spec:
               --manifest /workspace/input/source-manifest.json \
               --lakefs-ref "$LAKEFS_REF" \
               --readiness /workspace/input/readiness.json \
-              --lakefs-branch "$WEBANK_LAKEFS_CANDIDATE_BRANCH" \
-              --lakefs-endpoint "$WEBANK_LAKEFS_ENDPOINT"
+              --lakefs-branch "$WEBANK_DATASET_LAKEFS_BRANCH" \
+              --lakefs-endpoint "$WEBANK_LAKEFS_ENDPOINT" \
+              --lakefs-repository "$WEBANK_DATASET_LAKEFS_REPOSITORY"
         env:
           - name: LAKEFS_REF
             value: "{{`{{workflow.parameters.lakefs_ref}}`}}"
           - name: WEBANK_LAKEFS_ENDPOINT
             value: {{ $lakefs.endpoint | quote }}
-          - name: WEBANK_LAKEFS_CANDIDATE_BRANCH
-            value: {{ $lakefs.candidateBranch | quote }}
+          - name: WEBANK_DATASET_LAKEFS_REPOSITORY
+            value: {{ $datasetRepository | quote }}
+          - name: WEBANK_DATASET_LAKEFS_BRANCH
+            value: {{ $datasetBranch | quote }}
           - name: LAKEFS_ACCESS_KEY_ID
             valueFrom: { secretKeyRef: { name: {{ $lakefs.secretName | quote }}, key: {{ $lakefs.accessKey | quote }} } }
           - name: LAKEFS_SECRET_ACCESS_KEY
@@ -118,6 +133,10 @@ metadata:
   annotations:
     webank.io/adr: "0034"
     webank.io/observability-adr: "0035"
+    webank.io/dataset-lakefs-repository: {{ $datasetRepository | quote }}
+    webank.io/dataset-lakefs-branch: {{ $datasetBranch | quote }}
+    webank.io/model-lakefs-repository: {{ $candidateRepository | quote }}
+    webank.io/model-lakefs-branch: {{ $candidateBranch | quote }}
 {{- if eq $trainer "pad-liveness-pending" }}
     webank.io/execution-state: "blocked-by-pad-training-harness"
 {{- end }}
@@ -134,10 +153,13 @@ spec:
   arguments:
     parameters:
 {{- if eq $trainer "document-detector" }}
-      - name: dataset_uri
+      - name: dataset_ref
         description: >-
-          Required pinned document-detector LakeFS location:
-          lakefs://repository/64-character-commit/dataset-version.
+          Required immutable 64-character commit in this template's fixed
+          ds-document-detector LakeFS repository; branches and moving tags fail closed.
+      - name: dataset_version
+        description: >-
+          Required dataset version directory committed by the dataset-build workflow.
 {{- else if ne $trainer "pad-liveness-pending" }}
       - name: lakefs_ref
         description: Required immutable 64-character LakeFS commit for the dataset artifacts.
@@ -175,6 +197,7 @@ spec:
         args:
           - |
 {{- if eq $trainer "document-detector" }}
+            DATASET_URI="lakefs://${WEBANK_DATASET_LAKEFS_REPOSITORY}/${DATASET_REF}/${DATASET_VERSION}"
             cargo xtask training-data checkout-document-detector \
               --dataset-uri "$DATASET_URI" \
               --lakefs-endpoint "$WEBANK_LAKEFS_ENDPOINT" \
@@ -194,8 +217,9 @@ spec:
               --manifest /workspace/document-detector/governance/source-manifest.json \
               --lakefs-ref "$LAKEFS_SOURCE_REF" \
               --readiness /workspace/document-detector/governance/readiness.json \
-              --lakefs-branch "$WEBANK_LAKEFS_CANDIDATE_BRANCH" \
-              --lakefs-endpoint "$WEBANK_LAKEFS_ENDPOINT"
+              --lakefs-branch "$WEBANK_MODEL_LAKEFS_BRANCH" \
+              --lakefs-endpoint "$WEBANK_LAKEFS_ENDPOINT" \
+              --lakefs-repository "$WEBANK_MODEL_LAKEFS_REPOSITORY"
 {{- else if eq $trainer "document-recognizer" }}
             cargo xtask training-data readiness-gate \
               --manifest /workspace/governance/source-manifest.json \
@@ -211,8 +235,9 @@ spec:
               --manifest /workspace/governance/source-manifest.json \
               --lakefs-ref "$LAKEFS_REF" \
               --readiness /workspace/governance/readiness.json \
-              --lakefs-branch "$WEBANK_LAKEFS_CANDIDATE_BRANCH" \
-              --lakefs-endpoint "$WEBANK_LAKEFS_ENDPOINT"
+              --lakefs-branch "$WEBANK_MODEL_LAKEFS_BRANCH" \
+              --lakefs-endpoint "$WEBANK_LAKEFS_ENDPOINT" \
+              --lakefs-repository "$WEBANK_MODEL_LAKEFS_REPOSITORY"
 {{- else if eq $trainer "face-detector" }}
             cargo xtask training-data readiness-gate \
               --manifest /workspace/governance/source-manifest.json \
@@ -228,8 +253,9 @@ spec:
               --manifest /workspace/governance/source-manifest.json \
               --lakefs-ref "$LAKEFS_REF" \
               --readiness /workspace/governance/readiness.json \
-              --lakefs-branch "$WEBANK_LAKEFS_CANDIDATE_BRANCH" \
-              --lakefs-endpoint "$WEBANK_LAKEFS_ENDPOINT"
+              --lakefs-branch "$WEBANK_MODEL_LAKEFS_BRANCH" \
+              --lakefs-endpoint "$WEBANK_LAKEFS_ENDPOINT" \
+              --lakefs-repository "$WEBANK_MODEL_LAKEFS_REPOSITORY"
 {{- else if eq $trainer "sface" }}
             cargo xtask training-data readiness-gate \
               --manifest /workspace/governance/source-manifest.json \
@@ -245,16 +271,19 @@ spec:
               --manifest /workspace/governance/source-manifest.json \
               --lakefs-ref "$LAKEFS_REF" \
               --readiness /workspace/governance/readiness.json \
-              --lakefs-branch "$WEBANK_LAKEFS_CANDIDATE_BRANCH" \
-              --lakefs-endpoint "$WEBANK_LAKEFS_ENDPOINT"
+              --lakefs-branch "$WEBANK_MODEL_LAKEFS_BRANCH" \
+              --lakefs-endpoint "$WEBANK_LAKEFS_ENDPOINT" \
+              --lakefs-repository "$WEBANK_MODEL_LAKEFS_REPOSITORY"
 {{- else }}
             echo "PAD liveness candidate training is unavailable: the governed PAD dataset descriptor exists, but no PAD optimizer/trainer has landed. Refusing to fabricate a candidate." >&2
             exit 2
 {{- end }}
         env:
 {{- if eq $trainer "document-detector" }}
-          - name: DATASET_URI
-            value: "{{`{{workflow.parameters.dataset_uri}}`}}"
+          - name: DATASET_REF
+            value: "{{`{{workflow.parameters.dataset_ref}}`}}"
+          - name: DATASET_VERSION
+            value: "{{`{{workflow.parameters.dataset_version}}`}}"
 {{- else if ne $trainer "pad-liveness-pending" }}
           - name: LAKEFS_REF
             value: "{{`{{workflow.parameters.lakefs_ref}}`}}"
@@ -265,8 +294,14 @@ spec:
             value: "{{`{{workflow.parameters.run_name}}`}}"
           - name: WEBANK_LAKEFS_ENDPOINT
             value: {{ $lakefs.endpoint | quote }}
-          - name: WEBANK_LAKEFS_CANDIDATE_BRANCH
-            value: {{ $lakefs.candidateBranch | quote }}
+          - name: WEBANK_DATASET_LAKEFS_REPOSITORY
+            value: {{ $datasetRepository | quote }}
+          - name: WEBANK_DATASET_LAKEFS_BRANCH
+            value: {{ $datasetBranch | quote }}
+          - name: WEBANK_MODEL_LAKEFS_REPOSITORY
+            value: {{ $candidateRepository | quote }}
+          - name: WEBANK_MODEL_LAKEFS_BRANCH
+            value: {{ $candidateBranch | quote }}
           - name: LAKEFS_ACCESS_KEY_ID
             valueFrom: { secretKeyRef: { name: {{ $lakefs.secretName | quote }}, key: {{ $lakefs.accessKey | quote }} } }
           - name: LAKEFS_SECRET_ACCESS_KEY

--- a/charts/webank-training/values.yaml
+++ b/charts/webank-training/values.yaml
@@ -16,7 +16,6 @@ training:
     secretName: lakefs-proxy-admin
     accessKey: access-key-id
     secretKey: secret-access-key
-    candidateBranch: candidates
   otel:
     endpoint: ""
   # Every GPU-capable template is rendered only when these placement
@@ -36,6 +35,6 @@ training:
     shrinkRatio: 0.6
 
 # One entry produces exactly two public WorkflowTemplates: `<id>-dataset-build`
-# and `<id>-train`. Keep model-specific commands in the chart, selected by the
-# closed `trainer` enum below; values never provide executable shell text.
+# and `<id>-train`. Each entry must also bind a fixed `lakefs.dataset` and
+# `lakefs.model` destination; values never provide executable shell text.
 models: []

--- a/docs/integrations/webank-training-deployment.md
+++ b/docs/integrations/webank-training-deployment.md
@@ -7,13 +7,13 @@ for GPU candidate training. This is the deployment boundary for
 [Webank ADR-0034](https://github.com/ADORSYS-GIS/webank-models/blob/main/docs/adr/0034-training-job-orchestration-argo-workflows.md);
 it is neither a scheduler nor a model-serving deployment.
 
-| Model | Dataset template | Training template |
+| Model | Dataset template → LakeFS destination | Training template → LakeFS destination |
 | --- | --- | --- |
-| Document detector | `webank-document-detector-dataset-build` | `webank-document-detector-train` |
-| Document recognizer | `webank-document-recognizer-dataset-build` | `webank-document-recognizer-train` |
-| Face detector | `webank-face-detector-dataset-build` | `webank-face-detector-train` |
-| SFace | `webank-sface-dataset-build` | `webank-sface-train` |
-| PAD liveness | `webank-pad-liveness-dataset-build` | `webank-pad-liveness-train` |
+| Document detector | `webank-document-detector-dataset-build` → `ds-document-detector/main` | `webank-document-detector-train` → `model-document-detector/main` |
+| Document recognizer | `webank-document-recognizer-dataset-build` → `ds-document-recognizer/main` | `webank-document-recognizer-train` → `model-document-recognizer/main` |
+| Face detector | `webank-face-detector-dataset-build` → `ds-face-detector/main` | `webank-face-detector-train` → `model-face-detector/main` |
+| SFace | `webank-sface-dataset-build` → `ds-sface/main` | `webank-sface-train` → `model-sface/main` |
+| PAD liveness | `webank-pad-liveness-dataset-build` → `ds-pad-liveness/main` | `webank-pad-liveness-train` → `model-pad-liveness/main` |
 
 Each object has exactly one named template and fixes its own `entrypoint`
 (`build` or `train`). The Argo UI therefore cannot turn an implementation
@@ -31,7 +31,9 @@ Argo submission form requires three governed artifacts:
 It also requires `lakefs_ref`, the immutable commit declared by those two
 governance documents. The container materializes the model-specific descriptor
 and calls the narrow `training-data push` LakeFS boundary. It never accepts a
-dataset path or arbitrary shell command from the dashboard.
+dataset path, LakeFS destination, or arbitrary shell command from the
+dashboard. The destination repository and `main` branch come only from the
+model's reviewed `ai-helm-values` entry and must exist before the first run.
 
 The current materializers deliberately produce metadata descriptors. They do
 not invent document, biometric, identity, or PAD bytes. A data repository must
@@ -44,13 +46,15 @@ All `*-train` templates select `role=gpu`, tolerate
 `role=gpu:NoSchedule`, and request one `nvidia.com/gpu`. A submitted training
 workflow therefore cannot land on a CPU-only node.
 
-The document detector accepts one `dataset_uri` in the immutable form
-`lakefs://repository/64-character-commit/dataset-version`; its runtime checks
-out and gates the archive itself. The recognizer, face-detector, and SFace
+The document detector accepts `dataset_ref` and `dataset_version`; its runtime
+combines them with the fixed `ds-document-detector` repository to check out and
+gate `lakefs://ds-document-detector/64-character-commit/dataset-version`.
+The recognizer, face-detector, and SFace
 templates take a governed `dataset`, `manifest`, and `readiness` artifact plus
 the matching `lakefs_ref`; they run their closed, model-specific Rust trainer
 only after the readiness gate passes. All successful trainers write candidates
-back only through `training-data push`, never to the model registry.
+back only through `training-data push` into the fixed per-model `model-*`
+repository, never to the model registry.
 
 `run_name` is optional on every training template. Its default includes the
 generated Argo workflow name, so it is unique even when the operator leaves

--- a/docs/playbooks/webank-model-workflows.md
+++ b/docs/playbooks/webank-model-workflows.md
@@ -17,6 +17,11 @@ There is one template of each kind for document detector, document recognizer,
 face detector, SFace, and PAD liveness. Do not choose a different entrypoint:
 the displayed `build` or `train` entrypoint is fixed by the selected template.
 
+Each template's LakeFS destinations are fixed in reviewed `ai-helm-values`, not
+in the Argo form. Dataset builds use `ds-<model>/main`; training candidates use
+`model-<model>/main`. The repositories and their `main` branches must exist
+before an approved first run.
+
 ## Build a dataset descriptor
 
 1. In Argo, open the model's `*-dataset-build` template and select **Submit**.
@@ -26,7 +31,8 @@ the displayed `build` or `train` entrypoint is fixed by the selected template.
    `readiness`. They must be the model-specific source metadata, RFC-0006
    manifest, and matching readiness attestation from the data repository.
 4. Submit and inspect the `build` pod. A successful run writes only the
-   generated descriptor through the LakeFS training-data boundary.
+   generated descriptor through the LakeFS training-data boundary into that
+   model's fixed `ds-<model>/main` repository.
 
 If LakeFS is empty, this operation still cannot begin without an approved
 source artifact and its manifest/attestation. Do not use fixtures or a blank
@@ -36,11 +42,12 @@ reference as a substitute.
 
 1. Confirm the dataset and its governance evidence are already approved.
 2. Select the model's `*-train` template.
-3. For document detector, enter
-   `lakefs://<repository>/<64-character-commit>/<dataset-version>` as
-   `dataset_uri`. For document recognizer, face detector, and SFace, provide
-   the governed `dataset`, `manifest`, and `readiness` artifacts and the
-   matching `lakefs_ref`.
+3. For document detector, enter `dataset_ref` (the 64-character commit) and
+   `dataset_version`. The template composes the URI against its fixed
+   `ds-document-detector` repository; the form never accepts a repository or
+   branch. For document recognizer, face detector, and SFace, provide the
+   governed `dataset`, `manifest`, and `readiness` artifacts and the matching
+   `lakefs_ref`.
 4. Leave `run_name` empty unless a named experiment is needed. Its default is
    `<model>-<Argo workflow name>` and is the preferred unique correlation key.
 5. Submit. The pod must show `role=gpu`, the `role=gpu:NoSchedule` toleration,
@@ -60,7 +67,7 @@ as PAD training and do not create a candidate manually.
 
 | Symptom | Meaning | Action |
 | --- | --- | --- |
-| Argo rejects a missing dataset field | The data contract is intentionally required. | Supply the approved URI/artifacts; never fake a value. |
+| Argo rejects a missing dataset field | The data contract is intentionally required. | Supply the approved ref/version or artifacts; never fake a value. |
 | `readiness-gate` fails | Source manifest, readiness attestation, and pinned commit disagree or are not eligible. | Repair/reapprove data in its source repository. |
 | Pod remains Pending | GPU placement requirements cannot currently be met. | Check a `role=gpu` node and its allocatable GPU; do not remove placement constraints. |
 | PAD train exits immediately | There is no PAD trainer. | Keep it blocked until a model-specific trainer lands. |


### PR DESCRIPTION
## Summary

Implements the chart side of the per-model LakeFS routing defined by https://github.com/ADORSYS-GIS/webank-models/issues/326.

- require and validate each model’s fixed `ds-<model>/main` dataset destination and `model-<model>/main` candidate destination
- make those destinations runtime environment/configuration only, never dashboard fields
- replace document-detector’s free-form `dataset_uri` with fixed-repository `dataset_ref` and `dataset_version`
- document the dashboard contract and LakeFS repository preconditions

## Root cause

Workflow templates used one shared candidate branch and let document-detector training receive a free-form repository URI, so the GitOps model topology was neither enforced nor fully reflected in the Argo form.

## Source of truth

- https://github.com/ADORSYS-GIS/webank-models/issues/326
- https://github.com/ADORSYS-GIS/webank-models/blob/main/docs/rfc/0007-governed-dataset-materialization-and-local-weak-training.md
- https://github.com/ADORSYS-GIS/ai-helm-values/pull/168

## Verification evidence

- [x] `helm lint charts/webank-training --strict` with production values
- [x] production-values `helm template`
- [x] client-side dry-run of all ten WorkflowTemplates

## AI Usage Declaration

- [x] AI-assisted implementation and verification; reviewed the fixed destination validation, rendered templates, and playbooks.