### PR TITLE
feat(observability): add weekly/monthly/raw period filters to cost dashboards

### DIFF
--- a/charts/observability-dashboards/files/envoy-ai-gateway/actor-consumption.json
+++ b/charts/observability-dashboards/files/envoy-ai-gateway/actor-consumption.json
@@ -496,5 +496,19 @@
       "keepTime": true,
       "targetBlank": true
     }
-  ]
+  ],
+  "timepicker": {
+    "quickRanges": [
+      {
+        "display": "Weekly (this ISO week, Mon-now)",
+        "from": "now/w",
+        "to": "now"
+      },
+      {
+        "display": "Monthly (this calendar month, 1st-now)",
+        "from": "now/M",
+        "to": "now"
+      }
+    ]
+  }
 }

--- a/charts/observability-dashboards/files/envoy-ai-gateway/chats-by-user.json
+++ b/charts/observability-dashboards/files/envoy-ai-gateway/chats-by-user.json
@@ -284,5 +284,19 @@
       "keepTime": true,
       "targetBlank": true
     }
-  ]
+  ],
+  "timepicker": {
+    "quickRanges": [
+      {
+        "display": "Weekly (this ISO week, Mon-now)",
+        "from": "now/w",
+        "to": "now"
+      },
+      {
+        "display": "Monthly (this calendar month, 1st-now)",
+        "from": "now/M",
+        "to": "now"
+      }
+    ]
+  }
 }

--- a/charts/observability-dashboards/files/envoy-ai-gateway/cost-by-model.json
+++ b/charts/observability-dashboards/files/envoy-ai-gateway/cost-by-model.json
@@ -471,5 +471,19 @@
       "keepTime": true,
       "targetBlank": true
     }
-  ]
+  ],
+  "timepicker": {
+    "quickRanges": [
+      {
+        "display": "Weekly (this ISO week, Mon-now)",
+        "from": "now/w",
+        "to": "now"
+      },
+      {
+        "display": "Monthly (this calendar month, 1st-now)",
+        "from": "now/M",
+        "to": "now"
+      }
+    ]
+  }
 }

--- a/charts/observability-dashboards/files/envoy-ai-gateway/jwt-tokens.json
+++ b/charts/observability-dashboards/files/envoy-ai-gateway/jwt-tokens.json
@@ -586,5 +586,19 @@
       "keepTime": true,
       "targetBlank": true
     }
-  ]
+  ],
+  "timepicker": {
+    "quickRanges": [
+      {
+        "display": "Weekly (this ISO week, Mon-now)",
+        "from": "now/w",
+        "to": "now"
+      },
+      {
+        "display": "Monthly (this calendar month, 1st-now)",
+        "from": "now/M",
+        "to": "now"
+      }
+    ]
+  }
 }

--- a/charts/observability-dashboards/files/envoy-ai-gateway/my-usage.json
+++ b/charts/observability-dashboards/files/envoy-ai-gateway/my-usage.json
@@ -707,5 +707,19 @@
       "keepTime": true,
       "targetBlank": true
     }
-  ]
+  ],
+  "timepicker": {
+    "quickRanges": [
+      {
+        "display": "Weekly (this ISO week, Mon-now)",
+        "from": "now/w",
+        "to": "now"
+      },
+      {
+        "display": "Monthly (this calendar month, 1st-now)",
+        "from": "now/M",
+        "to": "now"
+      }
+    ]
+  }
 }

--- a/charts/observability-dashboards/files/envoy-ai-gateway/per-user.json
+++ b/charts/observability-dashboards/files/envoy-ai-gateway/per-user.json
@@ -1410,5 +1410,19 @@
       "keepTime": true,
       "targetBlank": true
     }
-  ]
+  ],
+  "timepicker": {
+    "quickRanges": [
+      {
+        "display": "Weekly (this ISO week, Mon-now)",
+        "from": "now/w",
+        "to": "now"
+      },
+      {
+        "display": "Monthly (this calendar month, 1st-now)",
+        "from": "now/M",
+        "to": "now"
+      }
+    ]
+  }
 }

--- a/charts/observability-dashboards/files/envoy-ai-gateway/ratelimit-quota.json
+++ b/charts/observability-dashboards/files/envoy-ai-gateway/ratelimit-quota.json
@@ -23,6 +23,25 @@
       },
       {
         "type": "query",
+        "name": "billing_week",
+        "label": "Billing week (ISO, Monday-start)",
+        "skipUrlSync": false,
+        "query": "label_values(gateway_ratelimit_spend_micro_usd, billing_week)",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "mimir"
+        },
+        "multi": false,
+        "allowCustomValue": true,
+        "refresh": 2,
+        "sort": 2,
+        "includeAll": false,
+        "auto": false,
+        "auto_min": "10s",
+        "auto_count": 30
+      },
+      {
+        "type": "query",
         "name": "plan",
         "label": "Plan",
         "skipUrlSync": false,
@@ -84,7 +103,7 @@
   "annotations": {},
   "uid": "envoy-ai-gateway-ratelimit-quota",
   "title": "AI Gateway — rate-limit quota",
-  "description": "WHO is consuming the Envoy AI Gateway and HOW MUCH of their budget, read from the rate-limit service's LIVE counters in redis-ha (ADR-0070) — the only place that current-window state exists. Mimir panels rank spend per account/plan for the selected calendar billing period (prometheus-redis-exporter → gateway_ratelimit_spend_micro_usd, ÷1e6 → USD); the bottom table is a direct redis-datasource census (zero scrape-lag), with a Billing period column parsed straight from the raw key so you can see rotation state live, without waiting on a scrape. RAW consumption only — budget limits are static Helm config (ADR-0021/0035), not derivable per-user here. NO per-model breakdown: since the #532 shared-budget cutover the budget is one counter per (account, plan) spanning ALL models and both planes, so the keys carry no model label — see the Mimir/Loki cost dashboards for per-model spend. $billing_period (ai-helm ADR-0111) defaults to the current calendar month — the correct temporal filter, replacing the old 30-day-epoch `window` label. Filters: plan, account. GENERATED — source: tools/dashboards/envoy_ai_gateway/ratelimit_quota.py.",
+  "description": "WHO is consuming the Envoy AI Gateway and HOW MUCH of their budget, read from the rate-limit service's LIVE counters in redis-ha (ADR-0070) — the only place that current-window state exists. Two parallel Mimir leaderboards rank spend per account/plan — one for the selected calendar month ($billing_period, ADR-0111), one for the selected ISO week ($billing_week, Monday-start, ADR-0119) — from prometheus-redis-exporter's gateway_ratelimit_spend_micro_usd (÷1e6 → USD). The bottom table is a direct redis-datasource census — RAW, zero scrape-lag, every row (both monthly and weekly rules) with no period filter at all — with Billing period / Billing week columns parsed straight from the raw key so you can see rotation state live, without waiting on a scrape (a row has exactly one of the two, never both). RAW consumption only — budget limits are static Helm config + ai-helm-values (ADR-0021/0035/0119), not derivable per-user here. NO per-model breakdown: since the #532 shared-budget cutover the budget is one counter per (account, plan) spanning ALL models and both planes, so the keys carry no model label — see the Mimir/Loki cost dashboards for per-model spend. The weekly rule is ADDITIVE to the monthly one (composes via AND at enforcement time) — it never raises the monthly ceiling, only tightens pacing within a week; the two leaderboards below are independent VIEWS of that same relationship, not alternatives. Filters: plan, account. GENERATED — source: tools/dashboards/envoy_ai_gateway/ratelimit_quota.py.",
   "tags": [
     "ai-gateway",
     "rate-limit",
@@ -106,7 +125,7 @@
       "collapsed": false,
       "id": 0,
       "panels": [],
-      "title": "Live budget consumption — selected billing period",
+      "title": "Monthly budget consumption — selected calendar month",
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -129,7 +148,7 @@
           }
         }
       ],
