### PR TITLE
fix(core-gateway): pin chart to 0.3.146, rolling back ADR-0116 sidecar

### DIFF
--- a/charts/apps/values.yaml
+++ b/charts/apps/values.yaml
@@ -587,7 +587,18 @@ applications:
       # untouched. No depsOverlay on this app, so it renders as a single source.
       repoURL: oci://ghcr.io/adorsys-gis/charts/core-gateway
       chart: "."
-      targetRevision: ">=0.0.0"
+      # ⚠️ TEMPORARY ROLLBACK PIN (2026-08-03 incident): 0.3.146 is the last
+      # published chart WITHOUT the ADR-0116 redact-extproc sidecar at all
+      # (0.3.147 = e7ea902/#900, the first commit that adds it). Live traffic
+      # was seeing near-half of ext_proc streams get an ImmediateResponse
+      # after #905 switched response.body to Buffered as a stopgap for the
+      # UTF-8 chunk-split bug — a bug already fixed properly upstream
+      # (lightbridge-governance#47, sha-b3c0a2e) but not yet re-verified live
+      # under that stopgap. Pinning below the whole feature is the fastest
+      # correct kill switch while the chart is reworked so Buffered/Streamed
+      # is a value, not a template literal (see redactExtproc.processingMode
+      # once that lands) — re-float to ">=0.0.0" once verified fixed.
+      targetRevision: "0.3.146"
       helm:
         releaseName: core-gateway
     destination:


### PR DESCRIPTION
## Summary
- Pins `core-gateway`'s `targetRevision` from the floating `>=0.0.0` range to the exact version `0.3.146` — the last chart published before the ADR-0116 redact-extproc sidecar existed at all.
- This is a temporary, explicit rollback, not a permanent pin. Re-float to `>=0.0.0` once the follow-up chart work lands and is verified.

## Intent
Live incident: after #905 changed `response.body` from `Streamed` to `Buffered` (a stopgap for the UTF-8 chunk-split bug, merged independently and *before* the real fix in lightbridge-governance#47 existed), ~46% of ext_proc streams on the gateway's listener were observed getting an `ImmediateResponse`, and streaming clients got no tokens at all until the full completion was ready. Rather than debug two stacked live fixes for the same symptom under production traffic, this pins below the whole ADR-0116 feature — verified via `git show e7ea902 -s --format=%cI` (10:34:01Z) matching chart `0.3.147`'s publish time (10:34:18Z) exactly, so `0.3.146` has none of it.

## Scope
`charts/apps/values.yaml`, one field (`targetRevision` on the `core-gateway` app entry). No chart template changes.

## Verification
\`\`\`
helm template x charts/apps --dry-run | grep -A2 targetRevision
  targetRevision: 0.3.146
helm lint charts/apps --strict
  0 chart(s) failed
\`\`\`
- [x] Confirmed 0.3.146 predates every ADR-0116 commit (e7ea902/#900 is the first, merged 10:34:01Z; chart 0.3.147 published 10:34:18Z).

## Risk Assessment
Medium — this removes an in-flight security feature (PII/credential redaction) from the live gateway until the follow-up lands. Deliberate trade: it was actively causing failures for a large fraction of real requests.

## AI Usage Declaration
- [x] AI (Claude) diagnosed the incident and authored this rollback at the maintainer's explicit direction.
- [x] Maintainer reviewed the diff and the version-boundary verification before merge.

Source of truth: adorsys-gis/lightbridge-governance#47, ADR-0116, #900, #905

## Reviewer Focus
This intentionally disables redaction cluster-wide until the follow-up (parameterizing Buffered/Streamed as a chart value, controlled from ai-helm-values) lands.