### PR TITLE
fix(webank-training): require explicit GPU requests

### DIFF
--- a/charts/webank-training/templates/workflowtemplate.yaml
+++ b/charts/webank-training/templates/workflowtemplate.yaml
@@ -12,6 +12,8 @@
 {{- if ne $gpuNodeLabel "true" }}{{ fail "webank-training: GPU-capable templates require training.gpu.nodeSelector[nvidia.com/gpu.present]=true (the live GPU node label — see charts/inference)" }}{{- end }}
 {{- $gpuLimit := index $training.gpu.resources.limits "nvidia.com/gpu" | default 0 -}}
 {{- if lt (int $gpuLimit) 1 }}{{ fail "webank-training: GPU-capable templates require limits.nvidia.com/gpu >= 1" }}{{- end }}
+{{- $gpuRequest := index $training.gpu.resources.requests "nvidia.com/gpu" | default 0 -}}
+{{- if lt (int $gpuRequest) 1 }}{{ fail "webank-training: GPU-capable templates require requests.nvidia.com/gpu >= 1" }}{{- end }}
 {{- $toleratesGpu := false -}}
 {{- range $training.gpu.tolerations }}
 {{- if and (eq (.key | default "") "nvidia.com/gpu") (eq (.operator | default "Equal") "Exists") (eq (.effect | default "") "NoSchedule") }}{{- $toleratesGpu = true }}{{- end }}

--- a/charts/webank-training/values.yaml
+++ b/charts/webank-training/values.yaml
@@ -22,8 +22,9 @@ training:
   # resource profile: `nvidia.com/gpu.present=true` (the live GPU node label,
   # matching charts/inference's `defaults.gpu` — see ADR-0114), an
   # `nvidia.com/gpu:NoSchedule` (Exists) toleration matching the live node
-  # taint, and a positive nvidia.com/gpu limit. Dataset construction receives
-  # the same reviewed CPU, memory, and GPU allocation as candidate training.
+  # taint, and an explicit positive nvidia.com/gpu request and limit. Dataset
+  # construction receives the same reviewed CPU, memory, and GPU allocation as
+  # candidate training.
   #
   # ⚠️ Prior to ADR-0114 this contract was `role: gpu`, which no node in the
   # cluster has ever carried — every GPU-requesting workflow pod was
@@ -35,7 +36,7 @@ training:
     tolerations: []
     priorityClassName: ""
     resources:
-      requests: { cpu: "4", memory: 16Gi }
+      requests: { cpu: "4", memory: 16Gi, nvidia.com/gpu: 1 }
       limits: { cpu: "8", memory: 16Gi, nvidia.com/gpu: 1 }
   documentDetector:
     stemChannels: 32


### PR DESCRIPTION
## Summary

Requires every Webank GPU dataset-build and train template to declare `nvidia.com/gpu: 1` in both `resources.requests` and `resources.limits`, instead of relying on Kubernetes' implicit request-from-limit default.

## Intent

The live contract must be explicit and mechanically verifiable. Read-only inspection found all ten templates carried the reviewed `16 CPU` / `48Gi` request and limit values, but GPU only in limits.

Source of truth:
- https://github.com/ADORSYS-GIS/ai-helm/pull/891
- https://github.com/ADORSYS-GIS/ai-helm-values/pull/179

## Scope

In scope:
- Add an explicit GPU request to the chart default profile.
- Fail chart rendering when an environment omits the GPU request.

Out of scope:
- Any workflow submission, LakeFS data access, or runtime data/model change.

## Verification

- [x] `helm lint charts/webank-training --strict -f charts/webank-training/ci/lint-values.yaml`
- [x] `helm template webank-training charts/webank-training -f charts/webank-training/ci/lint-values.yaml --namespace mlops`
- [x] Negative render: overriding `training.gpu.resources.requests.nvidia.com/gpu=0` fails closed.
- [x] `git diff --check`

## Risk assessment

Low: this makes the existing reviewed GPU allocation explicit. The accompanying values change is sequenced first so the floating chart can safely adopt the new fail-closed guard.

## AI usage declaration

- [x] AI assistance was used for inspection, implementation, and verification.

AI was used to inspect the live rendered resources, make the narrow chart change, and run the stated verification. No workflow, LakeFS data, credentials, model artifact, or synthetic evidence was accessed or created.

## Reviewer focus

- Confirm the request guard matches the existing GPU limit guard.
- Confirm the values-first sequencing prevents a floating-chart render failure.

