### PR TITLE
feat(webank-training): render fixed dataset builds

### DIFF
--- a/charts/webank-training/ci/lint-values.yaml
+++ b/charts/webank-training/ci/lint-values.yaml
@@ -16,8 +16,13 @@ training:
         effect: NoSchedule
 models:
   - id: document-detector
-    datasetMaterializer: materialize-document-detector-descriptor
     trainer: document-detector
+    datasetBuild:
+      target:
+        repository: ds-document-detector
+        branch: main
+        storageNamespace: s3://governed-ci/datasets/ds-document-detector
+      source: { strategy: hermetic-synthetic }
     lakefs:
       dataset:
         repository: ds-document-detector
@@ -25,26 +30,52 @@ models:
         storageNamespace: s3://governed-ci/datasets/ds-document-detector
       model: { repository: model-document-detector, branch: main }
   - id: document-recognizer
-    datasetMaterializer: materialize-document-recognizer-descriptor
     trainer: document-recognizer
+    datasetBuild:
+      target:
+        repository: ds-document-recognizer
+        branch: main
+        storageNamespace: s3://governed-ci/datasets/ds-document-recognizer
+      source: { strategy: hermetic-synthetic }
     lakefs:
       dataset: { repository: ds-document-recognizer, branch: main }
       model: { repository: model-document-recognizer, branch: main }
   - id: face-detector
-    datasetMaterializer: materialize-face-detector-descriptor
     trainer: face-detector
+    datasetBuild:
+      target:
+        repository: ds-face-detector
+        branch: main
+        storageNamespace: s3://governed-ci/datasets/ds-face-detector
+      source: { strategy: hermetic-synthetic }
     lakefs:
       dataset: { repository: ds-face-detector, branch: main }
       model: { repository: model-face-detector, branch: main }
   - id: sface
-    datasetMaterializer: materialize-sface-descriptor
     trainer: sface
+    datasetBuild:
+      target:
+        repository: ds-sface
+        branch: main
+        storageNamespace: s3://governed-ci/datasets/ds-sface
+      source:
+        strategy: governed-lakefs
+        repository: source-sface-consented
+        branch: main
     lakefs:
       dataset: { repository: ds-sface, branch: main }
       model: { repository: model-sface, branch: main }
   - id: pad-liveness
-    datasetMaterializer: materialize-pad-descriptor
     trainer: pad-liveness-pending
+    datasetBuild:
+      target:
+        repository: ds-pad-liveness
+        branch: main
+        storageNamespace: s3://governed-ci/datasets/ds-pad-liveness
+      source:
+        strategy: governed-lakefs
+        repository: source-pad-liveness-consented
+        branch: main
     lakefs:
       dataset: { repository: ds-pad-liveness, branch: main }
       model: { repository: model-pad-liveness, branch: main }

--- a/charts/webank-training/templates/workflowtemplate.yaml
+++ b/charts/webank-training/templates/workflowtemplate.yaml
@@ -18,22 +18,38 @@
 {{- if eq (len $training.gpu.tolerations) 0 }}{{ fail "webank-training: GPU-capable templates require at least one training.gpu.toleration" }}{{- end }}
 {{- range $model := .Values.models }}
 {{- $id := required "webank-training: models[].id is required" $model.id -}}
-{{- $materializer := required (printf "webank-training: %s datasetMaterializer is required" $id) $model.datasetMaterializer -}}
 {{- $trainer := required (printf "webank-training: %s trainer is required" $id) $model.trainer -}}
+{{- $datasetBuild := required (printf "webank-training: %s datasetBuild is required" $id) $model.datasetBuild -}}
+{{- $datasetTarget := required (printf "webank-training: %s datasetBuild.target is required" $id) $datasetBuild.target -}}
+{{- $datasetSource := required (printf "webank-training: %s datasetBuild.source is required" $id) $datasetBuild.source -}}
+{{- $sourceStrategy := required (printf "webank-training: %s datasetBuild.source.strategy is required" $id) $datasetSource.strategy -}}
 {{- $modelLakefs := required (printf "webank-training: %s lakefs is required" $id) $model.lakefs -}}
 {{- $datasetLakefs := required (printf "webank-training: %s lakefs.dataset is required" $id) $modelLakefs.dataset -}}
 {{- $candidateLakefs := required (printf "webank-training: %s lakefs.model is required" $id) $modelLakefs.model -}}
 {{- $datasetRepository := required (printf "webank-training: %s lakefs.dataset.repository is required" $id) $datasetLakefs.repository -}}
 {{- $datasetBranch := required (printf "webank-training: %s lakefs.dataset.branch is required" $id) $datasetLakefs.branch -}}