-      "title": "Total spend — this period",
+      "title": "Total spend — this month",
       "transparent": false,
       "datasource": {
         "type": "prometheus",
@@ -374,7 +393,7 @@
           }
         }
       ],
-      "title": "Top accounts by spend — this period",
+      "title": "Top accounts by spend — this month",
       "transparent": false,
       "datasource": {
         "type": "prometheus",
@@ -443,7 +462,7 @@
           }
         }
       ],
-      "title": "Spend share by plan — this period",
+      "title": "Spend share by plan — this month",
       "transparent": false,
       "datasource": {
         "type": "prometheus",
@@ -493,7 +512,7 @@
           }
         }
       ],
-      "title": "Consumption by account x plan — this period",
+      "title": "Consumption by account x plan — this month",
       "transparent": false,
       "datasource": {
         "type": "prometheus",
@@ -571,12 +590,477 @@
       "collapsed": false,
       "id": 0,
       "panels": [],
-      "title": "Spend over time (gauge history)",
+      "title": "Weekly budget consumption — selected ISO week (additive to monthly, ADR-0119)",
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
         "y": 29
+      }
+    },
+    {
+      "type": "stat",
+      "targets": [
+        {
+          "expr": "((sum(gateway_ratelimit_spend_micro_usd{billing_week=~\"$billing_week\", plan=~\"$plan\", account_id=~\"$account\"})) / 1e6)",
+          "refId": "A",
+          "instant": true,
+          "range": false,
+          "format": "time_series",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "mimir"
+          }
+        }
+      ],
+      "title": "Total spend — this week",
+      "transparent": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "mimir"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 30
+      },
+      "repeatDirection": "h",
+      "options": {
+        "graphMode": "area",
+        "colorMode": "value",
+        "justifyMode": "auto",
+        "textMode": "auto",
+        "wideLayout": true,
+        "showPercentChange": false,
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "values": false,
+          "fields": ""
+        },
+        "percentChangeColorMode": "standard",
+        "orientation": "horizontal"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "currencyUSD",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "value": null,
+                "color": "orange"
+              }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "stat",
+      "targets": [
+        {
+          "expr": "count(count by (account_id) (gateway_ratelimit_spend_micro_usd{billing_week=~\"$billing_week\", plan=~\"$plan\", account_id=~\"$account\"}))",
+          "refId": "A",
+          "instant": true,
+          "range": false,
+          "format": "time_series",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "mimir"
+          }
+        }
+      ],
+      "title": "Active accounts",
+      "transparent": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "mimir"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 30
+      },
+      "repeatDirection": "h",
+      "options": {
+        "graphMode": "area",
+        "colorMode": "value",
+        "justifyMode": "auto",
+        "textMode": "auto",
+        "wideLayout": true,
+        "showPercentChange": false,
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "values": false,
+          "fields": ""
+        },
+        "percentChangeColorMode": "standard",
+        "orientation": "horizontal"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "value": null,
+                "color": "blue"
+              }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "stat",
+      "targets": [
+        {
+          "expr": "count(gateway_ratelimit_spend_micro_usd{billing_week=~\"$billing_week\", plan=~\"$plan\", account_id=~\"$account\"})",
+          "refId": "A",
+          "instant": true,
+          "range": false,
+          "format": "time_series",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "mimir"
+          }
+        }
+      ],
+      "title": "Tracked counters (account x plan)",
+      "transparent": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "mimir"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 12,
+        "y": 30
+      },
+      "repeatDirection": "h",
+      "options": {
+        "graphMode": "area",
+        "colorMode": "value",
+        "justifyMode": "auto",
+        "textMode": "auto",
+        "wideLayout": true,
+        "showPercentChange": false,
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "values": false,
+          "fields": ""
+        },
+        "percentChangeColorMode": "standard",
+        "orientation": "horizontal"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "value": null,
+                "color": "purple"
+              }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "stat",
+      "targets": [
+        {
+          "expr": "count(count by (plan) (gateway_ratelimit_spend_micro_usd{billing_week=~\"$billing_week\", plan=~\"$plan\", account_id=~\"$account\"}))",
+          "refId": "A",
+          "instant": true,
+          "range": false,
+          "format": "time_series",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "mimir"
+          }
+        }
+      ],
+      "title": "Plans in use",
+      "transparent": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "mimir"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 18,
+        "y": 30
+      },
+      "repeatDirection": "h",
+      "options": {
+        "graphMode": "area",
+        "colorMode": "value",
+        "justifyMode": "auto",
+        "textMode": "auto",
+        "wideLayout": true,
+        "showPercentChange": false,
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "values": false,
+          "fields": ""
+        },
+        "percentChangeColorMode": "standard",
+        "orientation": "horizontal"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "value": null,
+                "color": "green"
+              }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "bargauge",
+      "targets": [
+        {
+          "expr": "((topk(20, sum by (account_id) (gateway_ratelimit_spend_micro_usd{billing_week=~\"$billing_week\", plan=~\"$plan\", account_id=~\"$account\"}))) / 1e6)",
+          "refId": "A",
+          "instant": true,
+          "range": false,
+          "format": "time_series",
+          "legendFormat": "{{account_id}}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "mimir"
+          }
+        }
+      ],
+      "title": "Top accounts by spend — this week",
+      "transparent": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "mimir"
+      },
+      "gridPos": {
+        "h": 12,
+        "w": 12,
+        "x": 0,
+        "y": 34
+      },
+      "repeatDirection": "h",
+      "options": {
+        "displayMode": "basic",
+        "valueMode": "color",
+        "namePlacement": "auto",
+        "showUnfilled": true,
+        "sizing": "auto",
+        "minVizWidth": 8,
+        "minVizHeight": 16,
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false,
+          "calcs": []
+        },
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "values": false,
+          "fields": ""
+        },
+        "maxVizHeight": 300,
+        "orientation": "horizontal"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "currencyUSD",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "value": null,
+                "color": "orange"
+              }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "piechart",
+      "targets": [
+        {
+          "expr": "((sum by (plan) (gateway_ratelimit_spend_micro_usd{billing_week=~\"$billing_week\", plan=~\"$plan\", account_id=~\"$account\"})) / 1e6)",
+          "refId": "A",
+          "instant": true,
+          "range": false,
+          "format": "time_series",
+          "legendFormat": "{{plan}}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "mimir"
+          }
+        }
+      ],
+      "title": "Spend share by plan — this week",
+      "transparent": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "mimir"
+      },
+      "gridPos": {
+        "h": 12,
+        "w": 12,
+        "x": 12,
+        "y": 34
+      },
+      "repeatDirection": "h",
+      "options": {
+        "pieType": "donut",
+        "tooltip": {
+          "mode": "single",
+          "sort": "asc"
+        },
+        "reduceOptions": {
+          "calcs": []
+        },
+        "legend": {
+          "values": [
+            "value",
+            "percent"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": false,
+          "calcs": []
+        },
+        "orientation": "auto"
+      }
+    },
+    {
+      "type": "table",
+      "targets": [
+        {
+          "expr": "((sum by (account_id, plan) (gateway_ratelimit_spend_micro_usd{billing_week=~\"$billing_week\", plan=~\"$plan\", account_id=~\"$account\"})) / 1e6)",
+          "refId": "A",
+          "instant": true,
+          "range": false,
+          "format": "table",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "mimir"
+          }
+        }
+      ],
+      "title": "Consumption by account x plan — this week",
+      "transparent": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "mimir"
+      },
+      "gridPos": {
+        "h": 12,
+        "w": 24,
+        "x": 0,
+        "y": 46
+      },
+      "repeatDirection": "h",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "renameByName": {
+              "account_id": "Account",
+              "plan": "Plan",
+              "Value #A": "Spend ($)"
+            },
+            "excludeByName": {
+              "Time": true
+            },
+            "indexByName": {
+              "account_id": 0,
+              "plan": 1,
+              "Value #A": 2
+            }
+          }
+        },
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "field": "Spend ($)",
+                "desc": true
+              }
+            ]
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "auto",
+            "inspect": false,
+            "filterable": true
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Spend ($)"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "currencyUSD"
+              },
+              {
+                "id": "decimals",
+                "value": 4
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "type": "row",
+      "collapsed": false,
+      "id": 0,
+      "panels": [],
+      "title": "Spend over time (gauge history)",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 58
       }
     },
     {
@@ -596,7 +1080,7 @@
           "interval": "1d"
         }
       ],
