### PR TITLE
fix(webank-training): require NVIDIA runtime

### DIFF
--- a/charts/webank-training/ci/lint-values.yaml
+++ b/charts/webank-training/ci/lint-values.yaml
@@ -8,6 +8,7 @@ training:
     endpoint: http://alloy.observability.svc.cluster.local:4318
   gpu:
     nodeSelector: { nvidia.com/gpu.present: "true" }
+    runtimeClassName: nvidia
     tolerations:
       - key: nvidia.com/gpu
         operator: Exists

--- a/charts/webank-training/templates/workflowtemplate.yaml
+++ b/charts/webank-training/templates/workflowtemplate.yaml
@@ -10,6 +10,7 @@
 {{- if eq (len .Values.models) 0 }}{{ fail "webank-training: models must declare the public model workflow catalogue" }}{{- end }}
 {{- $gpuNodeLabel := index $training.gpu.nodeSelector "nvidia.com/gpu.present" | default "" -}}
 {{- if ne $gpuNodeLabel "true" }}{{ fail "webank-training: GPU-capable templates require training.gpu.nodeSelector[nvidia.com/gpu.present]=true (the live GPU node label — see charts/inference)" }}{{- end }}
+{{- if ne ($training.gpu.runtimeClassName | default "") "nvidia" }}{{ fail "webank-training: GPU-capable templates require training.gpu.runtimeClassName=nvidia so host CUDA driver libraries are injected" }}{{- end }}
 {{- $gpuLimit := index $training.gpu.resources.limits "nvidia.com/gpu" | default 0 -}}
 {{- if lt (int $gpuLimit) 1 }}{{ fail "webank-training: GPU-capable templates require limits.nvidia.com/gpu >= 1" }}{{- end }}
 {{- $gpuRequest := index $training.gpu.resources.requests "nvidia.com/gpu" | default 0 -}}
@@ -92,6 +93,7 @@ spec:
           - name: readiness
             path: /workspace/input/readiness.json
 {{- end }}
+      runtimeClassName: {{ $training.gpu.runtimeClassName | quote }}
       nodeSelector:
         {{- toYaml $training.gpu.nodeSelector | nindent 8 }}
       {{- with $training.gpu.tolerations }}
@@ -235,6 +237,7 @@ spec:
           - name: readiness
             path: /workspace/governance/readiness.json
 {{- end }}
+      runtimeClassName: {{ $training.gpu.runtimeClassName | quote }}
       nodeSelector:
         {{- toYaml $training.gpu.nodeSelector | nindent 8 }}
       {{- with $training.gpu.tolerations }}

--- a/charts/webank-training/values.yaml
+++ b/charts/webank-training/values.yaml
@@ -22,9 +22,10 @@ training:
   # resource profile: `nvidia.com/gpu.present=true` (the live GPU node label,
   # matching charts/inference's `defaults.gpu` — see ADR-0114), an
   # `nvidia.com/gpu:NoSchedule` (Exists) toleration matching the live node
-  # taint, and an explicit positive nvidia.com/gpu request and limit. Dataset
-  # construction receives the same reviewed CPU, memory, and GPU allocation as
-  # candidate training.
+  # taint, the NVIDIA runtime class that injects host driver libraries, and an
+  # explicit positive nvidia.com/gpu request and limit. Dataset construction
+  # receives the same reviewed CPU, memory, and GPU allocation as candidate
+  # training.
   #
   # ⚠️ Prior to ADR-0114 this contract was `role: gpu`, which no node in the
   # cluster has ever carried — every GPU-requesting workflow pod was
@@ -33,6 +34,7 @@ training:
   # availability. Verified live 2026-08-02.
   gpu:
     nodeSelector: {}
+    runtimeClassName: ""
     tolerations: []
     priorityClassName: ""
     resources:

--- a/docs/integrations/webank-training-deployment.md
+++ b/docs/integrations/webank-training-deployment.md
@@ -24,7 +24,8 @@ stage into an alternative public operation.
 `*-dataset-build` templates are restricted-plane operations placed on
 `nvidia.com/gpu.present=true` nodes (the live GPU node label, matching
 `charts/inference`), tolerating `nvidia.com/gpu:NoSchedule` (Exists), and
-requesting the same reviewed CPU, memory, and one-GPU resource profile as
+using `runtimeClassName: nvidia` so the host CUDA driver libraries are mounted.
+They request the same reviewed CPU, memory, and one-GPU resource profile as
 candidate training (ADR-0114).
 Document detector is the one special case: its form has **no inputs**. It
 creates the fixed `ds-document-detector/main` repository if necessary, obtains
@@ -58,8 +59,9 @@ contract before an operator starts its template.
 ## Training templates
 
 All `*-train` templates select `nvidia.com/gpu.present=true`, tolerate
-`nvidia.com/gpu:NoSchedule` (Exists), and request one `nvidia.com/gpu`. A
-submitted training workflow therefore cannot land on a CPU-only node.
+`nvidia.com/gpu:NoSchedule` (Exists), use `runtimeClassName: nvidia`, and request
+one `nvidia.com/gpu`. A submitted training workflow therefore cannot land on a
+CPU-only node or start without the NVIDIA runtime injecting `libcuda.so.1`.
 
 The document detector accepts `dataset_ref` and `dataset_version`; its runtime
 combines them with the fixed `ds-document-detector` repository to check out and