-{{- $datasetStorageNamespace := "" -}}
-{{- if eq $id "document-detector" }}{{- $datasetStorageNamespace = required "webank-training: document-detector lakefs.dataset.storageNamespace is required for hermetic bootstrap" $datasetLakefs.storageNamespace }}{{- end }}
+{{- $datasetTargetRepository := required (printf "webank-training: %s datasetBuild.target.repository is required" $id) $datasetTarget.repository -}}
+{{- $datasetTargetBranch := required (printf "webank-training: %s datasetBuild.target.branch is required" $id) $datasetTarget.branch -}}
+{{- $datasetStorageNamespace := required (printf "webank-training: %s datasetBuild.target.storageNamespace is required" $id) $datasetTarget.storageNamespace -}}
 {{- $candidateRepository := required (printf "webank-training: %s lakefs.model.repository is required" $id) $candidateLakefs.repository -}}
 {{- $candidateBranch := required (printf "webank-training: %s lakefs.model.branch is required" $id) $candidateLakefs.branch -}}
 {{- if ne $datasetRepository (printf "ds-%s" $id) }}{{ fail (printf "webank-training: %s dataset repository must be ds-%s" $id $id) }}{{- end }}
+{{- if ne $datasetTargetRepository $datasetRepository }}{{ fail (printf "webank-training: %s datasetBuild target must match its training dataset repository" $id) }}{{- end }}
 {{- if ne $candidateRepository (printf "model-%s" $id) }}{{ fail (printf "webank-training: %s model repository must be model-%s" $id $id) }}{{- end }}
 {{- if ne $datasetBranch "main" }}{{ fail (printf "webank-training: %s dataset branch must be main" $id) }}{{- end }}
+{{- if ne $datasetTargetBranch $datasetBranch }}{{ fail (printf "webank-training: %s datasetBuild target must match its training dataset branch" $id) }}{{- end }}
 {{- if ne $candidateBranch "main" }}{{ fail (printf "webank-training: %s model branch must be main" $id) }}{{- end }}
-{{- if not (has $materializer (list "materialize-document-detector-descriptor" "materialize-document-recognizer-descriptor" "materialize-face-detector-descriptor" "materialize-sface-descriptor" "materialize-pad-descriptor")) }}{{ fail (printf "webank-training: %s has an unknown dataset materializer" $id) }}{{- end }}
+{{- if not (has $sourceStrategy (list "hermetic-synthetic" "governed-lakefs")) }}{{ fail (printf "webank-training: %s has an unknown dataset source strategy" $id) }}{{- end }}
+{{- if eq $sourceStrategy "hermetic-synthetic" }}
+{{- if not (has $id (list "document-detector" "document-recognizer" "face-detector")) }}{{ fail (printf "webank-training: %s cannot use hermetic-synthetic" $id) }}{{- end }}
+{{- if or ($datasetSource.repository | default "") ($datasetSource.branch | default "") }}{{ fail (printf "webank-training: %s hermetic source must not declare a LakeFS route" $id) }}{{- end }}
+{{- else }}
+{{- if not (has $id (list "sface" "pad-liveness")) }}{{ fail (printf "webank-training: %s must not use a governed biometric source" $id) }}{{- end }}
+{{- $sourceRepository := required (printf "webank-training: %s governed source repository is required" $id) $datasetSource.repository -}}
+{{- $sourceBranch := required (printf "webank-training: %s governed source branch is required" $id) $datasetSource.branch -}}
+{{- if ne $sourceBranch "main" }}{{ fail (printf "webank-training: %s governed source branch must be main" $id) }}{{- end }}
+{{- if or (eq $sourceRepository $datasetTargetRepository) (eq $sourceRepository $candidateRepository) }}{{ fail (printf "webank-training: %s governed source repository must be distinct from its targets" $id) }}{{- end }}
+{{- end }}
 {{- if not (has $trainer (list "document-detector" "document-recognizer" "face-detector" "sface" "pad-liveness-pending")) }}{{ fail (printf "webank-training: %s has an unknown trainer" $id) }}{{- end }}
 ---
 apiVersion: argoproj.io/v1alpha1
