### PR TITLE
fix(webank-training): render portable GPU runtime

### DIFF
--- a/charts/webank-training/ci/lint-values.yaml
+++ b/charts/webank-training/ci/lint-values.yaml
@@ -8,6 +8,7 @@ training:
     endpoint: http://alloy.observability.svc.cluster.local:4318
   gpu:
     nodeSelector: { nvidia.com/gpu.present: "true" }
+    resourceName: nvidia.com/gpu
     runtimeClassName: nvidia
     tolerations:
       - key: nvidia.com/gpu

--- a/charts/webank-training/templates/workflowtemplate.yaml
+++ b/charts/webank-training/templates/workflowtemplate.yaml
@@ -8,18 +8,14 @@
 {{- if not $training.otel.endpoint }}{{ fail "webank-training: training.otel.endpoint is required" }}{{- end }}
 {{- if not $workflow.serviceAccountName }}{{ fail "webank-training: workflow.serviceAccountName is required" }}{{- end }}
 {{- if eq (len .Values.models) 0 }}{{ fail "webank-training: models must declare the public model workflow catalogue" }}{{- end }}
-{{- $gpuNodeLabel := index $training.gpu.nodeSelector "nvidia.com/gpu.present" | default "" -}}
-{{- if ne $gpuNodeLabel "true" }}{{ fail "webank-training: GPU-capable templates require training.gpu.nodeSelector[nvidia.com/gpu.present]=true (the live GPU node label — see charts/inference)" }}{{- end }}
-{{- if ne ($training.gpu.runtimeClassName | default "") "nvidia" }}{{ fail "webank-training: GPU-capable templates require training.gpu.runtimeClassName=nvidia so host CUDA driver libraries are injected" }}{{- end }}
-{{- $gpuLimit := index $training.gpu.resources.limits "nvidia.com/gpu" | default 0 -}}
-{{- if lt (int $gpuLimit) 1 }}{{ fail "webank-training: GPU-capable templates require limits.nvidia.com/gpu >= 1" }}{{- end }}
-{{- $gpuRequest := index $training.gpu.resources.requests "nvidia.com/gpu" | default 0 -}}
-{{- if lt (int $gpuRequest) 1 }}{{ fail "webank-training: GPU-capable templates require requests.nvidia.com/gpu >= 1" }}{{- end }}
-{{- $toleratesGpu := false -}}
-{{- range $training.gpu.tolerations }}
-{{- if and (eq (.key | default "") "nvidia.com/gpu") (eq (.operator | default "Equal") "Exists") (eq (.effect | default "") "NoSchedule") }}{{- $toleratesGpu = true }}{{- end }}
-{{- end }}
-{{- if not $toleratesGpu }}{{ fail "webank-training: GPU-capable templates require an nvidia.com/gpu:NoSchedule (Exists) toleration — the live GPU node taint" }}{{- end }}
+{{- if eq (len $training.gpu.nodeSelector) 0 }}{{ fail "webank-training: GPU-capable templates require a non-empty training.gpu.nodeSelector" }}{{- end }}
+{{- if not ($training.gpu.runtimeClassName | default "") }}{{ fail "webank-training: GPU-capable templates require training.gpu.runtimeClassName" }}{{- end }}
+{{- $gpuResourceName := required "webank-training: training.gpu.resourceName is required" $training.gpu.resourceName -}}
+{{- $gpuLimit := index $training.gpu.resources.limits $gpuResourceName | default 0 -}}
+{{- if lt (int $gpuLimit) 1 }}{{ fail (printf "webank-training: GPU-capable templates require limits.%s >= 1" $gpuResourceName) }}{{- end }}
+{{- $gpuRequest := index $training.gpu.resources.requests $gpuResourceName | default 0 -}}
+{{- if lt (int $gpuRequest) 1 }}{{ fail (printf "webank-training: GPU-capable templates require requests.%s >= 1" $gpuResourceName) }}{{- end }}
+{{- if eq (len $training.gpu.tolerations) 0 }}{{ fail "webank-training: GPU-capable templates require at least one training.gpu.toleration" }}{{- end }}
 {{- range $model := .Values.models }}
 {{- $id := required "webank-training: models[].id is required" $model.id -}}
 {{- $materializer := required (printf "webank-training: %s datasetMaterializer is required" $id) $model.datasetMaterializer -}}
@@ -93,7 +89,8 @@ spec:
           - name: readiness
             path: /workspace/input/readiness.json
 {{- end }}
