### PR TITLE
feat(ai-models): make z-image-turbo internal-only, rename to z-image-turbo-internal (#830)

### DIFF
--- a/charts/ai-models/values.yaml
+++ b/charts/ai-models/values.yaml
@@ -572,14 +572,19 @@ backends:
   # ⚠️ `prefix: /v1` — LocalAI registers `/v1/images/generations` and `/v1/models`.
   # The retired home-GPU backend used `/`, which strips the version segment and
   # 404s.
-  z-image-turbo-local:
+  #
+  # ⚠️ RENAMED 2026-07-31 (issue #830): `z-image-turbo-local` → `z-image-turbo-internal`
+  # to follow the `-internal` suffix convention for disableExternal models (see the
+  # comment block above `models:` in this file). ai-helm-values must update any
+  # reference to this backend key in the same commit window.
+  z-image-turbo-internal:
     schema: OpenAI
     prefix: "/v1"
     fqdn:
       hostname: z-image-turbo.inference.svc.cluster.local
       port: 8080
     securityType: APIKey
-    resourceName: z-image-turbo-local-svc
+    resourceName: z-image-turbo-internal-svc
     secretRef:
       name: z-image-turbo-api-key
     externalSecret:
@@ -619,10 +624,11 @@ models:
 #  rather than left `enabled: false`, because a disabled entry still reads like
 #  something that could come back, and these cannot: the servers no longer exist.
 #
-#  Today `-local` is exactly: qwen3-vl-4b-thinking-local (vision-language) and
-#  z-image-turbo-local (image generation) — one per fleet card. Both text tiers
-#  (openmythos-27b-local, qwen3-8b-fast-local) are disabled. If you add another,
-#  it is on the fleet or it does not carry -local.
+#  Today `-local` is exactly: qwen3-vl-4b-thinking-local (vision-language). Both
+#  text tiers (openmythos-27b-local, qwen3-8b-fast-local) are disabled. If you
+#  add another, it is on the fleet or it does not carry -local.
+#  Note: z-image-turbo (image generation) was renamed to z-image-turbo-internal
+#  (issue #830) and carries `-internal`, not `-local`, because it is internal-only.
 # ═══════════════════════════════════════════════════════════════════════════════
 
 # ⚠️ INTERNAL-ONLY MODELS CARRY AN `-internal` SUFFIX (2026-07-28).
@@ -842,9 +848,21 @@ models:
   # install: LocalAI will fetch the `download_files` weights and cosign-verify the
   # backend for real (ADR-0105 flagged both as untested). Re-confirm one 1024×1024
   # generation after the first sync before treating this as done.
-  z-image-turbo-local:
+  #
+  # ⚠️ RENAMED 2026-07-31 (issue #830): `z-image-turbo-local` → `z-image-turbo-internal`
+  # (disableExternal: true — internal-plane only, LibreChat consumer only). Following
+  # the `-internal` suffix convention for models not exposed on api.ai.camer.digital.
+  # ⚠️ Cross-repo: ai-helm-values must rename any reference to `z-image-turbo-local`
+  # → `z-image-turbo-internal` (x-ai-eg-model header, allowed-model lists, token tables)
+  # in the same deployment window, or internal callers 404.
+  z-image-turbo-internal:
     enabled: true
     kind: image
+    # Blocked on the external host (api.ai.camer.digital) — only reachable on
+    # the internal plane (LibreChat and other in-cluster callers). The image-gen
+    # agent is a LibreChat-only consumer; external exposure is unnecessary attack
+    # surface (issue #830).
+    disableExternal: true
     minBackends: 1                   # one GPU, one backend, by design
     timeout:
       # 8 distilled steps at 1024×1024 is ~32 s — but the model holds a Mutex and
@@ -874,8 +892,8 @@ models:
       standard:
         effectivePerRequest: 0.0100
     backends:
-      z-image-turbo-local:
-        ref: z-image-turbo-local
+      z-image-turbo-internal:
+        ref: z-image-turbo-internal
         priority: 0
         # ⚠️ The id the ENGINE serves, read off /v1/models — not the catalog key.
         # Lowercase `z-image-turbo` because we define the model ourselves under

--- a/docs/playbooks/gateway-api-usage.md
+++ b/docs/playbooks/gateway-api-usage.md
@@ -21,12 +21,14 @@ curl -s $AI_BASE/v1/models -H "Authorization: Bearer $AI_TOKEN" | jq -r '.data[]
 curl -s $AI_BASE/v1/models/info -H "Authorization: Bearer $AI_TOKEN" | jq       # OpenRouter-shape catalog
 ```
 
-Self-hosted on our own GPUs: **`z-image-turbo-local`** (images) and
-**`qwen3-vl-4b-thinking-local`** (text + vision). Everything else is a SaaS
-backend behind a branded alias. Ids ending `-internal` are routed on the internal
-listener only — picking one externally returns `404 No matching route found`.
+Self-hosted on our own GPUs: **`z-image-turbo-internal`** (images, internal
+plane only) and **`qwen3-vl-4b-thinking-local`** (text + vision). Everything
+else is a SaaS backend behind a branded alias. Ids ending `-internal` are routed
+on the internal listener only — picking one externally returns
+`404 No matching route found`. `z-image-turbo-internal` is reachable only from
+in-cluster callers such as LibreChat, not from the public gateway.
 
-## Image generation — `z-image-turbo-local`
+## Image generation — `z-image-turbo-internal` (internal plane only)
 
 > ⚠️ **KNOWN LIMITATION (2026-07-29): only ≤512×512 works through the gateway.**
 > Anything larger fails with `HTTP 500` / `Internal Server Error`. It is not your
@@ -54,7 +56,7 @@ curl -s $AI_BASE/v1/images/generations \
   -H "Authorization: Bearer $AI_TOKEN" \
   -H "Content-Type: application/json" \
   -d '{
-    "model": "z-image-turbo-local",
+    "model": "z-image-turbo-internal",
     "prompt": "a red bicycle leaning on a blue wall",
     "size": "512x512",
     "n": 1,
@@ -70,7 +72,7 @@ curl -s $AI_BASE/v1/images/generations \
 | Timeout | 300 s request / 1 h idle — rides a short queue, not a cold start |
 | Billing | flat **$0.0100/image**, tokens always 0 (ADR-0104) |
 
-Image-only: `z-image-turbo-local` does **not** answer `/v1/chat/completions`.
+Image-only: `z-image-turbo-internal` does **not** answer `/v1/chat/completions`.
 
 ## Chat completions
 


### PR DESCRIPTION
## 1. Summary

This PR changes:

- Renamed backend key `z-image-turbo-local` → `z-image-turbo-internal` (and `resourceName: z-image-turbo-local-svc` → `z-image-turbo-internal-svc`) in `charts/ai-models/values.yaml`.
- Renamed model key `z-image-turbo-local` → `z-image-turbo-internal`.
- Added `disableExternal: true` to the model entry so its `AIGatewayRoute` is parented to the `api-internal` listener only — not the public `api-external` / `api.ai.camer.digital` host.
- Updated the inventory comment block to reflect the rename and document the `-internal` suffix convention distinction.

It solves:

- [#830 — LibreChat image-gen agent: remove from Envoy gateway, make internal-only](https://github.com/ADORSYS-GIS/ai-helm/issues/830)
- Parent epic: [#821 — LibreChat – Coder Agent, Image-Gen Refactor & Governance Skill](https://github.com/ADORSYS-GIS/ai-helm/issues/821)

---

## 2. Intent

The intent of this PR is:

> The image-gen agent (`z-image-turbo`) only needs to be reachable by LibreChat internally. Removing external exposure eliminates unnecessary attack surface — the model is not a consumer-facing feature and has no valid use case behind `api.ai.camer.digital`. The `-internal` suffix convention (established 2026-07-28) makes this constraint machine-readable and self-documenting.

---

## 3. Scope

### In Scope

- `charts/ai-models/values.yaml` — backend key rename, model key rename, `disableExternal: true` flag, inventory comment update.

### Out of Scope

- Changes to the underlying `z-image-turbo` model or its inference server (see #826 / #803).
- The b64→S3 image proxy (tracked separately in the Envoy epic).
- The `ai-helm-values` cross-repo rename — required in the same deployment window but tracked separately (⚠️ see cross-repo note below).

---

## 4. Verification

I verified this change by:

- [x] Running automated tests (helm lint/template)
- [ ] Running manual tests
- [ ] Checking logs
- [ ] Checking metrics
- [ ] Testing error cases
- [ ] Testing permissions/security behavior
- [ ] Testing rollback or failure behavior, if relevant

Commands run:

```bash
helm lint --strict charts/ai-models
helm template x charts/ai-models --dry-run | grep -A5 z-image-turbo-internal
helm template x charts/ai-models --dry-run | grep z-image-turbo-local
```

Results:

```text
helm lint: 0 chart(s) failed
helm template: z-image-turbo-internal appears correctly in rendered output with disableExternal: true
helm template: z-image-turbo-local no longer appears anywhere in rendered output
```

⚠️ **Cross-repo action required before deploying:** `ai-helm-values` must rename every reference to `z-image-turbo-local` → `z-image-turbo-internal` (the `x-ai-eg-model` header, allowed-model lists, token tables) in the same deployment window, or internal callers will 404. End-to-end image-generation test via LibreChat UI to be performed after both repos are updated.

---

## 5. Screenshots / Evidence

Not applicable — chart-only change, no UI. Rendered-manifest evidence is in Verification above.

---

## 6. Risk Assessment

Risk level:

* [x] Low
* [ ] Medium
* [ ] High

Potential risks:

* Internal callers (`z-image-turbo-local`) 404 until `ai-helm-values` is updated in the same window.

Mitigation:

* The rename in `ai-helm-values` must be sequenced in the same deployment window — flagged explicitly in the PR body and commit message. The `ai-helm-values` `render-check.yml` will guard the values side before merge there.
* `modelNameOverride` stays `z-image-turbo` (the engine-served name reported by LocalAI), so the upstream inference engine is unchanged.
* Reverting is a single key rename back.

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [ ] Refactoring
* [ ] Generating tests
* [x] Drafting documentation
* [ ] Reviewing the diff
* [ ] Not used

Human verification:

* [x] I understand every meaningful change in this PR
* [x] I checked generated code manually
* [ ] I checked generated tests manually
* [x] I removed unsupported AI assumptions
* [x] I accept responsibility for this PR

Detail: Antigravity (Gemini) assisted with commit structuring, chart key rename, and PR drafting. The architectural decision to use `disableExternal: true` and the `-internal` suffix convention follow the pattern established 2026-07-28. The author (@Guy-Ghis) owns and is accountable for this change.

---

## 8. Reviewer Focus

Please focus your review on:

* [x] Correctness
* [ ] Architecture
* [ ] Security
* [ ] Performance
* [ ] Tests
* [ ] Maintainability
* [x] Product intent
* [ ] Edge cases

In particular: confirm the `disableExternal: true` flag correctly restricts the `AIGatewayRoute` to the internal listener only, and confirm the cross-repo `ai-helm-values` rename sequencing is in place before approving merge to main.