### PR TITLE
fix(release): register webank training chart

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -32,5 +32,6 @@
   "charts/mongodb-backup": "0.1.2",
   "charts/observability-dashboards": "0.1.0",
   "charts/observability": "1.0.0",
-  "charts/same-origin-proxy": "0.1.0"
+  "charts/same-origin-proxy": "0.1.0",
+  "charts/webank-training": "0.1.1"
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -162,6 +162,9 @@
     },
     "charts/same-origin-proxy": {
       "component": "same-origin-proxy"
+    },
+    "charts/webank-training": {
+      "component": "webank-training"
     }
   }
 }


### PR DESCRIPTION
## 1. Summary

This PR changes:

- Registers `charts/webank-training` with Release Please.
- Records its existing `0.1.1` release floor.

It solves:

- The merged dataset GPU-placement change in #885 could not reach OCI because Release Please did not manage this chart.

---

## 2. Intent

> Let the standard generated release PR bump and publish `webank-training`; do not bypass the versioned OCI release path.

---

## 3. Scope

### In Scope

- Release Please package and manifest entries for `webank-training`.

### Out of Scope

- Workflow template logic, values, OCI publication outside the normal release PR, or workflow execution.

---

## 4. Verification

- [x] JSON validation
- [x] Diff validation
- [x] Release configuration reviewed against the chart's current `0.1.1` version

Commands run:

    jq empty .release-please-manifest.json
    jq empty release-please-config.json
    git diff --check

Results:

- Both JSON documents parse successfully.
- `git diff --check` is clean.

---

## 5. Screenshots / Evidence

Configuration-only change; release publication will be verified after the generated release PR merges.

---

## 6. Risk Assessment

Risk level: Low.

Risk: the generated release PR may include other already-pending chart releases.

Mitigation: inspect and merge that generated PR only when its checks and review state are clean; the OCI publisher remains version-driven.

---

## 7. AI Usage Declaration

AI was used for:

- [x] Understanding existing release configuration
- [x] Generating the configuration update
- [x] Generating verification commands
- [x] Reviewing the diff

Human verification:

- [x] I understand every meaningful change in this PR.
- [x] I checked the generated configuration manually.
- [x] I removed unsupported assumptions.
- [x] I accept responsibility for this PR.

---

## 8. Reviewer Focus

- [x] Correctness
- [x] Release behaviour
- [x] Maintainability
- [x] Edge cases