### PR TITLE
feat(webank-training): place dataset builds on GPU nodes

### DIFF
--- a/charts/webank-training/templates/workflowtemplate.yaml
+++ b/charts/webank-training/templates/workflowtemplate.yaml
@@ -90,6 +90,12 @@ spec:
           - name: readiness
             path: /workspace/input/readiness.json
 {{- end }}
+      nodeSelector:
+        {{- toYaml $training.gpu.nodeSelector | nindent 8 }}
+      {{- with $training.gpu.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       container:
         image: {{ $training.image | quote }}
         command: ["sh", "-ceu"]

--- a/charts/webank-training/values.yaml
+++ b/charts/webank-training/values.yaml
@@ -18,9 +18,10 @@ training:
     secretKey: secret-access-key
   otel:
     endpoint: ""
-  # Every GPU-capable template is rendered only when these placement
-  # invariants are present: `role: gpu`, a matching NoSchedule toleration,
-  # and a positive nvidia.com/gpu limit. The readiness gate remains CPU-only.
+  # Every dataset-build and training template is rendered only when these
+  # placement invariants are present: `role: gpu`, a matching NoSchedule
+  # toleration, and a positive nvidia.com/gpu limit. Dataset builds use the
+  # placement policy but retain their own CPU-only resource limits.
   gpu:
     nodeSelector: {}
     tolerations: []

--- a/docs/integrations/webank-training-deployment.md
+++ b/docs/integrations/webank-training-deployment.md
@@ -21,7 +21,9 @@ stage into an alternative public operation.
 
 ## Dataset-build templates
 
-`*-dataset-build` templates are CPU-only restricted-plane operations. Document
+`*-dataset-build` templates are restricted-plane operations placed on
+`role=gpu` nodes and tolerating `role=gpu:NoSchedule`. Their containers retain
+CPU-only resource limits and do not reserve an `nvidia.com/gpu` device. Document
 detector is the one special case: its form has **no inputs**. It creates the
 fixed `ds-document-detector/main` repository if necessary, obtains LakeFS's
 initial immutable commit, then runs the in-image Python builder to create the

--- a/docs/playbooks/webank-model-workflows.md
+++ b/docs/playbooks/webank-model-workflows.md
@@ -10,7 +10,7 @@ Start with the model-specific operation you actually need:
 
 | Need | Template pattern | Compute |
 | --- | --- | --- |
-| Materialize and publish a governed descriptor | `webank-<model>-dataset-build` | CPU |
+| Materialize and publish a governed descriptor | `webank-<model>-dataset-build` | GPU node; CPU resources |
 | Train a governed candidate | `webank-<model>-train` | one GPU |
 
 There is one template of each kind for document detector, document recognizer,
@@ -43,6 +43,10 @@ For every other model:
 4. Submit and inspect the `build` pod. A successful run writes only the
    generated descriptor through the LakeFS training-data boundary into that
    model's fixed `ds-<model>/main` repository.
+
+All dataset-build pods select `role=gpu` and tolerate `role=gpu:NoSchedule`.
+They run on the GPU node pool but deliberately do not request an
+`nvidia.com/gpu` device: materialization uses CPU resources only.
 
 If a non-document-detector LakeFS repository is empty, this operation still
 cannot begin without an approved source artifact and its manifest/attestation.


### PR DESCRIPTION
## 1. Summary

This PR changes:

- Places every `webank-*-dataset-build` template on nodes labelled `role=gpu`.
- Applies the existing `role=gpu:NoSchedule` toleration to every dataset builder.
- Keeps dataset-builder resource limits CPU-only and updates the operator playbook and deployment guide.

It solves:

- Dataset builds could be scheduled on CPU-only nodes even though the platform requires this workflow class to use the GPU node pool. Source of truth: #884.

---

## 2. Intent

> Make dataset-build placement consistent with candidate-training placement, without reserving an NVIDIA device for a CPU-only materialization job.

---

## 3. Scope

### In Scope

- `webank-training` WorkflowTemplate placement policy for all five dataset builders.
- Documentation of GPU-node placement versus GPU-device allocation.

### Out of Scope

- LakeFS routing, credentials, dataset contents, training GPU resource requests, and workflow execution.

---

## 4. Verification

- [x] Automated lint and rendered-manifest checks
- [x] Rendered placement and CPU-resource boundary assertions
- [x] Manual diff review

Commands run:

    helm lint charts/webank-training --strict -f charts/webank-training/ci/lint-values.yaml
    helm template webank-training charts/webank-training -f charts/webank-training/ci/lint-values.yaml
    git diff --check

Results:

- Helm lint: `1 chart(s) linted, 0 chart(s) failed`.
- Render assertion: exactly five dataset WorkflowTemplates, each with `role=gpu` and the matching NoSchedule toleration; none has an `nvidia.com/gpu` limit.
- `git diff --check` is clean.

---

## 5. Screenshots / Evidence

Manifest-only change; the rendered catalogue evidence is recorded above.

---

## 6. Risk Assessment

Risk level: Low.

Potential risk: a builder remains Pending if no GPU-pool node is schedulable.

Mitigation: this is the requested hard placement constraint; builders retain CPU-only resource limits and do not consume scarce GPU devices.

---

## 7. AI Usage Declaration

AI was used for:

- [x] Understanding existing code
- [x] Generating code
- [x] Drafting documentation
- [x] Generating verification commands
- [x] Reviewing the diff

Human verification:

- [x] I understand every meaningful change in this PR.
- [x] I checked the rendered manifests and generated documentation manually.
- [x] I removed unsupported assumptions.
- [x] I accept responsibility for this PR.

---

## 8. Reviewer Focus

- [x] Correctness
- [x] Architecture
- [x] Tests
- [x] Maintainability
- [x] Product intent
- [x] Edge cases
