### PR TITLE
feat(webank-training): bootstrap detector dataset in workflow

### DIFF
--- a/charts/webank-training/ci/lint-values.yaml
+++ b/charts/webank-training/ci/lint-values.yaml
@@ -18,7 +18,10 @@ models:
     datasetMaterializer: materialize-document-detector-descriptor
     trainer: document-detector
     lakefs:
-      dataset: { repository: ds-document-detector, branch: main }
+      dataset:
+        repository: ds-document-detector
+        branch: main
+        storageNamespace: s3://governed-ci/datasets/ds-document-detector
       model: { repository: model-document-detector, branch: main }
   - id: document-recognizer
     datasetMaterializer: materialize-document-recognizer-descriptor

--- a/charts/webank-training/templates/workflowtemplate.yaml
+++ b/charts/webank-training/templates/workflowtemplate.yaml
@@ -26,6 +26,8 @@
 {{- $candidateLakefs := required (printf "webank-training: %s lakefs.model is required" $id) $modelLakefs.model -}}
 {{- $datasetRepository := required (printf "webank-training: %s lakefs.dataset.repository is required" $id) $datasetLakefs.repository -}}
 {{- $datasetBranch := required (printf "webank-training: %s lakefs.dataset.branch is required" $id) $datasetLakefs.branch -}}
+{{- $datasetStorageNamespace := "" -}}
+{{- if eq $id "document-detector" }}{{- $datasetStorageNamespace = required "webank-training: document-detector lakefs.dataset.storageNamespace is required for hermetic bootstrap" $datasetLakefs.storageNamespace }}{{- end }}
 {{- $candidateRepository := required (printf "webank-training: %s lakefs.model.repository is required" $id) $candidateLakefs.repository -}}
 {{- $candidateBranch := required (printf "webank-training: %s lakefs.model.branch is required" $id) $candidateLakefs.branch -}}
 {{- if ne $datasetRepository (printf "ds-%s" $id) }}{{ fail (printf "webank-training: %s dataset repository must be ds-%s" $id $id) }}{{- end }}
@@ -47,7 +49,11 @@ metadata:
   annotations:
     webank.io/adr: "0034"
     webank.io/dataset-contract: "0006"
+{{- if eq $id "document-detector" }}
+    webank.io/materialization: "hermetic-synthetic-bootstrap"
+{{- else }}
     webank.io/materialization: "metadata-descriptor"
+{{- end }}
     webank.io/dataset-lakefs-repository: {{ $datasetRepository | quote }}
     webank.io/dataset-lakefs-branch: {{ $datasetBranch | quote }}
 spec:
@@ -60,6 +66,7 @@ spec:
   imagePullSecrets:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+{{- if ne $id "document-detector" }}
   arguments:
     parameters:
       - name: lakefs_ref
@@ -70,8 +77,10 @@ spec:
       - name: source
       - name: manifest
       - name: readiness
+{{- end }}
   templates:
     - name: build
+{{- if ne $id "document-detector" }}
       inputs:
         artifacts:
           - name: source
@@ -80,11 +89,35 @@ spec:
             path: /workspace/input/source-manifest.json
           - name: readiness
             path: /workspace/input/readiness.json
+{{- end }}
       container:
         image: {{ $training.image | quote }}
         command: ["sh", "-ceu"]
         args:
           - |
