### PR TITLE
fix(censgate-redact-gateway): pause the canary — upstream image cannot start (GLIBC_2.38)

### DIFF
--- a/charts/censgate-redact-gateway/values.yaml
+++ b/charts/censgate-redact-gateway/values.yaml
@@ -24,7 +24,18 @@ image:
 
 port: 8080
 
-replicas: 1
+# ⚠️ PAUSED 2026-08-02 -- replicas: 0, not 1. The only published image
+# (ghcr.io/censgate/redact-gateway:0.9.0, and equally :latest/:0/:0.9 -- all
+# four tags resolve to the same digest) cannot start on any host: its builder
+# stage (rust:1.93-slim) links against a newer glibc than its runtime stage
+# (gcr.io/distroless/cc-debian12) ships, so every container exits immediately
+# with `GLIBC_2.38' not found`. Reproduced with a plain `docker run`, not a
+# cluster-specific issue. Filed upstream: censgate/redact#114. Everything else
+# in this chart (the wiring, the NetworkPolicy, the internal-CA trust) is
+# unaffected and was verified correct against the live cluster before this
+# was found -- flip back to 1 once a fixed image is published, no other
+# change needed.
+replicas: 0
 # vault_kv2 (a shared token map) is required to scale beyond one replica -- see
 # upstream docs/gateway/deployment.md. This canary uses the `default` profile
 # (replace/block/mask only, no `tokenize`), so no token map is needed and one


### PR DESCRIPTION
## Summary

Sets `replicas: 0` on `charts/censgate-redact-gateway` — the only published upstream image cannot start on any host. Chart-only, one line.

## Intent

Post-merge verification of #889/#876 (the immediate next step "ensure it's stable" required on a GitOps platform with no staging environment — merge to `main` is a live deploy, ADR-0055) found the deployment reconciled cleanly but the pod immediately crash-looped:

```
/usr/local/bin/redact-gateway: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.38' not found (required by /usr/local/bin/redact-gateway)
```

Confirmed this is not our config: the running image is exactly the pinned digest, and the failure reproduces with a bare `docker run` of the published image, on any correctly configured host. Root cause read from upstream's own `Dockerfile.gateway`: the build stage (`rust:1.93-slim`) links against a newer glibc than the runtime stage (`gcr.io/distroless/cc-debian12`) ships. Filed upstream: [censgate/redact#114](https://github.com/censgate/redact/issues/114).

Source of truth: this PR's own verification, and the upstream issue above.

## Scope

### In scope
- `charts/censgate-redact-gateway/values.yaml`: `replicas: 1` → `0`, with a comment recording why and what unblocks reverting it.

### Out of scope
- No fix to the image itself — that's upstream's, tracked at censgate/redact#114.
- No workaround (e.g. building our own image from source) — that would contradict ADR-0113's whole premise (off-the-shelf, no custom build) for what should be a short-lived upstream defect. Revisit if the issue sits unfixed for a long time.
- Nothing else in the chart changes — the wiring (provider address, internal-CA trust, `CiliumNetworkPolicy` selectors) was verified correct against the live cluster before this was found, so `replicas: 1` is the only revert needed once a fixed image lands.

## Verification

- [x] **The failure was confirmed against the exact pinned digest, not a stale/wrong pull:**
  ```
  $ kubectl -n apps get pod -l app=censgate-redact-gateway -o jsonpath='{.items[0].status.containerStatuses[0].imageID}'
  ghcr.io/censgate/redact-gateway@sha256:29692a5abec3165aa2558cd87edce45e27d9cf249c55cad0fabc5ece160c70f9
  ```
  Matches `charts/censgate-redact-gateway/values.yaml`'s pinned `0.9.0` exactly.

- [x] **Confirmed no newer tag exists that might already fix this**, before filing upstream or writing this PR:
  ```
  $ gh api 'orgs/censgate/packages/container/redact-gateway/versions'
  {"tags":["latest","0","0.9","0.9.0"],"created":"2026-07-27T02:39:41Z"}
  ```
  All four tags resolve to the identical, broken build.

- [x] **Every other object reconciled Synced/Healthy** — the Certificate, Service, and `CiliumNetworkPolicy` are all fine; only the Deployment's pod fails, and only for this reason:
  ```
  $ kubectl --context admin@homeos -n argocd get application aii-censgate-redact-gateway \
      -o jsonpath='{range .status.resources[*]}{.kind}{" "}{.name}{" "}{.status}{"\n"}{end}'
  Service censgate-redact-gateway Synced
  Deployment censgate-redact-gateway Synced
  Certificate censgate-redact-gateway-internal-ca Synced
  CiliumNetworkPolicy censgate-redact-gateway-allow Synced
  ```

- [x] `helm lint --strict charts/censgate-redact-gateway` — 0 failed. `helm template ... | grep replicas` confirms `replicas: 0` renders.

## Risk Assessment

**Near zero.** Scaling a not-yet-cutover canary to zero replicas removes a crash-looping pod from the cluster; nothing depends on this proxy's traffic (no production client was ever routed through it — see #889). The alternative (leaving it crash-looping indefinitely under Kubernetes' backoff) is strictly worse: continued restart churn and noise for no benefit, since the pod cannot ever become Ready in its current state.

## AI Usage Declaration

- [x] AI (Claude) found this by actually verifying the live deployment after merge (not just trusting `helm template`/CI), diagnosed the root cause by reading the pod logs and cross-referencing upstream's own `Dockerfile.gateway`, confirmed it wasn't a config issue on our side, filed the upstream issue, and made this fix.
- [x] Every claim here was checked by running the command shown — the digest match, the tag list, the resource-level sync status.
- [x] A human (@stephane-segning) is accountable for this change.
- [x] No secrets, credentials, or customer data appear in this change.

## Reviewer Focus

- Whether `replicas: 0` (vs. e.g. removing the `charts/apps` entry entirely) is the right way to represent "paused, known why, easy to resume." I chose it because it keeps the Certificate/Service/NetworkPolicy live and reviewed — so resuming needs no re-verification of the wiring, only the image.
