### PR TITLE
feat(core-gateway): wire the redact-extproc sidecar (ADR-0116)

### DIFF
--- a/charts/core-gateway/templates/envoy-proxy.yaml
+++ b/charts/core-gateway/templates/envoy-proxy.yaml
@@ -30,6 +30,51 @@ spec:
         container:
           resources:
             {{- toYaml ($ep.resources | default dict) | nindent 12 }}
+        # redact-extproc (ADR-0116): a second native sidecar beside the one
+        # AIEG's own admission webhook injects. Direct assignment here
+        # (`InitContainers: deploymentConfig.InitContainers` in EG's own
+        # resource_provider.go) and AIEG's injection (an APPEND in its
+        # gateway_mutator.go, at Pod CREATE admission) happen at different
+        # layers — one writes the Deployment spec, the other patches the Pod
+        # — so this cannot displace AIEG's container. Verified against EG
+        # v1.8.2 / AIEG v1.0.0 source before relying on it; re-check on any
+        # major bump to either.
+        initContainers:
+          - name: redact-extproc
+            image: "{{ .Values.redactExtproc.image.repository }}:{{ .Values.redactExtproc.image.tag }}"
+            # The Kubernetes native-sidecar marker (1.28+, this cluster is
+            # 1.35): starts before the main containers, keeps running
+            # alongside them, and is what makes an initContainer entry behave
+            # as a sidecar rather than a run-once init step.
+            restartPolicy: Always
+            ports:
+              - name: redact-grpc
+                containerPort: {{ .Values.redactExtproc.listenPort | default 9500 }}
+              - name: redact-metrics
+                containerPort: {{ .Values.redactExtproc.metricsPort | default 9501 }}
+            env:
+              - name: LISTEN_ADDR
+                value: "127.0.0.1:{{ .Values.redactExtproc.listenPort | default 9500 }}"
+              - name: METRICS_LISTEN_ADDR
+                value: "0.0.0.0:{{ .Values.redactExtproc.metricsPort | default 9501 }}"
+              - name: REDACT_PROFILE
+                value: {{ .Values.redactExtproc.profile | default "coding-assistant" | quote }}
+              # Quoted deliberately: a bare number here renders as a YAML
+              # int/float that Kubernetes' string-typed EnvVar.value rejects.
+              - name: RESPONSE_HOLD_BACK_BYTES
+                value: {{ .Values.redactExtproc.responseHoldBackBytes | default 1024 | quote }}
+              - name: REDACT_HASH_SALT
+                valueFrom:
+                  secretKeyRef:
+                    name: {{ include "core-gateway.fullname" . }}-redact-extproc-env
+                    key: {{ .Values.redactExtproc.externalSecret.saltProperty | default "redact_extproc_hash_salt" }}
+                    # ⚠️ NEVER optional — see charts/redact-gateway's own
+                    # comment on this exact env var. An optional ref lets a
+                    # sidecar that beats ESO capture an empty salt and hash
+                    # with it forever.
+                    optional: false
+            resources:
+              {{- toYaml (.Values.redactExtproc.resources | default dict) | nindent 14 }}
         {{- if (default dict $ep.topologySpread).enabled }}
         pod:
           topologySpreadConstraints:

