### PR TITLE
feat(ai-models): federate qwen3-coder-30b-a3b-local into the gateway

### DIFF
--- a/charts/ai-models/values.yaml
+++ b/charts/ai-models/values.yaml
@@ -633,6 +633,24 @@ backends:
       key: ai/camer/digital/prod/env
       property: vllm_local_api_key
 
+  # Qwen3-Coder-30B-A3B — the fleet's CODING model (vLLM, MoE 30B/3B active,
+  # AWQ INT4). Cluster-local Service created by the `qwen3-coder-30b-a3b`
+  # inference entry. Same `vllm_local_api_key` ssegning-aws property every
+  # other fleet backend uses.
+  qwen3-coder-30b-a3b-local:
+    schema: OpenAI
+    prefix: "/v1"
+    fqdn:
+      hostname: qwen3-coder-30b-a3b.inference.svc.cluster.local
+      port: 8080
+    securityType: APIKey
+    resourceName: qwen3-coder-30b-a3b-local-svc
+    secretRef:
+      name: qwen3-coder-30b-a3b-api-key
+    externalSecret:
+      key: ai/camer/digital/prod/env
+      property: vllm_local_api_key
+
 # Models — each entry becomes one child Application using the `ai-model`
 # leaf chart. Setting `enabled: false` on a model skips its Application
 # (the AppSet controller will delete a previously-generated child).
@@ -740,6 +758,59 @@ models:
         ref: qwen3-8b-fast-local
         priority: 0
         modelNameOverride: "qwen3-8b-fast"   # = --served-model-name
+
+  # ─────────────────────────────────────────────────────────────────────────
+  # Qwen3-Coder-30B-A3B — CODING model on the GPU fleet (vLLM, MoE 30B/3B
+  # active, AWQ INT4).
+  #
+  # Serving spec: charts/inference/values.yaml `qwen3-coder-30b-a3b`.
+  #
+  # ⚠️ FEDERATED WITHOUT ITS LOAD GATE (ADR-0101) — deliberate, at the
+  # operator's request, so a real coding request can be exercised through the
+  # gateway end to end. The gate is still REQUIRED before this entry is
+  # trusted with real traffic: measure tok/s, VRAM headroom and answer
+  # QUALITY (two lossy layers stacked: AWQ INT4 + uncalibrated FP8 KV cache).
+  # Update this comment with the measured numbers when done.
+  #
+  # ⚠️ PRICING IS A PLACEHOLDER. Derived from the ADR-0104 node cost at an
+  # ASSUMED 35 tok/s decode (never measured; the 8B dense measured 45 tok/s
+  # with LMCache + CUDA graphs, this model is eager-mode):
+  #   €0.2968/h ÷ 3600 ÷ 35 tok/s = €2.36/1M output at saturation
+  #   × 3.45 duty-cycle uplift     = €8.13/1M ≈ $8.85/M (1 : 0.15 : 0.03 split)
+  # RE-DERIVE from the measured rate before relying on cost boards — never
+  # scale a placeholder (same rule as every corrected price in this file).
+  #
+  # ⚠️ Context is deliberately small (8192) until the load gate measures real
+  # headroom: --enforce-eager + fp8 KV cache at 0.90 GPU util leaves ~2.33 GiB
+  # of budget. Agentic coding through opencode can exceed 8K on turn one —
+  # raise it only after measurement.
+  #
+  # ⚠️ Thinking is OFF at the server (`reasoning: "off"` in the serving spec),
+  # so `supportedParameters` does NOT advertise `reasoning` — same policy as
+  # z-image-turbo. Clients opt in per request via chat_template_kwargs.
+  qwen3-coder-30b-a3b-local:
+    enabled: true
+    kind: text
+    minBackends: 1                   # one GPU, one backend, by design
+    timeout:
+      requestTimeout: 600s
+      connectionIdleTimeout: 1h
+    info:
+      displayName: "Qwen3-Coder-30B (self-hosted)"
+      contextLength: 8192            # = --max-model-len (vLLM: the per-request window)
+      maxOutputTokens: 4096
+      supportedParameters: *spStandard
+    pricing:
+      strategy: weighted
+      standard:
+        inputPer1M: 1.34
+        cachedInputPer1M: 0.27
+        outputPer1M: 8.85
+    backends:
+      qwen3-coder-30b-a3b-local:
+        ref: qwen3-coder-30b-a3b-local
+        priority: 0
+        modelNameOverride: "qwen3-coder-30b-a3b"   # = --served-model-name
 
   # ─────────────────────────────────────────────────────────────────────────
   # Z-Image-Turbo — IMAGE GENERATION, on the GPU fleet (ADR-0100).

--- a/charts/inference/values.yaml
+++ b/charts/inference/values.yaml
@@ -714,6 +714,15 @@ models:
        # for Qwen3 base models but produces plain-text tool calls on Coder.
        # Ref: https://docs.vllm.ai/en/stable/features/tool_calling/
        toolCallParser: qwen3_xml