@@ -48,13 +64,14 @@ metadata:
   annotations:
     webank.io/adr: "0034"
     webank.io/dataset-contract: "0006"
-{{- if eq $id "document-detector" }}
-    webank.io/materialization: "hermetic-synthetic-bootstrap"
-{{- else }}
-    webank.io/materialization: "metadata-descriptor"
+    webank.io/materialization: {{ ternary "hermetic-synthetic-bootstrap" "governed-lakefs" (eq $sourceStrategy "hermetic-synthetic") | quote }}
+    webank.io/source-strategy: {{ $sourceStrategy | quote }}
+    webank.io/dataset-lakefs-repository: {{ $datasetTargetRepository | quote }}
+    webank.io/dataset-lakefs-branch: {{ $datasetTargetBranch | quote }}
+{{- if eq $sourceStrategy "governed-lakefs" }}
+    webank.io/source-lakefs-repository: {{ $datasetSource.repository | quote }}
+    webank.io/source-lakefs-branch: {{ $datasetSource.branch | quote }}
 {{- end }}
-    webank.io/dataset-lakefs-repository: {{ $datasetRepository | quote }}
-    webank.io/dataset-lakefs-branch: {{ $datasetBranch | quote }}
 spec:
   entrypoint: build
   activeDeadlineSeconds: {{ $workflow.activeDeadlineSeconds }}
@@ -65,30 +82,8 @@ spec:
   imagePullSecrets:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-{{- if ne $id "document-detector" }}
-  arguments:
-    parameters:
-      - name: lakefs_ref
-        description: >-
-          Required immutable 64-character LakeFS commit named by the governed
-          manifest and readiness attestation. Branches and moving tags fail closed.
-    artifacts:
-      - name: source
-      - name: manifest
-      - name: readiness
-{{- end }}
   templates:
     - name: build
-{{- if ne $id "document-detector" }}
-      inputs:
-        artifacts:
-          - name: source
-            path: /workspace/input/source.json
-          - name: manifest
-            path: /workspace/input/source-manifest.json
-          - name: readiness
-            path: /workspace/input/readiness.json
-{{- end }}
       podSpecPatch: |
         runtimeClassName: {{ $training.gpu.runtimeClassName | quote }}
       nodeSelector:
@@ -120,46 +115,99 @@ spec:
               --lakefs-repository "$WEBANK_DATASET_LAKEFS_REPOSITORY" \
               --code-revision "$WEBANK_SOURCE_REVISION" \
               --policy /opt/webank-document-detector-dataset/bootstrap-policy.json
-            cargo xtask training-data push \
-              --destination training-data-lake \
-              --path /workspace/output/document-detector-bootstrap/document-detector-training-v1.tar \
-              --manifest /workspace/output/document-detector-bootstrap/governance/source-manifest.json \
-              --lakefs-ref "$BASE_REF" \
-              --readiness /workspace/output/document-detector-bootstrap/governance/readiness.json \
+            cargo xtask training-data fixed-dataset publish \
+              --model document-detector \
+              --bundle /workspace/output/document-detector-bootstrap/document-detector-training-v1.tar \
               --lakefs-branch "$WEBANK_DATASET_LAKEFS_BRANCH" \
               --lakefs-endpoint "$WEBANK_LAKEFS_ENDPOINT" \
