### PR TITLE
docs(plans): add the four-spec roadmap, amended for the calendar billing period

### DIFF
--- a/plans/README.md
+++ b/plans/README.md
@@ -1,0 +1,234 @@
+# Plans — the four directions and one roadmap
+
+Four specs arrived on 2026-07-31. This is the consolidated view: what each one really is,
+what they share, what order to build them in, and what I'd cut.
+
+**Status:** Proposed · **Date:** 2026-07-31 · **Maintainer:** @stephane-segning
+
+## Decisions taken (2026-07-31)
+
+| # | Question | Decision |
+|---|---|---|
+| 1 | Refill counter-reset semantics | **Correct as described** — a refill is an upgrade for the remainder of the period, not a top-up |
+| 2 | Multi-customer? | **No.** Us and repos we manage. Selling it means the customer runs their own install → *single-tenant, deployable*, not SaaS |
+| 3 | LGTM multi-tenancy | **Do not turn it on.** Single tenant for us; a customer decides for their own install |
+| 4 | What is the product | **The Grafana dashboards.** Per-tenant redaction policy is a "keep the door open," not a requirement |
+| 5 | Tier ladder | **A separate `x-budget-tier` header**, not more plans. Ladder `b-15 … b-1000`, 2 unaided rungs per period. ⚠️ Ships on a **period boundary** — which since ADR-0111/0112 means the **1st of a calendar month**, not a 30-day epoch bucket |
+| 6 | Who gets refills | **OIDC users only**, via self-service in `lightbridge-ss` (converse-ui). Internal/API-key clients get a different access model — no refill |
+| 7 | Arbitrary Rego | **Wanted** → OPA-Wasm is in scope as Phase 2b, behind the same §6 decision contract as the rule-data evaluator |
+| 8 | Loki retention | Keep **90 d**, document it as configurable |
+| 9 | Redacted-token billing | Document the consequence; no change |
+| 10 | `failOpen: false` in production | **Yes** |
+| 11 | Repo name | **`ADORSYS-GIS/lightbridge-governance`** |
+| 12 | Hostnames | `governance.ai.camer.digital`, `otel.ai.camer.digital` |
+| 13 | Keycloak roles | **Not hardcoded.** Roles ride a claim; Lightbridge maps claim values → the internal `budget:*` permission list via `config.yaml`. Fail-closed, unknown values → `default` |
+| — | Phase 6 cutover date | **Split.** ⚠️ **AMENDED 2026-08-01** — the original "6a ships 2026-08-01, ahead of the window-689 boundary" is **void**: ADR-0112 removed that boundary. 6a now targets **2026-09-01 or any later 1st**; 6b still has **no date constraint**. The window *is* a calendar month now |
+| 14 | Redaction engine | [`censgate/redact`](https://github.com/censgate/redact) — Rust, Apache-2.0. **It already ships `redact-gateway`**, an OpenAI-compatible proxy; no rewrite needed |
+
+Consequences: plan 2 loses its whole tenancy problem (§3 option C by default, B never
+needed for us); plan 1 loses the public-App/installation-webhook path; plan 4 gets the
+`x-budget-tier` ladder plus OPA-Wasm; plan 3 leads with the off-the-shelf `redact-gateway`
+front proxy.
+
+**Repos.** `lightbridge-authz` (exists) hosts `lightbridge-api` → budget-service.
+`lightbridge-ss` / converse-frontends (exists) is the self-service UI — **no new Vite app
+needed**. `lightbridge-governance` (new, Rust) holds the registry + both connectors.
+`censgate/redact` is upstream. Governance views are Grafana, so the only homeless surface
+is Foundry's integration-setup page — one server-rendered page on the governance API, or a
+screen in `lightbridge-ss`.
+
+---
+
+| # | Plan | Source spec | What it really is | Touches the inference data path? |
+|---|---|---|---|---|
+| 1 | [github-copilot-governance.md](./github-copilot-governance.md) | GitHub Copilot Governance MVP | A **pull** connector: poll GitHub's daily Copilot reports, store, report on them | No |
+| 2 | [microsoft-foundry-governance.md](./microsoft-foundry-governance.md) | Microsoft Foundry Governance MVP | A **push** connector: authenticated OTLP ingestion of *customer* agent telemetry | No |
+| 3 | [censgate-redact-extproc.md](./censgate-redact-extproc.md) | Envoy AI Gateway + Censgate Redact `ext_proc` | PII redaction/blocking **inside the gateway filter chain** | **Yes** |
+| 4 | [lightbridge-dynamic-budget.md](./lightbridge-dynamic-budget.md) | Lightbridge Dynamic Budget Refill + OPA-Wasm | Self-service budget refills, policy-driven, with an immutable grant ledger | **Yes**, at Phase 6 |
+
+Also here: [openai-alternative-plan.md](./openai-alternative-plan.md) (2026-06-04, prior work).
+
+---
+
+## 1. Sequencing insight — and how the 2026-07-31 decision changed it
+
+**As originally written, plans 3 and 4 were the same problem wearing different clothes.**
+Censgate needs a processor running *before* Envoy AI Gateway's ext_proc; plan 4's
+"Dynamic Budget Limiter" (option C) needed a component in the request path reading a live
+allowance. Both hinged on one question: can we insert a component at a chosen position in
+the filter chain on EG v1.8.2 + AIEG v1.0.0 without forking the AI Gateway?
+
+**That merged only if plan 4 went with option C. It didn't** — refills are discrete tiers
+(option A, decided 2026-07-31), which is expressible in the existing append-only
+rate-limit rule machinery with **no new data-path component at all**.
+
+Consequences:
+
+- **Plan 4 leaves the red-risk tier.** Its runtime phase becomes an append-only tier rule
+  set in `charts/ai-model` plus a Keycloak claim — the same shape as ADR-0110's quota
+  tiers. It can move much earlier in the roadmap.
+- **The ordering spike now has one consumer, not two.** It's still needed for plan 3, but
+  it can no longer be amortised across two projects — which weakens the case for
+  maintaining an AI Gateway fork, since a fork would now serve exactly one feature.
+- **Plan 3 becomes the only data-path project**, and can be deferred or dropped on its own
+  merits without holding anything else up.
+
+Plan 4 carries two consequences of option A that need product answers, not engineering
+ones — a tier change **resets the window's counter** (so a refill grants the full new
+tier, not the difference) and the tier must arrive as a **Keycloak claim**, so refills take
+effect at the next token refresh. Both are written up in plan 4 §0.1.
+
+---
+
+## 2. What plans 1 and 2 share
+
+They are **one product with two connectors**, which plan 1's amendment note already
+records. Shared foundations, built once:
+
+- **Tenant → Application → Environment → Integration registry** with credential issuance
+  and revocation. Both connectors need it, and retrofitting `tenant_id` underneath
+  existing tables means rewriting every primary key. **Build it first.**
+- **One `governance` role/database** on the existing `lightbridge-main-db` CNPG cluster —
+  a ~30-line addition alongside the six roles already there, not a new database.
+- **The Grafana-reads-Postgres pattern** (ADR-0063 precedent, `uid: keycloak`). It's what
+  lets both plans drop most of their Mimir metric-publishing and their low-cardinality
+  label constraints: usernames, repos, teams and applications become *columns*.
+- **Integer micro-USD everywhere.** Already the house unit and what
+  `gateway_ratelimit_spend_micro_usd` uses — so Copilot spend, Foundry estimated cost,
+  Lightbridge grants and existing gateway spend all stay commensurable in one view.
+
+---
+
+## 3. Risk, honestly ranked
+
+| Risk | Why |
+|---|---|
+| 🟢 **Plan 1 (Copilot)** | Nothing in production changes. Worst case is a CronJob that doesn't run. |
+| 🟡 **Plan 2 (Foundry)** | New namespace, contained blast radius — **except** the Authorino AuthConfig edit. A `sharedSecretRef` to a missing Secret fails AuthConfig readiness and 404s the **entire gateway**. That is the OPA-removal outage, and it is one YAML mistake away. |
+| 🟡 **Plan 4, phases 1–5** | Control-plane only, in its own repo, behind its own API. Safe to build. |
+| 🟡 **Plan 4, phase 6 (option A)** | No new data-path component — but it edits the append-only rate-limit rule list, and ADR-0084 exists because a *Helm map key sort* silently rebudgeted the entire fleet. Mechanically small, unforgiving of carelessness. |
+| 🔴 **Plan 3 (Censgate)** | New mandatory hop in the path of every AI request, `failOpen: false`, and possibly a maintained fork of the AI Gateway controller. |
+
+With option A chosen, **plan 3 is the only red row** — the only project that mutates the
+inference data path. It goes last and gets its own ADR.
+
+---
+
+## 4. The single roadmap
+
+Sizes are relative, not calendar commitments.
+
+### ~~Wave −1 — The budget re-key (2026-08-01, ahead of everything)~~ → folded into Wave 4
+
+> ⚠️ **AMENDED 2026-08-01.** This wave existed *only* because the budget window was a
+> drifting 30-day epoch bucket with a boundary at 2026-08-05 that would "absorb the reset."
+> Two ADRs landed in the meantime and removed that boundary:
+> **[ADR-0111](../docs/adr/0111-calendar-aligned-billing-period.md)** put a calendar
+> `YYYY-MM` `x-billing-period` marker in the key, and
+> **[ADR-0112](../docs/adr/0112-year-unit-so-the-billing-period-is-the-only-rotation.md)**
+> set `unit: Year` so that marker is the *only* rotation.
+>
+> **Consequence: shipping 6a today would have been the worst option, not the best.** The
+> 2026-08-05 reset it was counting on no longer happens, so the re-key would have orphaned
+> every account's August spend with no compensating boundary until 2026-09-01.
+>
+> **Phase 6a moves to Wave 4** and targets a **calendar month boundary (2026-09-01 or any
+> later 1st)**. It keeps its independence from phases 1–5 and may still be pulled forward —
+> it simply is no longer date-forced, and there is now no calendar-pinned item anywhere in
+> this roadmap. Full reasoning: plan 4 §0.3–§0.4.
+
+### Wave 0 — Answer the blocking questions (~1 week, mostly spikes)
+
+Cheap, and each one can invalidate weeks of downstream work.
+
+| Spike | Plan | Question | If it fails |
+|---|---|---|---|
+| GitHub App token access | 1 | Do App installation tokens work on `/copilot/metrics/reports/*` with Copilot metrics + seat management + **Members: read**, and the org's "Copilot metrics API access policy" enabled? | Fall back to a fine-grained PAT — structurally cheap |
+| **Tenancy decision** | 2 | LGTM is single-tenant (`multitenancy_enabled: false`, `auth_enabled: false`, Tempo `replicas: 1`) — so `X-Scope-OrgID` is a no-op. A, B or C? | Recommendation: C now, B as end state |
+| **Filter ordering** | 3 | Can a custom processor be positioned before AIEG's on EG v1.8.2 / AIEG v1.0.0? Four configurations, read `/config_dump` | Fork vs. front-proxy — decide with evidence, not the spec's hedge. Note this now serves **one** feature, so a fork is harder to justify |
+| ~~Discrete refill tiers?~~ | 4 | **Answered 2026-07-31: yes** → option A | — |
+| Streaming client | 3 | Is there a *non-streaming* production client to canary with? | No ⇒ SSE moves into the MVP, not post-MVP |
+
+**Do not start Wave 1 before these are answered.** Every one of them is an afternoon, and
+each one is currently load-bearing for a multi-sprint commitment.
+
+### Wave 1 — Shared foundation
+
+- Governance registry: tenant / application / environment / integration / agent.
+- `governance` role + database on `lightbridge-main-db`; credential issuance + revocation;
+  `/internal/v1/resolve`.
+- Repo: `ADORSYS-GIS/lightbridge-governance` (connectors as crates).
+- *In parallel, different repo:* Lightbridge plan 4 **Phase 1** — grant ledger, balances,
+  idempotency, replay tests. No dependency on the above.
+
+### Wave 2 — First value, lowest risk
+
+- **Plan 1 complete**: Copilot ingestion → Postgres + S3, ServiceMonitor, four dashboards,
+  five alerts. Proves the registry and the Postgres-to-Grafana pattern end to end.
+- *Parallel:* Lightbridge **Phases 2–3** — rule-data evaluator (**not** OPA-Wasm; see plan
+  4 §2) + policy lifecycle, versioning, simulation.
+
+### Wave 3 — Ingestion and workflows
+
+- **Plan 2**: `otel.` host + AuthConfig #3 + collector + three-signal fan-out + privacy
+  modes + normalization. ⚠️ Secret-first on the AuthConfig, or gateway-wide 404.
+- *Parallel:* Lightbridge **Phases 4–5** — refill workflows, review queue, automatic
+  augmentation with deterministic trigger keys.
+
+### Wave 4 — Governance surface
+
+- Cost engine, five policies, evidence to S3, the four Grafana views, one integration-setup
+  page, golden dataset in CI.
+- Lightbridge **Phase 6a** — the fleet-wide re-key (moved here from the retired Wave −1).
+  Append-only budget-tier rules in `charts/ai-model`, rendered strictly **after** the
+  ADR-0110 quota-tier rules so no existing rule index shifts, + the Keycloak attribute →
+  protocol mapper → claim → Authorino CEL stamp. ⚠️ **Must land on a calendar month
+  boundary (2026-09-01 or a later 1st)** — see plan 4 §0.3–§0.4. Small, but it is the
+  ADR-0084 blast zone — one PR, one reviewer, one ADR.
+- Lightbridge **Phase 6b** — grants write the tier attribute. **No date constraint**, once
+  6a has done the re-key.
+
+### Wave 5 — Data path (gated on the Wave 0 ordering spike)
+
+- **Plan 3** only: redact processor, canary internal gateway, filter-order verification on
+  every replica, fail-closed and rollback drills, plus the SSE decision.
+- Now separable — nothing else waits on it, so it can be deferred or dropped on its own
+  merits.
+
+---
+
+## 5. What I'd cut or change
+
+| Change | From | Why |
+|---|---|---|
+| **Parquet-on-S3 query layer** → Postgres | Plan 1 | Deletes the Parquet writer, the S3 query engine, the normalizer and the metrics publisher. S3 stays raw archive + replay. |
+| **Memcached** → in-process `moka` | Plans 1, 2 | There is no memcached in this cluster and the alternative (redis-ha) is TLS-only with a password — real wiring for a single-replica API over 6-hourly data. |
+| **Backfill `Job`** → self-healing CronJob | Plan 1 | A one-shot Job fights ArgoCD selfHeal; reading the DB high-water mark also gives late-report recovery for free. |
+| **Manual team mapping** → GitHub's own report | Plan 1 | `user-teams-1-day` exists at org scope; the spec says it's enterprise-only and is out of date. |
+| **Next.js console** → four Grafana views + one page | Plan 2 | Only integration-setup genuinely needs bespoke UI. |
+| **OPA-Wasm before the rule-data evaluator** → rule-data first, Wasm as Phase 2b | Plan 4 | Both are wanted (decision 7), but §5.1 rule data is the path ordinary admins use and is needed regardless. Building the policy *lifecycle* on the cheap engine first means Wasm lands onto a lifecycle that already works. |
+| **Building a redaction proxy** → deploy `redact-gateway` | Plan 3 | It already exists, in Rust, Apache-2.0, with OTel metrics. `redact-core` is the library seam if/when the ext_proc variant is wanted. |
+| **AI Gateway fork** → decide after the spike | Plan 3 | The spec's own hedge is "*may* not produce the required order" — and with the front proxy available, the spike may never need running. |
+| **SSE as post-MVP item #1** → decided during the MVP | Plan 3 | It's the gate on production use, not a follow-up. |
+
+---
+
+## 6. Process
+
+All four are governed work: the governance PR template (AI Usage Declaration,
+source-of-truth link, Verification evidence) on every PR in every repo; Conventional
+Commits enforced by hook + CI; values-repo-first for anything reaching `ai-helm-values`.
+
+ADRs — ⚠️ **renumbered 2026-08-01**: 0111 and 0112 were taken by the calendar-billing-period
+work while this plan sat unmerged, so these now start at **0113** (next free). Re-check
+`docs/adr/` before claiming a number; this repo moves fast.
+
+| ADR | Subject |
+|---|---|
+| 0113 | Governance registry + the tenancy model (including why LGTM multi-tenancy was rejected for the MVP) |
+| 0114 | Copilot connector |
+| 0115 | Foundry OTLP ingestion via core-gateway + Authorino |
+| 0116 | Redaction placement — ext_proc vs front-proxy, fail-closed, and the billing interaction |
+| 0117 | Budget refill as append-only discrete tiers (option A) — the tier ladder, the counter-reset semantics, and the Keycloak-claim propagation path. Builds on ADR-0021/0084/0110/0111/0112 |
+
+Plus one in `lightbridge-authz` for the grant/ledger domain model.

