### PR TITLE
fix(inference): raise qwen3-coder-30b-a3b memoryLimit to 32Gi

### DIFF
--- a/charts/inference/values.yaml
+++ b/charts/inference/values.yaml
@@ -742,8 +742,15 @@ models:
      resources:
        cpuRequest: "2"
        cpuLimit: "8"
-       memoryRequest: 8Gi
-       memoryLimit: 17Gi
+       # RAM, not VRAM. 17 Gi was too tight: vLLM stages the 16.8 GB of AWQ
+       # weights in RAM while loading (and the 30B/128-expert MoE engine init
+       # holds sizeable CPU-side structures on top), so the load OOM-killed
+       # before the port ever opened — pod never Ready, killed at the 30-min
+       # startup budget. Aligned with z-image-turbo (32 Gi), the fleet
+       # precedent for similarly-sized weights. Re-check after the load gate
+       # measures real headroom.
+       memoryRequest: 12Gi
+       memoryLimit: 32Gi
 
    # ─────────────────────────────────────────────────────────────────────────
    # Z-Image-Turbo — IMAGE GENERATION, served by LocalAI (ADR-0102/0103/0105).


### PR DESCRIPTION
## 1. Summary

This PR changes:

- Raise `qwen3-coder-30b-a3b` RAM limits in `charts/inference/values.yaml`: `memoryRequest` 8Gi → 12Gi, `memoryLimit` 17Gi → 32Gi.

It solves:

- The vLLM pod for qwen3-coder-30b-a3b never became Ready: the startup probe saw `connection refused` on :8080 for the whole 30-minute startup budget, after which the kubelet killed the pod (and the replacement pod re-queued behind a busy GPU fleet). Root cause: `memoryLimit: 17Gi` is too tight — vLLM stages the 16.8 GB of AWQ weights in RAM while loading, plus the 30B / 128-expert MoE engine init holds sizeable CPU-side structures, so the load gets OOM-killed (or thrashes) before the port opens. Ticket: #836.

## 2. Intent

The intent of this PR is:

> Make the coding model actually serve. The chart-level capacity layout is already correct on main (2 cards held by qwen3-coder-30b-a3b and z-image-turbo; qwen3-8b-fast / openmythos-27b intentionally disabled), so the only blocker left is the model failing to load in RAM. Aligning the limit with the fleet precedent (z-image-turbo uses 32Gi for similarly-sized weights) removes that blocker.

## 3. Scope

### In Scope

- `charts/inference/values.yaml`: `memoryRequest: 12Gi`, `memoryLimit: 32Gi` for the `qwen3-coder-30b-a3b` entry, with a comment documenting the incident.

### Out of Scope

- GPU scheduling / priority classes (ADR-0114 untouched — serving stays at `-10`, no intra-serving preemption).
- The pending ADR-0101 load gate (real tok/s, headroom measurement to later drop `--enforce-eager` and raise context past 8K).
- Any other model.

## 4. Verification

I verified this change by:

- [x] Running automated tests
- [ ] Running manual tests
- [ ] Checking logs
- [ ] Checking metrics
- [ ] Testing error cases
- [ ] Testing permissions/security behavior
- [ ] Testing rollback or failure behavior, if relevant

Commands run:

```bash
python3 -c "import yaml; yaml.safe_load(open('charts/inference/values.yaml'))"
helm lint --strict charts/inference
helm template inf charts/inference
tools/commit-lint.sh --message "fix(inference): raise qwen3-coder-30b-a3b memoryLimit to 32Gi"
```

Results:

```text
YAML OK
1 chart(s) linted, 0 chart(s) failed
helm template: rendered pod shows requests: { cpu: "2", memory: "12Gi" } / limits: { cpu: "8", memory: "32Gi" } for the coder Deployment and seed Job
MSG OK
```

Note: runtime verification (pod Ready, `/health` 200, first completion via `POST /v1/chat/completions` on `qwen3-coder-30b-a3b-local`) happens post-merge on ArgoCD sync — the previous deploy incident (startup probe `connection refused` for 30 min) is the exact failure this change addresses.

## 5. Screenshots / Evidence

* ArgoCD events before this fix (pod killed after 30-min startup budget, replacement `FailedScheduling` with `2 Insufficient nvidia.com/gpu`): reported in the issue/ticket thread.
* Post-merge evidence to attach: pod logs ending in `Application startup complete`, pod Ready 1/1, and a completion response from the gateway.

## 6. Risk Assessment

Risk level:

- [ ] Low
- [x] Medium
- [ ] High

Potential risks:

- Higher RAM limit reduces headroom on the GPU node for other pods' RAM (not VRAM — VRAM budget is unchanged via `gpuMemoryUtilization: 0.90`).
- If the real failure was something other than RAM, the pod still fails to load.

Mitigation:

- 32Gi matches the existing z-image-turbo precedent, already running on the same fleet — no new resource ceiling.
- The startup failure is observable in seconds in the pod log (OOM vs vLLM error), and rollback is a one-line revert of a single value.

## 7. AI Usage Declaration

AI was used for:

- [x] Understanding existing code
- [ ] Generating code
- [ ] Refactoring
- [ ] Generating tests
- [ ] Drafting documentation
- [x] Reviewing the diff
- [ ] Not used

Human verification:

- [x] I understand every meaningful change in this PR
- [x] I checked generated code manually
- [x] I checked generated tests manually
- [x] I removed unsupported AI assumptions
- [x] I accept responsibility for this PR

## 8. Reviewer Focus

Please focus your review on:

- [x] Correctness
- [ ] Architecture
- [ ] Security
- [x] Performance
- [ ] Tests
- [x] Maintainability
- [ ] Product intent
- [ ] Edge cases