-              --lakefs-repository "$WEBANK_DATASET_LAKEFS_REPOSITORY"
+              --lakefs-repository "$WEBANK_DATASET_LAKEFS_REPOSITORY" \
+              --lakefs-storage-namespace "$WEBANK_DATASET_LAKEFS_STORAGE_NAMESPACE"
+{{- else if eq $id "document-recognizer" }}
+            PYTHONPATH=/opt/webank-document-recognizer-dataset/src \
+              /opt/webank-document-detector-dataset/venv/bin/python \
+              -m webank_document_recognizer_dataset \
+              --output /workspace/output/document-recognizer-raw
+            cargo xtask training-data materialize-synthetic-source \
+              --model document-recognizer \
+              --source /workspace/output/document-recognizer-raw \
+              --output /workspace/output/document-recognizer-materialized
+            cargo xtask training-data fixed-dataset pack \
+              --model document-recognizer \
+              --input /workspace/output/document-recognizer-materialized \
+              --output /workspace/output/document-recognizer-training-bundle.tar
+            cargo xtask training-data fixed-dataset publish \
+              --model document-recognizer \
+              --bundle /workspace/output/document-recognizer-training-bundle.tar \
+              --lakefs-branch "$WEBANK_DATASET_LAKEFS_BRANCH" \
+              --lakefs-endpoint "$WEBANK_LAKEFS_ENDPOINT" \
+              --lakefs-repository "$WEBANK_DATASET_LAKEFS_REPOSITORY" \
+              --lakefs-storage-namespace "$WEBANK_DATASET_LAKEFS_STORAGE_NAMESPACE"
+{{- else if eq $id "face-detector" }}
+            PYTHONPATH=/opt/webank-face-detector-dataset/src \
+              /opt/webank-document-detector-dataset/venv/bin/python \
+              -m webank_face_detector_dataset \
+              --output /workspace/output/face-detector-raw
+            cargo xtask training-data materialize-synthetic-source \
+              --model face-detector \
+              --source /workspace/output/face-detector-raw \
+              --output /workspace/output/face-detector-materialized
+            cargo xtask training-data fixed-dataset pack \
+              --model face-detector \
+              --input /workspace/output/face-detector-materialized \
+              --output /workspace/output/face-detector-training-bundle.tar
+            cargo xtask training-data fixed-dataset publish \
+              --model face-detector \
+              --bundle /workspace/output/face-detector-training-bundle.tar \
+              --lakefs-branch "$WEBANK_DATASET_LAKEFS_BRANCH" \
+              --lakefs-endpoint "$WEBANK_LAKEFS_ENDPOINT" \
+              --lakefs-repository "$WEBANK_DATASET_LAKEFS_REPOSITORY" \
+              --lakefs-storage-namespace "$WEBANK_DATASET_LAKEFS_STORAGE_NAMESPACE"
 {{- else }}
-            cargo xtask training-data {{ $materializer }} \
-              --source /workspace/input/source.json \
-              --manifest /workspace/input/source-manifest.json \
-              --lakefs-ref "$LAKEFS_REF" \
-              --readiness /workspace/input/readiness.json \
-              --output /workspace/output/{{ $id }}-descriptor.json
-            cargo xtask training-data push \
-              --destination training-data-lake \
-              --path /workspace/output/{{ $id }}-descriptor.json \
-              --manifest /workspace/input/source-manifest.json \
-              --lakefs-ref "$LAKEFS_REF" \
-              --readiness /workspace/input/readiness.json \
+            SOURCE_REF="$(cargo xtask training-data resolve-governed-source-branch \
+              --model {{ $id }} \
+              --lakefs-branch "$WEBANK_SOURCE_LAKEFS_BRANCH" \
+              --lakefs-endpoint "$WEBANK_LAKEFS_ENDPOINT" \
+              --lakefs-repository "$WEBANK_SOURCE_LAKEFS_REPOSITORY")"
+            cargo xtask training-data checkout-governed-source \
+              --model {{ $id }} \
+              --source-ref "$SOURCE_REF" \
+              --output /workspace/output/{{ $id }}-source \
+              --lakefs-branch "$WEBANK_SOURCE_LAKEFS_BRANCH" \
+              --lakefs-endpoint "$WEBANK_LAKEFS_ENDPOINT" \
+              --lakefs-repository "$WEBANK_SOURCE_LAKEFS_REPOSITORY"
+            cargo xtask training-data materialize-governed-source \
+              --model {{ $id }} \
+              --source-ref "$SOURCE_REF" \
+              --source /workspace/output/{{ $id }}-source \
+              --output /workspace/output/{{ $id }}-materialized
+            cargo xtask training-data fixed-dataset pack \
+              --model {{ $id }} \
+              --input /workspace/output/{{ $id }}-materialized \
+              --output /workspace/output/{{ $id }}-training-bundle.tar
+            cargo xtask training-data fixed-dataset publish \
+              --model {{ $id }} \
+              --bundle /workspace/output/{{ $id }}-training-bundle.tar \
               --lakefs-branch "$WEBANK_DATASET_LAKEFS_BRANCH" \
               --lakefs-endpoint "$WEBANK_LAKEFS_ENDPOINT" \