-      runtimeClassName: {{ $training.gpu.runtimeClassName | quote }}
+      podSpecPatch: |
+        runtimeClassName: {{ $training.gpu.runtimeClassName | quote }}
       nodeSelector:
         {{- toYaml $training.gpu.nodeSelector | nindent 8 }}
       {{- with $training.gpu.tolerations }}
@@ -237,7 +234,8 @@ spec:
           - name: readiness
             path: /workspace/governance/readiness.json
 {{- end }}
-      runtimeClassName: {{ $training.gpu.runtimeClassName | quote }}
+      podSpecPatch: |
+        runtimeClassName: {{ $training.gpu.runtimeClassName | quote }}
       nodeSelector:
         {{- toYaml $training.gpu.nodeSelector | nindent 8 }}
       {{- with $training.gpu.tolerations }}

--- a/charts/webank-training/values.yaml
+++ b/charts/webank-training/values.yaml
@@ -21,11 +21,11 @@ training:
   # Every dataset-build and training template uses this GPU-node placement and
   # resource profile: `nvidia.com/gpu.present=true` (the live GPU node label,
   # matching charts/inference's `defaults.gpu` — see ADR-0114), an
-  # `nvidia.com/gpu:NoSchedule` (Exists) toleration matching the live node
-  # taint, the NVIDIA runtime class that injects host driver libraries, and an
-  # explicit positive nvidia.com/gpu request and limit. Dataset construction
-  # receives the same reviewed CPU, memory, and GPU allocation as candidate
-  # training.
+  # matching toleration and runtime class, and an explicit positive accelerator
+  # request and limit. Every cluster-specific name and placement value is
+  # supplied by ai-helm-values; this chart owns only the rendering contract.
+  # Dataset construction receives the same reviewed CPU, memory, and accelerator
+  # allocation as candidate training.
   #
   # ⚠️ Prior to ADR-0114 this contract was `role: gpu`, which no node in the
   # cluster has ever carried — every GPU-requesting workflow pod was
@@ -34,6 +34,7 @@ training:
   # availability. Verified live 2026-08-02.
   gpu:
     nodeSelector: {}
+    resourceName: ""
     runtimeClassName: ""
     tolerations: []
     priorityClassName: ""


### PR DESCRIPTION
## Summary

Uses Argo WorkflowTemplate `podSpecPatch` to apply the configured runtime class and removes NVIDIA-specific placement assumptions from chart validation.

## Root cause

Chart 0.2.14 rendered `runtimeClassName` directly on an Argo template. The live CRD rejects that field during server-side diff:

```text
.spec.templates[0].runtimeClassName: field not declared in schema
```

The same CRD exposes `podSpecPatch` at template level, which is the supported way to patch the generated Kubernetes PodSpec.

## Intent

`ai-helm` owns stable rendering mechanics. Cluster-specific runtime class, accelerator resource key, selectors, tolerations, capacity, image and LakeFS routes live in `ai-helm-values`. Future placement changes must not require chart edits.

Source of truth:
- https://github.com/ADORSYS-GIS/ai-helm/pull/911
- https://github.com/ADORSYS-GIS/ai-helm-values/pull/189
- https://github.com/ADORSYS-GIS/ai-helm/blob/main/docs/adr/0114-gpu-priority-preemption-over-a-serving-clock.md

## Scope

- Replace invalid template `runtimeClassName` with supported `podSpecPatch`.
- Add configurable `training.gpu.resourceName`.
- Validate non-empty placement/runtime/toleration values and positive request/limit for the configured resource.
- Remove exact NVIDIA runtime, resource, label and toleration checks from chart logic.
- No workflow submission, LakeFS access, data mutation, or model publication.

## Verification

- [x] Strict Helm lint passed.
- [x] Ten WorkflowTemplates rendered with the configured runtime patch.
- [x] Live CRD server-side dry-run accepted all ten rendered resources.
- [x] A synthetic non-NVIDIA runtime/resource pair rendered successfully.
- [x] Missing accelerator resource name fails closed.
- [x] `git diff --check`.

## Risk

Low and fail-closed. ai-helm-values #189 merged first, so the floating OCI chart can consume `resourceName` safely. Existing production NVIDIA values render to the same final PodSpec.

## AI Usage Declaration

- [x] AI assistance was used for diagnosis, implementation, and verification.

AI inspected the public CRD schema and Application comparison error. It did not start workflows or access LakeFS credentials/data or model artifacts.

## Reviewer focus

- Confirm template-level `podSpecPatch` is the correct Argo CRD surface.
- Confirm chart validation is vendor-neutral while remaining fail-closed.
- Confirm values-first sequencing via merged #189.