--- a/charts/core-gateway/templates/envoyextensionpolicy-redact.yaml
+++ b/charts/core-gateway/templates/envoyextensionpolicy-redact.yaml
@@ -1,0 +1,63 @@
+{{- /*
+ADR-0116: PII/credential redaction as an ext_proc filter, run by the
+redact-extproc sidecar declared in envoy-proxy.yaml's envoyDeployment.
+
+The Backend below is the whole trick that makes "sidecar" actually mean
+same-pod. A normal Service-selector backendRef resolves via EDS to EVERY
+matching pod — with `envoyProxy.hpa` running 3-5 replicas, that would let
+Envoy load-balance ext_proc calls to a DIFFERENT replica's sidecar,
+reintroducing the cross-pod network hop this design exists to avoid. A
+`Backend` with a literal `ip: 127.0.0.1` endpoint has no such ambiguity:
+every replica's own Envoy resolves 127.0.0.1 to itself, so this is the
+same-pod guarantee, expressed the only way the Gateway API's backendRef
+model allows it (there is no "self" primitive — verified against Envoy
+Gateway's own ext_proc docs, which show only Service-backed examples).
+*/}}
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: Backend
+metadata:
+  name: {{ include "core-gateway.fullname" . }}-redact-extproc
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "common.labels.standard" . | nindent 4 }}
+spec:
+  endpoints:
+    - ip:
+        address: 127.0.0.1
+        port: {{ .Values.redactExtproc.listenPort | default 9500 }}
+---
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: EnvoyExtensionPolicy
+metadata:
+  name: {{ include "core-gateway.fullname" . }}-redact-extproc
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "common.labels.standard" . | nindent 4 }}
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: {{ include "core-gateway.fullname" . }}
+  extProc:
+    - backendRefs:
+        - name: {{ include "core-gateway.fullname" . }}-redact-extproc
+          kind: Backend
+          group: gateway.envoyproxy.io
+      # Explicit on purpose: the CRD's own documented default is to send
+      # NEITHER headers nor body to the processor, which yields a filter
+      # that is attached, healthy, and inspecting nothing (ADR-0116 flags
+      # this as the same silent-no-op class as the `"n": 1` YAML-boolean
+      # trap). Request is Buffered — the whole JSON body arrives as one
+      # message, matching what crates/governance-redact's payload walker
+      # expects. Response is Streamed — see governance_redact::holdback for
+      # why buffering the whole completion is the wrong latency trade.
+      processingMode:
+        request:
+          body: Buffered
+        response:
+          body: Streamed
+      messageTimeout: {{ .Values.redactExtproc.messageTimeout | default "200ms" }}
+      # Matches decision 10 of the governance roadmap and every profile's
+      # own `fail_closed` stance: an outage of the redactor must fail the
+      # request, never silently forward unscanned content.
+      failOpen: false

--- a/charts/core-gateway/templates/externalsecret-redact.yaml
+++ b/charts/core-gateway/templates/externalsecret-redact.yaml
@@ -1,0 +1,27 @@
+{{- /*
+ADR-0116: the redact-extproc sidecar's hash-action salt (governance-redact's
+Engine::new — must be stable for the deployment's lifetime and secret, or a
+digest is trivially brute-forced from a known value list). Same
+ssegning-aws / ai/camer/digital/prod/env convention every other app secret
+in this repo uses (charts/lightbridge-secrets, charts/librechat-app, …).
+*/}}
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: {{ include "core-gateway.fullname" . }}-redact-extproc-env
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "common.labels.standard" . | nindent 4 }}
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: {{ .Values.redactExtproc.externalSecret.secretStore | default "ssegning-aws" }}
+    kind: ClusterSecretStore
+  target:
+    name: {{ include "core-gateway.fullname" . }}-redact-extproc-env
+    creationPolicy: Owner
+  data:
+    - secretKey: {{ .Values.redactExtproc.externalSecret.saltProperty | default "redact_extproc_hash_salt" }}
+      remoteRef:
+        key: {{ .Values.redactExtproc.externalSecret.remoteKey | default "ai/camer/digital/prod/env" | quote }}
+        property: {{ .Values.redactExtproc.externalSecret.saltProperty | default "redact_extproc_hash_salt" | quote }}

--- a/charts/core-gateway/templates/podmonitors-observability.yaml
+++ b/charts/core-gateway/templates/podmonitors-observability.yaml
@@ -44,3 +44,28 @@ spec:
     - targetPort: 19001
       path: /metrics
       interval: 30s
