### PR TITLE
fix(apps): attach an S3-cred deps overlay to mongodb-backup

### DIFF
--- a/charts/apps/values.yaml
+++ b/charts/apps/values.yaml
@@ -988,6 +988,15 @@ applications:
     # app to the new version on the next reconcile (no release/repoint needed).
     chart: mongodb-backup
     releaseName: mongodb-backup
+    # librechat-s3-config (the S3 upload creds the CronJob's `main` container
+    # needs) already exists in the `converse` namespace as librechat-app's own
+    # in-chart ExternalSecret, but Secrets are namespace-scoped and this app
+    # runs in `converse-chat` — so it never had a copy. Confirmed live
+    # 2026-08-02: every backup run failed on `secret "librechat-s3-config"
+    # not found` (CreateContainerConfigError) once the separate MONGODB_URI
+    # DNS bug was fixed. This overlay materialises the app's own copy from
+    # the same underlying creds.
+    depsOverlay: environments/prod/deps/mongodb-backup
     destination:
       namespace: converse-chat
 


### PR DESCRIPTION
## 1. Summary

This PR changes:

- Adds `depsOverlay: environments/prod/deps/mongodb-backup` to the `mongodb-backup` app entry in `charts/apps/values.yaml`, attaching a new kustomize deps Source (already merged in `ai-helm-values`) that materialises the `librechat-s3-config` Secret in the `converse-chat` namespace.

It solves:

- Every `mongodb-backup` CronJob run has been failing for days. Noticed in passing while investigating an unrelated issue, then dug into it end-to-end. Two independent, stacked bugs:
  1. **Fixed directly in `ai-helm-values`** (no chart change needed): the exporter init container's `MONGODB_URI` pointed at `librechat-db-0.librechat-db-headless` — a host that doesn't exist (wrong release name, missing `-app-`, and no namespace segment; the CronJob runs in `converse-chat`, the real DB `librechat-app-db` runs in `converse`). See `ADORSYS-GIS/ai-helm-values@e452fcc`.
  2. **This PR**: once (1) was fixed, the `main` (S3-upload) container failed with `secret "librechat-s3-config" not found`. That secret exists, but only as a namespace-scoped copy owned by `librechat-app`'s own in-chart `ExternalSecret`, in `converse` — Secrets can't cross namespaces, and `mongodb-backup` never had its own copy in `converse-chat`.

## 2. Intent

> Get the nightly LibreChat MongoDB backup actually running again — it's been silently failing (Init:Error / CreateContainerConfigError) with no working backup produced, for at least the last several days based on the failed-job history.

Source of truth: live cluster investigation (see Verification below) + the companion `ai-helm-values` commits, already merged there (values-repo-first): https://github.com/ADORSYS-GIS/ai-helm-values/commit/e452fccd0efb699e53d75b25b3a7db91f8c1b0b5 (MONGODB_URI fix) and https://github.com/ADORSYS-GIS/ai-helm-values/commit/0e93d1b313954d683b170d770d465dcb997aa208 (this PR's deps overlay).

## 3. Scope

### In Scope

- `charts/apps/values.yaml` — one field (`depsOverlay`) on the existing `mongodb-backup` app entry, plus a comment explaining why.

### Out of Scope

- The `MONGODB_URI` DNS fix — that was a pure `ai-helm-values` values change, already merged directly there (no ai-helm chart involvement).
- The `environments/{base,prod}/deps/mongodb-backup/` kustomize overlay itself — already merged in `ai-helm-values` (`0e93d1b`), values-repo-first, so this PR's `depsOverlay` path resolves to something that already exists.

## 4. Verification

I verified this change by:

- [x] Running automated tests
- [x] Running manual tests
- [ ] Checking logs
- [x] Checking metrics
- [ ] Testing error cases
- [ ] Testing permissions/security behavior
- [ ] Testing rollback or failure behavior, if relevant

Commands run:

```bash
helm dep build charts/apps/
helm lint charts/apps/ --strict
helm template ai-apps charts/apps/ --dry-run=client

# Root-cause verification, live on the Hetzner cluster, BEFORE either fix:
kubectl -n converse-chat logs mongodb-backup-<pod> -c exporter
# -> DNS NXDOMAIN on librechat-db-0.librechat-db-headless

kubectl -n converse-chat run dns-test --rm -i --restart=Never --image=busybox:1.36 -- \
  nslookup librechat-app-db-0.librechat-app-db-headless.converse.svc.cluster.local
# -> resolves; shorter forms (bare name, name+namespace without pod) do NOT

kubectl -n converse-chat run mongodump-test --rm -i --restart=Never --image=mongo:8.0 -- \
  mongodump --uri='mongodb://librechat-app-db-0.librechat-app-db-headless.converse.svc.cluster.local:27017' \
    --archive=/tmp/exported/mongo_backup.gz --gzip
# -> succeeded, 8.6MB archive, 3116 documents

# After merging the ai-helm-values MONGODB_URI fix + hard-refreshing ArgoCD:
kubectl create job --from=cronjob/mongodb-backup mongodb-backup-manual-verify-20260802 -n converse-chat
# -> exporter init container: exitCode 0, "Completed" (DNS bug confirmed fixed)
# -> main container: CreateContainerConfigError, "secret librechat-s3-config not found"
#    (the SEPARATE bug this PR fixes)

kubectl get secrets -A | grep librechat-s3-config
# -> exists ONLY in `converse` (age 59d), confirming it's namespace-scoped and
#    never existed in `converse-chat`
```

Results:

```text
helm lint: 1 chart(s) linted, 0 chart(s) failed
helm template: mongodb-backup Application renders with the new deps Source:
  - path: environments/prod/deps/mongodb-backup
    repoURL: https://github.com/adorsys-gis/ai-helm-values
    targetRevision: main
```

**Still to verify once this deploys**: that the `ExternalSecret` actually syncs in `converse-chat` and a full manual job run (exporter + main/upload) succeeds end-to-end. I'll re-run the manual verification job after this merges and syncs, and report back in this PR's thread.

## 5. Screenshots / Evidence

Add evidence here:

* Screenshot: N/A — verified via live `kubectl`/ArgoCD CLI output above, no UI involved.
* Logs: pasted inline above.
* Metrics: N/A
* Recording: N/A

## 6. Risk Assessment

Risk level:

* [x] Low
* [ ] Medium
* [ ] High

Potential risks:

* None to existing functionality — this only adds a missing dependency (an `ExternalSecret`) to a CronJob that has been failing on every run anyway; there's no working backup path today to regress.

Mitigation:

* N/A — purely additive; worst case the `ExternalSecret` fails to sync (e.g. a `ssegning-aws` store issue) and the job continues failing exactly as it does today, with a clear `SecretSyncedError`/`not found` signal either way.

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [ ] Refactoring
* [ ] Generating tests
* [ ] Drafting documentation
* [ ] Reviewing the diff
* [ ] Not used

Human verification:

* [x] I understand every meaningful change in this PR
* [x] I checked generated code manually
* [x] I removed unsupported AI assumptions
* [x] I accept responsibility for this PR

## 8. Reviewer Focus

Please focus your review on:

* [x] Correctness
* [ ] Architecture
* [ ] Security
* [ ] Performance
* [ ] Tests
* [ ] Maintainability
* [ ] Product intent
* [x] Edge cases
