### PR TITLE
feat(lightbridge-ci): add mcp controller baseline

### DIFF
--- a/charts/apps/values.yaml
+++ b/charts/apps/values.yaml
@@ -724,12 +724,12 @@ applications:
       # declares, which otherwise show a permanent cosmetic OutOfSync + selfHeal churn.
       # ServerSideDiff ignores those server-owned fields so the app reads Synced.
       argocd.argoproj.io/compare-options: ServerSideDiff=true
-      # Images aliased: cp/disp/recon/a2a (control-plane, role-selected), web, runner (the one-shot
+      # Images aliased: cp/disp/recon/a2a/mcp (control-plane, role-selected), web, runner (the one-shot
       # agent-runner/indexer image the dispatcher launches), and review (the slimmer review-only Job
       # image — no Python/Graphify — picked for review tasks; ADR-0004 per-kind images, #207).
       # `a2a` = the A2A surface (RFC-0006) — the SAME control-plane image, kept in lockstep so the a2a
       # role never lags the control-plane on a build.
-      argocd-image-updater.argoproj.io/image-list: cp=ghcr.io/adorsys-gis/lightbridge-control-plane,disp=ghcr.io/adorsys-gis/lightbridge-control-plane,recon=ghcr.io/adorsys-gis/lightbridge-control-plane,a2a=ghcr.io/adorsys-gis/lightbridge-control-plane,notifier=ghcr.io/adorsys-gis/lightbridge-control-plane,web=ghcr.io/adorsys-gis/lightbridge-web,runner=ghcr.io/adorsys-gis/lightbridge-agent-runner,review=ghcr.io/adorsys-gis/lightbridge-agent-review
+      argocd-image-updater.argoproj.io/image-list: cp=ghcr.io/adorsys-gis/lightbridge-control-plane,disp=ghcr.io/adorsys-gis/lightbridge-control-plane,recon=ghcr.io/adorsys-gis/lightbridge-control-plane,a2a=ghcr.io/adorsys-gis/lightbridge-control-plane,notifier=ghcr.io/adorsys-gis/lightbridge-control-plane,mcp=ghcr.io/adorsys-gis/lightbridge-control-plane,web=ghcr.io/adorsys-gis/lightbridge-web,runner=ghcr.io/adorsys-gis/lightbridge-agent-runner,review=ghcr.io/adorsys-gis/lightbridge-agent-review
       # ── control-plane ──
       argocd-image-updater.argoproj.io/cp.update-strategy: newest-build
       argocd-image-updater.argoproj.io/cp.allow-tags: regexp:^sha-[0-9a-f]+$
@@ -788,6 +788,19 @@ applications:
       argocd-image-updater.argoproj.io/notifier.signature-type: cosign
       argocd-image-updater.argoproj.io/notifier.cosign.certificate-oidc-issuer: https://token.actions.githubusercontent.com
       argocd-image-updater.argoproj.io/notifier.cosign.certificate-identity-regexp: ^https://github\.com/ADORSYS-GIS/lightbridge-code-intelligence/\.github/workflows/build-images\.yml@.*$
+      # ── mcp (SAME image as control-plane, role-selected; story #508) — keeps its tag in lockstep so
+      #    the MCP surface never lags the control-plane on a build. Without this alias the `mcp` tag
+      #    seeded in ai-helm-values would never auto-update (image-updater only tracks aliases listed
+      #    here), unlike every other role. ──
+      argocd-image-updater.argoproj.io/mcp.update-strategy: newest-build
+      argocd-image-updater.argoproj.io/mcp.allow-tags: regexp:^sha-[0-9a-f]+$
+      argocd-image-updater.argoproj.io/mcp.force-update: "true"
+      argocd-image-updater.argoproj.io/mcp.pull-secret: pullsecret:argocd/adorsys-gis-ghcr-pull
+      argocd-image-updater.argoproj.io/mcp.helm.image-name: lci.controllers.mcp.containers.main.image.repository
+      argocd-image-updater.argoproj.io/mcp.helm.image-tag: lci.controllers.mcp.containers.main.image.tag
+      argocd-image-updater.argoproj.io/mcp.signature-type: cosign
+      argocd-image-updater.argoproj.io/mcp.cosign.certificate-oidc-issuer: https://token.actions.githubusercontent.com
+      argocd-image-updater.argoproj.io/mcp.cosign.certificate-identity-regexp: ^https://github\.com/ADORSYS-GIS/lightbridge-code-intelligence/\.github/workflows/build-images\.yml@.*$
       # ── web ──
       argocd-image-updater.argoproj.io/web.update-strategy: newest-build
       argocd-image-updater.argoproj.io/web.allow-tags: regexp:^sha-[0-9a-f]+$

--- a/charts/lightbridge-code-intelligence/values.yaml
+++ b/charts/lightbridge-code-intelligence/values.yaml
@@ -952,6 +952,78 @@ lci:
             capabilities:
               drop: [ALL]
 
