### PR TITLE
fix(core-gateway): put the redact-extproc secret in the data-plane namespace

### DIFF
--- a/charts/core-gateway/templates/externalsecret-redact.yaml
+++ b/charts/core-gateway/templates/externalsecret-redact.yaml
@@ -4,12 +4,24 @@ Engine::new — must be stable for the deployment's lifetime and secret, or a
 digest is trivially brute-forced from a known value list). Same
 ssegning-aws / ai/camer/digital/prod/env convention every other app secret
 in this repo uses (charts/lightbridge-secrets, charts/librechat-app, …).
+
+⚠️ Namespace is `internal.proxyNamespace` (envoy-gateway-system), NOT
+`.Release.Namespace` (converse-gateway, where this chart's own Gateway/
+EnvoyProxy control objects live). `secretKeyRef` only ever resolves within
+a Pod's own namespace, and the ACTUAL data-plane pod redact-extproc runs
+in is one Envoy Gateway's controller creates in envoy-gateway-system —
+this chart's own `internal.hostname` comment already documents that split
+for the internal-plane Service; missing it here for the Secret produced a
+live `secret "core-gateway-redact-extproc-env" not found` on rollout
+(caught live, 2026-08-03 — the ExternalSecret synced fine in the WRONG
+namespace, so `SecretSynced: True` was not evidence anything was wired
+correctly).
 */}}
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: {{ include "core-gateway.fullname" . }}-redact-extproc-env
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Values.gateway.internal.proxyNamespace | default "envoy-gateway-system" }}
   labels:
     {{- include "common.labels.standard" . | nindent 4 }}
 spec:


### PR DESCRIPTION
## Summary

Fixes a live rollout failure introduced by [#900](https://github.com/adorsys-gis/ai-helm/pull/900): the `redact-extproc` sidecar's `ExternalSecret` was created in the wrong namespace, so the new gateway replica couldn't find its own secret.

**Source of truth:** [ADR-0116](docs/adr/0116-redaction-as-ext-proc.md); the failure was caught live on the Hetzner cluster, 2026-08-03, immediately after #900 rolled out.

## Intent

`secretKeyRef` only ever resolves within a Pod's own namespace. This chart's own control objects (Gateway, EnvoyProxy) and the Helm release itself live in `converse-gateway`, but Envoy Gateway's controller runs the actual data-plane pods in `envoy-gateway-system` — a namespace split this same chart already documents for the internal-plane Service (`gateway.internal.proxyNamespace`). The new `ExternalSecret` used `.Release.Namespace` instead, landing the Secret in `converse-gateway` where no pod that needs it will ever look.

## Scope

`externalsecret-redact.yaml` — one line, `.Release.Namespace` → `gateway.internal.proxyNamespace` (defaulting to `envoy-gateway-system`).

## Verification

Live evidence this is the actual root cause, not a guess:

```console
$ kubectl -n envoy-gateway-system describe pod envoy-converse-gateway-core-gateway-c480b207-6d4955cb8f-lcmf6
...
Warning  Failed  kubelet  spec.initContainers{redact-extproc}: Error: secret "core-gateway-redact-extproc-env" not found

$ kubectl get externalsecret core-gateway-redact-extproc-env -n converse-gateway
NAME                               STORE          STATUS      READY
core-gateway-redact-extproc-env    ssegning-aws   SecretSynced   True   # synced fine — just in the wrong namespace

$ kubectl get secret -A | grep redact-extproc
converse-gateway   core-gateway-redact-extproc-env   Opaque   1   # exists, but the pod is in envoy-gateway-system
```

After the fix:

```console
$ helm lint charts/core-gateway --strict
1 chart(s) linted, 0 chart(s) failed

$ helm template cg charts/core-gateway --namespace converse-gateway \
    | awk '/^kind: ExternalSecret$/{f=1} f{print; if(/^spec:/) exit}'
kind: ExternalSecret
metadata:
  name: cg-core-gateway-redact-extproc-env
  namespace: envoy-gateway-system   # was converse-gateway before this fix

$ helm template cg charts/core-gateway --namespace converse-gateway \
    | kubectl apply --dry-run=server -f - 2>&1 | grep -i redact
backend.gateway.envoyproxy.io/cg-core-gateway-redact-extproc created (server dry run)
envoyextensionpolicy.gateway.envoyproxy.io/cg-core-gateway-redact-extproc created (server dry run)
externalsecret.external-secrets.io/cg-core-gateway-redact-extproc-env created (server dry run)
```

## Risk Assessment

No production traffic impact from the original bug or this fix: the three pre-cutover replicas stayed `3/3 Running` throughout (untouched, still on the old ReplicaSet); only the single new replica #900's rollout created got stuck at `Init:CreateContainerConfigError`, and Kubernetes never routed traffic to it since it never reached Ready. This PR lets that (or the next) replica actually start.

## AI Usage Declaration

- [x] AI was used to write code in this PR.

AI (Claude Opus 5) diagnosed the failure from the live pod's events and the ExternalSecret's actual namespace, identified the root cause by re-reading this chart's own existing `gateway.internal.proxyNamespace` comment, and verified the fix against both `helm template` and a live server-side dry-run.

- [x] I have reviewed this change and take accountability for it.

## Reviewer Focus

None — one-line namespace fix, verified live.