+       # Fleet convention for Qwen3 text models (same as qwen3-8b-fast,
+       # openmythos-27b): thinking OFF at the server. Without a configured
+       # `--reasoning-parser`, vLLM's Qwen3 default emits the trace as RAW
+       # `<think>` tags inside `content` — visible markup in every answer.
+       # Thinking also eats the tight 8K window + output budget at the eager
+       # mode this model is forced into. Clients opt in per request with
+       # `chat_template_kwargs.enable_thinking=true` (vLLM merges request
+       # kwargs over --default-chat-template-kwargs).
+       reasoning: "off"
        # Fleet default: 0.90 → 17.99 GiB budget (0.90 × 19.99). Weights are
        # ~15.66 GiB, leaving ~2.33 GiB for KV cache + CUDA graphs + activations.
        gpuMemoryUtilization: 0.90


### PR DESCRIPTION
## 1. Summary

This PR changes:

- `charts/ai-models/values.yaml`: adds the cluster-local backend `qwen3-coder-30b-a3b-local` (→ `qwen3-coder-30b-a3b.inference.svc.cluster.local:8080`) and the model entry `qwen3-coder-30b-a3b-local` (`enabled: true`, `kind: text`, ctx 8192, `modelNameOverride: qwen3-coder-30b-a3b`) — generating the AIGatewayRoute that advertises the model in `/v1/models`.
- `charts/inference/values.yaml`: sets `reasoning: "off"` on the coder serving entry (fleet Qwen3 convention) so vLLM does not leak raw ` thinking` tags into `content`.

It solves:

- Making the self-hosted Qwen3-Coder-30B-A3B (already served on the GPU fleet via #857) **visible and usable** through `api.ai.camer.digital`.

---

## 2. Intent

The intent of this PR is:

> Federate the coding model into the camerdigital gateway so a real coding request can be exercised end to end. This is the "offer it to users" half of the two-step model lifecycle (serve on GPU, then federate) documented in `charts/inference/values.yaml` and ADR-0094.

---

## 3. Scope

### In Scope

- Federation of `qwen3-coder-30b-a3b-local` in `charts/ai-models/values.yaml` (backend + model entry).
- `reasoning: "off"` on the coder serving entry in `charts/inference/values.yaml`.

### Out of Scope

- The load gate (ADR-0101): measuring tok/s, VRAM headroom and answer quality. Pricing is a placeholder derived from the ADR-0104 node cost at an assumed 35 tok/s — re-derive from the measured rate before trusting cost boards.
- Adding the model to the `.well-known/opencode` picker (fleet `-local` models are intentionally not listed there).

---

## 4. Verification

I verified this change by:

- [x] Running automated tests
- [ ] Running manual tests
- [ ] Checking logs
- [ ] Checking metrics
- [ ] Testing error cases
- [ ] Testing permissions/security behavior
- [ ] Testing rollback or failure behavior, if relevant

Commands run:

```bash
./tools/check-model-catalogs.sh
helm lint charts/inference --strict
helm lint charts/ai-models --strict
helm template chk charts/ai-models
tools/commit-lint.sh --message "feat(ai-models): federate qwen3-coder-30b-a3b-local into the gateway"
```

Results:

```text
check-model-catalogs: OK (2 served on the GPU fleet, 2 federated cluster-local)
==> Linting charts/inference: 1 chart(s) linted, 0 chart(s) failed
==> Linting charts/ai-models: 1 chart(s) linted, 0 chart(s) failed
helm template: RENDER OK (AIGatewayRoute qwen3-coder-30b-a3b-local generated)
commit-lint: MESSAGE OK
```

---

## 5. Screenshots / Evidence

Add evidence here:

* Screenshot: [link]
* Logs: [link]
* Metrics: [link]
* Recording: [link]

---

## 6. Risk Assessment

Risk level:

* [x] Medium

Potential risks:

- The model is federated **without its load gate** (ADR-0101): two lossy layers stacked (AWQ INT4 + uncalibrated FP8 KV cache) — quality must be measured before real traffic is trusted.
- Pricing is a placeholder (assumed 35 tok/s), not measured — cost boards will be off until re-derived.

Mitigation:

- The entry is explicitly commented as load-gated-pending; the serving entry keeps a conservative 8192 context and `--enforce-eager`.
- Re-derive pricing from the measured tok/s before relying on it.

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [ ] Refactoring
* [ ] Generating tests
* [ ] Drafting documentation
* [x] Reviewing the diff
* [ ] Not used

Human verification:

* [x] I understand every meaningful change in this PR
* [x] I checked generated code manually
* [ ] I checked generated tests manually
* [x] I removed unsupported AI assumptions
* [x] I accept responsibility for this PR

---

## 8. Reviewer Focus

Please focus your review on:

* [x] Correctness
* [ ] Architecture
* [ ] Security
* [ ] Performance
* [ ] Tests
* [x] Maintainability
* [x] Product intent
* [ ] Edge cases