--- a/plans/censgate-redact-extproc.md
+++ b/plans/censgate-redact-extproc.md
@@ -1,0 +1,245 @@
+# Plan: Censgate Redact `ext_proc` on the AI Gateway
+
+> `~/Downloads/envoy-censgate-redact-extproc-mvp-plan.md` assessed against the gateway
+> that is actually running: **Envoy Gateway v1.8.2 + Envoy AI Gateway v1.0.0** (CRDs
+> v1.0.0, lockstep per ADR-0069), Authorino ext_authz on two listeners, `charts/ai-model`
+> rate-limit + cost CEL on top.
+>
+> Unlike the [Copilot](./github-copilot-governance.md) and
+> [Foundry](./microsoft-foundry-governance.md) plans, this one touches the **production
+> data path for every AI request in the org**. It is planned accordingly.
+
+**Status:** Proposed plan · **Date:** 2026-07-31 · **Maintainer:** @stephane-segning
+
+---
+
+## 0. Two findings that should reshape the plan before anyone writes code
+
+### Finding 1 — The MVP as scoped can never front production traffic
+
+The scope freeze excludes `stream: true` and returns **HTTP 400** for it. Our production
+traffic is overwhelmingly streaming: opencode and LibreChat both stream by default, and
+the whole of [ADR-0034](../docs/adr/0034-restore-streaming-timeouts-and-extproc-headroom.md)
+exists because long streaming generations were being cut mid-stream. Its own words about
+the AI Gateway's processor: it "holds state for the whole stream."
+
+So the MVP's exit criteria are all reachable — on a canary, against a mock provider — but
+"migrate one non-critical application to the canary hostname" (§14) means migrating an
+application that **does not stream**, and there may not be one. Everything real here
+streams.
+
+This isn't an argument against the MVP. It's an argument against the roadmap ordering:
+**incremental SSE processing is not post-MVP item #1, it is the gate on any production
+use whatsoever.** I'd restructure so the SSE design is settled during the MVP (even if
+implemented after), rather than discovered at promotion time. Concretely: add "decide the
+SSE strategy — incremental vs buffered-for-sensitive-profiles — and prove it on one
+fixture" to Milestone 3.
+
+### Finding 2 — Don't budget the fork until you've measured the ordering
+
+§9 says "a standard `EnvoyExtensionPolicy` **may** not produce the required order" and
+jumps to a pinned fork of Envoy AI Gateway. That hedge is doing a lot of work, and the
+premise looks like it was written against a pre-1.0 AIEG.
+
+What I could establish from upstream: AIEG attaches its own processor through the *same
+public mechanism* — an `EnvoyExtensionPolicy` named `ai-eg-route-extproc-${name}` — not a
+privileged hardcoded insertion. Envoy Gateway also exposes `EnvoyProxy.spec.filterOrder`
+(`{name, before, after}`), and **we already ship an `EnvoyProxy` CR** at
+`charts/core-gateway/templates/envoy-proxy.yaml`. The known gap is that `filterOrder`
+matches on filter *name*, and two ext_proc instances share the `envoy.filters.http.ext_proc/…`
+prefix — which is precisely what upstream
+[envoyproxy/gateway#8789](https://github.com/envoyproxy/gateway/issues/8789) ("Add name
+and statPrefix fields to EnvoyExtensionPolicy extProc") is about. So it may genuinely not
+be expressible today. **But that is a measurement, not a deduction.**
+
+This repo has an expensive precedent for exactly this mistake: the `/v1/models` filtering
+verdict was written down as unfixable in two separate migration docs, three layers of
+workaround were built on top of it, and the fix turned out to be one field
+(`AIGatewayRoute.spec.hostnames`) that had shipped in the version already running.
+
+**Spike first, one afternoon, before Milestone 5 is budgeted.** Deploy a no-op pass-through
+ext_proc against the canary gateway and read `/config_dump` for each of:
+
+| # | Configuration to try |
+|---|---|
+| a | `EnvoyExtensionPolicy` on the **Gateway** vs on the **HTTPRoute** (AIEG's is route-attached) |
+| b | Two `extProc` entries in a **single** policy's `spec.extProc[]` list |
+| c | `EnvoyProxy.spec.filterOrder` with `before: envoy.filters.http.ext_proc` |
+| d | Whether creation timestamp / name sort decides ties |
+
+If (a)–(d) all fail, file upstream against #8789 **and then** choose between the fork and
+the alternative below — don't default to the fork.
+
+### The alternative that sidesteps §9 entirely — and it is already written
+
+[`censgate/redact`](https://github.com/censgate/redact) (Rust, Apache-2.0, v0.9.0) does
+not just ship the traversal library this plan assumed. It ships **`redact-gateway`, an
+OpenAI-compatible privacy proxy** — alongside `redact-core` (the library), `redact-cli`,
+`redact-api` and `redact-wasm`. So the front-proxy option is not "write a reverse proxy,"
+it is "deploy theirs":
+
+```text
+client → redact-gateway (off the shelf) → core-gateway (authorino → AIEG → provider)
+```
+
+No ext_proc protocol, no filter ordering, no fork, no new code. Precedent for the shape is
+solid — `charts/mcp` renders per-MCP Caddy/openresty *normalizing proxies* for exactly this
+"can't fix it at the Envoy layer" reason
+([ADR-0040](../docs/adr/0040-external-mcps-via-caddy-normalizing-proxy.md)), and
+`lakefs-proxy` is a first-party Rust reverse proxy already in production.
+
+`redact-core` also covers the four MVP actions (replace / mask / hash, plus reversible
+encrypt on the gateway), 54 pattern-based entity types, 18 secret/credential types, and
+emits OpenTelemetry metrics — which is the actual deliverable here.
+
+**Its real cost:** it sits **before** Authorino, so it has no authenticated identity, which
+forecloses per-tenant policy profiles until it moves inside the filter chain. It also
+processes unauthenticated traffic (a DoS surface the gateway currently absorbs) and needs
+its own host + certificate.
+
+**Recommended path given the stated priorities** — the product is the dashboard, and
+per-tenant policy is "would be cool, not now":
+
+1. **Deploy `redact-gateway` as the front proxy first.** It gets redaction, blocking and
+   the trim-per-request metrics into Grafana with essentially zero build, and defers the
+   ordering/fork question indefinitely.
+2. **Treat `redact-extproc` as the upgrade** that unlocks per-tenant policy. When it's
+   wanted, the build is "wrap `redact-core` in `tonic`" — not a redaction engine — and the
+   ordering spike happens then, with a real requirement behind it.
+
+⚠️ **Turn the ML NER off for any data-path deployment.** The ONNX transformer path
+(PERSON/ORGANIZATION/LOCATION) means model download, significant memory, and variable
+latency inside a `failOpen: false` hop. The 54 pattern-based recognisers cover the MVP's
+entity list; add NER later behind measurement.
+
+**On `EnvoyPatchPolicy`:** the spec is right to warn against it, and this platform agrees
+from experience — ADR-0039's `EnvoyPatchPolicy` for MCP backend TLS was built, shipped,
+found to have **zero effect**, and removed in ADR-0040. The `eg` app entry in
+`charts/apps/values.yaml` now notes upstream issues affecting "EnvoyPatchPolicy/extension-server
+users only, which we don't use." Endorsed — don't reach for it.
+
+---
+
+## 1. What forking AIEG actually costs here
+
+If the spike says the fork is necessary, price it honestly before agreeing:
+
+- AIEG is consumed as an **upstream OCI Helm chart pinned to `v1.0.0`**, with
+  `aieg-crd` held in **lockstep** (ADR-0069). A fork means building and hosting our own
+  controller image and re-basing it on every upstream bump — of the component that is the
+  single point of failure for all AI traffic in the org.
+- We are already carrying two upstream AIEG workarounds
+  ([#2218](https://github.com/envoyproxy/ai-gateway/issues/2218) refero content-type,
+  [#2219](https://github.com/envoyproxy/ai-gateway/issues/2219) firecrawl SSE) via the
+  `charts/mcp` proxy engines, both explicitly labelled INTERIM pending upstream fixes.
+  Adding a maintained fork on top changes the character of that debt.
+- The maintainer's standing preference is hard cutovers over parallel paths, and no
+  dormant code. A fork is the opposite: a permanent parallel path.
+
+The post-MVP roadmap already lists "removal of the AI Gateway fork through an upstream
+pre-AI-filter ordering capability" as item #8. If the fork is genuinely needed, **open
+that upstream issue in Milestone 1, not at the end** — the fork's exit path should be in
+flight the whole time it exists.
+
+---
+
+## 2. Where things go on this platform
+
+| Spec says | Here |
+|---|---|
+| Namespace `ai-redact-mvp` | `redact-canary` (short-name convention) |
+| Canary `Gateway` | **Internal** Gateway — ClusterIP, no Hetzner LB, no public DNS/cert. Precedent: core-gateway's `api-internal` listener + `templates/service-internal.yaml`, TLS from `self-signed-ca`. A second public Gateway means a second Hetzner LB (cost) and another ACME cert for no MVP benefit. |
+| Raw Deployment/Service/ConfigMap YAML | `charts/redact-extproc` (bjw-template leaf, no own `templates/` ⇒ CI lints it non-strict) + `charts/redact-extproc-secrets` if needed; values in `ai-helm-values` |
+| `NetworkPolicy` | **`CiliumNetworkPolicy`** — a plain `NetworkPolicy` `ipBlock` does not match on Cilium. New namespace ⇒ no default-deny baseline, so ship the restriction yourself. ⚠️ Must include `fromEntities: [host, remote-node, health]` or kubelet probes fail and it reads as a crash-loop. |
+| `ServiceMonitor` | Yes — copy `charts/inference-server/templates/servicemonitor.yaml`. Metrics are pull-based here, not OTLP. |
+| Dashboard | `tools/dashboards/src/dashboards/redact/*.py` → generated JSON, registered in `_DASHBOARD_MODULES`. Hand-written JSON fails `dashboards-drift`. Folder needs `resyncPeriod`. |
+| Image | `ghcr.io/adorsys-gis/redact-extproc`, private ⇒ namespace-scoped `dockerconfigjson`; bjw-s resolves it from `defaultPodOptions.imagePullSecrets`, **not** `global.imagePullSecrets`. ⚠️ Build with `cargo-auditable` or Trivy scans zero crates and the green result is meaningless. |
+
+**Policy ConfigMap reload gotcha.** The spec excludes hot reload, so a policy change needs
+a pod roll — and on this platform `kubectl rollout restart` is **reverted by ArgoCD
+selfHeal**. Use the repo's documented pattern: a generation counter in values feeding a
+checksum annotation on the pod template, so the roll is declarative. (Also: mount the
+ConfigMap as a directory, not `subPath` — subPath mounts don't update in place at all.)
+
+---
+
+## 3. Interactions with what's already on that path
+
+These are not in the spec and each one is load-bearing:
+
+1. **Authorino runs first (ext_authz, before any ext_proc).** So redaction always sees an
+   authenticated request, and the ADR-0011 `x-oidc-*` headers plus the ADR-0021 rate-limit
+   descriptors (`x-account-id`, `x-billing-plan`) are already stamped. That's the identity
+   metadata post-MVP item #4 wants — available for free **if** redaction stays inside the
+   filter chain. Another point on the ext_proc side of the §0 trade-off.
+2. **Redacting before AIEG changes what gets billed.** AIEG's processor does token
+   counting and the cost CEL (`charts/ai-model`), feeding the per-account monthly µ$
+   budgets in redis. If redaction mutates the body first, the tokens counted are the
+   *redacted* tokens — defensible, arguably correct, but it must be a stated decision
+   because it silently changes the numbers on the cost dashboards. A blocked request
+   never reaches AIEG at all, so it costs nothing and appears in no cost series — which
+   is why `redact_extproc_blocks_total` matters as the only record.
+3. **`failOpen: false` on the production gateway means a redactor outage is a total AI
+   outage.** That is the correct security posture and I'd keep it — but two healthy
+   replicas of a new Rust service become a hard dependency of everything. Give it a PDB
+   from the start (the spec defers it), and treat its availability target as the
+   gateway's.
+4. **AIEG v1.0 ships built-in "request/response body redaction"** for observability. That
+   is *not* what this MVP does (it doesn't stop data reaching the provider), but it may
+   already satisfy the "no raw payloads in logs or traces" exit criterion — check before
+   building anything for it.
+
+---
+
+## 4. On the code
+
+I could not find a `censgate` or `redact` repo under `~/dev`, so this plan assumes the
+"existing Redact request/response traversal" the spec refers to is real and lives outside
+what's checked out here. Everything below is about the new `crates/redact-extproc` binary.
+
+The house Rust baseline applies: `tonic`/`prost` for the ext_proc gRPC service, plus the
+existing workspace idiom from `lightbridge-repo-auth` — `thiserror` at the library edge,
+`anyhow` at the binary, `tracing-subscriber` with the `json` feature, `mimalloc`, and
+`reqwest`/`rustls` if it needs egress. The spec's per-request-state struct and "do not log
+or persist raw bodies" rule are exactly right; make it structural rather than
+disciplinary — **wrap body types in a newtype whose `Debug`/`Display` print
+`<redacted>`**, so a stray `tracing` field can't leak one. Test #11 ("raw payloads do not
+appear in logs") then tests the type, not the reviewer.
+
+The 12 unit tests and the four-message protocol sequence are a good list; keep them. The
+one I'd add: **a fixture asserting that a request AIEG later rewrites (provider
+translation) still round-trips correctly after body mutation** — that's the interaction
+the mock-provider tests won't catch, because the mock speaks OpenAI natively and our
+real backends include Anthropic and Google translations.
+
+---
+
+## 5. Sequencing
+
+Milestones 1–4 and 6 stand as written. Two changes:
+
+- **Milestone 0 (new, ~1 day):** the §0 Finding-2 ordering spike, plus the §2 inventory
+  (which the spec rightly wants version-controlled — put it in
+  `docs/migrations/2026-XX-XX-redact-extproc-canary.md`). Output: fork / no-fork / front-proxy.
+- **Milestone 3 gains:** decide and prove the SSE strategy on one fixture. Not implement —
+  decide, with evidence. Otherwise promotion discovers it.
+- **Milestone 5** is conditional on Milestone 0 and may be deleted entirely.
+
+ADR: one, covering the placement decision (ext_proc vs front-proxy), fail-closed, and the
+billing interaction. Numbering follows whatever the governance ADRs take (0111+).
+
+---
+
+## 6. Open questions
+
+1. **Is per-tenant policy the actual product?** If yes, ext_proc wins and §0's fork
+   question must be answered properly. If the single static profile is genuinely enough
+   for a year, the front-proxy is much cheaper and carries no upstream risk.
+2. **Is there a non-streaming production client to canary with?** If not, §14's promotion
+   gate can't be exercised as written and SSE moves into the MVP.
+3. **Do we accept redacted-token billing** (§3.2), or should cost be computed pre-redaction?
+4. **Where does Censgate Redact live**, and is the traversal library already usable as a
+   Rust dependency?
+5. **Is `failOpen: false` acceptable for the eventual production attach**, given it makes
+   the redactor a hard dependency of all AI traffic — or does production want fail-open
+   with an alert, accepting leakage during an outage?

--- a/plans/github-copilot-governance.md
+++ b/plans/github-copilot-governance.md
@@ -1,0 +1,534 @@
+# Plan: GitHub Copilot governance connector (Rust + k8s)
+
+> Turn `~/Downloads/github-copilot-governance-mvp.md` into something buildable on
+> **this** platform. Source doc = the product shape; this plan = the shape it takes
+> given ai-helm, ai-helm-values, home-remote, CNPG, Alloy/Mimir/Loki, grafana-operator
+> and the ADR/governance process already in place.
+
+**Status:** Proposed plan · **Date:** 2026-07-31 · **Maintainer:** @stephane-segning
+
+> ⚠️ **Amended the same day by [`microsoft-foundry-governance.md`](./microsoft-foundry-governance.md).**
+> A second connector spec arrived, which settles open question #4 below: there *will* be
+> more than one provider. Three things change — the repo becomes
+> **`lightbridge-governance`** (connectors as crates, not repos), the DB role becomes
+> **`governance`**, and the **tenant/application/integration registry is built first**,
+> before this connector, because retrofitting `tenant_id` under existing tables means
+> rewriting every primary key. Copilot stays the **first connector to ship** (pull-based,
+> our own org, no public endpoint, no LGTM changes) — it just lands on the registry
+> rather than inventing its own identity model. Everything else below stands.
+
+---
+
+## 0. What I'd change from the source doc, and why
+
+Five deviations. Everything else in the doc survives intact.
+
+| # | Source doc says | This plan says | Why |
+|---|---|---|---|
+| 1 | Query layer = **Parquet on S3**, "no new database" | Query layer = **Postgres on the existing `lightbridge-main-db` CNPG cluster** (new `copilotgov` role + database). S3 keeps raw-archive/replay only. | It isn't a *new* database — it's a 30-line addition to `charts/lightbridge-db/values.yaml`, alongside the six roles already there (`repoauth`, `codeintel`, `coder`, `lakefs`, `mlflow`, `grafana_ro`). Barman backups to S3 already configured. Deletes an entire subsystem: no Parquet writer, no Arrow/DataFusion in Rust, no S3 query engine, no `normalize`+`publish-metrics` commands. Idempotent reprocessing becomes `ON CONFLICT DO UPDATE`. **And** Grafana reads it directly — see #3. |
+| 2 | **Memcached** for query caching | **No cache service.** In-process `moka` in the API. | There is no memcached in this cluster and adding one is a whole chart + NetworkPolicy + ADR. The only alternative already deployed is redis-ha, which is TLS-only with an internal CA and a password — real wiring cost for a single-replica API serving 6-hourly-refreshed data. Installation tokens (1 h TTL) are per-process anyway. If the API ever needs >1 replica, revisit → redis-ha (LibreChat/ratelimit already prove the wiring). |
+| 3 | Dashboards read **Mimir**; keep usernames out of labels | Dashboards 1–3 read the **Postgres datasource** (`uid: copilotgov`); only dashboard 4 reads Mimir. | Precedent exists: ADR-0063 already runs a read-only Postgres `GrafanaDatasource` (`uid: keycloak`) for exactly this reason. Usernames/repos/teams are *columns*, not Prometheus labels — the entire "keep cardinality low / avoid `username` labels" constraint evaporates for the business dashboards, and Mimir keeps only the ~10 low-cardinality *operational* metrics from Phase 8. |
+| 4 | Separate **`Job/copilot-initial-backfill`** | No backfill Job. The CronJob's normal run reads the DB high-water mark and backfills up to 28 days when it's behind. | A one-shot `Job` is a bad GitOps citizen (immutable spec; re-running means deleting the object out-of-band, and selfHeal fights you). Self-healing backfill also makes the "recover when a report is published late" requirement fall out for free. |
+| 5 | Team attribution needs a **manual mapping table**; native team report is enterprise-only | GitHub ships **`/orgs/{org}/copilot/metrics/reports/user-teams-1-day` at org scope**. Ingest it. Keep a mapping table only for *cost-center* / internal-user identity. | The doc is out of date on this. Caveat that survives: GitHub omits teams with <5 seated Copilot users. |
+
+Plus one hard finding that changes Phase 1 — see §1.2.
+
+---
+
+## 1. GitHub side
+
+### 1.1 One GitHub App, not two (for now)
+
+Register **one** App in the `adorsys-gis` org:
+
+```text
+Name:        AI Governance – Copilot Metrics
+Public:      no (org-internal for the MVP)
+Webhook:     disabled          ← reports are polled; no webhook in the MVP
+Permissions (Organization):
+  Copilot metrics          Read
+  Copilot seat management  Read
+  Members                  Read
+  Metadata                 Read
+```
+
+Committed as `github-app-manifest.json` in the new repo, exactly like
+[`lightbridge-repo-auth`](https://github.com/ADORSYS-GIS/lightbridge-repo-auth) does.
+
+**Not** requested: repository contents, issues, pull requests, code. **Deferred entirely:**
+the billing App (`Administration: read` for AI-credit spend) — that's a *second, separate*
+App registered in Sprint 3, so the metrics collector never holds org-admin.
+
+### 1.2 ⚠️ Two prerequisites the source doc understates
+
+1. **Three org permissions, not two.** The reports endpoints 400/403 without
+   `Members: read` in addition to Copilot metrics + seat management.
+2. **The org must enable the "Copilot metrics API access policy."** This is an org
+   *setting*, not a permission — the App is correctly installed and still gets 403
+   until an org owner flips it. Do this before Sprint 1, it costs a minute.
+
+**Spike this on day 1** (~2 h, before any code): install a throwaway App with those
+permissions against `adorsys-gis` and `curl` one report end-to-end. GitHub's public docs
+describe the fine-grained permission ("View Organization Copilot Metrics") and the
+OAuth/PAT scope (`read:org`) but do **not** state that App installation tokens are
+accepted on `/copilot/metrics/reports/*`; community reports say they are, at org scope,
+with the three permissions above. Enterprise scope definitively does **not** accept App
+tokens — which is exactly why the MVP is org-scoped.
+
+Fallback if the spike fails: a fine-grained PAT in `ssegning-aws`. Structurally cheap —
+the collector's credential layer resolves to a bearer token either way — but it changes
+whether we register an App at all, so we settle it first.
+
+### 1.3 Endpoints (verified against GitHub docs, API version `2026-03-10`)
+
+```http
+GET /orgs/{org}/copilot/metrics/reports/organization-1-day?day=YYYY-MM-DD
+GET /orgs/{org}/copilot/metrics/reports/users-1-day?day=YYYY-MM-DD
+GET /orgs/{org}/copilot/metrics/reports/repos-1-day?day=YYYY-MM-DD
+GET /orgs/{org}/copilot/metrics/reports/user-teams-1-day?day=YYYY-MM-DD
+GET /orgs/{org}/copilot/metrics/reports/organization-28-day/latest
+GET /orgs/{org}/copilot/metrics/reports/users-28-day/latest
+GET /orgs/{org}/copilot/billing/seats?per_page=100&page=N
+```
+
+Headers: `Accept: application/vnd.github+json`, `X-GitHub-Api-Version: 2026-03-10`.
+Reports are **NDJSON behind short-lived signed URLs** — download in the same job run.
+Data exists from 2025-10-10 and stays available ~1 year.
+
+---
+
+## 2. Repos
+
+### 2.1 New: `ADORSYS-GIS/copilot-governance` (private)
+
+Rust workspace, modelled directly on `lightbridge-repo-auth` (same edition, same
+dependency set, same CI). **One repo, one image, two binaries.**
+
+```text
+copilot-governance/
+├── Cargo.toml                       # workspace, resolver = "3", edition 2024
+├── rust-toolchain.toml
+├── crates/copilot-governance-core/  # github client, models, ingest, store (sqlx)
+├── app/copilot-governance/          # axum API server        (bin)
+├── app/copilot-govctl/              # collector CLI          (bin)
+│     └── subcommands: sync-latest | sync-day | backfill | verify | status
+├── migrations/                      # sqlx migrations
+├── .docker/Dockerfile               # cargo-auditable → distroless, nonroot
+├── github-app-manifest.json
+├── docs/{auth-model,github-app-permissions,sysadmin-guide}.md
+└── .github/workflows/{ci,docker,governance}.yml
+```
+
+Dependency baseline lifted verbatim from `lightbridge-repo-auth`'s workspace
+`Cargo.toml` — it is already the house answer to every question here:
+
+- `axum 0.8` + `tokio` + `mimalloc` (per your ask)
+- `reqwest 0.13` `default-features = false` + `rustls`/`ring` — no OpenSSL in distroless
+- `jsonwebtoken 10` with `features = ["rust_crypto"]` — ⚠️ v10 made the crypto backend a
+  *required* feature choice; with neither selected, App-JWT signing panics at runtime.
+  This is the exact trap repo-auth already hit; inherit the pin.
+- `sqlx 0.8` (postgres, chrono, json, macros, migrate)
+- `thiserror` for library errors, `anyhow` at the binary edge
+- `tracing-subscriber` with the `json` feature — Phase 8's structured logs
+- `clap` (derive + env) for the subcommands
+- `utoipa` for the OpenAPI surface
+
+New, not in repo-auth: `aws-sdk-s3` (or `object_store`) for the raw tier, `moka` for the
+in-process cache, and the OTLP trace exporter (`opentelemetry-otlp`).
+
+**⚠️ Build with `cargo-auditable`.** Without it Trivy scans zero Rust crates and reports
+a meaningless green — the platform rule from `lakefs-proxy`.
+
+Image: `ghcr.io/adorsys-gis/copilot-governance`, both bins in one layer.
+CI: copy `docker.yml` (buildx + `docker/metadata-action` → `sha-<short>` tags + gha cache)
+and `governance.yml`. Runners must be `runs-on: adorsys-gis-runner` — GitHub-hosted
+runners are billing-blocked org-wide.
+
+### 2.2 `ai-helm` (this repo) — charts live here, not in the code repo
+
+Two shapes exist on this platform:
+
+- `lightbridge-repo-auth` — chart lives in the *code* repo, ai-helm pins a commit SHA.
+- `lakefs-proxy` — image in the code repo, **chart in ai-helm**.
+
+**Take the `lakefs-proxy` shape.** It gets OCI chart publish, release-please versioning,
+the `helm-lint` gate, and the ai-helm-values split for free; repo-auth's shape needs
+ArgoCD read-creds for a private repo and a manual SHA bump on every deploy. Revisit only
+if we ever ship this to customers who install the chart themselves.
+
+New/changed in ai-helm:
+
+```text
+charts/copilot-governance/           # App-of-Apps orchestrator, 3 children (ADR-0019)
+charts/copilot-governance-secrets/   # ESO leaf  (child, wave 0)
+charts/copilot-governance-app/       # bjw-template leaf: Deployment + CronJob (wave 1)
+charts/copilot-governance-auth/      # → upstream oauth2-proxy chart (wave 2)
+charts/lightbridge-db/values.yaml    # + copilotgov role + Database + ESO password
+charts/apps/values.yaml              # + the orchestrator entry (controlPlane: false)
+tools/dashboards/src/dashboards/copilot/{overview,licenses,adoption,connector_health}.py
+tools/dashboards/src/dashboards/_common.py          # + COPILOT_UID = "copilotgov"
+tools/dashboards/src/dashboards/main.py             # + 4 entries in _DASHBOARD_MODULES
+charts/observability-dashboards/values.yaml         # + folder `copilot` + 4 dashboards + alerts
+charts/observability-dashboards/files/copilot/*.json # generated, committed
+docs/adr/0111-github-copilot-governance-connector.md
+docs/integrations/github-copilot-governance.md
+```
+
+Structurally this is **`longhorn-auth`/`homepage` with three children** — an established,
+copy-able pattern (ADR-0019 App-of-Apps via plain Helm, `templates/applications.yaml`
+iterating `.Values.children`).
+
+`copilot-governance-app` carries no `templates/` dir (everything from `bjw-template`), so
+CI lints it non-strict automatically. bjw-common already ships a `cronjob` controller
+class, so one chart renders both the Deployment and the CronJob.
+
+### 2.3 `ai-helm-values` (private) — everything deployed
+
+```text
+environments/prod/values/copilot-governance-app.yaml    # image tag, org list, schedule, knobs
+environments/prod/values/copilot-governance-auth.yaml   # oauth2-proxy config
+environments/prod/values/grafana.yaml                   # + GrafanaDatasource uid: copilotgov
+environments/prod/deps/copilot-governance/
+  ├── kustomization.yaml
+  ├── certificate.yaml                                  # ingress TLS
+  └── ciliumnetworkpolicy.yaml                          # egress lockdown (§5)
+```
+
+⚠️ **Values-repo-first, always.** These files must be on `ai-helm-values@main` *before*
+the ai-helm change merges, or `ignoreMissingValueFiles` silently falls back to chart
+defaults.
+
+---
+
+## 3. Runtime topology
+
+Namespace **`governance`** (platform convention is short names — `converse`, `mlops`,
+`coder`; not the doc's `ai-governance-connectors`).
+
+```text
+governance/
+├── CronJob/copilot-sync          0 */6 * * *   concurrencyPolicy: Forbid
+│                                 backoffLimit 4, activeDeadlineSeconds 1800
+│                                 successfulJobsHistoryLimit 3 / failed 5
+├── Deployment/copilot-api        axum, 1 replica, readOnlyRootFilesystem, nonroot
+├── Deployment/copilot-auth       oauth2-proxy, reverse-proxy mode
+├── Service ×2 (ClusterIP)
+├── Ingress                       governance.ai.camer.digital → copilot-auth only
+├── ExternalSecret ×N             (secrets child)
+└── CiliumNetworkPolicy           (deps overlay)
+```
+
+Destination: **`home-remote`** (ordinary workload — not `controlPlane`, not
+`homeCluster`). Project: `ai`, inherited.
+
+Ingress TLS: `cert-home-cert-http` (**HTTP-01**). ⚠️ Not `cert-cloudflare` —
+`ai.camer.digital` is NS-delegated to Route53, so a DNS-01 `Certificate` there reports
+`Presented: true` and then stalls forever on `not yet propagated`. HTTP-01 is unaffected
+by delegation.
+
+Auth: oauth2-proxy against Keycloak, **role-restricted** (not any-authenticated-user) —
+the ADR-0093 Longhorn precedent, appropriate because raw user-level Copilot data is
+governance-admin material. ⚠️ `cookie-secret` must decode to exactly 16/24/32 bytes —
+`openssl rand -hex 16`; a padded base64 (44 chars) crashloops.
+
+### The data flow
+
+```text
+CronJob (every 6h)
+  → mint installation token (1h, never persisted)
+  → for day in [D-1, D-2, D-3]  (and up to D-28 when the DB is behind):
+        GET report → follow signed URL → NDJSON
+        ├─→ S3  s3://ssegning-k8s-state/copilot-governance/raw/org=…/day=…/*.ndjson
+        └─→ Postgres  INSERT … ON CONFLICT (org, report_day, …) DO UPDATE
+  → GET /copilot/billing/seats (paginated) → same two sinks
+  → write manifest row + object
+  → emit OTLP traces + push operational metrics
+
+Deployment/copilot-api
+  → SELECT from Postgres, moka-cached 5–15 min
+  → /api/v1/copilot/{overview,adoption,seats,users,repositories,costs,pipeline-health}
+  → /api/v1/connectors/github-copilot/status
+  → /metrics  (scraped by ServiceMonitor)
+```
+
+S3: reuse the shared `ssegning-k8s-state` bucket at `nbg1.your-objectstorage.com`, own
+prefix `copilot-governance/`, creds from `ssegning-aws` key `prod/meta/test-app`
+(`s3_backup_cnpg_client_id` / `s3_backup_cnpg_secret`) — the same pattern LibreChat,
+MLflow, Argo Workflows and the CNPG backups all use. Region `us-east-1` (Ceph-RGW).
+
+### Postgres schema (sketch)
+
+```sql
+-- role/db added in charts/lightbridge-db/values.yaml, like `repoauth`/`codeintel`
+copilot_org_daily(tenant_id, org, report_day PK…, active_users, engaged_users,
+                  interactions, code_generations, code_acceptances,
+                  loc_suggested, loc_added, loc_deleted, ai_credits, net_cost_micro, currency)
+copilot_user_daily(tenant_id, org, provider_user_id, report_day PK…, last_activity_at,
+                   interactions, code_generations, code_acceptances, ai_credits,
+                   models jsonb, features jsonb, languages jsonb, ides jsonb)
+copilot_repo_daily(tenant_id, org, repository, report_day PK…, coding_agent_activity,
+                   code_review_activity, pull_request_activity)
+copilot_user_teams(tenant_id, org, provider_user_id, team_slug, report_day PK…)
+copilot_seat_snapshot(tenant_id, org, provider_user_id, snapshot_day PK…,
+                      seat_assigned_at, last_activity_at, last_activity_editor,
+                      seat_state, pending_cancellation_date)
+identity_map(tenant_id, provider, provider_user_id, internal_user_id,
+             team_id, cost_center_id, valid_from, valid_to, mapping_source)
+ingest_manifest(tenant_id, org, report_day, report_type PK…, status, record_count,
+                checksum, schema_version, started_at, completed_at)
+```
+
+Money in **integer minor units** (`net_cost_micro` = µ$), never floats — the house rule,
+and the same unit the ratelimit spend metric already uses.
+
+Sizing: ~500 seats × 365 days ≈ 200k rows/yr on the user table. Nothing.
+
+Team attribution: `copilot_user_teams` comes straight from GitHub. `identity_map` exists
+only to reach *internal* identity / cost-center — joined to Keycloak `user_entity` by
+verified email, reusing the ADR-0063 read-only datasource. Never match on display name.
+
+---
+
+## 4. Observability
+
+**Metrics are pull-based `ServiceMonitor`, not OTLP.** That is the platform contract:
+Alloy runs `prometheus.operator.servicemonitors` cluster-wide → `prometheus.remote_write`
+→ Mimir. Traces go OTLP to `alloy.observability.svc.cluster.local:4317`; logs are picked
+up from pod stdout by Alloy's Kubernetes SD.
+
+So the collector needs a metrics endpoint a CronJob pod can't serve. Two options — pick
+**(a)**:
+
+- **(a) The API Deployment owns the metrics.** The collector writes run outcomes to the
+  `ingest_manifest` table; the API exposes `governance_connector_*` gauges/counters
+  derived from it on `/metrics`, scraped by one ServiceMonitor. Always-scrapeable, no
+  push gateway, and `last_success_timestamp` / `report_age_seconds` are naturally
+  *derived* rather than remembered.
+- (b) A Prometheus pushgateway. Rejected — new component, stale-metric semantics.
+
+Metric names as the doc specifies (`governance_connector_sync_runs_total`,
+`…_sync_errors_total`, `…_last_success_timestamp`, `…_report_age_seconds`,
+`…_records_processed_total`, `…_s3_write_errors_total`,
+`…_github_rate_limit_remaining`, `…_download_duration_seconds`,
+`…_normalization_duration_seconds`, `…_unmapped_users`), labels limited to
+`provider`, `tenant_id`, `organization_id`, `report_type`, `status`.
+
+ServiceMonitor shape: copy `charts/inference-server/templates/servicemonitor.yaml`
+(namespaceSelector + matchLabels + `argocd.argoproj.io/sync-wave: "1"`).
+
+### Dashboards (Phase 9) — 4 modules, generated
+
+Python generator only; hand-written JSON is a CI failure (`dashboards-drift`).
+
+```text
+tools/dashboards/src/dashboards/copilot/
+  overview.py          → charts/observability-dashboards/files/copilot/overview.json
+  licenses.py          → …/licenses.json
+  adoption.py          → …/adoption.json
+  connector_health.py  → …/connector-health.json
+```
+
+Each module exports `OUTPUT_PATH: str` and `build() -> dict`; register the four dotted
+paths in `_DASHBOARD_MODULES` in `tools/dashboards/src/dashboards/main.py`; add
+`COPILOT_UID = "copilotgov"` to `_common.py`; then `uv run dashboards build` **and commit
+the JSON**.
+
+Then in `charts/observability-dashboards/values.yaml`:
+
+```yaml
+folders:
+  - name: copilot
+    title: "GitHub Copilot governance"
+    resyncPeriod: 5m          # ⚠️ REQUIRED — Grafana is stateless (ADR-0023)
+
+dashboards:
+  - name: copilot-overview
+    folderRef: copilot
+    file: files/copilot/overview.json
+    resyncPeriod: 5m
+  # … licenses, adoption, connector-health
+```
+
+⚠️ Omit `resyncPeriod` on the folder and the first Grafana pod roll silently wipes it;
+the operator's cached `ApplySuccessful` status means it is never re-created, and every
+`folderRef` dashboard sticks on `[400] folder not found`.
+
+Dashboards 1–3 (`overview`, `licenses`, `adoption`) target `uid: copilotgov`, the new
+read-only Postgres datasource. Dashboard 4 (`connector-health`) targets `mimir`.
+
+Datasource, in `ai-helm-values` `environments/prod/values/grafana.yaml`, modelled on the
+ADR-0063 `keycloak` one: `GrafanaDatasource`, `type: postgres`, pointing at the CNPG
+`-ro` replica, credentials from ESO. Grant the Grafana role **SELECT only**, on the
+reporting tables only. Grafana → CNPG egress needs a Cilium allow (the `observability`
+namespace is default-deny-egress) — same overlay edit ADR-0063 already made for Keycloak.
+
+### Alerts (Phase 10) — 5, in `charts/observability-dashboards/values.yaml`
+
+Grafana unified alerting via grafana-operator; there is no `PrometheusRule` anywhere in
+this repo. Compact authoring shape, one `ruleGroups` entry:
+
+```yaml
+  ruleGroups:
+    - name: copilot-connector-health
+      folderRef: copilot
+      interval: 5m
+      rules:
+        - uid: cg-no-sync-36h
+          title: Copilot connector — no successful sync in 36h
+          datasourceUid: mimir
+          expr: '(time() - max(governance_connector_last_success_timestamp)) or vector(0)'
+          fromSeconds: 3600
+          op: gt
+          threshold: 129600
+          for: 30m
+          severity: critical
+          summary: "..."
+        # cg-report-stale-72h, cg-github-auth-failed, cg-write-errors, cg-unmapped-users-10pct
+```
+
+⚠️ Two house rules that bite: every expression needs `or vector(0)` (with
+`noDataState: OK`, a no-data alert is permanently green — it never fires); and a
+notification-policy route may only name an **enabled** contact point, or Grafana rejects
+the *entire* policy tree with `[PUT /v1/provisioning/policies][400] receiver '…' does not
+exist` and all delivery stops. Route to the existing `discord` contact point; don't add a
+new one unless the Secrets-Manager property exists and shows `SecretSynced=True` first.
+
+Aggregate by tenant/org. Never alert per user or per repository.
+
+---
+
+## 5. Security
+
+The `governance` namespace is **new**, so — like `converse` and `mlops` — it inherits
+**no** Cilium default-deny baseline and pods egress freely. Phase 11's "egress restricted
+to GitHub API and S3" is therefore something we ship ourselves, in the deps overlay:
+
+```yaml
+# environments/prod/deps/copilot-governance/ciliumnetworkpolicy.yaml
+egress:
+  - toEndpoints: [kube-system/kube-dns]           # DNS
+  - toFQDNs:
+      - matchName: "api.github.com"
+      - matchPattern: "*.githubusercontent.com"   # signed report downloads
+      - matchPattern: "*.your-objectstorage.com"  # S3
+  - toEntities: [cluster]                          # CNPG, Alloy OTLP
+ingress:
+  - fromEntities: [host, remote-node, health]      # ⚠️ kubelet probes
+  - fromEntities: [cluster]                        # Traefik → auth → api
+```
+
+⚠️ Omit `fromEntities: [host, remote-node, health]` and kubelet probes fail — the pod
+never goes Ready and it reads as a crash-loop. This has bitten the inference charts.
+⚠️ A plain k8s `NetworkPolicy` `ipBlock` does **not** match on Cilium; it must be a
+`CiliumNetworkPolicy`.
+
+The signed-download host is a **spike output** — confirm it during §1.2 and pin the
+`toFQDNs` list then rather than guessing.
+
+Rest of Phase 11, all standard here:
+
+- Dedicated ServiceAccount, `automountServiceAccountToken: false` (nothing talks to the API server).
+- `runAsNonRoot`, `readOnlyRootFilesystem: true`, `capabilities: drop [ALL]`, `seccompProfile: RuntimeDefault`.
+- No collector Ingress; the API is reachable only via oauth2-proxy.
+- Secrets via ESO from `ssegning-aws`, **never `optional: true`** on a `secretKeyRef`
+  env — env vars bind once at pod start and never refresh, so an optional ref lets a pod
+  that beats ESO capture an empty credential and 401/403 forever. This is the context7
+  `MCP_TOKEN` incident; required refs make the pod wait in `ContainerCreating` instead.
+- Installation tokens minted per-need, never written to disk or DB.
+- **Redaction is a type, not a discipline:** wrap tokens and signed URLs in a newtype
+  whose `Debug`/`Display` print `<redacted>`, so a stray `tracing` field can't leak one.
+- Audit every user-level API query (row in `audit_log`, or a structured log line with
+  `actor` + `filters`).
+- GHCR package will be private → the namespace needs its own `dockerconfigjson` pull
+  secret (pull secrets are namespace-scoped; bjw-s resolves them from
+  `defaultPodOptions.imagePullSecrets`, **not** `global.imagePullSecrets`).
+
+---
+
+## 6. Sequence
+
+### Sprint 0 — Spike (~1 day, blocking)
+
+- Verify App-installation-token access to `/copilot/metrics/reports/*` at org scope with
+  the three permissions + the org policy toggle enabled (§1.2). Decide App vs PAT.
+- Capture one real `organization-1-day`, `users-1-day`, `repos-1-day`,
+  `user-teams-1-day` and `seats` payload → these fix the schema.
+- Note the signed-URL download host → fixes the `toFQDNs` allowlist.
+
+**Exit:** a checked-in fixture set and a go/no-go on the GitHub App.
+
+### Sprint 1 — Working ingestion
+
+Repo + `copilot-governance-core` + `copilot-govctl`; sqlx migrations; S3 raw writer;
+CNPG role/database in `charts/lightbridge-db`; the three ai-helm charts + orchestrator
+entry; deps overlay + values files in ai-helm-values; ServiceMonitor + `/metrics` +
+`/api/v1/connectors/github-copilot/status`; OTLP traces.
+
+**Exit:** the CronJob has been running unattended for 48 h; 28 days of Copilot data is in
+Postgres *and* replayable from S3; re-running a day changes no row counts.
+
+### Sprint 2 — Governance data & API
+
+Seats + user-teams ingestion; identity map + Keycloak join; the seven query endpoints
+with server-side filters and pagination; moka cache; the `copilotgov` GrafanaDatasource;
+dashboards 1–4; the 5 alerts.
+
+**Exit:** dashboard totals reconcile against the stored source reports for a spot-checked
+day; alerts fire in a deliberate failure drill (revoke the credential, watch Discord).
+
+### Sprint 3 — Product experience
+
+oauth2-proxy gate + Keycloak role restriction; inactive-seat reclamation
+*recommendations* (never automatic); cost-center attribution; the **second** billing App
++ AI-credit ingestion; raw-data retention/deletion job.
+
+**Exit:** an admin connects, sees adoption + seat waste + spend, and exports it, with no
+manual data handling.
+
+### Explicitly out (from the doc, endorsed)
+
+Raw prompt/code collection · VS Code interception · real-time claims · automatic seat
+removal · automatic budget changes · enterprise billing creds · enterprise audit-log
+streaming · ClickHouse · cross-provider benchmarking · productivity scoring.
+
+---
+
+## 7. Process obligations
+
+- **ADR-0111** (next free number) — `docs/adr/0111-github-copilot-governance-connector.md`,
+  covering: org-scope boundary, CNPG-over-Parquet, no-memcached, Postgres-datasource
+  dashboards, the two-App billing split. Template is `docs/adr/template.md` — three bold
+  metadata lines under the H1, **no YAML front-matter**, `Deciders: @stephane-segning`.
+  Open as `Status: Proposed`, flip to `Accepted` when it lands, and update the index table
+  in `docs/adr/README.md`. Accepted ADRs are immutable — supersede, never edit.
+- **Docs:** `docs/integrations/github-copilot-governance.md` (consuming a specific
+  product surface ⇒ `integrations/`), indexed in **both** `docs/README.md` and
+  `docs/integrations/README.md`. Add to `docs/arc42.md` §5 (building blocks) and §9
+  (decisions); add the topology to `docs/architecture.md`. If a durable gotcha emerges
+  (it will — the org policy toggle is one), add a bullet to `CLAUDE.md`.
+- **Every PR** (both repos) uses the governance template: AI Usage Declaration, a real
+  source-of-truth link, Verification evidence. The `governance / governance-check` job
+  fails a non-compliant body.
+- **Conventional Commits** enforced by `commit-msg` hook + CI; scope = chart dir name.
+  release-please owns the chart `MAJOR.MINOR` floor.
+- **Verification loop** in ai-helm: `helm dep build` → `helm lint` → `helm template` →
+  `uv run dashboards build && uv run dashboards check` → `ruff format/check`.
+
+---
+
+## 8. Open questions for you
+
+1. **CNPG vs Parquet-on-S3** (§0 #1) — the biggest call. My recommendation is CNPG; it
+   deletes the most code and unlocks direct Grafana SQL. Say the word if you'd rather
+   hold the "no database" line, and I'll re-plan Phase 5/7 around `object_store` +
+   DataFusion.
+2. **Multi-tenant now or later?** The doc is written for a product ("a customer installs
+   the app"), the MVP for our own org. `tenant_id` is in every table and prefix either
+   way, but *if* multi-tenant is real, the App must be public and Sprint 1 needs an
+   `installation` webhook + onboarding flow. Cheap now, expensive to retrofit.
+   *(Carried into the Foundry plan's open question #2 — answer it once, for both.)*
+3. **Hostname** — I assumed `governance.ai.camer.digital`. Fine, or something else?
+4. ~~**Repo name**~~ — **settled** by the Foundry spec: one `lightbridge-governance`
+   repo, connectors as crates. See the amendment note at the top.
+5. **Which Keycloak role gates the API?** New (`copilot_governance_roles`) or an existing
+   admin claim.

--- a/plans/lightbridge-dynamic-budget.md
+++ b/plans/lightbridge-dynamic-budget.md
@@ -1,0 +1,391 @@
+# Plan: Lightbridge dynamic budget refill + OPA-Wasm policy
+
+> `~/Downloads/lightbridge_dynamic_budget_refill_opa_wasm_plan.md` assessed against the
+> budget system actually in production: ADR-0021 (dual-plane authz + per-model rate
+> limiting), ADR-0035 (per-person budgets), ADR-0070 (live quota in redis),
+> **ADR-0084** (plan order is append-only) and **ADR-0110** (project quota tiers).
+>
+> Phases 1–5 land in `ADORSYS-GIS/lightbridge-authz` (its own Rust workspace + ADR
+> series). Only Phase 6 touches `ai-helm`, and it touches the part that is hardest to
+> change.
+
+**Status:** Proposed plan · **Date:** 2026-07-31 · **Maintainer:** @stephane-segning
+
+---
+
+## 0. The finding that decides the shape of this project
+
+**"A refill changes the allowance" is not expressible in the mechanism that enforces
+budgets today.**
+
+The monthly budget is a **static Envoy rate-limit rule**, rendered by Helm into a
+`BackendTrafficPolicy` (`charts/ai-model/templates/backendtrafficpolicy.yaml`): one rule
+per billing plan, the limit value baked in from `.Values.plans[].monthlyBudgetUsd`, with
+`cost` charged from `llm_custom_total_cost`. The Lyft ratelimit service then keys each
+counter in redis on the rule's **position in the rendered list** — plan names are `Exact`
+matches and render as masked constants, so the rule index is the only carrier of plan
+identity.
+
+That is not a design detail, it's a live incident: ADR-0084 records that adding an
+`enterprise` plan to a Helm **map** sorted it to index 0 mid-window, shifted `free` and
+`pro` to new indices, orphaned every account's accumulated spend, and silently handed the
+whole fleet a fresh budget. Hence the append-only-list rule, restated in ADR-0110 for
+quota tiers.
+
+So there is no per-account allowance to raise. There are N static limits and a counter
+per (rule index, account, window). Three ways out:
+
+| | Approach | Verdict |
+|---|---|---|
+| **A** | **Discrete refill tiers** — refills move an account between pre-defined budget tiers, each an append-only rule, exactly like ADR-0110's quota tiers. Authorino stamps the tier header; the grant ledger records which tier and why. | **Cheapest by far and it fits the machinery that exists.** The product cost is that refills are steps, not arbitrary amounts. If "user requests $5" can become "user requests the next tier up," this is the MVP. |
+| **B** | **Grants decrement the counter** — a $5 grant subtracts 5 000 000 µ$ from the redis counter instead of raising the limit. | Mechanically the simplest, and the spec explicitly forbids it (§15) for good reasons. It also makes `gateway_ratelimit_spend_micro_usd` mean *net of grants*, silently changing what the ADR-0070 quota dashboard displays. Only worth it as a stopgap, and only with the dashboard relabelled in the same change. |
+| **C** | **Replace Envoy's rate-limit enforcement with the spec's "Dynamic Budget Limiter"** — a component that reads the live allowance from Postgres and does reserve-and-settle against its own redis keys. | What the spec assumes throughout, without saying so. It is the honest end state, and it **retires ADR-0021/0084/0110's enforcement machinery**. It is also a new component in the inference data path — the same insertion-order problem as the [Censgate plan](./censgate-redact-extproc.md), and it should share that spike. Scope it as its own project, not as "Phase 6". |
+
+**Decided (2026-07-31): option A — refills are discrete tiers.** C stays available as a
+later successor if arbitrary amounts ever become a product requirement, but it is out of
+scope and is no longer sharing an insertion point with the Censgate plan.
+
+### 0.1 What option A actually costs — two consequences of the counter key
+
+Verified against `charts/ai-model/templates/backendtrafficpolicy.yaml`: the monthly-budget
+rule matches on `x-account-id` (`Distinct`) **plus** `x-billing-plan` (`Exact`, the plan
+id). So exactly one budget rule matches per request, and the redis counter key is a
+function of *which rule matched*. Two things follow, and neither is optional.
+
+**(a) A tier change resets the window's counter — the refill grants the full new tier,
+not the difference.** Move an account from a $15 rule to a $20 rule and it stops matching
+the first and starts matching the second: new descriptor, new key, counter at zero. A user
+who had consumed $15 of $15 does not get $5 more, they get $20 more. This is precisely the
+ADR-0084 incident mechanism, invoked deliberately this time.
+
+That is a **product decision, not a bug** — but it has to be stated and priced:
+
+- Refill semantics become *"upgrade for the remainder of the period,"* not *"top up by
+  £X."* The tier ladder should be defined that way (`b-base`, `b-plus`, `b-max`), with
+  each tier's number being a **total** for the period.
+- Repeated refills inflate: second refill ⇒ another reset. Cap the number of tier steps
+  per period in policy (the grant ledger already counts them — `selfServiceGrantCount` is
+  in the spec's policy input).
+- The ledger stays truthful regardless: grants are immutable and record which tier and
+  why, so audit is unaffected even though the runtime counter resets.
+- The alternative — seeding the new counter with the old consumed value — means writing
+  into the Lyft ratelimit service's key space. We already *read* those keys (ADR-0070), so
+  it's possible, but writing another service's keys is fragile and I would not build it.
+
+**(b) The tier has to reach Authorino as a claim, not a lookup.** The stamped header is
+what selects the rule, so the gateway must know the account's *current* tier at request
+time. The obvious route — Authorino calls Lightbridge for live budget scope — is exactly
+the pattern disabled on 2026-07-02 (§1.2 below). So: **Lightbridge writes the tier to a
+Keycloak user attribute when a grant lands, a protocol mapper turns it into a claim, and
+Authorino stamps it with a CEL default** — the same shape `billing_plan` already uses.
+
+Consequence to state in the product: **a refill takes effect on the next token refresh**,
+not instantly. That is acceptable and honest; a "your refill is active from your next
+sign-in / token refresh" message costs nothing.
+
+**The internal plane is out of scope for refills (decided 2026-07-31).** API-key clients
+(LibreChat, cron jobs, k8s SAs) authenticate differently and get a different access model;
+they keep their plan-level budget with no self-service refill. That removes the only case
+where the tier couldn't ride a claim.
+
+### 0.2 The tier ladder — a separate header, not more plans (decided)
+
+Two shapes were possible: extend the plan list (`free` → `free+1` → `free+2`, per plan), or
+move the budget dimension onto its **own header**. **Decided: the separate header.**
+
+- `x-budget-tier` is stamped on every request. Your **plan** determines the starting rung;
+  a refill moves you up the ladder. The plan header keeps meaning exactly one thing.
+- One ladder shared by all plans — no plans × steps combinatorics.
+- The budget rules in `charts/ai-model` / `core-gateway` key on `x-account-id` (`Distinct`)
+  + `x-budget-tier` (`Exact`), and the existing per-plan budget rules retire.
+
+Starting ladder, anchored on the live values (`free` 15 → `enterprise` 1000; note the
+`charts/ai-models` copies are **dormant** since the #532 shared-budget cutover, so the live
+numbers are `core-gateway`'s `monthlyBudget.plans`):
+
+```text
+b-15     ← free starts here
+b-30
+b-60
+b-120
+b-250
+b-500
+b-1000   ← enterprise starts here
+```
+
+Roughly doubling, so a rung is always a meaningful jump. The only *policy* numbers are then
+how many rungs a user may climb unaided per period (**2** to start — a free user reaches
+$60, then needs a human) and what happens past that (**manual review**, already modelled).
+Both live in rule data, so they change without a deploy.
+
+⚠️ **This is a migration, and it must land on a period boundary.** Retiring the per-plan
+budget rules and introducing tier rules moves every counter to a new key. Done mid-window
+that is the ADR-0084 incident, deliberately, for the entire fleet at once. Done at a period
+boundary — when every counter resets anyway — it costs nothing. **This is a hard scheduling
+constraint on Phase 6, not a preference.**
+
+### 0.3 ⚠️ AMENDED 2026-08-01 — the period boundary IS now the first of the month
+
+> **This section originally said the opposite, and was correct when written.** Two ADRs
+> landed between drafting and scheduling this plan and jointly replaced the window model:
+>
+> - **[ADR-0111](../docs/adr/0111-calendar-aligned-billing-period.md)** (2026-07-31) folds a
+>   calendar `YYYY-MM` marker into the key as an `x-billing-period` descriptor, stamped by a
+>   Lua `EnvoyExtensionPolicy`, so a new counter is minted at **00:00 UTC on the 1st**.
+> - **[ADR-0112](../docs/adr/0112-year-unit-so-the-billing-period-is-the-only-rotation.md)**
+>   (2026-08-01) sets **`unit: Year`** on all four monthly-budget rule families, because
+>   ADR-0111 alone left the 30-day epoch segment *also* in the key — so counters were
+>   rotating twice, and every account was being handed a spurious extra budget ~12×/year.
+>
+> Net effect on this plan: **the fixed 30-day epoch grid is gone as a scheduling
+> constraint.** The table below is retained as history; do not schedule against it.
+
+~~The budget window is a **fixed 30-day epoch bucket** — `floor(now / 2592000) * 2592000`~~
+— superseded. Historical boundaries, for reading old incident notes only:
+
+| Window | Starts (UTC) | Note |
+|---|---|---|
+| 688 | 2026-07-06 | current when this plan was drafted |
+| 689 | 2026-08-05 | ⚠️ **no longer a reset** — ADR-0112 pinned the epoch |
+| 690 | 2026-09-04 | ⚠️ no longer a reset |
+
+**The live boundary is now the 1st of each calendar month, 00:00 UTC.** The nearest ones
+are **2026-09-01**, 2026-10-01, 2026-11-01. Verify with one `SCAN` of the ratelimit keys
+before deploying — the key now carries a `2026-08`-style segment, not a bare epoch integer.
+
+### 0.4 Split Phase 6 — ⚠️ AMENDED 2026-08-01, the 6a rush is off
+
+Phase 6 is two separable things, and coupling them was my mistake:
+
+- **6a — the mechanical re-key.** Retire the per-plan budget rules, introduce the
+  `x-budget-tier` ladder, stamp every account with its plan's **base rung**. Behaviour is
+  identical to today; only the counter key changes. **Needs nothing from phases 1–5.**
+- **6b — refills actually move accounts between rungs.** Needs phases 1–5.
+
+> **Original decision: "6a ships 2026-08-01, four days before the window-689 boundary, and
+> the boundary cleans up after us." That reasoning is void** — ADR-0112 removed the
+> 2026-08-05 reset entirely, so nothing would have cleaned up after us. Had 6a shipped on
+> its original date under the original rationale, the re-key would have orphaned every
+> account's August spend with **no** compensating boundary until 2026-09-01. The plan was
+> right about the mechanism and wrong about the calendar.
+
+**Revised: 6a lands on a month boundary, and there is no longer any urgency to rush it.**
+
+- The migration still moves every counter to a new key, so it still wants a boundary — but
+  the boundary is now a *calendar* one, and there are twelve a year instead of a drifting
+  grid. **Target 2026-09-01 00:00 UTC**, or any later 1st.
+- Landing exactly on a boundary is also no longer the fiddly 00:00-UTC deploy it used to
+  be: because rotation is driven by the `x-billing-period` header value rather than by
+  elapsed time, a deploy in the first hours of the 1st lands in a window whose counters are
+  all near-zero anyway. The cost of being a few hours late is a few hours of spend, not a
+  fleet-wide orphaning.
+- 6a keeps its independence from phases 1–5, so it can still go first — it just no longer
+  *has* to.
+
+**After 6a the roadmap is schedule-free.** Moving an account between existing rungs resets
+only *that* account's counter — the intended refill semantic (§0.1a), not a migration.
+Adding new rungs later is append-only and safe any time.
+
+⚠️ **Co-change required in the same PR: the redis exporter's key patterns.** The ADR-0070
+`prometheus-redis-exporter` SCANs `REDIS_EXPORTER_CHECK_KEYS=db0=*rule-2-match-0*,db0=*rule-7-match-0*`
+— rule **indices** — and its own values file says to keep it in lockstep with
+`monthlyBudget.plans`. Retiring those rules without updating the patterns makes
+`gateway_ratelimit_spend_micro_usd` go silent and the `ratelimit-quota` dashboard go blank.
+Update the exporter config, the `ServiceMonitor` `metricRelabelings` (they parse
+`plan` out of the key) and `tools/dashboards/.../ratelimit_quota.py` together. Keep the
+rotation segment as a label — dropping it collides two windows at rollover.
+
+⚠️ **AMENDED 2026-08-01:** that rotation segment is no longer the bare `window` epoch this
+plan was written against. Post-ADR-0111/0112 the key carries a calendar `2026-08` segment
+(`billing_period`) plus a now-static year epoch. The exporter, the `ServiceMonitor`
+relabelings and the dashboard were already migrated to `billing_period` on `main`
+(`ea1c81b`, `3b1c69d`, `1d8743e`, `#866`) — so this co-change must be written against
+**`billing_period`**, and re-introducing a `window` label would be a regression.
+
+Verify the live key shape with one `SCAN` of the ratelimit keys immediately before
+deploying, rather than trusting any table in this document.
+
+⚠️ The ladder is **append-only** like everything else in this area. `b-2000` can be added
+later; no rung may ever be reordered or removed.
+
+---
+
+## 1. Three more things the spec walks into
+
+### 1.1 This OPA is not the OPA that was removed — and the ADR must say so
+
+`CLAUDE.md` is blunt: the OPA path is **gone** (2026-06-04), the `lightbridge-validation`
+HTTP metadata source and `enforce-valid-key` step were deleted, and nothing OPA-shaped
+returns without a new ADR. That history will be the first objection this plan meets, and
+it's the wrong objection.
+
+What was removed was an **HTTP call to an external OPA inside the ext_authz hot path**,
+whose missing Secret 404'd the entire gateway. What this spec proposes is an **embedded
+Wasm evaluator inside a control-plane API** that decides refill requests — off the
+inference path entirely, with a last-known-good fallback and a fail-closed default. The
+blast radius isn't comparable. Say that explicitly in the ADR rather than letting the
+name do the arguing.
+
+### 1.2 §17 puts a database read back into the ext_authz hot path
+
+The spec has Authorino consult Lightbridge introspection for "live identity and budget
+scope." This platform tried that shape and **disabled it on 2026-07-02** (#533): the
+Keycloak introspection metadata step is commented out in `security-policies.yaml` with a
+long note explaining that the ext_authz timeout is shorter than the introspection
+latency, so a slow dependency turns into fail-open on every request.
+
+The spec's own instinct is right — "the limiter should retrieve the current allowance
+using `budget_account_id`, not depend only on cached Authorino metadata." Keep it that
+way: Authorino stamps only **stable** identifiers (`x-budget-account-id`,
+`x-budget-period`), which it can do from the credential alone, and the *limiter* does the
+allowance lookup. Never add a budget lookup to the Authorino step.
+
+### 1.3 Reserve-and-settle doesn't exist today; requests are charged after the fact
+
+Envoy's rate-limit `cost` is `llm_custom_total_cost`, computed by AIEG's ext_proc **after
+the response**. So today a request is allowed and then charged — overshoot past the budget
+is possible by design, bounded by one request. §16's reserve-and-settle is a genuine
+improvement, but it requires a pre-request cost estimate and a component that runs before
+the model call. It is therefore part of option C, not something that can be added to the
+current path.
+
+### 1.4 OPA's Wasm target has real built-in gaps — but the spec already dodges them
+
+Not every Rego built-in compiles to Wasm. The spec passes `now` in as input rather than
+calling `time.now_ns()`, which suggests the author knew. Verify the specific built-ins the
+production policy needs during Phase 2, and keep the rule-data interpreter free of
+anything exotic.
+
+---
+
+## 2. The simplification worth taking
+
+§5 defines two authoring levels: **rule data as JSON** (for ordinary admins, the primary
+path) and **advanced Rego** (for a restricted `policy-admin` role).
+
+The §5.1 rule data is just ordered predicates over numeric fields — `consumptionRatioGte`,
+`requestedAmountMicrosLte`, `selfServiceTotalMicrosLte` — with a priority and an effect.
+**A plain Rust evaluator covers 100% of that with none of the Wasm machinery**: no
+`opa build`, no bundle signing, no hot-swap, no last-known-good, no Wasm runtime.
+
+Rego/Wasm earns its keep only for §5.2 — cross-entity queries ("approve only if no other
+project member refilled this period"), set and aggregate logic, computed relationships
+("approve up to 20% of last period's consumption"). **Decided 2026-07-31: those are wanted,
+so OPA-Wasm is in scope** — but the two engines still land in order, because the spec's own
+design has both:
+
+- **Phase 2:** typed input/decision schemas + a Rust **rule-data evaluator** + the §6
+  decision contract + decision logging. This is §5.1, the path ordinary administrators use,
+  and it is needed regardless of whether Rego exists.
+- **Phase 2b:** the **OPA-Wasm engine** behind the same §6 contract, for the `policy-admin`
+  role. Bundle build/sign/verify, atomic hot-swap, last-known-good fallback, evaluation
+  timeout, revision in the health endpoint.
+
+Sequencing them this way is not deferral — it puts the entire policy *lifecycle* (§18–§21:
+versioning, staging, activation, rollback, simulation, decision logs) on the cheap engine
+first, where it's testable in isolation, and adds the second engine to a lifecycle that
+already works. Every §19 lifecycle state applies to versioned rule data just as well as to
+signed bundles.
+
+⚠️ Verify during Phase 2b which Rego built-ins the production policy needs actually compile
+to Wasm — the target does not support all of them. The spec already dodges the obvious one
+by passing `now` in as input rather than calling `time.now_ns()`.
+
+---
+
+### 2.1 Permissions: claim → internal permission list, via config (decided)
+
+No Keycloak roles are hardcoded. The token carries a claim (roles/groups); Lightbridge maps
+claim values onto the internal `budget:*` permission set of §22 through a `config.yaml`.
+That keeps the permission model ours, keeps Keycloak free to reorganise, and makes
+`policy-admin` just another entry rather than a special case.
+
+```yaml
+# illustrative shape
+permissionMapping:
+  claim: realm_access.roles          # or a dedicated claim
+  map:
+    ai-user:          [budget:read, budget:self-refill]
+    budget-approver:  [budget:read, budget:review]
+    budget-admin:     [budget:read, budget:grant, budget:revoke, budget:audit-read]
+    policy-author:    [budget:policy-read, budget:policy-write, budget:policy-simulate]
+    policy-operator:  [budget:policy-read, budget:policy-activate]
+  default: [budget:read]
+```
+
+Four things this has to get right:
+
+- ⚠️ **Fail closed.** A `config.yaml` that is missing or unparseable grants **no**
+  permissions and the service refuses to start — never "no mapping ⇒ allow."
+- ⚠️ **Unknown claim values map to `default`, not to everything.** The mirror of the
+  `FalseyValueParser` trap: an unrecognised value in a security switch must not be guessed.
+- **Keep §22's write/activate split real.** `policy-author` and `policy-operator` above are
+  deliberately different entries — with arbitrary Rego in scope (§2), `budget:policy-write`
+  means "ship executable code into the decision path," and it should not be the same person
+  who activates it.
+- **Where it lives + how it reloads.** Deployed config ⇒ `ai-helm-values`
+  (`environments/prod/values/lightbridge-app.yaml`), values-repo-first. Mount the ConfigMap
+  as a **directory, not `subPath`** (subPath mounts never update in place), and roll pods via
+  a checksum annotation — `kubectl rollout restart` is reverted by ArgoCD selfHeal. Same
+  mechanism the redaction policy config needs in the [Censgate plan](./censgate-redact-extproc.md).
+
+---
+
+## 3. What's genuinely good here and should be kept intact
+
+- **Immutable grant ledger + materialized balance, rebuildable by replay** (§12–§13).
+  Correct, and the reconciliation test is the one that matters.
+- **Integer micro-units** (§12). Already the house rule and the unit the existing
+  `gateway_ratelimit_spend_micro_usd` series uses — so budget, Foundry cost and gateway
+  spend stay commensurable.
+- **Deterministic trigger keys with a unique constraint** (§10). This is the right answer
+  to "don't grant repeatedly while the budget stays above the threshold," and the
+  `auto:{revision}:{period}:{account}:{rule}:{threshold}` shape is well judged.
+- **Re-evaluate under lock before applying** (§11, §25.8). Right.
+- **Separating `budget:policy-write` from `budget:policy-activate`** (§22). Right.
+- **The failure-mode table** (§23) is the best part of the document. Keep it as the test
+  matrix.
+- **Stable runtime counter identity** (§15). Right in principle — note that today's keys
+  are the Lyft service's, which embed the rule index, so "stable identity" is exactly what
+  option C would fix and what options A and B live without.
+
+---
+
+## 4. Sequencing
+
+| Phase | Where | Notes |
+|---|---|---|
+| 1 — Grant/request domain | `lightbridge-authz` | Unchanged from the spec. Ledger, balances, idempotency, replay tests. |
+| 2 — Rule-data evaluator | `lightbridge-authz` | §2 above. Decision contract §6 is the seam. |
+| 3 — Policy management | `lightbridge-authz` | §18–§20 lifecycle over versioned rule data. Simulation endpoint. |
+| **2b — OPA-Wasm engine** | `lightbridge-authz` | Second engine behind the §6 contract, for `policy-admin`. Bundle build/sign/verify, atomic hot-swap, last-known-good, eval timeout, revision in `/health`. Lands onto the lifecycle Phase 3 already built. |
+| 4 — Refill workflows | `lightbridge-authz` | User request, admin grant, review queue, expiry. **OIDC users only** — the internal/API-key plane is excluded (§0.1). |
+| 5 — Automatic augmentation | `lightbridge-authz` | Trigger keys, worker, scheduled reconciliation. |
+| **6a — Re-key to the tier ladder** | **`ai-helm`** + Keycloak | ⚠️ **AMENDED — targets a month boundary (2026-09-01 or later), not 2026-08-01** (§0.4; ADR-0112 removed the boundary the original date was racing). May still go ahead of phases 1–5; no longer has to. Tier rules replace the per-plan budget rules; every account lands on its plan's base rung; behaviour unchanged. + Keycloak attribute → protocol mapper → claim → Authorino CEL stamp. ⚠️ Same PR must update the redis-exporter key patterns, the ServiceMonitor relabelings and the `ratelimit_quota` dashboard (now keyed on `billing_period`), or the quota board goes blank. No rung may ever be reordered or removed (ADR-0084). |
+| **6b — Refills move rungs** | `lightbridge-authz` + Keycloak | Grants write the tier attribute. No schedule constraint — a rung change resets one account's counter, which is the intended semantic (§0.1a). |
+| 7 — Hardening | both | Metrics per §21, alerts, load tests. Include a test that a tier change produces the expected new counter key and that the old one is left orphaned by design (§0.1a). |
+
+ADRs: one in `lightbridge-authz` for the grant/ledger domain model; one in `ai-helm` for
+the Phase-6 enforcement decision (this is the one that touches ADR-0021/0084/0110 and
+must say which of A/B/C it chose and why); one more if OPA-Wasm lands later.
+
+## 5. Open questions
+
+1. ~~**Can refills be discrete tiers?**~~ — **answered 2026-07-31: yes.** Option A. See
+   §0.1 for the two consequences that now need decisions (below).
+2. ~~**Do API-key clients get refills?**~~ — **answered: no.** Internal/API-key clients get
+   a different access model and keep plan-level budgets. Refill is OIDC-only.
+3. ~~**Define the tier ladder**~~ — **answered:** separate `x-budget-tier` header, ladder in
+   §0.2, 2 unaided rungs per period to start.
+4. ~~**Confirm the reset semantics**~~ — **answered: correct as described.**
+5. ~~**Does anyone need arbitrary Rego?**~~ — **answered: yes**, so OPA-Wasm is in scope as
+   Phase 2b (§2).
+6. ~~**Keycloak role mapping**~~ — **answered:** roles ride a **claim**, and Lightbridge maps
+   claim values → the internal `budget:*` permission list via a `config.yaml`. See §2.1.
+7. ~~**Which period boundary?**~~ — **answered: the next achievable one.** ⚠️ **AMENDED
+   2026-08-01:** boundaries are now **calendar month starts** (00:00 UTC on the 1st), not
+   30-day epoch buckets — ADR-0111 + ADR-0112, see §0.3. So the target is **2026-09-01**,
+   with 2026-10-01 as fallback. Phases 1–5 no longer have to land before it: 6a is
+   independent of them, and 6b carries no boundary constraint at all.
+8. **Who actually reviews** in the manual-review flow — which claim value maps to
+   `budget:review`? A mapping mechanism doesn't pick the people.

--- a/plans/microsoft-foundry-governance.md
+++ b/plans/microsoft-foundry-governance.md
@@ -1,0 +1,331 @@
+# Plan: Microsoft Foundry governance connector (OTLP ingestion)
+
+> `~/Downloads/microsoft-foundry-governance-mvp-plan.md` mapped onto this platform.
+> Companion to [`github-copilot-governance.md`](./github-copilot-governance.md) — the two
+> specs are **one product with two connectors**, and §1 below says what that means for
+> both.
+
+**Status:** Proposed plan · **Date:** 2026-07-31 · **Maintainer:** @stephane-segning
+
+---
+
+## 0. The headline finding
+
+**The LGTM stack is single-tenant today, and the spec's entire isolation model rests on
+`X-Scope-OrgID`, which currently does nothing.** Verified in `ai-helm-values`:
+
+```yaml
+# environments/prod/values/mimir.yaml:16
+multitenancy_enabled: false
+# environments/prod/values/loki.yaml:21
+auth_enabled: false
+# environments/prod/values/tempo.yaml:7
+replicas: 1                # single-binary, retention: 720h
+```
+
+There is even a comment in `mimir.yaml:207` reading "a multi-tenant fleet we don't run."
+
+So Increment 3 ("Tempo uses this header to isolate tenant trace data") and Increment 10's
+isolation matrix ("tenant A cannot query tenant B") are **not** configuration tweaks on
+top of what's running — they are a migration of the observability stack that currently
+monitors our own production. §3 is the decision that follows, and it's the one that
+should be settled before any code is written.
+
+The good news, and it's substantial: **Increment 2 is already built.** Not "something
+similar" — the exact flow. See §2.
+
+---
+
+## 1. These two specs are one product
+
+The Foundry spec's Increment 1 (Tenant → Application → Environment → Integration → Agent,
+plus credential issuance and revocation) is **not Foundry-specific**. The Copilot
+connector needs the same `tenant_id`, the same application record, and the same identity
+map. The Foundry spec's Increment 5 explicitly frames normalization as provider-agnostic;
+the Copilot spec's Phase 5 says the same thing in different words ("normalize all
+providers into a generic AI-application model").
+
+That resolves open question #4 in the Copilot plan. Consequences:
+
+| | Copilot plan said | Now |
+|---|---|---|
+| Repo | `ADORSYS-GIS/copilot-governance` | **`ADORSYS-GIS/lightbridge-governance`** — one workspace, `crates/governance-core` + `crates/connector-copilot` + `crates/connector-foundry` |
+| Namespace | `governance` | `governance` (unchanged — it was already the right call) |
+| Database | `copilotgov` role on `lightbridge-main-db` | **`governance`** role/DB, shared: registry + both connectors' tables |
+| Charts | `copilot-governance{,-app,-secrets,-auth}` | `lightbridge-governance{,-api,-collector,-secrets,-auth}` |
+| Sequencing | Copilot Sprint 1 = ingestion | **Registry first.** Increment 1 here is the prerequisite for *both* connectors |
+
+**The sequencing change is the important one.** Building the Copilot connector first and
+retrofitting a tenant registry underneath it means rewriting every table's primary key.
+Build the registry (~1 sprint), then both connectors land against it.
+
+I'd still ship **Copilot first** as the second milestone — it's pull-based, single-tenant
+in practice (our own org), needs no public endpoint, and no LGTM changes. It proves the
+registry and the Postgres+Grafana pattern at low risk. Foundry is the harder one and
+benefits from going second.
+
+---
+
+## 2. Increment 2 is already in production — don't rebuild it
+
+The spec asks for: public HTTPS :443 → bearer token → authentication service → token
+lookup → trusted integration context → collector, with the producer forbidden from
+setting `X-Scope-OrgID` or `governance.*` itself.
+
+That is a description of `core-gateway` + Authorino as currently deployed. Concretely,
+this is live in `ai-helm-values` `security-policies.yaml` today:
+
+```yaml
+    metadata:
+      "repobinding":
+        http:
+          url: http://lightbridge-repo-auth.converse.svc.cluster.local:3000/v1/resolve
+          method: POST
+          credentials:
+            customHeader:
+              name: X-Internal-Token
+          sharedSecretRef:
+            name: lightbridge-repo-auth-internal
+            key: internal-token
+```
+
+An Authorino AuthConfig calling a first-party Rust service's `/v1/resolve` over a shared
+secret, to turn a credential into trusted context, and then stamping the result as
+headers via `response.success.headers`. **That is the spec's Increment 2 authentication
+design, already running.**
+
+So the Foundry ingestion path is:
+
+```text
+Foundry agent
+  → https://otel.ai.camer.digital (core-gateway, public LB, ACME HTTP-01)
+  → Authorino AuthConfig #3 (host-indexed, alongside main + internal)
+        authentication: bearer integration token
+        metadata.http → governance-api /internal/v1/resolve  (X-Internal-Token)
+        response.success.headers → X-Scope-OrgID, governance.tenant.id,
+                                   governance.application.id, governance.integration.id
+  → BackendTrafficPolicy (per-token rate limit + quota, redis-backed — ADR-0021)
+  → OpenTelemetryCollector/foundry-gateway  (OTLP/HTTP :4318)
+        memory_limiter → redaction → transform → batch
+  → fan-out
+```
+
+What this buys you, free: TLS termination + ACME, a stable public endpoint, 401 on bad
+tokens, server-side revocation (the resolve call is authoritative every request), per-token
+rate limiting and monthly quotas with live counters in redis, and the existing
+gateway dashboards.
+
+**Three traps carried over from how this is already wired:**
+
+- ⚠️ A `sharedSecretRef` pointing at a Secret that doesn't exist makes the AuthConfig fail
+  readiness → **gateway-wide 404**. This is the OPA-removal outage, documented in
+  `docs/migrations/2026-hetzner-cutover.md`. Create the `ssegning-aws` property and confirm
+  `SecretSynced=True` *before* the AuthConfig references it.
+- ⚠️ Authorino attaches per-**listener** via the SecurityPolicy's `sectionNames` (today
+  `api-https` + `api-internal`). A new `otel-https` listener must be added there or it is
+  silently unauthenticated.
+- ⚠️ The resolve endpoint must be ClusterIP-only and trust the posted body **only** with
+  the internal token — repo-auth's own comment says exactly this.
+
+**Not free, and worth stating plainly:** Authorino evaluates the AuthConfig on every
+request, so `/internal/v1/resolve` is in the hot path of customer telemetry. Cache the
+token→tenant resolution in-process (`moka`, 60 s TTL) inside the governance API, and
+accept that revocation takes up to one TTL to propagate. The spec's acceptance test
+"revoked tokens stop working" then means "within 60 s" — say so in the docs rather than
+implying instant.
+
+---
+
+## 3. The tenancy decision (blocking, settle before code)
+
+Three options. I recommend **C for the MVP, B as the stated end state.**
+
+### A — Turn on multi-tenancy in the existing LGTM stack
+
+Flip `multitenancy_enabled` / `auth_enabled` to `true`, tenant our own data, tenant the
+customers'. **Reject.** It means: every existing writer must start sending
+`X-Scope-OrgID` (Alloy's `prometheus.remote_write`, the core-gateway OTel collector,
+every log path); every Grafana datasource gains the header; existing Mimir blocks written
+under the implicit tenant don't relabel themselves, so there's a cutover with a data
+discontinuity in the boards that watch production. And it puts customer telemetry volume
+in the same ingesters as the monitoring you need *during* an incident caused by that
+volume. Wrong blast radius for an MVP.
+
+### B — A second, multi-tenant LGTM instance for customer telemetry
+
+Own namespace, own S3 prefixes in `ssegning-k8s-state`, multi-tenant from birth, our
+production stack untouched. This is the correct end state and satisfies every isolation
+test in Increment 10 as written. It is also a whole second observability stack to operate
+— and the existing one has cost real incidents (the Mimir memberlist ring wedge, the
+Alloy egress trap, the datasource UID substitution). Not a first milestone.
+
+### C — MVP: governance Postgres is the tenant-isolated system of record
+
+Customer telemetry still flows to Tempo/Loki/Mimir, single-tenant, **for operator use
+only** — no customer Grafana access at all. Everything the customer sees comes from the
+governance API and the governance Postgres, where isolation is a `WHERE tenant_id = $1`
+enforced in one place and testable. The normalized execution record keeps `trace_id` /
+`span_id` so an *operator* can jump to Tempo.
+
+What this costs you against the spec, stated honestly:
+
+- Increment 3's acceptance test "a tenant-isolated query result in Grafana" is **not
+  met**; it becomes "an operator-isolated query result."
+- DoD step 7, "Open its Tempo trace," is operator-only. A customer-facing deep link would
+  rely on 128-bit trace IDs being unguessable — that's non-enumerability, not
+  authorization, and it should not be sold as isolation.
+- Increment 10's isolation matrix reduces to three rows (write-as, query-as, S3 path),
+  all of which C *does* satisfy, plus two that are deferred with B.
+
+If customer-facing Grafana is non-negotiable for the MVP, that is a legitimate call — it
+just means B moves into scope and adds roughly a sprint.
+
+### Loki cardinality (applies to B and C alike)
+
+The spec is right that `trace_id`/`session_id`/`user_id`/`model`/`agent_id` must be
+structured metadata, not stream labels. Two platform-specific additions:
+
+- Loki's **native OTLP endpoint** with structured metadata is the right receiver, and
+  it is what the spec asks for. Note our Alloy path uses `otelcol.exporter.loki`, which
+  is the *older* shape and stores the line as `{"attributes":…,"resources":…}` — ADR-0046
+  and a lot of pain. Don't copy the existing Envoy-access-log pipeline for this; go
+  native OTLP.
+- ⚠️ **"Full prompt content: 7 days maximum" (Increment 10) is not achievable with our
+  current Loki config.** `retention_period: 90d` is global. Per-stream retention needs
+  `limits_config.retention_stream` matched on a **label** — so content-bearing streams
+  must carry a distinguishing stream label (e.g. `content_capture="full"`), which is one
+  of the very few places a label is justified. Design it in from the start; retrofitting
+  means the 7-day promise silently isn't kept.
+
+---
+
+## 4. What to build, by increment
+
+### Increment 1 — Registry (shared, first)
+
+`governance` role + database on `lightbridge-main-db` (same 30-line addition as the
+Copilot plan). Tables: `tenant`, `application`, `environment`, `integration`, `agent`,
+`agent_version`, `identity_map`, plus the connector tables.
+
+Credentials: issue an opaque token, store **only** `credential_hash` (argon2id), never
+the token. `POST /api/v1/integrations` returns it once. Revocation = a status flip that
+`/internal/v1/resolve` reads.
+
+⚠️ Foundry constraint the spec flags and it's load-bearing: **changing the OTLP env vars
+requires publishing a new agent version.** So endpoint and token must be *stable* —
+rotation is expensive for the customer. Design for long-lived tokens with server-side
+revocation (which C gives you), not short-lived tokens with rotation.
+
+### Increment 2 — Ingestion
+
+`charts/lightbridge-governance-collector` renders an `OpenTelemetryCollector` CR. Precedent and
+its two hard-won notes are in `charts/core-gateway/templates/otel.yaml`:
+
+- ⚠️ `mode:` is **required** — the v1beta1 webhook rejects an empty mode with a confusing
+  message — and **immutable**; changing it means deleting the CR once so ArgoCD recreates it.
+- ⚠️ `memory_limiter` **must be first** in every pipeline; it sheds load before OOM, and
+  an OOM loses data outright. This regressed once already (ADR-0034).
+
+Three replicas, PDB, anti-affinity, HPA — all standard, all in the chart. Namespace
+`governance` (not the spec's `governance-ingestion`; short names, and the collector and
+API want to be co-resident anyway).
+
+⚠️ New namespace ⇒ no Cilium default-deny baseline, so ship a `CiliumNetworkPolicy` in
+the deps overlay, and **it must include `fromEntities: [host, remote-node, health]`** or
+kubelet probes fail and it reads as a crash-loop.
+
+### Increment 3 — Fan-out
+
+Three pipelines as the spec writes them. Exporters: `otlp/tempo`, `otlphttp/loki`
+(native), `otlphttp/mimir`, plus `otlphttp/governance` to our own ingestion API.
+
+⚠️ Mimir's native OTLP endpoint — verify against the installed chart version before
+relying on it; the fallback is remote-write via the `prometheusremotewrite` exporter.
+
+### Increment 4 — Privacy (release blocker, agreed)
+
+`redaction` + `filter` + `transform` processors, three capture modes, default
+`metadata_only`. The mode is resolved from the **integration record**, not the payload —
+which means the collector needs it as a trusted header from Authorino, or the governance
+API enforces it post-hoc. Prefer the header: redact before the data reaches Tempo/Loki,
+not after.
+
+### Increment 5 — Normalization
+
+Execution / model-call / tool-call records as specified, keeping `trace_id`, `span_id`,
+`raw_backend`, `raw_schema_version`. One change: **money in integer µ$**, never floats —
+house rule, and it makes Foundry cost commensurable with the existing
+`gateway_ratelimit_spend_micro_usd` series so one board can show both.
+
+### Increment 6 — Cost + policies
+
+The versioned pricing table is right (Foundry reports Azure OpenAI models, not ours).
+Shape it like `charts/ai-models/values.yaml`'s per-model `pricing:` blocks (ADR-0028) so
+the two cost models read the same way, but keep it in Postgres — it's customer-editable
+data, not chart config.
+
+Five policies, evidence to S3 (`s3://ssegning-k8s-state/lightbridge-governance/evidence/…`),
+searchable metadata in Postgres. Exactly as specified.
+
+### Increment 7 — UI: four of the five views are Grafana
+
+**Applications, Application overview, Executions, Policies are all SQL over the
+governance Postgres** — the same `GrafanaDatasource` trick as the Copilot plan (ADR-0063
+precedent). Only **Integration setup** genuinely needs a bespoke page: create app, mint
+token once, show copyable Foundry config, live "receiving telemetry" status.
+
+So build **one small server-rendered page** off the axum API (askama/maud), not a Next.js
+console. `lightbridge-code-intelligence` has a Next.js console and it is a lot of surface
+to carry for four tables and a form. Revisit when the product earns it.
+
+### Increments 8–10
+
+Dashboards via `tools/dashboards/` Python only (hand-written JSON fails
+`dashboards-drift`), folder `lightbridge-governance`, `resyncPeriod` on the folder or the first
+Grafana pod roll wipes it. The **platform ingestion health** dashboard is the one the
+spec correctly calls essential — "no violations" vs "no telemetry" — and it reads Mimir.
+
+Increment 9's golden-dataset-in-CI is the best idea in either spec. Make it a fixture
+replayed through the real collector config in CI on every change to collector config,
+normalization, pricing, or policy logic.
+
+Increment 10: rate limiting and quotas are `BackendTrafficPolicy` config (ADR-0021), not
+code. Retention: Tempo 30d ✓, Mimir 90d ✓, Loki 90d vs the spec's 14–30d (decide), full
+content ≤7d needs the `retention_stream` work from §3.
+
+---
+
+## 5. Sequencing across both specs
+
+```text
+M1  Registry + credentials + /internal/v1/resolve + governance DB      (shared)
+M2  Copilot connector  → proves registry + Postgres/Grafana, low risk
+M3  Foundry ingestion  → otel host + AuthConfig #3 + collector + fan-out
+M4  Normalization + cost + 5 policies + evidence                       (shared)
+M5  Grafana views + integration-setup page + golden dataset in CI
+M6  Hardening: quotas, isolation tests, retention, load test
+    (+ option B — second LGTM instance — if customer Grafana access is in scope)
+```
+
+## 6. ADRs
+
+Three, not one. `0111` registry + tenancy model (including the §3 decision and why A was
+rejected); `0112` Copilot connector; `0113` Foundry OTLP ingestion via core-gateway +
+Authorino. Template is `docs/adr/template.md` — three bold metadata lines, no YAML
+front-matter, next free number is 0111.
+
+## 7. Open questions
+
+1. **§3 — A, B or C?** Everything else depends on it. My recommendation: C now, B stated
+   as the end state, and be explicit in customer-facing docs that MVP Grafana access is
+   operator-only.
+2. **Is this actually multi-customer, or is "tenant" us + a pilot?** It changes whether
+   token issuance needs self-service in M1 or can be `govctl` + a row in Postgres.
+3. **Loki retention** — drop to 30d globally to match the spec, or keep 90d and treat the
+   spec's table as a floor?
+4. **Repo name** — `lightbridge-governance`, or keep the connectors in separate repos
+   with a shared core crate published to a private registry? (One repo is simpler; I'd
+   only split if the connectors get separate release cadences.)
+5. Does the Foundry agent's OTLP client tolerate a **401 with a JSON body** from
+   Authorino, or does it need a specific challenge shape? Worth a 30-minute check against
+   a real hosted agent before M3.


### PR DESCRIPTION
## Summary

Lands the consolidated planning set for the four specs that arrived on 2026-07-31, plus `plans/README.md` — the single roadmap across all four. Docs only; nothing rendered, nothing deployed.

## Intent

These four specs were reviewed and decided on together (14 decisions, recorded in the README's decision table) because they overlap heavily — plans 1 and 2 are one product with two connectors, and plans 3 and 4 *appeared* to share a data-path problem until decision 5 removed it. Committing them makes that shared reasoning citable, so the epics and stories being opened against it have a real source of truth instead of a local file path.

**They are committed already amended, not as-drafted**, because two ADRs invalidated a load-bearing premise within a day of them being written.

Source of truth: the four specs themselves, copied into the repo alongside the plans, plus the decisions taken with @stephane-segning on 2026-07-31 (README §"Decisions taken"). Existing related work: epic #531 (projects + quota tiers), ADR-0110, ADR-0111, ADR-0112.

## Scope

### In scope
- `plans/{github-copilot-governance,microsoft-foundry-governance,censgate-redact-extproc,lightbridge-dynamic-budget}.md`
- `plans/README.md` — decision table, risk ranking, the single roadmap, ADR reservations
- The 2026-08-01 amendment described below

### Out of scope
- No chart, template, values or dashboard change. `git show --stat` is five files under `plans/`.
- The ADRs themselves (0113–0117 are *reserved* here, not written).
- Any implementation. The epics/stories/tickets opened against this PR carry that.

## The amendment — and why it is the most important part of this PR

Plan 4 was written against the budget window as a **fixed 30-day epoch bucket**, `floor(now/2592000)*2592000`. Its §0.3/§0.4 argued for shipping the budget re-key (phase 6a) on **2026-08-01 specifically**, four days before the window-689 boundary at 2026-08-05, so that boundary would "absorb the reset."

Between drafting and scheduling, two ADRs replaced that model:

- **ADR-0111** (2026-07-31) folded a calendar `YYYY-MM` `x-billing-period` marker into every monthly-budget rate-limit key.
- **ADR-0112** (2026-08-01) then set `unit: Year`, because ADR-0111 alone left the 30-day epoch segment *also* in the key — so counters were rotating twice and every account was silently getting a spurious extra budget ~12×/year.

**The 2026-08-05 boundary no longer exists.** Shipping 6a today on its original rationale would therefore have orphaned every account's August spend with no compensating reset until 2026-09-01. The plan was right about the mechanism and wrong about the calendar, in the fail-*open*-looking direction that produces no alert.

Amended with the original reasoning left visible (struck through and annotated) rather than silently rewritten, since the point of these documents is the reasoning:

- **Wave −1 is retired.** Phase 6a folds into Wave 4 and targets a calendar month boundary — 2026-09-01 or any later 1st. **No wave in the roadmap is date-pinned any more.**
- The redis-exporter / `ServiceMonitor` / `ratelimit_quota` co-change is rewritten against the **`billing_period`** label that `ea1c81b`, `3b1c69d`, `1d8743e` and #866 already shipped. The original text said to keep a `window` label; re-introducing one would now be a regression.
- The reserved ADR block moves **0111–0115 → 0113–0117**, since 0111/0112 were taken while this sat unmerged.

## Verification

Documentation-only, so verification is that it changes nothing and that its claims are true.

- [x] **Nothing outside `plans/` is touched:**
  ```
  $ git diff --stat origin/main...HEAD
   plans/README.md                        | ...
   plans/censgate-redact-extproc.md       | ...
   plans/github-copilot-governance.md     | ...
   plans/lightbridge-dynamic-budget.md    | ...
   plans/microsoft-foundry-governance.md  | ...
  ```
  No chart, template, values file or dashboard source in the diff — so `helm-lint`, `dashboards-drift` and the render gates have nothing to react to.

- [x] **The premise that triggered the amendment was checked against the ADRs on `main`, not assumed** — `docs/adr/0111-calendar-aligned-billing-period.md` and `docs/adr/0112-year-unit-so-the-billing-period-is-the-only-rotation.md`, both `Status: Accepted`. ADR-0112's own Context section records the live `SCAN` evidence (one account holding counters under two window epochs, `1780704000` and `1783296000`) and names **2026-08-05 00:00 UTC** as the rollover it removed — the exact boundary plan 4 was scheduling against.

- [x] **The ADR renumber was checked against the tree, not inferred:** `git ls-tree origin/main docs/adr/` shows `0111-` and `0112-` present, `0113` free.

- [x] **The `billing_period` rewrite was checked against shipped work**, not proposed: `ea1c81b` ("refresh rate-limit quota doc for shared budget + billing_period"), `3b1c69d`, `1d8743e`/#866.

- [x] Cross-references resolve — the amendment links ADR-0111/0112 by their real relative paths under `docs/adr/`.

## Risk Assessment

**Low as a diff, and that is the point.** Five markdown files under a new `plans/` directory; no CI gate in this repo reads it.

The real risk this PR *retires* is a scheduling one: the roadmap as drafted instructed a fleet-wide rate-limit re-key today, on reasoning that ADR-0112 had already invalidated. That is the ADR-0084 blast zone — a rule-index change that orphans every account's accumulated spend. Merging the amendment is what stops that instruction being followed.

Residual: these are `Proposed` planning documents, not ADRs, and the decisions they record are binding only once the corresponding ADR (0113–0117) is written. A reader who treats `plans/` as authoritative architecture would be over-reading it; the README says `Status: Proposed` at the top.

## Reviewer Focus

- **The §0.3/§0.4 amendment in `plans/lightbridge-dynamic-budget.md`.** Specifically: do you agree the calendar boundary makes 2026-09-01 the right 6a target, and that 6a keeping its independence from phases 1–5 is still worth preserving now that nothing forces it early?
- **Whether the `x-budget-tier` ladder should remain a separate rule family from ADR-0110's `x-quota-tier` menu**, or collapse into it. The plan keeps them separate and appends after the quota-tier rules so no index shifts — deliberate, but it is two rule families keyed on the same account and worth a second opinion before ADR-0117.
- The ADR reservations 0113–0117 — shout now if any of those numbers are spoken for.

## AI Usage Declaration

- [x] AI (Claude) drafted the plans and the roadmap, reviewed the four source specs, and found the ADR-0111/0112 conflict while preparing to open the implementation backlog.
- [x] The conflict was verified by reading both ADRs on `main` and their recorded live-`SCAN` evidence — not inferred from the commit subjects.
- [x] A human (@stephane-segning) took all 14 decisions in the decision table and is accountable for this change.
- [x] No secrets, credentials, or customer data appear in this change.

## Reviewer note on scope creep

None. The amendment is in-scope precisely because publishing the un-amended plan would publish an instruction to perform a destructive re-key on a date whose justification no longer holds.
