### PR TITLE
feat(webank-training): allocate GPUs to dataset builds

### DIFF
--- a/charts/webank-training/templates/workflowtemplate.yaml
+++ b/charts/webank-training/templates/workflowtemplate.yaml
@@ -164,8 +164,7 @@ spec:
           - name: OTEL_SERVICE_NAME
             value: {{ printf "webank-%s-dataset-build" $id | quote }}
         resources:
-          requests: { cpu: 250m, memory: 512Mi }
-          limits: { cpu: "1", memory: 1Gi }
+          {{- toYaml $training.gpu.resources | nindent 10 }}
 ---
 apiVersion: argoproj.io/v1alpha1
 kind: WorkflowTemplate

--- a/charts/webank-training/values.yaml
+++ b/charts/webank-training/values.yaml
@@ -18,10 +18,10 @@ training:
     secretKey: secret-access-key
   otel:
     endpoint: ""
-  # Every dataset-build and training template is rendered only when these
-  # placement invariants are present: `role: gpu`, a matching NoSchedule
-  # toleration, and a positive nvidia.com/gpu limit. Dataset builds use the
-  # placement policy but retain their own CPU-only resource limits.
+  # Every dataset-build and training template uses this GPU-node placement and
+  # resource profile: `role: gpu`, a matching NoSchedule toleration, and a
+  # positive nvidia.com/gpu limit. Dataset construction receives the same
+  # reviewed CPU, memory, and GPU allocation as candidate training.
   gpu:
     nodeSelector: {}
     tolerations: []

--- a/docs/integrations/webank-training-deployment.md
+++ b/docs/integrations/webank-training-deployment.md
@@ -22,14 +22,14 @@ stage into an alternative public operation.
 ## Dataset-build templates
 
 `*-dataset-build` templates are restricted-plane operations placed on
-`role=gpu` nodes and tolerating `role=gpu:NoSchedule`. Their containers retain
-CPU-only resource limits and do not reserve an `nvidia.com/gpu` device. Document
-detector is the one special case: its form has **no inputs**. It creates the
-fixed `ds-document-detector/main` repository if necessary, obtains LakeFS's
-initial immutable commit, then runs the in-image Python builder to create the
-reviewed hermetic synthetic starter set. It fetches no source dataset from the
-network and passes the resulting manifest/readiness pair through the normal
-Rust gate and LakeFS write boundary.
+`role=gpu` nodes, tolerating `role=gpu:NoSchedule`, and requesting the same
+reviewed CPU, memory, and one-GPU resource profile as candidate training.
+Document detector is the one special case: its form has **no inputs**. It
+creates the fixed `ds-document-detector/main` repository if necessary, obtains
+LakeFS's initial immutable commit, then runs the in-image Python builder to
+create the reviewed hermetic synthetic starter set. It fetches no source
+dataset from the network and passes the resulting manifest/readiness pair
+through the normal Rust gate and LakeFS write boundary.
 
 The other dataset-build forms require three governed artifacts:
 

--- a/docs/playbooks/webank-model-workflows.md
+++ b/docs/playbooks/webank-model-workflows.md
@@ -10,7 +10,7 @@ Start with the model-specific operation you actually need:
 
 | Need | Template pattern | Compute |
 | --- | --- | --- |
-| Materialize and publish a governed descriptor | `webank-<model>-dataset-build` | GPU node; CPU resources |
+| Materialize and publish a governed descriptor | `webank-<model>-dataset-build` | one GPU |
 | Train a governed candidate | `webank-<model>-train` | one GPU |
 
 There is one template of each kind for document detector, document recognizer,
@@ -44,9 +44,9 @@ For every other model:
    generated descriptor through the LakeFS training-data boundary into that
    model's fixed `ds-<model>/main` repository.
 
-All dataset-build pods select `role=gpu` and tolerate `role=gpu:NoSchedule`.
-They run on the GPU node pool but deliberately do not request an
-`nvidia.com/gpu` device: materialization uses CPU resources only.
+All dataset-build pods select `role=gpu`, tolerate `role=gpu:NoSchedule`, and
+request the reviewed one-GPU CPU/memory resource profile. This guarantees that
+dataset materialization has the same GPU-node allocation as candidate training.
 
 If a non-document-detector LakeFS repository is empty, this operation still
 cannot begin without an approved source artifact and its manifest/attestation.


### PR DESCRIPTION
## 1. Summary

This PR changes:

- Gives every model-specific dataset-build workflow the shared GPU resource profile.
- Reserves one `nvidia.com/gpu` plus the reviewed CPU and memory requests/limits.
- Updates the values contract and dashboard playbooks.

It solves:

- Dataset workflows were placed on GPU nodes but retained a small CPU-only container allocation. Source of truth: #885.

---

## 2. Intent

> Dataset construction is a first-class GPU workload and must receive the same reviewed capacity as candidate training.

---

## 3. Scope

### In Scope

- Shared resource allocation for the five `*-dataset-build` WorkflowTemplates.
- Accurate operator and deployment documentation.

### Out of Scope

- Changing dataset builders' commands, LakeFS routing, credentials, or starting workflows.

---

## 4. Verification

- [x] Strict Helm lint
- [x] Rendered all five dataset WorkflowTemplates
- [x] Asserted selector, toleration, CPU, memory, and GPU resource values
- [x] Checked the diff

Commands run:

    helm lint charts/webank-training --strict -f charts/webank-training/ci/lint-values.yaml
    helm template webank-training charts/webank-training -f charts/webank-training/ci/lint-values.yaml
    git diff --check

Results:

- Helm lint: `1 chart(s) linted, 0 chart(s) failed`.
- Five dataset builders render with `role=gpu`, the matching NoSchedule toleration, CPU request 4, memory request 16Gi, CPU limit 8, memory limit 16Gi, and `nvidia.com/gpu: 1`.
- `git diff --check` is clean.

---

## 5. Screenshots / Evidence

Manifest-only change; the rendered resource assertions are recorded above.

---

## 6. Risk Assessment

Risk level: Medium.

Potential risk: a builder remains Pending while both GPU devices are allocated to training.

Mitigation: that is the intentional capacity reservation; Argo queues the build instead of silently running it on an undersized CPU-only node.

---

## 7. AI Usage Declaration

AI was used for:

- [x] Understanding existing chart logic
- [x] Generating the resource-profile update
- [x] Drafting documentation
- [x] Generating verification commands
- [x] Reviewing the diff

Human verification:

- [x] I understand every meaningful change in this PR.
- [x] I checked rendered manifests manually.
- [x] I removed unsupported assumptions.
- [x] I accept responsibility for this PR.

---

## 8. Reviewer Focus

- [x] Correctness
- [x] Capacity behaviour
- [x] Tests
- [x] Product intent
- [x] Edge cases