### PR TITLE
fix(webank-training): call released repository bootstrap

### DIFF
--- a/charts/webank-training/templates/workflowtemplate.yaml
+++ b/charts/webank-training/templates/workflowtemplate.yaml
@@ -106,7 +106,9 @@ spec:
         args:
           - |
 {{- if eq $id "document-detector" }}
-            BASE_REF="$(cargo xtask training-data bootstrap-document-detector-repository \
+            BASE_REF="$(cargo xtask training-data bootstrap-model-repository \
+              --model document-detector \
+              --role dataset \
               --lakefs-branch "$WEBANK_DATASET_LAKEFS_BRANCH" \
               --lakefs-endpoint "$WEBANK_LAKEFS_ENDPOINT" \
               --lakefs-repository "$WEBANK_DATASET_LAKEFS_REPOSITORY" \


### PR DESCRIPTION
## Summary

Fixes the live document-detector Dataset Build command to call the repository-bootstrap subcommand that actually ships in the digest-pinned webank-models v1.4.0 training image.

## Root cause

The chart rendered:

```text
cargo xtask training-data bootstrap-document-detector-repository
```

That subcommand has never existed. The live Workflow `webank-document-detector-dataset-build-j6nz4` therefore exited before any LakeFS operation with:

```text
error: unrecognized subcommand 'bootstrap-document-detector-repository'
tip: a similar subcommand exists: 'bootstrap-model-repository'
```

The released typed CLI requires `bootstrap-model-repository --model document-detector --role dataset`.

## Intent

Keep environment and routing values in ai-helm-values while making the chart's stable orchestration contract match the released training binary. No image or production values change is required.

Source of truth:
- https://github.com/ADORSYS-GIS/ai-helm/pull/884
- https://github.com/ADORSYS-GIS/webank-models/blob/v1.4.0/xtask/src/training_data/command.rs
- https://github.com/ADORSYS-GIS/webank-models/blob/v1.4.0/xtask/src/training_data/route.rs

## Scope

- Replace the nonexistent bootstrap subcommand with `bootstrap-model-repository`.
- Pass the required fixed model and repository role.
- Preserve all image, GPU, LakeFS, and resource values.
- Do not submit/retry workflows or access LakeFS credentials/data.

## Verification

- [x] `helm lint charts/webank-training --strict -f <production-values>`
- [x] Production render contains `bootstrap-model-repository --model document-detector --role dataset`.
- [x] Production render contains no `bootstrap-document-detector-repository`.
- [x] Live Argo CRD server-side dry-run accepted all ten rendered WorkflowTemplates.
- [x] `git diff --check`.

## Risk

Low. The change is limited to the command name and its two required typed routing arguments. The existing image digest, environment-owned values, and fixed LakeFS destination remain unchanged.

## AI Usage Declaration

- [x] AI assistance was used for diagnosis, implementation, verification, and drafting this PR.

The runtime log and v1.4.0 CLI source were checked directly. No workflow was started and no LakeFS credential or dataset content was accessed.

## Reviewer focus

- Confirm the chart invocation matches the v1.4.0 Clap contract.
- Confirm the fixed `document-detector` / `dataset` route preserves the fail-closed repository policy.