+{{- if eq $id "document-detector" }}
+            BASE_REF="$(cargo xtask training-data bootstrap-document-detector-repository \
+              --lakefs-branch "$WEBANK_DATASET_LAKEFS_BRANCH" \
+              --lakefs-endpoint "$WEBANK_LAKEFS_ENDPOINT" \
+              --lakefs-repository "$WEBANK_DATASET_LAKEFS_REPOSITORY" \
+              --lakefs-storage-namespace "$WEBANK_DATASET_LAKEFS_STORAGE_NAMESPACE")"
+            /opt/webank-document-detector-dataset/venv/bin/python \
+              -m webank_document_detector_dataset.cli bootstrap \
+              --output /workspace/output/document-detector-bootstrap \
+              --lakefs-ref "$BASE_REF" \
+              --lakefs-repository "$WEBANK_DATASET_LAKEFS_REPOSITORY" \
+              --code-revision "$WEBANK_SOURCE_REVISION" \
+              --policy /opt/webank-document-detector-dataset/bootstrap-policy.json
+            cargo xtask training-data push \
+              --destination training-data-lake \
+              --path /workspace/output/document-detector-bootstrap/document-detector-training-v1.tar \
+              --manifest /workspace/output/document-detector-bootstrap/governance/source-manifest.json \
+              --lakefs-ref "$BASE_REF" \
+              --readiness /workspace/output/document-detector-bootstrap/governance/readiness.json \
+              --lakefs-branch "$WEBANK_DATASET_LAKEFS_BRANCH" \
+              --lakefs-endpoint "$WEBANK_LAKEFS_ENDPOINT" \
+              --lakefs-repository "$WEBANK_DATASET_LAKEFS_REPOSITORY"
+{{- else }}
             cargo xtask training-data {{ $materializer }} \
               --source /workspace/input/source.json \
               --manifest /workspace/input/source-manifest.json \
@@ -100,15 +133,22 @@ spec:
               --lakefs-branch "$WEBANK_DATASET_LAKEFS_BRANCH" \
               --lakefs-endpoint "$WEBANK_LAKEFS_ENDPOINT" \
               --lakefs-repository "$WEBANK_DATASET_LAKEFS_REPOSITORY"
+{{- end }}
         env:
+{{- if ne $id "document-detector" }}
           - name: LAKEFS_REF
             value: "{{`{{workflow.parameters.lakefs_ref}}`}}"
+{{- end }}
           - name: WEBANK_LAKEFS_ENDPOINT
             value: {{ $lakefs.endpoint | quote }}
           - name: WEBANK_DATASET_LAKEFS_REPOSITORY
             value: {{ $datasetRepository | quote }}
           - name: WEBANK_DATASET_LAKEFS_BRANCH
             value: {{ $datasetBranch | quote }}
+{{- if eq $id "document-detector" }}
+          - name: WEBANK_DATASET_LAKEFS_STORAGE_NAMESPACE
+            value: {{ $datasetStorageNamespace | quote }}
+{{- end }}
           - name: LAKEFS_ACCESS_KEY_ID
             valueFrom: { secretKeyRef: { name: {{ $lakefs.secretName | quote }}, key: {{ $lakefs.accessKey | quote }} } }
           - name: LAKEFS_SECRET_ACCESS_KEY

--- a/docs/integrations/webank-training-deployment.md
+++ b/docs/integrations/webank-training-deployment.md
@@ -21,8 +21,15 @@ stage into an alternative public operation.
 
 ## Dataset-build templates
 
-`*-dataset-build` templates are CPU-only restricted-plane operations. The
-Argo submission form requires three governed artifacts:
+`*-dataset-build` templates are CPU-only restricted-plane operations. Document
+detector is the one special case: its form has **no inputs**. It creates the
+fixed `ds-document-detector/main` repository if necessary, obtains LakeFS's
+initial immutable commit, then runs the in-image Python builder to create the
+reviewed hermetic synthetic starter set. It fetches no source dataset from the
+network and passes the resulting manifest/readiness pair through the normal
+Rust gate and LakeFS write boundary.
+
+The other dataset-build forms require three governed artifacts:
 
 - `source` — the model-specific source metadata;
 - `manifest` — the RFC-0006 source manifest; and
@@ -33,12 +40,16 @@ governance documents. The container materializes the model-specific descriptor
 and calls the narrow `training-data push` LakeFS boundary. It never accepts a
 dataset path, LakeFS destination, or arbitrary shell command from the
 dashboard. The destination repository and `main` branch come only from the
-model's reviewed `ai-helm-values` entry and must exist before the first run.
+model's reviewed `ai-helm-values` entry. Document detector's reviewed storage
+namespace is used only if that fixed repository must be created; an existing
+repository is never reset or reconfigured.
 
 The current materializers deliberately produce metadata descriptors. They do