+---
+# redact-extproc (ADR-0116): same pods as the "envoy-proxy" monitor above (the
+# sidecar shares the gateway pod's labels — labels are pod-scoped, not
+# per-container), scraping its OWN metrics container port by name. Cross-pod
+# scrape, unlike the sidecar's gRPC port — see values.yaml's comment on why
+# METRICS_LISTEN_ADDR binds 0.0.0.0 while LISTEN_ADDR stays loopback-only.
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: {{ include "core-gateway.fullname" . }}-redact-extproc
+  namespace: envoy-gateway-system
+  labels:
+    app.kubernetes.io/part-of: core-gateway
+spec:
+  namespaceSelector:
+    matchNames:
+      - envoy-gateway-system
+  selector:
+    matchLabels:
+      app.kubernetes.io/managed-by: envoy-gateway
+      app.kubernetes.io/name: envoy
+  podMetricsEndpoints:
+    - targetPort: redact-metrics
+      path: /metrics
+      interval: 30s

--- a/charts/core-gateway/values.yaml
+++ b/charts/core-gateway/values.yaml
@@ -345,6 +345,70 @@ extProc:
       # under concurrency were the OOM risk; this gives headroom.
       memory: "1Gi"
 
+# ────────────────────────────────────────────────────────────────────────
+# redact-extproc (ADR-0116): PII/credential redaction as a NATIVE SIDECAR in
+# this same Envoy pod, beside the `extProc` block above — sidecar is the
+# topology, ext_proc is the protocol, and AIEG already uses both; this adds a
+# second processor rather than a new one. Filter order is measured, not
+# assumed: EG v1.8.2 fixes ExtProc at `100 + index` in its own chain, and
+# AIEG's processor is inserted ahead of that table entirely, so ours always
+# runs AFTER Authorino (order 5) and AFTER AIEG — acceptable only because
+# every AIServiceBackend on this fleet is `schema.name: OpenAI` (verified
+# live), so AIEG never rewrites the body into a shape our walker won't
+# recognise. If that stops being true, `redact_uninspected_bodies_total`
+# (exported on `metricsPort`) is the alarm — see the ADR.
+#
+# ⚠️ `image.tag` is a placeholder. No `redact-extproc` image has been built
+# or published yet (Dockerfile + docker.yml entry land in
+# `lightbridge-governance`, the same repo that owns `crates/governance-redact`).
+# Do not merge this chart change to `main` until a real tag exists here —
+# `restartPolicy: Always` makes this an init container the kubelet must start
+# before the pod is Ready, so an unpullable image blocks the WHOLE gateway
+# pod, not just redaction. Values-repo-first, same shape as the ADR-0055
+# ordering rule, for the same reason: land the dependency before the chart
+# change that assumes it.
+# ────────────────────────────────────────────────────────────────────────
+redactExtproc:
+  image:
+    repository: ghcr.io/adorsys-gis/redact-extproc
+    tag: "TBD-no-image-published-yet"
+  # Loopback only — reached solely by Envoy in this same pod (shared network
+  # namespace), never over the pod network. See templates/backend-redact.yaml:
+  # the EnvoyExtensionPolicy's Backend targets `127.0.0.1` specifically so
+  # every gateway replica always talks to ITS OWN sidecar, never another
+  # replica's — a Service-selector backendRef could not guarantee that with
+  # `envoyProxy.hpa` running 3-5 replicas.
+  listenPort: 9500
+  # 0.0.0.0: unlike the gRPC port above, Alloy scrapes this cross-pod (see
+  # podmonitors-observability.yaml), so it must be reachable via the pod IP.
+  metricsPort: 9501
+  profile: coding-assistant
+  # Bytes of a streamed response held back before release — see
+  # governance_redact::holdback for the sizing rationale. Quoted in the
+  # container env (a bare number renders as a YAML float/int that Kubernetes'
+  # string-typed EnvVar.value rejects — the same class of bug as ADR-0109's
+  # `"n": 1` trap and the MAX_BODY_BYTES scientific-notation one).
+  responseHoldBackBytes: 1024
+  # Per-message ext_proc budget. The CRD default (200ms) is the whole
+  # redaction budget per chunk; regex/validator recognizers fit comfortably
+  # inside it, an NER pass would not (ADR-0115 — NER is a separate service).
+  messageTimeout: 200ms
+  resources:
+    requests:
+      cpu: "100m"
+      memory: "128Mi"
+    limits:
+      cpu: "500m"
+      memory: "256Mi"
+  externalSecret:
+    secretStore: ssegning-aws
+    remoteKey: ai/camer/digital/prod/env
+    # ⚠️ Populate this property in ssegning-aws BEFORE this syncs, or the
+    # ExternalSecret sits in SecretSyncedError and the sidecar never starts
+    # (`optional: false` on the env — see charts/redact-gateway's own
+    # comment on why an optional ref is unacceptable for a hash salt).
+    saltProperty: redact_extproc_hash_salt
+
 # NOTE: the `mcpBackendTls` EnvoyPatchPolicy (ADR-0039) was REMOVED by ADR-0040.
 # External MCPs no longer terminate TLS at Envoy — they're fronted by per-MCP
 # Caddy normalizing proxies (charts/mcps, `mode: proxiedExternal`) that do the