-      "title": "Spend over time — top accounts",
+      "title": "Spend over time — top accounts (monthly)",
       "transparent": false,
       "datasource": {
         "type": "prometheus",
@@ -606,7 +1090,68 @@
         "h": 10,
         "w": 24,
         "x": 0,
-        "y": 30
+        "y": 59
+      },
+      "repeatDirection": "h",
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": false,
+          "calcs": [
+            "last",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "currencyUSD",
+          "custom": {
+            "drawStyle": "bars",
+            "lineWidth": 1.0,
+            "fillOpacity": 70.0,
+            "showPoints": "never",
+            "stacking": {
+              "mode": "normal"
+            }
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "((topk(10, sum by (account_id) (gateway_ratelimit_spend_micro_usd{billing_week=~\"$billing_week\", plan=~\"$plan\", account_id=~\"$account\"}))) / 1e6)",
+          "refId": "A",
+          "instant": false,
+          "range": true,
+          "format": "time_series",
+          "legendFormat": "{{account_id}}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "mimir"
+          },
+          "interval": "1d"
+        }
+      ],
+      "title": "Spend over time — top accounts (weekly)",
+      "transparent": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "mimir"
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 69
       },
       "repeatDirection": "h",
       "options": {
@@ -645,12 +1190,12 @@
       "collapsed": false,
       "id": 0,
       "panels": [],
-      "title": "Live limiter census — direct from Redis",
+      "title": "Live limiter census — direct from Redis (RAW, unfiltered, every row)",
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 40
+        "y": 79
       }
     },
     {
@@ -669,7 +1214,7 @@
           "size": 2000
         }
       ],
-      "title": "Live limiter counters — direct from Redis (zero scrape-lag)",
+      "title": "Live limiter counters — direct from Redis (zero scrape-lag, RAW/unfiltered)",
       "transparent": false,
       "datasource": {
         "type": "redis-datasource",
@@ -679,7 +1224,7 @@
         "h": 12,
         "w": 24,
         "x": 0,
-        "y": 41
+        "y": 80
       },
       "repeatDirection": "h",
       "transformations": [
@@ -688,7 +1233,7 @@
           "options": {
             "source": "key",
             "format": "regexp",
-            "regExp": "/^(?:.*\\/converse\\/(?<Model>[^/]+)\\/)?.*_rule-\\d+-match-0_(?<Account>.+?)_rule-\\d+-match-1(?:_rule-\\d+-match-1)?(?:_rule-\\d+-match-2_(?<BillingPeriod>\\d{4}-\\d{2}))?/",
+            "regExp": "/^(?:.*\\/converse\\/(?<Model>[^/]+)\\/)?.*_rule-\\d+-match-0_(?<Account>.+?)_rule-\\d+-match-1(?:_rule-\\d+-match-1)?(?:_rule-\\d+-match-2_(?:(?<BillingPeriod>\\d{4}-\\d{2})|(?<BillingWeek>\\d{4}-W\\d{2})))?/",
             "keepFields": true
           }
         },
@@ -697,7 +1242,8 @@
           "options": {
             "renameByName": {
               "key": "Redis key",
-              "BillingPeriod": "Billing period"
+              "BillingPeriod": "Billing period",
+              "BillingWeek": "Billing week"
             },
             "excludeByName": {
               "type": true,
@@ -709,7 +1255,8 @@
               "Account": 0,
               "Model": 1,
               "Billing period": 2,
-              "Redis key": 3
+              "Billing week": 3,
+              "Redis key": 4
             }
           }
         }
@@ -737,5 +1284,19 @@
       "keepTime": true,
       "targetBlank": true
     }
-  ]
+  ],
+  "timepicker": {
+    "quickRanges": [
+      {
+        "display": "Weekly (this ISO week, Mon-now)",
+        "from": "now/w",
+        "to": "now"
+      },
+      {
+        "display": "Monthly (this calendar month, 1st-now)",
+        "from": "now/M",
+        "to": "now"
+      }
+    ]
+  }
 }

--- a/charts/observability-dashboards/files/envoy-ai-gateway/scoreboard.json
+++ b/charts/observability-dashboards/files/envoy-ai-gateway/scoreboard.json
@@ -1010,5 +1010,19 @@
       "keepTime": true,
       "targetBlank": true
     }
-  ]
+  ],
+  "timepicker": {
+    "quickRanges": [
+      {
+        "display": "Weekly (this ISO week, Mon-now)",
+        "from": "now/w",
+        "to": "now"
+      },
+      {
+        "display": "Monthly (this calendar month, 1st-now)",
+        "from": "now/M",
+        "to": "now"
+      }
+    ]
+  }
 }

--- a/charts/observability-dashboards/files/envoy-ai-gateway/sessions-grants.json
+++ b/charts/observability-dashboards/files/envoy-ai-gateway/sessions-grants.json
@@ -659,5 +659,19 @@
       "keepTime": true,
       "targetBlank": true
     }
-  ]
+  ],
+  "timepicker": {
+    "quickRanges": [
+      {
+        "display": "Weekly (this ISO week, Mon-now)",
+        "from": "now/w",
+        "to": "now"
+      },
+      {
+        "display": "Monthly (this calendar month, 1st-now)",
+        "from": "now/M",
+        "to": "now"
+      }
+    ]
+  }
 }

--- a/charts/observability-dashboards/files/envoy-ai-gateway/user-directory.json
+++ b/charts/observability-dashboards/files/envoy-ai-gateway/user-directory.json
@@ -289,5 +289,19 @@
       "keepTime": true,
       "targetBlank": true
     }
-  ]
+  ],
+  "timepicker": {
+    "quickRanges": [
+      {
+        "display": "Weekly (this ISO week, Mon-now)",
+        "from": "now/w",
+        "to": "now"
+      },
+      {
+        "display": "Monthly (this calendar month, 1st-now)",
+        "from": "now/M",
+        "to": "now"
+      }
+    ]
+  }
 }

--- a/charts/observability-dashboards/files/envoy-ai-gateway/user-tokens-cost.json
+++ b/charts/observability-dashboards/files/envoy-ai-gateway/user-tokens-cost.json
@@ -723,5 +723,19 @@
       "keepTime": true,
       "targetBlank": true
     }
-  ]
+  ],
+  "timepicker": {
+    "quickRanges": [
+      {
+        "display": "Weekly (this ISO week, Mon-now)",
+        "from": "now/w",
+        "to": "now"
+      },
+      {
+        "display": "Monthly (this calendar month, 1st-now)",
+        "from": "now/M",
+        "to": "now"
+      }
+    ]
+  }
 }

--- a/docs/patterns/ratelimit-quota-observability.md
+++ b/docs/patterns/ratelimit-quota-observability.md
@@ -13,6 +13,16 @@
 > read that first for the full counter-key anatomy and its history). The key
 > shape below has been updated to match the current **shared** (gateway-wide,
 > not per-model) counter.
+>
+> ⚠️ It also predates the **additive weekly sub-budget**
+> ([ADR-0119](../adr/0119-weekly-sub-budget-anti-front-loading.md)) — the
+> dashboard now shows TWO parallel leaderboards (monthly + ISO-week,
+> Monday-start), plus a `billing_week` column on the raw Redis-census table
+> below. Same key shape, same rule-index-is-plan-identity contract, just a
+> second rule family (`rule-3/4/5` = enterprise/free/pro, weekly) appended
+> after the existing monthly ones (`rule-0/1/2`) — see
+> `shared-cross-model-budget.md`'s own "Weekly sub-budget" section for the
+> `x-billing-week` marker details.
 
 ## Why this exists
 