+    # ── mcp (Model Context Protocol) ──────────────────────────────────────────────────────────────
+    # The SAME control-plane image in the `mcp` role. It serves the RMCP over SSE on :8080.
+    mcp:
+      enabled: false
+      type: deployment
+      strategy: RollingUpdate
+      replicas: 2
+      annotations:
+        argocd.argoproj.io/sync-wave: "2"
+      containers:
+        main:
+          image:
+            repository: ghcr.io/adorsys-gis/lightbridge-control-plane
+            tag: "0.1.0"
+            pullPolicy: IfNotPresent
+          env:
+            CONTROL_PLANE_ROLE: "mcp"
+            RUST_LOG: "info"
+            MCP_BIND: "0.0.0.0:8080"
+            METRICS_ADDR: "0.0.0.0:9090"
+            PERMISSIONS_CLAIM: "permissions"
+            OIDC_ISSUER: ""
+            OIDC_AUDIENCE: ""
+            MCP_QUOTA_MAX: "20"
+            MCP_QUOTA_WINDOW_SECS: "3600"
+            DB_PASSWORD:
+              valueFrom:
+                secretKeyRef:
+                  name: lightbridge-codeintel-db-role
+                  key: password
+            DATABASE_URL:
+              dependsOn: DB_PASSWORD
+              value: ""
+            NEO4J_URI:
+              value: "bolt://{{ .Release.Name }}-neo4j:7687"
+            NEO4J_USERNAME: "neo4j"
+            NEO4J_PASSWORD:
+              valueFrom:
+                secretKeyRef:
+                  name: '{{ .Release.Name }}-neo4j-auth'
+                  key: password
+          probes:
+            liveness:
+              enabled: true
+              custom: true
+              spec:
+                httpGet:
+                  path: /healthz
+                  port: 9090
+                initialDelaySeconds: 5
+                periodSeconds: 15
+            readiness:
+              enabled: true
+              custom: true
+              spec:
+                httpGet:
+                  path: /healthz
+                  port: 9090
+                initialDelaySeconds: 5
+                periodSeconds: 10
+            startup:
+              enabled: false
+          resources:
+            requests: { cpu: 50m, memory: 64Mi }
+            limits: { cpu: 500m, memory: 256Mi }
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsUser: 1000
+            capabilities:
+              drop: [ALL]
+
     # ── notifier (RFC-0006 Phase 3 / ADR-0079) ────────────────────────────────────────────────────
     # The SAME control-plane image in the `notifier` role: a HEADLESS worker (like dispatcher/
     # reconciler) that drains the A2A push-notification outbox and delivers webhook POSTs to the URLs
@@ -1080,6 +1152,12 @@ lci:
       ports:
         http:
           port: 8080
+    mcp:
+      enabled: false
+      controller: mcp
+      ports:
+        http:
+          port: 8080
     # Metrics-only Service for the notifier role (METRICS_ADDR :9090) — same pattern as the dispatcher
     # Service above: the headless notifier has no other Service, so this gives its ServiceMonitor
     # (templates/servicemonitor.yaml) a stable Endpoints target for its push-delivery metrics. `enabled`
@@ -1105,6 +1183,8 @@ lci:
     # ⚠️ This exposes a PUBLIC authenticated Ingress: the agent card is served unauthenticated (spec),
     # every A2A binding behind it is OIDC-gated in-app (no anonymous access).
     a2a:
+      enabled: false
+    mcp:
       enabled: false
 
   # NetworkPolicies (bjw-s `networkpolicies` — rendered by bjw-common as networking.k8s.io/v1

--- a/charts/lightbridge-code-intelligence/values.yaml
+++ b/charts/lightbridge-code-intelligence/values.yaml
@@ -975,6 +975,15 @@ lci:
             PERMISSIONS_CLAIM: "permissions"
             OIDC_ISSUER: ""
             OIDC_AUDIENCE: ""
+            # Externally reachable base URL of this MCP surface (e.g. https://<host>/mcp) — the
+            # `resource` identifier in the role's RFC 9728 protected-resource metadata
+            # (/.well-known/oauth-protected-resource) and the `resource_metadata` pointer in its 401
+            # `WWW-Authenticate` challenge, which is how an MCP client discovers WHICH authorization
+            # server to get a token from. The pod cannot infer it — Traefik strips the `/mcp` prefix
+            # before the request arrives — so, exactly like A2A_BASE_URL, it is DEPLOYMENT-SPECIFIC
+            # → ai-helm-values; empty here. Empty = no metadata document and no challenge (the
+            # pre-discovery behaviour); the transport stays OIDC-gated either way.
+            MCP_PUBLIC_URL: ""
             MCP_QUOTA_MAX: "20"
             MCP_QUOTA_WINDOW_SECS: "3600"
             DB_PASSWORD:

--- a/charts/lightbridge-code-intelligence/values.yaml
+++ b/charts/lightbridge-code-intelligence/values.yaml
@@ -1007,9 +1007,8 @@ lci:
               enabled: true
               custom: true
               spec:
-                httpGet:
-                  path: /healthz
-                  port: 9090
+                tcpSocket:
+                  port: 8080
                 initialDelaySeconds: 5
                 periodSeconds: 10
             startup:


### PR DESCRIPTION
## 1. Summary

This PR changes:

- Adds the `mcp` baseline configuration to `lci.controllers.mcp`.
- Adds the `mcp` service definition to `lci.service.mcp`.
- Adds the `mcp` ingress toggle to `lci.ingress.mcp`.
- **Update (review round):** Adds the missing `mcp` alias to `charts/apps/values.yaml`'s `argocd-image-updater.argoproj.io/image-list` (and its per-alias `update-strategy`/`allow-tags`/`force-update`/`pull-secret`/`helm.image-name`/`helm.image-tag`/`signature-type`/cosign annotations, mirroring `a2a`/`notifier` exactly). Without this, the `mcp` role's image tag would never auto-update the way every other control-plane role does — a real gap found while cross-checking this PR against ai-helm-values#185.

It solves:

- https://github.com/ADORSYS-GIS/lightbridge-code-intelligence/issues/508
- Ensures structural parity with the existing `a2a` role for the new `mcp` endpoint in `lightbridge-code-intelligence`.

---

## 2. Intent

The intent of this PR is:

> To provide a structural baseline for the MCP server role inside the base helm chart. This ensures deployment properties like image, `CONTROL_PLANE_ROLE`, `MCP_BIND`, resource requests, health probes, and security contexts are uniformly configured across all deployments, allowing consumers (like `ai-helm-values`) to just toggle `enabled: true` and pass environment-specific secrets. That promise was incomplete without the image-updater alias — this update closes it.

---

## 3. Scope

### In Scope

- `values.yaml` defaults (disabled) for the `mcp` controller, service, and ingress.
- `charts/apps/values.yaml`: the `mcp` argocd-image-updater alias, so the tag ai-helm-values seeds stays current the same way `a2a`/`notifier` do.

### Out of Scope

- Environment overrides (handled in `ai-helm-values`).
- `servicemonitor.yaml` (metrics are exposed via `METRICS_ADDR: :9090` but are un-monitored by default, matching `a2a`).
- **A NetworkPolicy restricting Ingress to the `mcp` pod.** Considered this while reviewing alongside lightbridge-code-intelligence#591's `disable_allowed_hosts()` (it drops rmcp's own Host-header/DNS-rebinding guard on the 0.0.0.0 listener, relying on Traefik being the only thing that can reach the pod — an assumption nothing in this chart currently enforces). Didn't add it here: this chart's `networkpolicies:` block renders plain `networking.k8s.io/v1 NetworkPolicy` (via bjw-common), which has no way to allow kubelet-sourced health-probe traffic once a pod is selected for `Ingress` — that needs an entity-based exemption (e.g. `CiliumNetworkPolicy`'s `fromEntities: [host]`), which this block can't express. The existing `notifier` policy in this same file deliberately restricts only `Egress` and leaves `Ingress` untouched for exactly this reason ("kubelet probes... keep working"). Getting an Ingress-restricting policy wrong here risks bricking the `mcp` pod's readiness (`tcpSocket:8080`) the moment it's turned on — needs verifying Cilium's actual host-probe exemption behavior on hetzner-prod before it's safe to write. Flagging as a follow-up rather than guessing.

---

## 4. Verification

I verified this change by:

- [ ] Running automated tests
- [x] Running manual tests
- [ ] Checking logs
- [ ] Checking metrics
- [ ] Testing error cases
- [ ] Testing permissions/security behavior
- [ ] Testing rollback or failure behavior, if relevant

Commands run:

```bash
helm lint charts/lightbridge-code-intelligence
helm lint charts/apps
```

Results:

```text
==> Linting charts/lightbridge-code-intelligence
1 chart(s) linted, 0 chart(s) failed

==> Linting charts/apps
1 chart(s) linted, 0 chart(s) failed
```

---

## 5. Screenshots / Evidence

N/A

---

## 6. Risk Assessment

Risk level:

* [x] Low
* [ ] Medium
* [ ] High

Potential risks:

* None for the controller/service/ingress baseline (feature is disabled by default via `enabled: false`).
* The image-updater alias is purely additive (a new annotation key) — no effect on any currently-tracked role.
* Follow-up needed: no NetworkPolicy backstops `disable_allowed_hosts()` yet (see Out of Scope) — not a regression from this PR, but worth a dedicated ticket before `mcp` carries real traffic.

Mitigation:

* The feature must be explicitly opted into per environment.

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [ ] Refactoring
* [ ] Generating tests
* [x] Drafting documentation
* [x] Reviewing the diff
* [ ] Not used

Human verification:

* [x] I understand every meaningful change in this PR
* [x] I checked generated code manually
* [ ] I checked generated tests manually
* [ ] I removed unsupported AI assumptions
* [x] I accept responsibility for this PR

---

## 8. Reviewer Focus

Please focus your review on:

* [x] Correctness
* [x] Architecture
* [ ] Security
* [ ] Performance
* [ ] Tests
* [x] Maintainability
* [ ] Product intent
* [ ] Edge cases