--- a/charts/core-gateway/values.yaml
+++ b/charts/core-gateway/values.yaml
@@ -358,20 +358,21 @@ extProc:
 # recognise. If that stops being true, `redact_uninspected_bodies_total`
 # (exported on `metricsPort`) is the alarm — see the ADR.
 #
-# ⚠️ `image.tag` is a placeholder. No `redact-extproc` image has been built
-# or published yet (Dockerfile + docker.yml entry land in
-# `lightbridge-governance`, the same repo that owns `crates/governance-redact`).
-# Do not merge this chart change to `main` until a real tag exists here —
-# `restartPolicy: Always` makes this an init container the kubelet must start
-# before the pod is Ready, so an unpullable image blocks the WHOLE gateway
-# pod, not just redaction. Values-repo-first, same shape as the ADR-0055
-# ordering rule, for the same reason: land the dependency before the chart
-# change that assumes it.
+# Image built + published from lightbridge-governance's docker.yml
+# (lightbridge-governance#44, merged into its main at 54718b2; this tag is
+# the immutable per-commit build from main's current tip, 415d877 — a
+# docs-only README commit on top of #44, confirmed to touch neither
+# app/redact-extproc nor crates/governance-redact source, so it's the same
+# binary). `restartPolicy: Always` makes this an init container the kubelet
+# must start before the pod is Ready, so pin the immutable sha-<commit> tag
+# here rather than the floating `main` tag — an unrelated later push to
+# that repo's main must not silently change what THIS chart deploys.
 # ────────────────────────────────────────────────────────────────────────
 redactExtproc:
   image:
     repository: ghcr.io/adorsys-gis/redact-extproc
-    tag: "TBD-no-image-published-yet"
+    # sha256:05e5fbe1b5ec2dabc6a6e7e670c1782fb907507e3509dad341aecdd1a4d24c81
+    tag: "sha-415d877"
   # Loopback only — reached solely by Envoy in this same pod (shared network
   # namespace), never over the pod network. See templates/backend-redact.yaml:
   # the EnvoyExtensionPolicy's Backend targets `127.0.0.1` specifically so


### PR DESCRIPTION
## Summary

Wires the `redact-extproc` sidecar into `charts/core-gateway` (ADR-0116) with a real, published image tag.

**Source of truth:** [ai-helm#873](https://github.com/adorsys-gis/ai-helm/issues/873) (governance epic), [ADR-0116](docs/adr/0116-redaction-as-ext-proc.md), image built in [lightbridge-governance#44](https://github.com/adorsys-gis/lightbridge-governance/pull/44).

## Intent

Redaction moves from a front proxy into the Envoy filter chain as a native ext_proc sidecar, beside AIEG's own injected processor. See the ADR for the full rationale (the front proxy's justification — "a working binary already exists" — died the same day ADR-0115 rejected censgate).

## Scope

- `envoy-proxy.yaml` — `redact-extproc` as an `initContainers` entry with `restartPolicy: Always` (the native-sidecar marker), alongside AIEG's own.
- `envoyextensionpolicy-redact.yaml` — the ext_proc filter, and a `Backend` targeting a literal `ip: 127.0.0.1` rather than a Service selector.
- `externalsecret-redact.yaml` — the hash-salt secret via `ssegning-aws` / `ai/camer/digital/prod/env`.
- `podmonitors-observability.yaml` — a third `PodMonitor` for the sidecar's metrics.
- `values.yaml` — pinned to the real, published image tag (`sha-415d877`).

