### PR TITLE
feat(governance): add OpenCode and LibreChat governance skill (#828)

### DIFF
--- a/.opencode/README.md
+++ b/.opencode/README.md
@@ -79,6 +79,32 @@ When AGENTS.md changes, run `/update-agents` to update agent configurations. The
 
 - **Agents**: `.opencode/agents/*.md` - Agent definitions
 - **Commands**: `.opencode/commands/*.md` - Command definitions
+- **Skills**: `.opencode/skills/<name>/SKILL.md` - Reusable behavior loaded on-demand
+
+## Skills
+
+Skills are Markdown files loaded on-demand by any agent via the native `skill`
+tool. The agent reads the `description` field to decide whether a skill is
+relevant, then loads the full body when needed.
+
+### Available skills
+
+| Name | Trigger | File |
+|---|---|---|
+| `governance` | Creating or editing an Epic, User Story, Dev Ticket, PR, or ADR | `.opencode/skills/governance/SKILL.md` |
+
+### Adding a skill
+
+1. Create `.opencode/skills/<kebab-name>/SKILL.md`.
+2. Add YAML frontmatter with `name` (kebab-case, matches directory name) and
+   `description` (≤ 1024 chars — this is what the agent reads to decide
+   relevance; make it specific).
+3. Write the skill body in plain Markdown.
+4. Merge to `main` — OpenCode picks it up automatically on the next session
+   (no `opencode.json` change required).
+
+See the [OpenCode Skills docs](https://opencode.ai/docs/skills/) for the full
+frontmatter spec.
 
 ## Config Notes
 

--- a/.opencode/skills/governance/SKILL.md
+++ b/.opencode/skills/governance/SKILL.md
@@ -1,0 +1,180 @@
+---
+name: governance
+description: Use when creating or editing any of these five artifact types in the ADORSYS-GIS/ai-helm repository: Epic (GitHub issue), User Story (GitHub issue), Dev Ticket (GitHub issue), Pull Request, or Architecture Decision Record (ADR). This skill instructs the agent to fetch and apply the ADORSYS-GIS AI governance templates from https://adorsys-gis.github.io/ai-governance/ before producing any artifact, ensuring each type uses its correct template. Also apply when reviewing whether an existing issue, PR, or ADR matches the governance format.
+compatibility: opencode
+---
+
+# AI Governance — Artifact Templates
+
+All artifacts in this repository (GitHub issues, pull requests, and ADRs) must
+follow the ADORSYS-GIS AI Governance templates. This skill tells you where each
+template lives and what you must do before producing any artifact.
+
+**Governance source of truth:** https://adorsys-gis.github.io/ai-governance/
+
+---
+
+## The one rule
+
+> **Before drafting any artifact, fetch the relevant template below. Do not
+> invent sections not present in the template. Do not omit required sections.**
+
+---
+
+## Template index
+
+### 1. Epic (GitHub issue)
+
+**When:** the work is large, spans multiple tickets, and represents a meaningful
+business or technical objective.
+
+**GitHub form:** `.github/ISSUE_TEMPLATE/epic.yml` (auto-applied when opening
+an issue with the Epic type — used as reference for section names).
+
+**Governance page:** https://adorsys-gis.github.io/ai-governance/
+
+**Required sections** (in order):
+- Executive Summary — *We want to [outcome] because [reason]. This epic exists
+  to solve [the real problem].*
+- Strategic Intent — 1–3 sentences; a person must be able to say this verbally.
+- Problem Statement — current pains + impact on users / ops / business.
+- Desired Outcome — what is observable when this epic is complete.
+- Scope (In / Out) — anything not listed must be clarified before implementation.
+- Source of truth (links) — full URLs or #123. No source of truth = not ready.
+- Stakeholders — Product Owner, Tech Lead, Delivery Owner, Security/Compliance.
+- Key Assumptions — each must be validated or converted to a risk before delivery.
+- Constraints — technical, security, compliance, timeline, dependency, operational.
+- Risks — Risk / Probability / Impact / Mitigation.
+- Success metrics — Metric / current / target / source (outcomes, not activity).
+- Child User Stories — each must have its own AC and verification evidence.
+- Human accountable owner — @github-handle / Name (required).
+- AI Usage Declaration — select all that apply (required).
+- Human verification checkboxes — the accountability box is required.
+
+---
+
+### 2. User Story (GitHub issue)
+
+**When:** the work describes a user need or a valuable capability.
+
+**GitHub form:** `.github/ISSUE_TEMPLATE/user-story.yml`
+
+**Governance page:** https://adorsys-gis.github.io/ai-governance/
+
+**Required sections** (in order):
+- Story Statement — *As a [user], I want [capability], so that [benefit].*
+- Real Intent — why this story matters (not a copy of an AI-generated summary).
+- Background and Context — current behavior, limitation, and pain.
+- Source of truth (links) — required; missing source of truth = not ready.
+- Acceptance Criteria — Given/When/Then, negative/edge cases, non-functional.
+- Out of Scope — explicit exclusions.
+- Dependencies and Blockers.
+- Assumptions.
+- Implementation Notes — guidance, not unquestionable truth.
+- Test Expectations.
+- Verification evidence — required; no evidence = not done.
+- Human accountable owner — required.
+- AI Usage Declaration — required.
+- Human verification checkboxes — accountability box required.
+
+---
+
+### 3. Dev Ticket (GitHub issue)
+
+**When:** implementation work, bugs, refactors, technical tasks, spikes, or
+operational work.
+
+**GitHub form:** `.github/ISSUE_TEMPLATE/dev-ticket.yml`
+
+**Governance page:** https://adorsys-gis.github.io/ai-governance/
+
+**Required sections** (in order):
+- Type — Feature / Bug / Refactor / Technical debt / Spike / Security /
+  Performance / Documentation / Operational task (required dropdown).
+- Summary — *We need to [do what] because [why]. Expected result: …*
+- Intent — the real intention; if you cannot explain it, the ticket is not ready.
+- Source of truth (links) — required; no source of truth = must be challenged.
+- Current Behavior — with evidence (logs, screenshots, metrics).
+- Expected Behavior — how the system should behave after this ticket.
+- Acceptance Criteria — Given/When/Then, error cases, no regressions, tests added.
+- Out of Scope.
+- Technical Context — relevant files, services, constraints.
+- Risks.
+- Test Plan — unit / integration / e2e / manual / regression / security commands.
+- Verification evidence — required.
+- Human accountable owner — required.
+- AI Usage Declaration — required.
+- Human verification checkboxes — accountability box required.
+
+---
+
+### 4. Pull Request
+
+**When:** any code or configuration change is being merged.
+
+**GitHub template:** `.github/PULL_REQUEST_TEMPLATE.md` (auto-applied by GitHub
+when opening a PR — used as reference for section names).
+
+**Governance page:** https://adorsys-gis.github.io/ai-governance/
+
+**Required sections** (in order):
+1. Summary — bullet list of changes; what problem/ticket it solves.
+2. Intent — why this change exists.
+3. Scope — In Scope / Out of Scope lists.
+4. Verification — checklist + commands run + results (paste or link).
+5. Screenshots / Evidence — screenshot, logs, metrics, or recording links.
+6. Risk Assessment — Low / Medium / High + risks + mitigations.
+7. AI Usage Declaration — select all that apply + human verification checklist.
+8. Reviewer Focus — select the review dimensions that matter for this PR.
+
+---
+
+### 5. Architecture Decision Record (ADR)
+
+**When:** a significant architectural or technical decision is being recorded.
+
+**Local template:** `docs/adr/template.md` — copy it to
+`docs/adr/<NNNN>-<short-title>.md` and fill in the sections.
+
+**Naming convention:** `ADR-NNNN` where NNNN is the next available number in
+`docs/adr/README.md`.
+
+**Required sections** (in order):
+- Header — `# ADR-NNNN: <short imperative title>` with Status / Date / Deciders.
+- Context — 3–6 sentences on the situation forcing the decision.
+- Decision — what was chosen, stated as imperative ("Adopt X", "Replace Y with Z").
+- Consequences — positive, negative, and neutral/follow-ups. Be honest.
+- Alternatives considered — for each rejected option: what it was, why it lost.
+- Related — commit SHA, docs, charts/files touched, supersedes/superseded-by.
+
+> ⚠️ **ADRs are immutable once Accepted.** To change a decision, write a new
+> ADR that supersedes the old one — do not edit the original body.
+
+---
+
+## Hard rules (apply to all artifact types)
+
+1. **Fetch before you draft.** Visit the governance page or the local template
+   file before producing the artifact. Do not work from memory.
+2. **No invented sections.** Do not add headings not present in the template.
+3. **No omitted required sections.** Every section marked required must be
+   present, even if the answer is "N/A — not applicable because …".
+4. **AI Usage Declaration is mandatory on every artifact.** Fill it in honestly.
+5. **Human accountable owner is mandatory on issues.** It must be a real person
+   (@github-handle), not "the team" or "TBD".
+6. **Source of truth must be linked.** No source of truth = the artifact is not
+   ready. Do not proceed without it.
+7. **Blank issues are disabled.** GitHub enforces this via `blank_issues_enabled:
+   false` — always use the appropriate issue form.
+
+---
+
+## Review checklist (when checking an existing artifact)
+
+- [ ] Correct template type used (Epic ≠ Story ≠ Ticket).
+- [ ] All required sections present and non-empty.
+- [ ] Source of truth linked (URL or #issue).
+- [ ] AI Usage Declaration filled in.
+- [ ] Human accountable owner named.
+- [ ] Verification evidence provided (issues) or commands/results present (PRs).
+- [ ] ADR: status is set; if Accepted, body is not being edited inline.

--- a/skills/governance/SKILL.md
+++ b/skills/governance/SKILL.md
@@ -1,0 +1,179 @@
+---
+name: governance
+description: Use when creating or editing any of these five artifact types in the ADORSYS-GIS/ai-helm repository: Epic (GitHub issue), User Story (GitHub issue), Dev Ticket (GitHub issue), Pull Request, or Architecture Decision Record (ADR). This skill instructs the agent to fetch and apply the ADORSYS-GIS AI governance templates from https://adorsys-gis.github.io/ai-governance/ before producing any artifact, ensuring each type uses its correct template. Also apply when reviewing whether an existing issue, PR, or ADR matches the governance format.
+---
+
+# AI Governance — Artifact Templates
+
+All artifacts in this repository (GitHub issues, pull requests, and ADRs) must
+follow the ADORSYS-GIS AI Governance templates. This skill tells you where each
+template lives and what you must do before producing any artifact.
+
+**Governance source of truth:** https://adorsys-gis.github.io/ai-governance/
+
+---
+
+## The one rule
+
+> **Before drafting any artifact, fetch the relevant template below. Do not
+> invent sections not present in the template. Do not omit required sections.**
+
+---
+
+## Template index
+
+### 1. Epic (GitHub issue)
+
+**When:** the work is large, spans multiple tickets, and represents a meaningful
+business or technical objective.
+
+**GitHub form:** `.github/ISSUE_TEMPLATE/epic.yml` (auto-applied when opening
+an issue with the Epic type — used as reference for section names).
+
+**Governance page:** https://adorsys-gis.github.io/ai-governance/
+
+**Required sections** (in order):
+- Executive Summary — *We want to [outcome] because [reason]. This epic exists
+  to solve [the real problem].*
+- Strategic Intent — 1–3 sentences; a person must be able to say this verbally.
+- Problem Statement — current pains + impact on users / ops / business.
+- Desired Outcome — what is observable when this epic is complete.
+- Scope (In / Out) — anything not listed must be clarified before implementation.
+- Source of truth (links) — full URLs or #123. No source of truth = not ready.
+- Stakeholders — Product Owner, Tech Lead, Delivery Owner, Security/Compliance.
+- Key Assumptions — each must be validated or converted to a risk before delivery.
+- Constraints — technical, security, compliance, timeline, dependency, operational.
+- Risks — Risk / Probability / Impact / Mitigation.
+- Success metrics — Metric / current / target / source (outcomes, not activity).
+- Child User Stories — each must have its own AC and verification evidence.
+- Human accountable owner — @github-handle / Name (required).
+- AI Usage Declaration — select all that apply (required).
+- Human verification checkboxes — the accountability box is required.
+
+---
+
+### 2. User Story (GitHub issue)
+
+**When:** the work describes a user need or a valuable capability.
+
+**GitHub form:** `.github/ISSUE_TEMPLATE/user-story.yml`
+
+**Governance page:** https://adorsys-gis.github.io/ai-governance/
+
+**Required sections** (in order):
+- Story Statement — *As a [user], I want [capability], so that [benefit].*
+- Real Intent — why this story matters (not a copy of an AI-generated summary).
+- Background and Context — current behavior, limitation, and pain.
+- Source of truth (links) — required; missing source of truth = not ready.
+- Acceptance Criteria — Given/When/Then, negative/edge cases, non-functional.
+- Out of Scope — explicit exclusions.
+- Dependencies and Blockers.
+- Assumptions.
+- Implementation Notes — guidance, not unquestionable truth.
+- Test Expectations.
+- Verification evidence — required; no evidence = not done.
+- Human accountable owner — required.
+- AI Usage Declaration — required.
+- Human verification checkboxes — accountability box required.
+
+---
+
+### 3. Dev Ticket (GitHub issue)
+
+**When:** implementation work, bugs, refactors, technical tasks, spikes, or
+operational work.
+
+**GitHub form:** `.github/ISSUE_TEMPLATE/dev-ticket.yml`
+
+**Governance page:** https://adorsys-gis.github.io/ai-governance/
+
+**Required sections** (in order):
+- Type — Feature / Bug / Refactor / Technical debt / Spike / Security /
+  Performance / Documentation / Operational task (required dropdown).
+- Summary — *We need to [do what] because [why]. Expected result: …*
+- Intent — the real intention; if you cannot explain it, the ticket is not ready.
+- Source of truth (links) — required; no source of truth = must be challenged.
+- Current Behavior — with evidence (logs, screenshots, metrics).
+- Expected Behavior — how the system should behave after this ticket.
+- Acceptance Criteria — Given/When/Then, error cases, no regressions, tests added.
+- Out of Scope.
+- Technical Context — relevant files, services, constraints.
+- Risks.
+- Test Plan — unit / integration / e2e / manual / regression / security commands.
+- Verification evidence — required.
+- Human accountable owner — required.
+- AI Usage Declaration — required.
+- Human verification checkboxes — accountability box required.
+
+---
+
+### 4. Pull Request
+
+**When:** any code or configuration change is being merged.
+
+**GitHub template:** `.github/PULL_REQUEST_TEMPLATE.md` (auto-applied by GitHub
+when opening a PR — used as reference for section names).
+
+**Governance page:** https://adorsys-gis.github.io/ai-governance/
+
+**Required sections** (in order):
+1. Summary — bullet list of changes; what problem/ticket it solves.
+2. Intent — why this change exists.
+3. Scope — In Scope / Out of Scope lists.
+4. Verification — checklist + commands run + results (paste or link).
+5. Screenshots / Evidence — screenshot, logs, metrics, or recording links.
+6. Risk Assessment — Low / Medium / High + risks + mitigations.
+7. AI Usage Declaration — select all that apply + human verification checklist.
+8. Reviewer Focus — select the review dimensions that matter for this PR.
+
+---
+
+### 5. Architecture Decision Record (ADR)
+
+**When:** a significant architectural or technical decision is being recorded.
+
+**Local template:** `docs/adr/template.md` — copy it to
+`docs/adr/<NNNN>-<short-title>.md` and fill in the sections.
+
+**Naming convention:** `ADR-NNNN` where NNNN is the next available number in
+`docs/adr/README.md`.
+
+**Required sections** (in order):
+- Header — `# ADR-NNNN: <short imperative title>` with Status / Date / Deciders.
+- Context — 3–6 sentences on the situation forcing the decision.
+- Decision — what was chosen, stated as imperative ("Adopt X", "Replace Y with Z").
+- Consequences — positive, negative, and neutral/follow-ups. Be honest.
+- Alternatives considered — for each rejected option: what it was, why it lost.
+- Related — commit SHA, docs, charts/files touched, supersedes/superseded-by.
+
+> ⚠️ **ADRs are immutable once Accepted.** To change a decision, write a new
+> ADR that supersedes the old one — do not edit the original body.
+
+---
+
+## Hard rules (apply to all artifact types)
+
+1. **Fetch before you draft.** Visit the governance page or the local template
+   file before producing the artifact. Do not work from memory.
+2. **No invented sections.** Do not add headings not present in the template.
+3. **No omitted required sections.** Every section marked required must be
+   present, even if the answer is "N/A — not applicable because …".
+4. **AI Usage Declaration is mandatory on every artifact.** Fill it in honestly.
+5. **Human accountable owner is mandatory on issues.** It must be a real person
+   (@github-handle), not "the team" or "TBD".
+6. **Source of truth must be linked.** No source of truth = the artifact is not
+   ready. Do not proceed without it.
+7. **Blank issues are disabled.** GitHub enforces this via `blank_issues_enabled:
+   false` — always use the appropriate issue form.
+
+---
+
+## Review checklist (when checking an existing artifact)
+
+- [ ] Correct template type used (Epic ≠ Story ≠ Ticket).
+- [ ] All required sections present and non-empty.
+- [ ] Source of truth linked (URL or #issue).
+- [ ] AI Usage Declaration filled in.
+- [ ] Human accountable owner named.
+- [ ] Verification evidence provided (issues) or commands/results present (PRs).
+- [ ] ADR: status is set; if Accepted, body is not being edited inline.


### PR DESCRIPTION
## 1. Summary

This PR changes:

- Added `.opencode/skills/governance/SKILL.md` — an OpenCode project-local skill covering all five governed artifact types.
- Added `skills/governance/SKILL.md` — a LibreChat skill copy, picked up by the existing `config.skillSync` mechanism.
- Updated `.opencode/README.md` — added a **Skills** section documenting the new directory, the governance skill, and how to add more skills.

It solves:

- #828 (Add OpenCode governance skill to ai-helm, child of Epic #821)

---

## 2. Intent

The intent of this PR is:

> AI agents working in this repo (via OpenCode or LibreChat) currently have no automated guidance on which template to use when producing Epics, User Stories, Dev Tickets, PRs, or ADRs. Without this skill the agent must be told manually each time — or it guesses and produces a freeform artifact that drifts from the governance format. This skill makes the correct template available to any agent on-demand, declaratively and from Git, with no manual install and no chart change required.

---

## 3. Scope

### In Scope

- One OpenCode skill file auto-discovered at `.opencode/skills/governance/SKILL.md`.
- One LibreChat skill file auto-synced at `skills/governance/SKILL.md` (hourly or on pod start; no chart change needed).
- Documentation update to `.opencode/README.md` covering the new skills subsystem.
- Coverage of all five artifact types: Epic, User Story, Dev Ticket, Pull Request, ADR.

### Out of Scope

- No Helm chart changes.
- No CI workflow changes.
- No `opencode.json` changes (skills are auto-discovered by design).
- No changes to the governance templates themselves (they live in `adorsys-gis/ai-governance`).

---

## 4. Verification

I verified this change by:

- [x] Running manual tests
- [x] Checking logs

Commands run:

```bash
# Confirm OpenCode skill frontmatter is valid
head -6 .opencode/skills/governance/SKILL.md

# Confirm LibreChat skill has NO unknown frontmatter keys (would fail sync)
grep -c "compatibility" skills/governance/SKILL.md
# Output: 0  ✓

# Confirm body size is within limits (< 100 KB)
wc -c < skills/governance/SKILL.md
# Output: 8159  ✓

# Confirm name matches directory name (required by spec)
grep "^name:" .opencode/skills/governance/SKILL.md
# Output: name: governance  ✓
```

Results:

```text
---
name: governance
description: Use when creating or editing any of these five artifact types ...
compatibility: opencode
---

LibreChat compatibility: key=0 (no unknown keys)  ✓
Body size: 8159 bytes  ✓
Directory name matches SKILL.md name: governance == governance  ✓
```

---

## 5. Screenshots / Evidence

- Commit: `7b1bb1f` — all three files pushed to branch `feat/828-opencode-governance-skill`.
- Governance source of truth referenced in both skill files: https://adorsys-gis.github.io/ai-governance/
- LibreChat skill sync docs: `skills/README.md` — no chart change required, hourly sync.

---

## 6. Risk Assessment

Risk level:

* [x] Low

Potential risks:

* LibreChat sync rejects the skill if a frontmatter key is not in the allowlist — mitigated by verifying `grep -c "compatibility" skills/governance/SKILL.md` returns 0.
* OpenCode session does not discover the skill — mitigated by placing the file exactly at `.opencode/skills/governance/SKILL.md` per the [OpenCode Skills spec](https://opencode.ai/docs/skills/).

Mitigation:

* Both risks are structural (wrong path or wrong key) and are caught at first load/sync, not silently. No data loss or service disruption possible from a plain Markdown file addition.

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [x] Drafting documentation

Human verification:

* [x] I understand every meaningful change in this PR
* [x] I checked generated code manually
* [x] I removed unsupported AI assumptions
* [x] I accept responsibility for this PR

---

## 8. Reviewer Focus

Please focus your review on:

* [x] Correctness (skill frontmatter valid for both OpenCode and LibreChat)
* [x] Maintainability (skill body covers all five artifact types accurately)
* [x] Product intent (does the skill body faithfully reflect the governance templates at https://adorsys-gis.github.io/ai-governance/)