-              --lakefs-repository "$WEBANK_DATASET_LAKEFS_REPOSITORY"
+              --lakefs-repository "$WEBANK_DATASET_LAKEFS_REPOSITORY" \
+              --lakefs-storage-namespace "$WEBANK_DATASET_LAKEFS_STORAGE_NAMESPACE"
 {{- end }}
         env:
-{{- if ne $id "document-detector" }}
-          - name: LAKEFS_REF
-            value: "{{`{{workflow.parameters.lakefs_ref}}`}}"
-{{- end }}
           - name: WEBANK_LAKEFS_ENDPOINT
             value: {{ $lakefs.endpoint | quote }}
           - name: WEBANK_DATASET_LAKEFS_REPOSITORY
-            value: {{ $datasetRepository | quote }}
+            value: {{ $datasetTargetRepository | quote }}
           - name: WEBANK_DATASET_LAKEFS_BRANCH
-            value: {{ $datasetBranch | quote }}
-{{- if eq $id "document-detector" }}
+            value: {{ $datasetTargetBranch | quote }}
           - name: WEBANK_DATASET_LAKEFS_STORAGE_NAMESPACE
             value: {{ $datasetStorageNamespace | quote }}
+          - name: WEBANK_DATASET_SOURCE_STRATEGY
+            value: {{ $sourceStrategy | quote }}
+{{- if eq $sourceStrategy "governed-lakefs" }}
+          - name: WEBANK_SOURCE_LAKEFS_REPOSITORY
+            value: {{ $datasetSource.repository | quote }}
+          - name: WEBANK_SOURCE_LAKEFS_BRANCH
+            value: {{ $datasetSource.branch | quote }}
 {{- end }}
           - name: LAKEFS_ACCESS_KEY_ID
             valueFrom: { secretKeyRef: { name: {{ $lakefs.secretName | quote }}, key: {{ $lakefs.accessKey | quote }} } }

--- a/charts/webank-training/values.yaml
+++ b/charts/webank-training/values.yaml
@@ -49,6 +49,7 @@ training:
     shrinkRatio: 0.6
 
 # One entry produces exactly two public WorkflowTemplates: `<id>-dataset-build`
-# and `<id>-train`. Each entry must also bind a fixed `lakefs.dataset` and
-# `lakefs.model` destination; values never provide executable shell text.
+# and `<id>-train`. `datasetBuild` selects one closed source strategy and fixes
+# its target route; `lakefs` retains the fixed training input/candidate routes.
+# Values never provide executable shell text.
 models: []

--- a/docs/integrations/webank-training-deployment.md
+++ b/docs/integrations/webank-training-deployment.md
@@ -27,34 +27,29 @@ stage into an alternative public operation.
 using `runtimeClassName: nvidia` so the host CUDA driver libraries are mounted.
 They request the same reviewed CPU, memory, and one-GPU resource profile as
 candidate training (ADR-0114).
-Document detector is the one special case: its form has **no inputs**. It
-creates the fixed `ds-document-detector/main` repository if necessary, obtains
-LakeFS's initial immutable commit, then runs the in-image Python builder to
-create the reviewed hermetic synthetic starter set. It fetches no source
-dataset from the network and passes the resulting manifest/readiness pair
-through the normal Rust gate and LakeFS write boundary.
+Every Dataset Build form has **no inputs**. Its target repository, `main`
+branch, reviewed storage namespace, and closed source strategy come only from
+`ai-helm-values`; the dashboard cannot choose a LakeFS reference, source
+archive, URL, or destination.
 
-The other dataset-build forms require three governed artifacts:
+Document detector, document recognizer, and face detector run their bundled
+offline Python builders. Recognizer and face-detector output then passes
+through the typed `materialize-synthetic-source` adapter before the complete
+training directory is packed. Document detector's builder already emits the
+fixed bundle contract. All three publish only through `fixed-dataset publish`
+to their configured `ds-<model>/main` target.
 