--- a/docs/playbooks/webank-model-workflows.md
+++ b/docs/playbooks/webank-model-workflows.md
@@ -45,9 +45,10 @@ For every other model:
    model's fixed `ds-<model>/main` repository.
 
 All dataset-build pods select `nvidia.com/gpu.present=true`, tolerate
-`nvidia.com/gpu:NoSchedule` (Exists), and request the reviewed one-GPU
-CPU/memory resource profile. This guarantees that dataset materialization has
-the same GPU-node allocation as candidate training.
+`nvidia.com/gpu:NoSchedule` (Exists), use `runtimeClassName: nvidia`, and request
+the reviewed one-GPU CPU/memory resource profile. This guarantees that dataset
+materialization has the same GPU-node allocation and CUDA driver injection as
+candidate training.
 
 If a non-document-detector LakeFS repository is empty, this operation still
 cannot begin without an approved source artifact and its manifest/attestation.
@@ -65,9 +66,9 @@ Do not use fixtures or a blank reference as a substitute.
    `lakefs_ref`.
 4. Leave `run_name` empty unless a named experiment is needed. Its default is
    `<model>-<Argo workflow name>` and is the preferred unique correlation key.
-5. Submit. The pod must show `nvidia.com/gpu.present=true`, the
-   `nvidia.com/gpu:NoSchedule` (Exists) toleration, and a one-GPU request
-   before it begins candidate training.
+5. Submit. The pod must show `runtimeClassName: nvidia`,
+   `nvidia.com/gpu.present=true`, the `nvidia.com/gpu:NoSchedule` (Exists)
+   toleration, and a one-GPU request before it begins candidate training.
 
 The run can only publish a candidate. Evaluation and governed promotion remain
 separate procedures.
@@ -86,4 +87,5 @@ as PAD training and do not create a candidate manually.
 | Argo rejects a missing dataset field | The data contract is intentionally required. | Supply the approved ref/version or artifacts; never fake a value. |
 | `readiness-gate` fails | Source manifest, readiness attestation, and pinned commit disagree or are not eligible. | Repair/reapprove data in its source repository. |
 | Pod remains Pending | GPU placement requirements cannot currently be met, or MLOps is preempted by serving (ADR-0114). | Check an `nvidia.com/gpu.present=true` node and its allocatable GPU; do not remove placement constraints. |
+| `libcuda.so.1` cannot be opened | The pod did not use the NVIDIA runtime handler, so host driver libraries were not injected. | Confirm the rendered template and pod both have `runtimeClassName: nvidia`; do not copy CUDA driver files into the image. |
 | PAD train exits immediately | There is no PAD trainer. | Keep it blocked until a model-specific trainer lands. |


### PR DESCRIPTION
## Summary

Renders `runtimeClassName: nvidia` on every Webank dataset-build and training template and fails chart rendering when the reviewed runtime is absent.

## Intent

The fresh workflow `webank-document-detector-dataset-build-bsfgc` scheduled onto `hetzner-k8s-gpu-2` with 16 CPU, 48 GiB, and one GPU, then `/usr/local/bin/xtask` exited 127 because `libcuda.so.1` was unavailable. GPU capacity advertisement and node placement were correct; the pod had no runtime class, so the NVIDIA container runtime never injected the host driver libraries.

Source of truth:
- https://github.com/ADORSYS-GIS/ai-helm/blob/main/docs/adr/0114-gpu-priority-preemption-over-a-serving-clock.md
- https://github.com/ADORSYS-GIS/ai-helm-values/pull/188

## Scope

- Add a structural `training.gpu.runtimeClassName` chart value.
- Require the live `nvidia` handler at render time.
- Render it on all dataset-build and train templates.
- Update the deployment guide and workflow playbook, including the `libcuda.so.1` diagnostic.
- No workflow submission, LakeFS access, data mutation, or model publication.

## Verification

- [x] `helm lint charts/webank-training --strict -f charts/webank-training/ci/lint-values.yaml`
- [x] `helm template` rendered ten WorkflowTemplates, each with `runtimeClassName: nvidia`.
- [x] Negative render with an empty runtime class failed closed.
- [x] `git diff --check`.
- [x] Read-only live diagnosis confirmed the failed pod had no runtime class while the cluster exposes the `nvidia` RuntimeClass.

## Risk

Low and fail-closed. Production values PR #188 is sequenced first because the OCI chart floats in ArgoCD; this PR must not merge before that values change is live.

## AI Usage Declaration

- [x] AI assistance was used for diagnosis, implementation, documentation, and verification.

AI inspected read-only workflow and pod metadata plus the relevant error line. It did not access LakeFS credentials, dataset contents, or model artifacts.

## Reviewer focus

- Confirm RuntimeClass is applied at the Argo template level for both public operations.
- Confirm the exact `nvidia` guard matches the target cluster runtime handler.
- Confirm values-first sequencing prevents an ArgoCD render failure.