## Why a `Backend` with a literal IP, not a Service

`envoyProxy.hpa` runs 3-5 replicas. A Service-selector `backendRef` resolves via EDS to *every* matching pod — Envoy could load-balance ext_proc calls to a different replica's sidecar, reintroducing the cross-pod hop this design exists to avoid. Envoy Gateway's own ext_proc docs show only Service-backed examples, no sidecar pattern, so this is a derivation, not a copied recipe: the `Backend` CRD's `endpoints[].ip` field supports a literal address, and `127.0.0.1` has no cross-replica ambiguity — every replica's own Envoy resolves it to itself.

## Verification

Real output from the commands actually run against this branch:

```console
$ helm dep build charts/core-gateway && helm lint charts/core-gateway --strict
==> Linting charts/core-gateway
[INFO] Chart.yaml: icon is recommended
1 chart(s) linted, 0 chart(s) failed

$ helm template cg charts/core-gateway --namespace converse-gateway \
    | kubectl apply --dry-run=server -f - 2>&1 | grep -iE "redact|error validating"
backend.gateway.envoyproxy.io/cg-core-gateway-redact-extproc created (server dry run)
envoyextensionpolicy.gateway.envoyproxy.io/cg-core-gateway-redact-extproc created (server dry run)
externalsecret.external-secrets.io/cg-core-gateway-redact-extproc-env created (server dry run)
error: error validating "STDIN": ... GatewayConfigList.metadata ...   # pre-existing, see below

$ gh api orgs/adorsys-gis/packages/container/redact-extproc --jq '{visibility}'
{"visibility":"public"}
```

- The `GatewayConfigList` error is **pre-existing**, not introduced here — reproduced identically with this entire change stashed out (`git stash -u`, needed because two of the new template files are untracked and a plain `git stash` would silently have left them in place, invalidating the control run).
- Ran the repo-wide lint/render sweep (matching CI's exact logic in `helm-lint.yaml`) — `core-gateway` does not appear in the failure list; every chart that does fails on a pre-existing missing subchart dependency (`bjw-template`, `meilisearch`, `common` not built), unrelated to this change.
- **Image tag provenance**: pinned to `sha-415d877` — the immutable per-commit tag from `lightbridge-governance` main's current tip, not the floating `main` tag (an unrelated later push to that repo must not silently change what this chart deploys) and not the merge commit itself (`415d877` is one commit ahead of the merge, docs-only — checked [its diff](https://github.com/adorsys-gis/lightbridge-governance/commit/415d877) to confirm it touches no `redact-extproc`/`governance-redact` source before trusting it as the same binary). Resolved digest: `sha256:05e5fbe1b5ec2dabc6a6e7e670c1782fb907507e3509dad341aecdd1a4d24c81`.

## Risk Assessment

`restartPolicy: Always` means this container gates the whole gateway pod's readiness — an unpullable image would take down the gateway, not just redaction. That's why the tag is pinned to a verified-public, verified-built image rather than merged with a placeholder.

⚠️ **Out-of-band-secret-first**: `redact_extproc_hash_salt` must be populated under `ai/camer/digital/prod/env` in `ssegning-aws` before this syncs, or the `ExternalSecret` sits in `SecretSyncedError` and the sidecar never starts.

No production client traffic depends on this yet — it's a live sidecar wired into the gateway pod but redaction itself has no consumer routed through it (this is the mechanism, not the cutover).

## AI Usage Declaration

- [x] AI was used to write code in this PR.

AI (Claude Opus 5) wrote the chart templates, derived the `Backend`-over-`Service` approach after checking Envoy Gateway's own docs lacked a sidecar pattern, and ran every verification command shown above.

- [x] I have reviewed this change and take accountability for it.

## Reviewer Focus

The `Backend` static-IP approach (`envoyextensionpolicy-redact.yaml`) — it's the least-documented part of this PR (no upstream example to point to) and the one place a well-intentioned "simplify to a Service" edit would reintroduce cross-replica ext_proc calls.