-- `source` — the model-specific source metadata;
-- `manifest` — the RFC-0006 source manifest; and
-- `readiness` — the matching attestation.
+SFace and PAD use a distinct, fixed governed LakeFS source repository. The
+workflow resolves its configured `main` branch to an immutable commit, checks
+out only the sealed source bundle, proves the embedded source commit matches,
+materializes the model-specific trainer contract, then packs and publishes the
+derived bundle. A missing or unapproved source fails closed. No workflow
+invents identity labels, consent, or physical-attack labels.
 
-It also requires `lakefs_ref`, the immutable commit declared by those two
-governance documents. The container materializes the model-specific descriptor
-and calls the narrow `training-data push` LakeFS boundary. It never accepts a
-dataset path, LakeFS destination, or arbitrary shell command from the
-dashboard. The destination repository and `main` branch come only from the
-model's reviewed `ai-helm-values` entry. Document detector's reviewed storage
-namespace is used only if that fixed repository must be created; an existing
-repository is never reset or reconfigured.
-
-The current materializers deliberately produce metadata descriptors. They do
-not invent biometric, identity, or PAD bytes. The document-detector bootstrap
-creates only generic synthetic scenes and exact programmatic labels; it is
-training input, never real-world evaluation or promotion evidence. Every other
-model still needs an approved model-specific source and governed artifact
-contract before an operator starts its template.
+Every target repository may be created only with its reviewed storage
+namespace. An existing repository is never reset or reconfigured. The
+synthetic builders create starter training data, never real-world evaluation
+or promotion evidence.
 
 ## Training templates
 

--- a/docs/playbooks/webank-model-workflows.md
+++ b/docs/playbooks/webank-model-workflows.md
@@ -10,39 +10,37 @@ Start with the model-specific operation you actually need:
 
 | Need | Template pattern | Compute |
 | --- | --- | --- |
-| Materialize and publish a governed descriptor | `webank-<model>-dataset-build` | one GPU |
+| Build and publish a fixed training dataset | `webank-<model>-dataset-build` | one GPU |
 | Train a governed candidate | `webank-<model>-train` | one GPU |
 
 There is one template of each kind for document detector, document recognizer,
 face detector, SFace, and PAD liveness. Do not choose a different entrypoint:
 the displayed `build` or `train` entrypoint is fixed by the selected template.
 
-Each template's LakeFS destinations are fixed in reviewed `ai-helm-values`, not
-in the Argo form. Dataset builds use `ds-<model>/main`; training candidates use
-`model-<model>/main`. The document-detector Dataset Build template is allowed
-to create its own fixed empty repository from its reviewed storage namespace;
-every other repository and `main` branch must exist before its first run.
+Each template's LakeFS routes are fixed in reviewed `ai-helm-values`, not in
+the Argo form. Dataset builds use `ds-<model>/main`; training candidates use
+`model-<model>/main`. Every Dataset Build target may be created from its
+reviewed storage namespace. SFace and PAD additionally resolve distinct fixed
+governed-source repositories; those sources must already exist and be approved.
 
-## Build a dataset descriptor
+## Build a dataset
 
-For **document detector**, open
-`webank-document-detector-dataset-build` and select **Submit** with no fields.
-Its fixed entrypoint builds the reviewed hermetic synthetic starter set from
-the image-bundled policy, reports the LakeFS commit in its logs, and accepts no
-source artifact, repository, branch, prompt, or transform. It must not be used
-as real-world evaluation data.
+Open the model's `webank-<model>-dataset-build` template and select **Submit**
+with no fields. No Dataset Build accepts a LakeFS ref, source artifact,
+repository, branch, URL, prompt, or transform from the dashboard.
 
-For every other model:
+- Document detector, document recognizer, and face detector build their
+  reviewed hermetic synthetic starter data from image-bundled policies. They
+  fetch no source dataset at runtime and must not be used as real-world
+  evaluation data.
+- SFace and PAD resolve the configured governed-source `main` branch to an
+  immutable commit internally. They fail closed if the sealed source bundle,
+  manifest, or approval is absent or inconsistent; fix that governed source
+  rather than supplying an alternate input.
 