-not invent document, biometric, identity, or PAD bytes. A data repository must
-provide an approved model-specific source and its governed artifact contract
-before an operator starts one of these templates.
+not invent biometric, identity, or PAD bytes. The document-detector bootstrap
+creates only generic synthetic scenes and exact programmatic labels; it is
+training input, never real-world evaluation or promotion evidence. Every other
+model still needs an approved model-specific source and governed artifact
+contract before an operator starts its template.
 
 ## Training templates
 

--- a/docs/playbooks/webank-model-workflows.md
+++ b/docs/playbooks/webank-model-workflows.md
@@ -19,10 +19,20 @@ the displayed `build` or `train` entrypoint is fixed by the selected template.
 
 Each template's LakeFS destinations are fixed in reviewed `ai-helm-values`, not
 in the Argo form. Dataset builds use `ds-<model>/main`; training candidates use
-`model-<model>/main`. The repositories and their `main` branches must exist
-before an approved first run.
+`model-<model>/main`. The document-detector Dataset Build template is allowed
+to create its own fixed empty repository from its reviewed storage namespace;
+every other repository and `main` branch must exist before its first run.
 
 ## Build a dataset descriptor
+
+For **document detector**, open
+`webank-document-detector-dataset-build` and select **Submit** with no fields.
+Its fixed entrypoint builds the reviewed hermetic synthetic starter set from
+the image-bundled policy, reports the LakeFS commit in its logs, and accepts no
+source artifact, repository, branch, prompt, or transform. It must not be used
+as real-world evaluation data.
+
+For every other model:
 
 1. In Argo, open the model's `*-dataset-build` template and select **Submit**.
 2. Set `lakefs_ref` to the 64-character immutable commit recorded by the
@@ -34,9 +44,9 @@ before an approved first run.
    generated descriptor through the LakeFS training-data boundary into that
    model's fixed `ds-<model>/main` repository.
 
-If LakeFS is empty, this operation still cannot begin without an approved
-source artifact and its manifest/attestation. Do not use fixtures or a blank
-reference as a substitute.
+If a non-document-detector LakeFS repository is empty, this operation still
+cannot begin without an approved source artifact and its manifest/attestation.
+Do not use fixtures or a blank reference as a substitute.
 
 ## Start candidate training
 


### PR DESCRIPTION
## Summary

Makes only `webank-document-detector-dataset-build` a zero-input, hermetic dataset bootstrap workflow. It calls the in-image Python generator after ensuring the fixed LakeFS repository, then uses the existing Rust gate and push boundary.

Source of truth: https://github.com/ADORSYS-GIS/webank-models/issues/48

## Scope

- Document-detector Dataset Build has no arguments, inputs, or source artifacts.
- Its LakeFS destination and storage namespace are fixed GitOps values.
- The other four model dataset-build templates retain their governed source-artifact contracts.

Out of scope: starting a workflow, external source acquisition, data/model promotion, and changing training templates.

## Verification

- [x] `helm dependency build charts/webank-training`
- [x] `helm lint charts/webank-training --strict -f charts/webank-training/ci/lint-values.yaml`
- [x] `helm template webank-training charts/webank-training -f charts/webank-training/ci/lint-values.yaml`
- [x] Rendered with production values: detector has null `spec.arguments` and null template inputs; its storage namespace is `s3://ssegning-k8s-state/lakefs/datasets/ds-document-detector`.

## Risk and mitigation

Medium: this consumes a new image capability and a matching values key. Do not merge this chart until the matching released `webank-train-gpu` digest and values PR are merged. The template is deliberately fixed to the one model/repository and has no operator-controlled source path.

## AI usage declaration

- [x] Understanding the existing chart
- [x] Generating template and documentation changes
- [x] Reviewing the rendered manifest

## Reviewer focus

Confirm the detector is the only zero-input bootstrap and that fixed LakeFS routing does not alter the other four dataset-build workflows.