### PR TITLE
fix(core-gateway): stop hardcoding redact-extproc image tag in chart

### DIFF
--- a/charts/core-gateway/values.yaml
+++ b/charts/core-gateway/values.yaml
@@ -369,10 +369,14 @@ extProc:
 # that repo's main must not silently change what THIS chart deploys.
 # ────────────────────────────────────────────────────────────────────────
 redactExtproc:
+  # ADR-0055/0056: the deployed tag is workload config, not chart structure —
+  # it lives in ai-helm-values (environments/prod/values/core-gateway.yaml),
+  # not here. This placeholder previously held a real live tag by mistake
+  # (ai-helm#900/#901), which meant the fix in lightbridge-governance#47
+  # published to GHCR but was never referenced anywhere ArgoCD reads.
   image:
     repository: ghcr.io/adorsys-gis/redact-extproc
-    # sha256:05e5fbe1b5ec2dabc6a6e7e670c1782fb907507e3509dad341aecdd1a4d24c81
-    tag: "sha-415d877"
+    tag: "TBD-no-image-published-yet"
   # Loopback only — reached solely by Envoy in this same pod (shared network
   # namespace), never over the pod network. See templates/backend-redact.yaml:
   # the EnvoyExtensionPolicy's Backend targets `127.0.0.1` specifically so


### PR DESCRIPTION
## Summary
- Removes the real live image tag from `charts/core-gateway/values.yaml`, replacing it with the repo's standard `TBD-no-image-published-yet` chart-default placeholder.
- The deployed tag now comes solely from ai-helm-values via `core-gateway`'s existing `valuesFromRepo: true` — matching ADR-0055/0056, which this PR previously violated by mistake.

## Intent
Fixes a self-inflicted deploy gap: lightbridge-governance#47 (UTF-8 chunk-boundary fix) published `sha-b3c0a2e` to GHCR, but nothing referenced it — the tag was hardcoded in this chart instead of in ai-helm-values, so a chart release would have been required to ship it. **Merge order matters: adorsys-gis/ai-helm-values#183 must merge first**, or `ignoreMissingValueFiles` falls back to this chart default and the sidecar image tag becomes literally invalid (empty tag suffix).

## Scope
`charts/core-gateway/values.yaml` only — one field.

## Verification
\`\`\`
helm lint charts/core-gateway --strict   # 0 chart(s) failed
helm template x charts/core-gateway --dry-run | grep redact-extproc:
  image: \"ghcr.io/adorsys-gis/redact-extproc:TBD-no-image-published-yet\"
\`\`\`
- [x] Confirmed no other template references `.Values.redactExtproc.image` besides `templates/envoy-proxy.yaml`.

## Risk Assessment
Low — values-only change to a chart default; the live deploy source moves to ai-helm-values, ordering handled by merging #183 first.

## AI Usage Declaration
- [x] AI (Claude) identified the ADR-0055/0056 violation and authored this fix at the maintainer's direction, correcting a mistake introduced earlier in the same session (ai-helm#900/#901).
- [x] Maintainer reviewed the diff and lint/render evidence before merge.

Source of truth: adorsys-gis/ai-helm-values#183, adorsys-gis/lightbridge-governance#47

## Reviewer Focus
Merge order: this PR is safe to merge only after ai-helm-values#183 is on `main`.