### PR TITLE
docs(adr): note Fireworks priority tier as a deferred follow-up (ADR-0117)

### DIFF
--- a/docs/adr/0117-deepinfra-priority-service-tier-and-deepseek-v4-flash-0731.md
+++ b/docs/adr/0117-deepinfra-priority-service-tier-and-deepseek-v4-flash-0731.md
@@ -111,6 +111,26 @@ not just callers who would have opted in themselves.
   header + a second `AIGatewayRoute` rule per affected model, or per-model
   `-priority` catalog variants (see Alternatives) — not a small change to
   today's shared-anchor shape.
+- **Fireworks priority tier — investigated, deliberately deferred
+  (2026-08-02).** Fireworks supports the identical field
+  (`"service_tier": "priority"`, OpenAI-compatible chat completions and the
+  Anthropic-compatible `messages` API — docs.fireworks.ai/serverless/serving-paths),
+  so the same `bodyMutation` mechanism this ADR uses for DeepInfra would
+  drop in directly on the `fwBackendPrimary`/`fwBackendSecondary` anchors.
+  Not applied because, checked live against Fireworks' own catalog: (1)
+  Priority tier is documented as "available on select models," and neither
+  of the two models currently routed through Fireworks —
+  `qwen3-embedding-8b` and `qwen3p7-plus` — shows a Priority badge or
+  Priority pricing on its own Fireworks model page; (2) unlike DeepInfra,
+  Fireworks' docs do not state what happens when `service_tier=priority` is
+  sent to a model that doesn't support it — DeepInfra's documented safe
+  fallback (standard billing, `service_tier: "default"` echoed) is what
+  makes sending the field unconditionally safe there, and that guarantee is
+  unverified for Fireworks; (3) `qwen3-embedding-8b` is an `/v1/embeddings`
+  model — priority tier is documented only for chat completions and
+  `messages`, so the field is likely a no-op there at best. Revisit when
+  either current Fireworks model gains a Priority badge on its own page, or
+  a new Fireworks-backed chat model is added to the catalog that shows one.
 
 ## Alternatives considered
 
@@ -140,4 +160,6 @@ not just callers who would have opted in themselves.
 - External references:
   [anomalyco/opencode#12297](https://github.com/anomalyco/opencode/issues/12297),
   [deepinfra.com/blog/priority-service-tier](https://deepinfra.com/blog/priority-service-tier),
-  [deepinfra.com/deepseek-ai/DeepSeek-V4-Flash-0731](https://deepinfra.com/deepseek-ai/DeepSeek-V4-Flash-0731)
+  [deepinfra.com/deepseek-ai/DeepSeek-V4-Flash-0731](https://deepinfra.com/deepseek-ai/DeepSeek-V4-Flash-0731),
+  [docs.fireworks.ai/serverless/serving-paths](https://docs.fireworks.ai/serverless/serving-paths)
+  (Fireworks priority tier — deferred follow-up, see above)


### PR DESCRIPTION
## 1. Summary

This PR changes:

- Adds a "Fireworks priority tier — investigated, deliberately deferred" bullet to [ADR-0117](docs/adr/0117-deepinfra-priority-service-tier-and-deepseek-v4-flash-0731.md)'s Neutral/follow-ups section, plus a source link.

It solves:

- Follow-up to [#894](https://github.com/ADORSYS-GIS/ai-helm/pull/894): after confirming DeepInfra's `service_tier=priority` live, the natural next question was whether to do the same for Fireworks. This records why that was investigated and deliberately NOT done, so it isn't silently forgotten or re-investigated from scratch later.

---

## 2. Intent

Fireworks supports the identical `"service_tier": "priority"` field on chat completions (docs.fireworks.ai/serverless/serving-paths) — the same `bodyMutation` mechanism ADR-0117 wired up for DeepInfra would drop in directly on the `fwBackendPrimary`/`fwBackendSecondary` anchors.

Checked live against Fireworks' own catalog before touching any chart: neither model currently routed through Fireworks (`qwen3-embedding-8b`, `qwen3p7-plus`) shows a Priority badge or Priority pricing on its own Fireworks model page, and — unlike DeepInfra, which explicitly documents a safe standard-tier fallback for unsupported models — Fireworks' docs don't state what happens if an unsupported model receives the field. `qwen3-embedding-8b` is also an `/v1/embeddings` model, a different API shape than what priority tier is documented for. Wiring it up blind risked breaking the only two Fireworks routes this catalog has.

This is a documentation-only PR: no chart/values change, because the decision was to hold off. Source of truth: [ADR-0117](docs/adr/0117-deepinfra-priority-service-tier-and-deepseek-v4-flash-0731.md) (this PR's diff), [docs.fireworks.ai/serverless/serving-paths](https://docs.fireworks.ai/serverless/serving-paths).

---

## 3. Scope

### In Scope

- `docs/adr/0117-deepinfra-priority-service-tier-and-deepseek-v4-flash-0731.md` — one new bullet under Neutral/follow-ups + one external reference link.

### Out of Scope

- Any change to `charts/ai-models/values.yaml`'s Fireworks (`fwBackendPrimary`/`Secondary`) anchors — deliberately not touched, per the deferral.
- A new standalone ADR — judged this doesn't rise to that bar (no decision changed, just a follow-up note on an existing one), and it only touches the Neutral/follow-ups list, not ADR-0117's Context/Decision sections.

---

## 4. Verification

I verified this change by:

- [ ] Running automated tests
- [ ] Running manual tests
- [ ] Checking logs
- [ ] Checking metrics
- [ ] Testing error cases
- [ ] Testing permissions/security behavior
- [ ] Testing rollback or failure behavior, if relevant

Commands run:

```bash
git diff docs/adr/0117-deepinfra-priority-service-tier-and-deepseek-v4-flash-0731.md
```

Results:

```text
Doc-only diff: 23 insertions, 1 deletion, one file. No chart/template/values
touched, so no helm lint/template re-verification is needed beyond what
already passed in #894 (unchanged).
```

---

## 5. Screenshots / Evidence

Not applicable — Markdown-only change.

---

## 6. Risk Assessment

Risk level:

* [x] Low
* [ ] Medium
* [ ] High

Potential risks:

* None — no chart, template, or values file is touched; this cannot affect a live deploy.

Mitigation:

* N/A.

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [ ] Generating code
* [ ] Refactoring
* [ ] Generating tests
* [x] Drafting documentation
* [ ] Reviewing the diff

Human verification:

* [x] I understand every meaningful change in this PR
* [x] I checked generated code manually
* [ ] I checked generated tests manually
* [x] I removed unsupported AI assumptions
* [x] I accept responsibility for this PR

Detail: Claude Code fetched Fireworks' live docs and both relevant model pages (`qwen3-embedding-8b`, `qwen3p7-plus`) to check Priority-tier support before proposing any chart change, surfaced the undocumented-fallback risk, and the maintainer (@stephane-segning) explicitly decided to hold off entirely rather than wire it up speculatively. This PR only records that decision.

---

## 8. Reviewer Focus

Please focus your review on:

* [ ] Correctness
* [ ] Architecture
* [ ] Security
* [ ] Performance
* [ ] Tests
* [ ] Maintainability
* [x] Product intent
* [ ] Edge cases

In particular: whether editing ADR-0117's Neutral/follow-ups section post-Accepted is acceptable under this repo's "ADRs are immutable once accepted" convention, or whether this should instead have been a new standalone ADR. Flagged explicitly in the prior conversation; judged as within bounds here since only the follow-ups list changed, not the Decision.