@@ -51,8 +61,8 @@ converse-gateway/core-gateway_converse-gateway/core-gateway/rule/<N>_...
 | Part | Meaning |
 |---|---|
 | `rule-<N>-match-0_<x-account-id>` | the Distinct `x-account-id` value — a Keycloak `sub` UUID, or a named service caller (`benie-joy`, `koufan-king`). `x-billing-plan`/`x-ai-eg-model` are fixed Exact matches → masked constants, so **plan is the rule index, not a value**. |
-| `rule-<N>` | the rule index → the plan. ⚠️ **The index is the ONLY carrier of plan identity** (the plan is an `Exact` match ⇒ masked to a constant), and it is **positional**, so renumbering a rule ORPHANS its counter rather than migrating it. `monthlyBudget.plans` is an **append-only ordered list** ([ADR-0084](../adr/0084-ratelimit-plan-order-is-append-only.md): today `rule-0` = enterprise, `rule-1` = free, `rule-2` = pro); read the current index↔plan mapping off the rendered comment (`# rule/1 · free …`), never off alphabetical order or a hardcoded index — it has renumbered before. |
-| `rule-<N>-match-2_<billing_period>` | the Distinct `x-billing-period` value — a calendar `YYYY-MM` string ([ADR-0111](../adr/0111-calendar-aligned-billing-period.md)), stamped on every request by a Lua `EnvoyExtensionPolicy`. Forces a **new** key at the real 1st-of-the-month, independent of where the `<window>` epoch below happens to land. |
+| `rule-<N>` | the rule index → the plan. ⚠️ **The index is the ONLY carrier of plan identity** (the plan is an `Exact` match ⇒ masked to a constant), and it is **positional**, so renumbering a rule ORPHANS its counter rather than migrating it. `monthlyBudget.plans` is an **append-only ordered list** ([ADR-0084](../adr/0084-ratelimit-plan-order-is-append-only.md): today `rule-0` = enterprise, `rule-1` = free, `rule-2` = pro, and since [ADR-0119](../adr/0119-weekly-sub-budget-anti-front-loading.md) `rule-3/4/5` = the same three plans' WEEKLY sub-budget, appended after — never interleaved with — the monthly rules); read the current index↔plan mapping off the rendered comment (`# rule/1 · free …`), never off alphabetical order or a hardcoded index — it has renumbered before. |
+| `rule-<N>-match-2_<billing_period>` | the Distinct `x-billing-period` value — a calendar `YYYY-MM` string ([ADR-0111](../adr/0111-calendar-aligned-billing-period.md)), stamped on every request by a Lua `EnvoyExtensionPolicy`. Forces a **new** key at the real 1st-of-the-month, independent of where the `<window>` epoch below happens to land. On a WEEKLY rule (`rule-3/4/5`) this same match-2 position instead carries an ISO `GGGG-Www` string (`x-billing-week`, ADR-0119) — a row has exactly one of `billing_period`/`billing_week`, never both. |
 | trailing `<window>` | the legacy 30-day budget bucket start (Unix epoch, a multiple of **2592000** = Lyft's MONTH unit). A pure function of wall-clock time, so it drifts off the calendar by ~5 days/year — `billing_period` above is what actually fixes that. Value = micro-USD spent this window. The previous bucket lingers until TTL. |
 
 Burst (per-minute) keys used to exist alongside these but churned every minute

--- a/tools/dashboards/src/dashboards/_common.py
+++ b/tools/dashboards/src/dashboards/_common.py
@@ -120,6 +120,16 @@ RL_LABEL_WINDOW = "window"
 # aligned-billing-period.md.
 RL_LABEL_BILLING_PERIOD = "billing_period"
 
+# The ISO-8601, Monday-start "GGGG-Www" marker (ai-helm ADR-0119) stamped as
+# `x-billing-week` on the additive weekly sub-budget rules. Only ever set on
+# rows from those rules (the exporter's regex is anchored on the `-W` shape,
+# which a billing_period value never has, and vice versa) — a monthly row's
+# billing_week is always empty and a weekly row's billing_period is always
+# empty, which is what lets a single `billing_week=~"<value>"` selector
+# exclude every monthly row with no separate period-type label needed. See
+# docs/adr/0119-weekly-sub-budget-anti-front-loading.md.
+RL_LABEL_BILLING_WEEK = "billing_week"
+
 
 # ---------------------------------------------------------------------------
 # Phase-3 "gamified scoreboard" knobs (ADR-0060).

--- a/tools/dashboards/src/dashboards/_period_filter.py
+++ b/tools/dashboards/src/dashboards/_period_filter.py
@@ -1,0 +1,64 @@
+"""Weekly / monthly / raw time-picker quick-ranges for the cost dashboards."""
+
+from __future__ import annotations
+
+# Every dashboard in this set reads spend/usage data that's meaningful bucketed
+# by ISO week (Monday-start) or calendar month, matching the gateway's own
+# rate-limit budget windows (ai-helm ADR-0111/0119). Injecting quick-range
+# shortcuts into the time picker gives a uniform "Weekly / Monthly / raw"
+# 3-way filter across all of them with NO panel-query changes: every panel
+# already scopes its PromQL/LogQL to the dashboard's own time range
+# ($__range), so snapping that range via the picker is enough.
+#
+# Deliberately excludes `chat_overview` (a Tempo trace-feed / chat-quality
+# board, not a cost/usage one) and the GPU/engine/platform dashboards (no
+# cost or billing dimension at all).
+PERIOD_FILTER_MODULES: frozenset[str] = frozenset(
+    {
+        "dashboards.envoy_ai_gateway.per_user",
+        "dashboards.envoy_ai_gateway.cost_by_model",
+        "dashboards.envoy_ai_gateway.actor_consumption",
+        "dashboards.envoy_ai_gateway.user_tokens_cost",
+        "dashboards.envoy_ai_gateway.user_directory",
+        "dashboards.envoy_ai_gateway.sessions_grants",
+        "dashboards.envoy_ai_gateway.jwt_tokens",
+        "dashboards.envoy_ai_gateway.scoreboard",
+        "dashboards.envoy_ai_gateway.ratelimit_quota",
+        "dashboards.envoy_ai_gateway.my_usage",
+        "dashboards.envoy_ai_gateway.chats_by_user",
+    }
+)
+
+# `{display, from, to}` — Grafana's dashboard-level time-picker quick-ranges
+# (added ~Grafana 10.3, confirmed present in the in-cluster 12.x). The
+# grafana-foundation-sdk's typed `TimePicker` model (schema v39) exposes only
+# the older `time_options` (relative-duration strings like "7d") and has no
+# field for this newer, richer `{display, from, to}` shape — same class of gap
+# as `SCHEMA_VERSION` (no fluent setter), so it's injected as a raw dict in
+# `main.py::_emit`, the same single choke point `_report.py` uses.
+#
+# `now/w` / `now/M` round DOWN to the start of the current ISO week/month —
+# Grafana's week-start default is Monday, matching the gateway's own
+# Monday-start ISO week (ADR-0119). If that default is ever overridden in
+# Grafana's org preferences, these two stop agreeing — verify live if the
+# "Weekly" quick-range ever looks like it starts on the wrong day.
+# `to: "now"` (not `now/w` / `now/M`) deliberately gives a week/month-TO-DATE
+# view, not the full (partly-future) calendar period.
+_QUICK_RANGES: list[dict[str, str]] = [
+    {"display": "Weekly (this ISO week, Mon-now)", "from": "now/w", "to": "now"},
+    {"display": "Monthly (this calendar month, 1st-now)", "from": "now/M", "to": "now"},
+]
+
+
+def inject_period_quick_ranges(dashboard: dict, module_name: str) -> None:
+    """Add the Weekly/Monthly time-picker shortcuts to an in-scope dashboard.
+
+    "Raw" needs no entry of its own — it's simply the picker's existing
+    default relative-range options (7d/30d/custom/...), left untouched.
+    No-op for any dashboard not in `PERIOD_FILTER_MODULES`.
+    """
+    if module_name not in PERIOD_FILTER_MODULES:
+        return
+    timepicker = dashboard.get("timepicker") or {}
+    timepicker["quickRanges"] = list(_QUICK_RANGES)
+    dashboard["timepicker"] = timepicker

--- a/tools/dashboards/src/dashboards/_report.py
+++ b/tools/dashboards/src/dashboards/_report.py
@@ -21,7 +21,7 @@ def inject_report_link(dashboard: dict) -> None:
         return
     url = f"{REPORT_PLUGIN_PATH}?dashUid={uid}"
     links = dashboard.get("links") or []
-    if any(isinstance(l, dict) and l.get("url") == url for l in links):
+    if any(isinstance(link, dict) and link.get("url") == url for link in links):
         return
     links.append(
         {

--- a/tools/dashboards/src/dashboards/envoy_ai_gateway/ratelimit_quota.py
+++ b/tools/dashboards/src/dashboards/envoy_ai_gateway/ratelimit_quota.py
@@ -5,34 +5,40 @@ from the rate-limit service's LIVE counters in redis-ha — the only place that
 state exists (Mimir/Loki hold historical cost, not the limiter's current-window
 budget; ADR-0070). Two read paths over the SAME Redis keys:
 
-  1. Mimir leaderboard (the numbers). prometheus-redis-exporter SCANs the
-     monthly-budget keys and exports `gateway_ratelimit_spend_micro_usd` with
-     parsed account_id / plan / plane / window / billing_period labels. These
-     panels rank spend per account and per plan for the selected calendar
-     billing period.
-  2. Redis census (the live "who's active right now"). A `redis-datasource`
-     tmscan straight against redis-ha — zero scrape-lag, the limiter's own view.
-     Also shows a "Billing period" column parsed straight from the raw key, so
-     you can see which accounts have already rotated to the new calendar-aligned
-     key vs. which are still on their old 30-day-epoch one, live, without
-     waiting on the exporter's scrape.
+  1. Mimir leaderboards (the numbers). prometheus-redis-exporter SCANs the
+     monthly AND weekly budget keys (ADR-0021/0119) and exports
+     `gateway_ratelimit_spend_micro_usd` with parsed account_id / plan / plane /
+     window / billing_period / billing_week labels. Two parallel panel sets rank
+     spend per account and per plan — one for the selected calendar month, one
+     for the selected ISO week — composing the SAME way the underlying rate
+     limit rules do (ADR-0119: weekly is additive to monthly, never a
+     replacement).
+  2. Redis census (the live "who's active right now", i.e. RAW/unfiltered —
+     every row, both monthly and weekly rules, no period selection at all). A
+     `redis-datasource` tmscan straight against redis-ha — zero scrape-lag, the
+     limiter's own view. Shows "Billing period" and "Billing week" columns
+     parsed straight from the raw key (a row has exactly one of the two, never
+     both), so you can see which accounts have rotated to the calendar-aligned
+     keys, live, without waiting on the exporter's scrape.
 
 RAW consumption only (no quota/% overlay): the budget LIMITS live in static Helm
-config (free $50/mo, pro $200, per-model overrides — charts/ai-models) and a
-user's plan isn't on the key, so a precise "% of quota" can't be derived here.
-The value shown is micro-USD spent this billing period (÷1e6 → USD).
+config + ai-helm-values (free/pro/enterprise, per ADR-0021/0119) and a user's
+plan isn't on the key, so a precise "% of quota" can't be derived here. The
+value shown is micro-USD spent in the selected period (÷1e6 → USD).
 
-`billing_period` is the calendar "YYYY-MM" marker (ai-helm ADR-0111) and is the
-primary temporal filter — it rotates on the real 1st-of-the-month, unlike the
-legacy `window` label (a fixed 30-day Unix-epoch bucket that drifts off the
-calendar and is no longer surfaced here). The $billing_period picker defaults
-to the newest (current) month; pick an older one to see a past period.
+`billing_period` (calendar "YYYY-MM", ADR-0111) and `billing_week` (ISO
+"GGGG-Www", Monday-start, ADR-0119) are the primary temporal filters — they
+rotate on the real 1st-of-the-month / Monday respectively, unlike the legacy
+`window` label (a fixed 30-day Unix-epoch bucket that drifts off the calendar
+and is no longer surfaced here). Each picker defaults to the newest (current)
+period; pick an older one to see a past period. The Redis census table below
+both is the "raw" view — no period picker, every row at once.
 
 The JSON file is regenerated from this module — do **not** hand-edit it::
 
     uv run dashboards build
 
-ADR: docs/adr/0070-ratelimit-quota-observability.md (+ ADR-0008, ADR-0111).
+ADR: docs/adr/0070-ratelimit-quota-observability.md (+ ADR-0008, ADR-0111, ADR-0119).
 """
 
 from __future__ import annotations
@@ -50,6 +56,7 @@ from dashboards._common import (
     REDIS_RATELIMIT_UID,
     RL_LABEL_ACCOUNT,
     RL_LABEL_BILLING_PERIOD,
+    RL_LABEL_BILLING_WEEK,
     RL_LABEL_PLAN,
 )
 from dashboards.envoy_ai_gateway import _shared as sh
@@ -60,6 +67,7 @@ _M = METRIC_RATELIMIT_SPEND_MICRO_USD
 _A = RL_LABEL_ACCOUNT
 _PL = RL_LABEL_PLAN
 _BP = RL_LABEL_BILLING_PERIOD
+_BW = RL_LABEL_BILLING_WEEK
 
 # ⚠️ NO `model` / `plane` dimension here, by design. Since the #532 shared-budget
 # cutover the monthly budget is ONE counter per (account, plan) on the gateway-wide
@@ -69,15 +77,29 @@ _BP = RL_LABEL_BILLING_PERIOD
 # a `$model` variable here would blank the whole board, not just its own panels.
 # Per-model spend still lives in the Mimir/Loki cost dashboards (ADR-0058/0046).
 #
-# All filters refine the same metric. $billing_period is single-select (default
-# newest) so totals are for ONE calendar month; the rest are multi (default All →
-# .+). The legacy `window` label still exists on the metric (kept by the exporter
-# for the lingering pre-rollover bucket) but is deliberately NOT selected on here
-# — it's a vestigial 30-day epoch artifact, not something a user should filter by
-# directly; summing across it within one billing_period gives the correct total
-# even if the underlying window happened to roll over mid-month.
-_SEL = f'{{{_BP}=~"$billing_period", {_PL}=~"$plan", {_A}=~"$account"}}'
-_MSEL = f"{_M}{_SEL}"
+# All filters refine the same metric. $billing_period / $billing_week are each
+# single-select (default newest) so totals are for ONE period; the rest are
+# multi (default All → .+). The legacy `window` label still exists on the
+# metric (kept by the exporter for the lingering pre-rollover bucket) but is
+# deliberately NOT selected on here — it's a vestigial 30-day epoch artifact,
+# not something a user should filter by directly; summing across it within one
+# billing_period/billing_week gives the correct total even if the underlying
+# window happened to roll over mid-period.
+#
+# Monthly and weekly are TWO SEPARATE selectors, not one toggle. A monthly row
+# has billing_week empty and a weekly row has billing_period empty (the
+# exporter's regexes are anchored so the two value shapes never collide — see
+# `prometheus-redis-exporter.yaml` in ai-helm-values), so `billing_week=~"X"`
+# already excludes every monthly row on its own — no extra period-type label
+# needed. Deliberately NOT one PromQL selector switched by a "mode" variable:
+# that would need $billing_week's value substituted INTO another variable's
+# raw value (nested variable interpolation), which is not a verified-reliable
+# Grafana behaviour here — two parallel, always-valid selectors are simpler
+# and can't silently break if that assumption were ever wrong.
+_MONTHLY_SEL = f'{{{_BP}=~"$billing_period", {_PL}=~"$plan", {_A}=~"$account"}}'
+_WEEKLY_SEL = f'{{{_BW}=~"$billing_week", {_PL}=~"$plan", {_A}=~"$account"}}'
+_MSEL = f"{_M}{_MONTHLY_SEL}"
+_WSEL = f"{_M}{_WEEKLY_SEL}"
 
 _LEGEND_ACCOUNT = "{{" + _A + "}}"
 _LEGEND_PLAN = "{{" + _PL + "}}"
@@ -110,79 +132,84 @@ class _RedisTmscanTarget:
         return self._d
 
 
-# ── Mimir leaderboard (the numbers) ────────────────────────────────────────────
-def _panel_total_spend() -> object:
+# ── Mimir leaderboards (the numbers) ───────────────────────────────────────────
+# Every panel below is parametrized by `msel` (the FULL metric+selector string —
+# either `_MSEL` or `_WSEL`) and `period` (a title suffix), so the SAME panel
+# shapes render twice: once for the selected calendar month, once for the
+# selected ISO week. `_period_section()` assembles one full row set at a given
+# grid `y` and returns where the NEXT section should start.
+def _panel_total_spend(*, period: str, msel: str, grid: tuple[int, int, int, int]) -> object:
     return sh.stat_panel(
-        title="Total spend — this period",
-        expr=sh.usd(f"sum({_MSEL})"),
+        title=f"Total spend — {period}",
+        expr=sh.usd(f"sum({msel})"),
         unit="currencyUSD",
         color="orange",
-        grid=(4, 6, 0, 1),
+        grid=grid,
     )
 
 
-def _panel_active_accounts() -> object:
+def _panel_active_accounts(*, msel: str, grid: tuple[int, int, int, int]) -> object:
     return sh.stat_panel(
         title="Active accounts",
-        expr=f"count(count by ({_A}) ({_MSEL}))",
+        expr=f"count(count by ({_A}) ({msel}))",
         unit="short",
         color="blue",
-        grid=(4, 6, 6, 1),
+        grid=grid,
     )
 
 
-def _panel_counters() -> object:
+def _panel_counters(*, msel: str, grid: tuple[int, int, int, int]) -> object:
     return sh.stat_panel(
         title="Tracked counters (account x plan)",
-        expr=f"count({_MSEL})",
+        expr=f"count({msel})",
         unit="short",
         color="purple",
-        grid=(4, 6, 12, 1),
+        grid=grid,
     )
 
 
-def _panel_plans() -> object:
+def _panel_plans(*, msel: str, grid: tuple[int, int, int, int]) -> object:
     # Was "Models in use" before the shared-budget cutover removed the model
     # dimension from the budget counters. Same grid slot, plan-keyed.
     return sh.stat_panel(
         title="Plans in use",
-        expr=f"count(count by ({_PL}) ({_MSEL}))",
+        expr=f"count(count by ({_PL}) ({msel}))",
         unit="short",
         color="green",
-        grid=(4, 6, 18, 1),
+        grid=grid,
     )
 
 
-def _panel_top_accounts() -> object:
+def _panel_top_accounts(*, period: str, msel: str, grid: tuple[int, int, int, int]) -> object:
     return sh.bargauge_panel(
-        title="Top accounts by spend — this period",
-        expr=sh.usd(f"topk(20, sum by ({_A}) ({_MSEL}))"),
+        title=f"Top accounts by spend — {period}",
+        expr=sh.usd(f"topk(20, sum by ({_A}) ({msel}))"),
         legend=_LEGEND_ACCOUNT,
         unit="currencyUSD",
         color="orange",
-        grid=(12, 12, 0, 5),
+        grid=grid,
     )
 
 
-def _panel_spend_by_plan() -> object:
+def _panel_spend_by_plan(*, period: str, msel: str, grid: tuple[int, int, int, int]) -> object:
     # Was "Spend share by model". Same grid slot; billing tier is the dimension
     # the shared budget actually has.
     return sh.pie_panel(
-        title="Spend share by plan — this period",
-        expr=sh.usd(f"sum by ({_PL}) ({_MSEL})"),
+        title=f"Spend share by plan — {period}",
+        expr=sh.usd(f"sum by ({_PL}) ({msel})"),
         legend_label=_LEGEND_PLAN,
-        grid=(12, 12, 12, 5),
+        grid=grid,
     )
 
 
-def _panel_breakdown_table() -> table.Panel:
+def _panel_breakdown_table(*, period: str, msel: str, y: int) -> table.Panel:
     # One row per account x plan, instant → table, ranked by spend.
-    expr = sh.usd(f"sum by ({_A}, {_PL}) ({_MSEL})")
+    expr = sh.usd(f"sum by ({_A}, {_PL}) ({msel})")
     panel = (
         table.Panel()
-        .title("Consumption by account x plan — this period")
+        .title(f"Consumption by account x plan — {period}")
         .datasource(sh.MIMIR_DS)
-        .grid_pos(dm.GridPos(h=12, w=24, x=0, y=17))
+        .grid_pos(dm.GridPos(h=12, w=24, x=0, y=y))
         .filterable(True)
         .with_target(sh.prom_target(expr, ref_id="A", instant=True, fmt="table"))
         .with_transformation(
@@ -219,21 +246,45 @@ def _panel_breakdown_table() -> table.Panel:
     )
 
 
-def _panel_spend_over_time() -> object:
-    # The gauge over time — accumulation within the billing period, per top account.
-    expr = sh.usd(f"topk(10, sum by ({_A}) ({_MSEL}))")
+def _panel_spend_over_time(*, period: str, msel: str, y: int) -> object:
+    # The gauge over time — accumulation within the period, per top account.
+    expr = sh.usd(f"topk(10, sum by ({_A}) ({msel}))")
     return sh.daily_bars_panel(
-        title="Spend over time — top accounts",
+        title=f"Spend over time — top accounts ({period})",
         expr=expr,
         legend=_LEGEND_ACCOUNT,
         unit="currencyUSD",
-        grid=(10, 24, 0, 30),
+        grid=(10, 24, 0, y),
         legend_calcs=["last", "max"],
     )
 
 
-# ── Redis census (the live "who's active now") ─────────────────────────────────
-def _panel_live_census() -> table.Panel:
+def _period_section(*, row_title: str, period: str, msel: str, y0: int) -> tuple[list[object], int]:
+    """Row + 4 stats + top-accounts/spend-by-plan + breakdown table, for ONE
+    period (monthly or weekly). Returns (panels, next_free_y)."""
+    y = y0
+    panels: list[object] = [sh.row(row_title, y=y)]
+    y += 1
+    stat_y = y
+    panels += [
+        _panel_total_spend(period=period, msel=msel, grid=(4, 6, 0, stat_y)),
+        _panel_active_accounts(msel=msel, grid=(4, 6, 6, stat_y)),
+        _panel_counters(msel=msel, grid=(4, 6, 12, stat_y)),
+        _panel_plans(msel=msel, grid=(4, 6, 18, stat_y)),
+    ]
+    y += 4
+    panels += [
+        _panel_top_accounts(period=period, msel=msel, grid=(12, 12, 0, y)),
+        _panel_spend_by_plan(period=period, msel=msel, grid=(12, 12, 12, y)),
+    ]
+    y += 12
+    panels.append(_panel_breakdown_table(period=period, msel=msel, y=y))
+    y += 12
+    return panels, y
+
+
+# ── Redis census (the live "who's active now", RAW — every row, no period filter) ─
+def _panel_live_census(*, y: int) -> table.Panel:
     # Direct redis-datasource tmscan of the per-account counter keys (any
     # *-match-0* = an x-account-id-keyed budget/burst counter). Zero scrape-lag,
     # the limiter's own current view. extractFields carves Account + Model out of
@@ -279,11 +330,18 @@ def _panel_live_census() -> table.Panel:
     #      (The trailing `/` before `stringToJsRegex`'s own non-greedy `.*?`
     #      still finds the TRUE closing delimiter correctly across our
     #      pattern's internal `/`s — verified live, not just reasoned about.)
+    #
+    # ADR-0119: the match-2 group now tries TWO alternative named captures —
+    # BillingPeriod (`\d{4}-\d{2}`, monthly) or BillingWeek (`\d{4}-W\d{2}`,
+    # weekly) — since a row is one or the other, never both. JS regex allows
+    # differently-named groups in each alternation branch; whichever doesn't
+    # match a given row is simply `undefined` → renders empty, same as the
+    # existing "legacy key, no match-2 at all" case already handles.
     return (
         table.Panel()
-        .title("Live limiter counters — direct from Redis (zero scrape-lag)")
+        .title("Live limiter counters — direct from Redis (zero scrape-lag, RAW/unfiltered)")
         .datasource(_REDIS_DS)
-        .grid_pos(dm.GridPos(h=12, w=24, x=0, y=41))
+        .grid_pos(dm.GridPos(h=12, w=24, x=0, y=y))
         .filterable(True)
         .with_target(_RedisTmscanTarget(ref_id="A", match="*-match-0*"))
         .with_transformation(
@@ -296,7 +354,8 @@ def _panel_live_census() -> table.Panel:
                         r"/^(?:.*\/converse\/(?<Model>[^/]+)\/)?"
                         r".*_rule-\d+-match-0_(?<Account>.+?)_rule-\d+-match-1"
                         r"(?:_rule-\d+-match-1)?"
-                        r"(?:_rule-\d+-match-2_(?<BillingPeriod>\d{4}-\d{2}))?/"
+                        r"(?:_rule-\d+-match-2_"
+                        r"(?:(?<BillingPeriod>\d{4}-\d{2})|(?<BillingWeek>\d{4}-W\d{2})))?/"
                     ),
                     "keepFields": True,
                 },
@@ -306,13 +365,18 @@ def _panel_live_census() -> table.Panel:
             dm.DataTransformerConfig(
                 id_val="organize",
                 options={
-                    "renameByName": {"key": "Redis key", "BillingPeriod": "Billing period"},
+                    "renameByName": {
+                        "key": "Redis key",
+                        "BillingPeriod": "Billing period",
+                        "BillingWeek": "Billing week",
+                    },
                     "excludeByName": {"type": True, "memory": True, "cursor": True, "count": True},
                     "indexByName": {
                         "Account": 0,
                         "Model": 1,
                         "Billing period": 2,
-                        "Redis key": 3,
+                        "Billing week": 3,
+                        "Redis key": 4,
                     },
                 },
             )
@@ -323,18 +387,24 @@ def _panel_live_census() -> table.Panel:
 _DESCRIPTION = (
     "WHO is consuming the Envoy AI Gateway and HOW MUCH of their budget, read from "
     "the rate-limit service's LIVE counters in redis-ha (ADR-0070) — the only place "
-    "that current-window state exists. Mimir panels rank spend per account/plan "
-    "for the selected calendar billing period (prometheus-redis-exporter → "
-    "gateway_ratelimit_spend_micro_usd, ÷1e6 → USD); the bottom table is a direct "
-    "redis-datasource census (zero scrape-lag), with a Billing period column "
-    "parsed straight from the raw key so you can see rotation state live, "
-    "without waiting on a scrape. RAW consumption only — budget "
-    "limits are static Helm config (ADR-0021/0035), not derivable per-user here. "
+    "that current-window state exists. Two parallel Mimir leaderboards rank spend "
+    "per account/plan — one for the selected calendar month ($billing_period, "
+    "ADR-0111), one for the selected ISO week ($billing_week, Monday-start, "
+    "ADR-0119) — from prometheus-redis-exporter's gateway_ratelimit_spend_micro_usd "
+    "(÷1e6 → USD). The bottom table is a direct redis-datasource census — RAW, "
+    "zero scrape-lag, every row (both monthly and weekly rules) with no period "
+    "filter at all — with Billing period / Billing week columns parsed straight "
+    "from the raw key so you can see rotation state live, without waiting on a "
+    "scrape (a row has exactly one of the two, never both). RAW consumption "
+    "only — budget limits are static Helm config + ai-helm-values "
+    "(ADR-0021/0035/0119), not derivable per-user here. "
     "NO per-model breakdown: since the #532 shared-budget cutover the budget is one "
     "counter per (account, plan) spanning ALL models and both planes, so the keys "
     "carry no model label — see the Mimir/Loki cost dashboards for per-model spend. "
-    "$billing_period (ai-helm ADR-0111) defaults to the current calendar month — "
-    "the correct temporal filter, replacing the old 30-day-epoch `window` label. "
+    "The weekly rule is ADDITIVE to the monthly one (composes via AND at "
+    "enforcement time) — it never raises the monthly ceiling, only tightens "
+    "pacing within a week; the two leaderboards below are independent VIEWS of "
+    "that same relationship, not alternatives. "
     "Filters: plan, account. "
     "GENERATED — source: tools/dashboards/envoy_ai_gateway/ratelimit_quota.py."
 )
@@ -357,8 +427,39 @@ def _billing_period_var() -> db.QueryVariable:
     )
 
 
-def _dashboard() -> db.Dashboard:
+def _billing_week_var() -> db.QueryVariable:
+    # ADR-0119. Same shape/reasoning as _billing_period_var(): single-select,
+    # newest-first. "GGGG-Www" (ISO week-numbering year + zero-padded week
+    # number) sorts lexicographically newest-first exactly like "YYYY-MM" does.
     return (
+        db.QueryVariable("billing_week")
+        .label("Billing week (ISO, Monday-start)")
+        .datasource(sh.MIMIR_DS)
+        .query(sh.label_values(_M, _BW))
+        .refresh(dm.VariableRefresh.ON_TIME_RANGE_CHANGED)
+        .sort(dm.VariableSort.ALPHABETICAL_DESC)
+        .multi(False)
+        .include_all(False)
+    )
+
+
+def _dashboard() -> db.Dashboard:
+    monthly_panels, y = _period_section(
+        row_title="Monthly budget consumption — selected calendar month",
+        period="this month",
+        msel=_MSEL,
+        y0=0,
+    )
+    weekly_panels, y = _period_section(
+        row_title="Weekly budget consumption — selected ISO week (additive to monthly, ADR-0119)",
+        period="this week",
+        msel=_WSEL,
+        y0=y,
+    )
+    over_time_y = y + 1
+    census_y = over_time_y + 10 + 10 + 1
+
+    d = (
         db.Dashboard("AI Gateway — rate-limit quota")
         .uid("envoy-ai-gateway-ratelimit-quota")
         .tags(["ai-gateway", "rate-limit", "quota", "redis"])
@@ -369,25 +470,31 @@ def _dashboard() -> db.Dashboard:
         .refresh("1m")
         .time("now-30d", "now")
         .with_variable(_billing_period_var())
+        .with_variable(_billing_week_var())
         .with_variable(sh.multi_var(name="plan", label="Plan", definition=sh.label_values(_M, _PL)))
         # NB: no `$model` variable — the shared-budget counters carry no `model`
         # label, and the multi-var default `.+` would match nothing at all.
         .with_variable(
             sh.multi_var(name="account", label="Account", definition=sh.label_values(_M, _A))
         )
-        .with_panel(sh.row("Live budget consumption — selected billing period", y=0))
-        .with_panel(_panel_total_spend())
-        .with_panel(_panel_active_accounts())
-        .with_panel(_panel_counters())
-        .with_panel(_panel_plans())
-        .with_panel(_panel_top_accounts())
-        .with_panel(_panel_spend_by_plan())
-        .with_panel(_panel_breakdown_table())
-        .with_panel(sh.row("Spend over time (gauge history)", y=29))
-        .with_panel(_panel_spend_over_time())
-        .with_panel(sh.row("Live limiter census — direct from Redis", y=40))
-        .with_panel(_panel_live_census())
     )
+    for p in monthly_panels:
+        d = d.with_panel(p)
+    for p in weekly_panels:
+        d = d.with_panel(p)
+    d = (
+        d.with_panel(sh.row("Spend over time (gauge history)", y=y))
+        .with_panel(_panel_spend_over_time(period="monthly", msel=_MSEL, y=over_time_y))
+        .with_panel(_panel_spend_over_time(period="weekly", msel=_WSEL, y=over_time_y + 10))
+        .with_panel(
+            sh.row(
+                "Live limiter census — direct from Redis (RAW, unfiltered, every row)",
+                y=census_y - 1,
+            )
+        )
+        .with_panel(_panel_live_census(y=census_y))
+    )
+    return d
 
 
 def build() -> dict:

--- a/tools/dashboards/src/dashboards/main.py
+++ b/tools/dashboards/src/dashboards/main.py
@@ -25,6 +25,7 @@ from pathlib import Path
 from types import ModuleType
 
 from dashboards._common import SCHEMA_VERSION
+from dashboards._period_filter import inject_period_quick_ranges
 from dashboards._report import inject_report_link
 
 # Registry of every generated dashboard. Import-by-string so Python's
@@ -79,6 +80,7 @@ def _emit(mod: ModuleType, target_dir: Path) -> Path:
     # default. See `_common.SCHEMA_VERSION`.
     dashboard["schemaVersion"] = SCHEMA_VERSION
     inject_report_link(dashboard)
+    inject_period_quick_ranges(dashboard, mod.__name__)
     out_path = target_dir / mod.OUTPUT_PATH  # type: ignore[attr-defined]
     out_path.parent.mkdir(parents=True, exist_ok=True)
     out_path.write_text(


### PR DESCRIPTION
## 1. Summary

This PR changes:

- Adds "Weekly" (this ISO week, Monday-start) and "Monthly" (this calendar month) time-picker quick-ranges to 11 cost/usage dashboards under `tools/dashboards/src/dashboards/envoy_ai_gateway/` — "Raw" is simply the picker's existing default options, unchanged.
- Rebuilds the rate-limit quota dashboard with a real `$billing_week` label-based picker (alongside the existing `$billing_period`), a parallel "Weekly budget consumption" panel row, and a "Billing week" column on the raw Redis-census table.
- Regenerates the affected dashboard JSON + doc updates.

It solves:

- The maintainer asked for weekly/monthly/raw filters across the cost dashboards, extending the observability side of the additive weekly sub-budget shipped in [ADR-0119](docs/adr/0119-weekly-sub-budget-anti-front-loading.md) (already merged, [#909](https://github.com/ADORSYS-GIS/ai-helm/pull/909)).

Companion PR (no merge-order dependency, but needed for the weekly panels to show real data): [ADORSYS-GIS/ai-helm-values#187](https://github.com/ADORSYS-GIS/ai-helm-values/pull/187).

---

## 2. Intent

> Source of truth: this session's design discussion, resolved via two scoping questions with the maintainer — (1) mechanism: a label-based picker for the rate-limit quota dashboard (its data is a Redis GAUGE keyed by discrete period markers, so no other option works) vs. time-range quick-presets for the other dashboards (their data is continuous Mimir counters already scoped to $__range, so no new metric labels or Mimir cardinality cost needed); (2) scope: the ~10 cost/usage dashboards under envoy_ai_gateway/, not GPU/engine/platform dashboards with no billing dimension, and not chat_overview.py (a Tempo trace-feed board, not a cost one).

---

## 3. Scope

### In Scope

- `_period_filter.py` (new) + `main.py` wiring — time-picker quick-ranges for 11 dashboards.
- `ratelimit_quota.py` — `$billing_week` variable, parallel weekly panel row, extended Redis-census regex.
- `_common.py` — new `RL_LABEL_BILLING_WEEK` constant.
- Regenerated dashboard JSON (`charts/observability-dashboards/files/envoy-ai-gateway/*.json`).
- `docs/patterns/ratelimit-quota-observability.md` pointers to the new mechanism.

### Out of Scope

- `chat_overview.py` and the GPU/llamacpp/vllm/platform dashboards — no cost/billing dimension, explicitly excluded per the scoping discussion.
- Mimir-side cardinality changes (e.g. adding `billing_period`/`billing_week` as labels on the precomputed usage counters) — deliberately rejected; would permanently multiply series count ~12x-52x on metrics already flagged in ADR-0005 as "safe up to a few thousand." Time-range quick-presets achieve the identical UX at zero cardinality cost.
- A single dropdown-driven "period mode" toggle on the rate-limit quota dashboard — considered, rejected as relying on unverified nested-variable-interpolation behavior in Grafana; two parallel, always-valid selectors are more robust.

---

## 4. Verification

I verified this change by:

- [x] Running automated tests (`uv run dashboards build`/`check`, `ruff format`/`check`, `helm lint --strict`, `helm template --dry-run` — matches this repo's CI)
- [x] Running manual tests
- [ ] Checking logs
- [ ] Checking metrics
- [ ] Testing error cases
- [ ] Testing permissions/security behavior
- [x] Testing rollback or failure behavior, if relevant

Commands run:

```bash
cd tools/dashboards
uv run dashboards build
uv run dashboards check
uv run ruff format . && uv run ruff check .
cd ..
helm dep build charts/observability-dashboards/
helm lint charts/observability-dashboards/ --strict
helm template x charts/observability-dashboards/ --dry-run
# Grid-layout + PromQL sanity check (dumped every panel's y/h/w/x and expr)
```

Results:

```text
dashboards build: 16/16 dashboards written, no errors.
dashboards check: "ok -- every dashboard matches its generator".
ruff: all checks passed on every file I touched (one pre-existing E741 in
_report.py, a file I didn't touch, left alone as out of scope).
helm lint --strict: 0 chart(s) failed.
helm template --dry-run: renders cleanly.
Quick-range injection scoped correctly: cost-by-model.json and
ratelimit-quota.json got the Weekly/Monthly timepicker.quickRanges block;
chat-overview.json and gpu-fleet.json did not (confirmed via direct JSON
inspection).
ratelimit-quota.json panel layout dumped: monthly section (y=0-28), weekly
section (y=29-57), spend-over-time (y=58-78), raw Redis census (y=79-91) --
no overlaps, sequential.
Rendered PromQL for every panel confirmed syntactically valid and correctly
scoped: monthly panels filter billing_period, weekly panels filter
billing_week, never both.
```

---

## 5. Screenshots / Evidence

Add evidence here:

* N/A — no live Grafana access from this session; evidence is the JSON/PromQL dumps above. Recommend a visual check once deployed, particularly that Grafana's `now/w` quick-range actually starts on Monday in the live org's date preferences (documented as a verify-live caveat in `_period_filter.py`).

---

## 6. Risk Assessment

Risk level:

* [x] Low
* [ ] Medium
* [ ] High

Potential risks:

* The new weekly panels on the rate-limit quota dashboard will show "No data" until the companion [ai-helm-values#187](https://github.com/ADORSYS-GIS/ai-helm-values/pull/187) lands and the exporter picks up real `billing_week`-labeled data — not broken, just empty in the interim.
* Grafana's `now/w` week-start default (normally Monday) could disagree with the actual ISO week-numbering if the org's date preferences were ever overridden — would make the "Weekly" quick-range subtly misaligned with the actual billing week. Not verified live from this session.

Mitigation:

* No merge-order requirement with the companion PR (both purely additive) — safe to merge in either order.
* Flagged the Grafana week-start caveat explicitly in code comments for whoever verifies this live.

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [ ] Refactoring
* [ ] Generating tests
* [x] Drafting documentation
* [ ] Reviewing the diff
* [ ] Not used

Human verification:

* [ ] I understand every meaningful change in this PR
* [ ] I checked generated code manually
* [ ] I checked generated tests manually
* [ ] I removed unsupported AI assumptions
* [ ] I accept responsibility for this PR

---

## 8. Reviewer Focus

Please focus your review on:

* [x] Correctness
* [x] Architecture
* [ ] Security
* [ ] Performance
* [ ] Tests
* [x] Maintainability
* [x] Product intent
* [x] Edge cases
PRBODY