-1. In Argo, open the model's `*-dataset-build` template and select **Submit**.
-2. Set `lakefs_ref` to the 64-character immutable commit recorded by the
-   approved source manifest. A branch name is rejected.
-3. Provide the three restricted artifacts: `source`, `manifest`, and
-   `readiness`. They must be the model-specific source metadata, RFC-0006
-   manifest, and matching readiness attestation from the data repository.
-4. Submit and inspect the `build` pod. A successful run writes only the
-   generated descriptor through the LakeFS training-data boundary into that
-   model's fixed `ds-<model>/main` repository.
+A successful run writes one validated training bundle through the fixed
+LakeFS boundary into that model's `ds-<model>/main` repository and reports the
+server-issued immutable commit.
 
 All dataset-build pods select `nvidia.com/gpu.present=true`, tolerate
 `nvidia.com/gpu:NoSchedule` (Exists), use `runtimeClassName: nvidia`, and request
@@ -50,9 +48,9 @@ the reviewed one-GPU CPU/memory resource profile. This guarantees that dataset
 materialization has the same GPU-node allocation and CUDA driver injection as
 candidate training.
 
-If a non-document-detector LakeFS repository is empty, this operation still
-cannot begin without an approved source artifact and its manifest/attestation.
-Do not use fixtures or a blank reference as a substitute.
+If an SFace or PAD governed-source repository is empty, the operation fails
+before materialization. Do not use fixtures or placeholder evidence as a
+substitute.
 
 ## Start candidate training
 


### PR DESCRIPTION
## Summary

Makes all five Webank Dataset Build WorkflowTemplates zero-input and renders their complete fixed-route source-to-LakeFS pipelines from reviewed deployment values.

## Intent

Dataset routing is GitOps configuration, not an Argo dashboard choice. The chart now consumes only a closed `hermetic-synthetic` or `governed-lakefs` strategy, while target/source repositories, branches, storage namespaces, image, and GPU placement remain in `ai-helm-values`.

Source of truth:
- https://github.com/ADORSYS-GIS/webank-models/blob/main/docs/rfc/0009-fixed-lakefs-model-dataset-workflows.md
- https://github.com/ADORSYS-GIS/webank-models/pull/349
- https://github.com/ADORSYS-GIS/ai-helm-values/pull/194 (merged values-first)

## Scope

- Remove `spec.arguments`, entrypoint inputs, `lakefs_ref`, and source artifacts from every Dataset Build template.
- Render the document-detector Python bootstrap followed by `fixed-dataset publish`.
- Render document-recognizer and face-detector Python builds followed by `materialize-synthetic-source`, pack, and publish.
- Render SFace and PAD fixed-source resolve, checkout, materialize, pack, and publish flows.
- Validate fixed target routes, `main` branches, strategy/model compatibility, and governed-source separation from both targets.
- Preserve `runtimeClassName` through `podSpecPatch`, node selector, toleration, priority, and the values-supplied CPU/memory/GPU resources.
- Update the deployment guide and operator playbook.

No workflow was submitted or retried. No LakeFS credential, source data, dataset, or model artifact was accessed or created.

## Verification

- [x] `helm lint charts/webank-training --strict -f charts/webank-training/ci/lint-values.yaml`.
- [x] Production values rendered exactly ten WorkflowTemplates and five Dataset Build templates.
- [x] Every rendered Dataset Build has no `spec.arguments` and no entrypoint `inputs`.
- [x] Every rendered Dataset Build uses the v1.5.0 immutable image, fixed route/strategy annotations and environment, and requests+limits 16 CPU, 48Gi, and one `nvidia.com/gpu`.
- [x] Rendered Dataset Build commands contain five fixed publishes, two synthetic materializations, two governed-source resolvers, and no workflow parameters or `/workspace/input` path.
- [x] The live Argo CRD accepted all ten production-rendered WorkflowTemplates with server-side dry-run.
- [x] `git diff --check` passed.

## Risk

Moderate and fail-closed. The three hermetic builders perform no source-data network access. SFace/PAD require their distinct configured source repositories and reject missing, unapproved, malformed, or commit-mismatched bundles before target publication. Existing training-template inputs are deliberately outside this scoped Dataset Build cutover.

## AI Usage Declaration

- [x] AI assistance was used for implementation, documentation, and verification.
- [x] The released v1.5.0 CLI contracts and rendered manifests were checked directly.

## Reviewer focus

- Confirm no Dataset Build public input remains.
- Confirm the strategy branches call only released v1.5.0 typed commands.
- Confirm runtime and routing literals remain supplied by `ai-helm-values`, not hardcoded in the chart.