### PR TITLE
fix(provider-billing-exporter): send billing periods to DeepInfra in …

### DIFF
--- a/charts/provider-billing-exporter/files/poller.py
+++ b/charts/provider-billing-exporter/files/poller.py
@@ -198,11 +198,25 @@ def parse_usage(payload: dict) -> tuple[list, dict, bool]:
     return series, invoice_final, True
 
 
+def _api_period(period: str) -> str:
+    """Convert the repo's YYYY-MM period convention to the API's YYYY.MM format.
+
+    DeepInfra's /payment/usage/tokens endpoint expects periods as YYYY.MM (dot),
+    while the repo's metric labels and BILLING_PERIOD env use YYYY-MM (dash).
+    Sending the dash form yields HTTP 400 (validation error).
+    """
+    return period.replace("-", ".")
+
+
 def fetch_usage(api_url: str, token: str, from_period: str, to_period: str | None = None) -> dict:
-    """One GET /payment/usage/tokens call covering [from_period, to_period]."""
-    params = [("from", from_period)]
+    """One GET /payment/usage/tokens call covering [from_period, to_period].
+
+    Periods are given in the repo's YYYY-MM form and converted to the API's
+    YYYY.MM form for the request.
+    """
+    params = [("from", _api_period(from_period))]
     if to_period:
-        params.append(("to", to_period))
+        params.append(("to", _api_period(to_period)))
     url = f"{api_url}/payment/usage/tokens?{urlencode(params)}"
     req = urllib.request.Request(url, headers={"Authorization": f"Bearer {token}"})
     with urllib.request.urlopen(req, timeout=30) as resp:

--- a/tools/dashboards/tests/test_provider_billing_poller.py
+++ b/tools/dashboards/tests/test_provider_billing_poller.py
@@ -169,6 +169,33 @@ def test_provider_correction_overwrites() -> None:
 # --- error classification (permanent vs transient) ----------------------------
 
 
+def test_api_period_converts_dash_to_dot() -> None:
+    # The repo uses YYYY-MM for labels/env, but the DeepInfra API expects YYYY.MM.
+    # Sending the dash form yields HTTP 400 (the bug that caused "no data").
+    assert poller._api_period("2026-08") == "2026.08"
+    assert poller._api_period("2026-07") == "2026.07"
+    # Idempotent if already in dot form.
+    assert poller._api_period("2026.08") == "2026.08"
+
+
+def test_fetch_usage_uses_dot_period_format(monkeypatch) -> None:
+    """The request URL must use YYYY.MM (dot), not YYYY-MM (dash)."""
+    captured = {}
+
+    def _fake_urlopen(req, timeout=30):
+        captured["url"] = req.full_url
+        captured["auth"] = req.get_header("Authorization")
+        import io
+        return io.BytesIO(b'{"months": []}')
+
+    monkeypatch.setattr(poller.urllib.request, "urlopen", _fake_urlopen)
+    poller.fetch_usage("https://api.deepinfra.com", "tok", "2026-07", "2026-08")
+    assert "from=2026.07" in captured["url"]
+    assert "to=2026.08" in captured["url"]
+    assert "2026-07" not in captured["url"]
+    assert captured["auth"] == "Bearer tok"
+
+
 def test_permanent_http_errors() -> None:
     # Bad token / forbidden / missing endpoint are permanent: retrying cannot fix.
     for code in (400, 401, 403, 404, 405, 422):


### PR DESCRIPTION
…YYYY.MM format

The poller sent the billing period as YYYY-MM (the repo's label/env convention), but DeepInfra's /payment/usage/tokens endpoint expects YYYY.MM (dot). The API rejected the request with HTTP 400, so the poller never emitted cost data and the dashboard showed no data. Convert periods to YYYY.MM for the request (labels keep YYYY-MM). Adds tests for the conversion and the request URL.

## 1. Summary

This PR changes:

- [Change 1]
- [Change 2]
- [Change 3]

It solves:

- [Problem / ticket / story link]

---

## 2. Intent

The intent of this PR is:

> [Explain why this change exists.]

---

## 3. Scope

### In Scope

- [Included change 1]
- [Included change 2]

### Out of Scope

- [Excluded change 1]
- [Excluded change 2]

---

## 4. Verification

I verified this change by:

- [ ] Running automated tests
- [ ] Running manual tests
- [ ] Checking logs
- [ ] Checking metrics
- [ ] Testing error cases
- [ ] Testing permissions/security behavior
- [ ] Testing rollback or failure behavior, if relevant

Commands run:

```bash
[command 1]
[command 2]
```

Results:

```text
[paste result or link]
```

---

## 5. Screenshots / Evidence

Add evidence here:

* Screenshot: [link]
* Logs: [link]
* Metrics: [link]
* Recording: [link]

---

## 6. Risk Assessment

Risk level:

* [ ] Low
* [ ] Medium
* [ ] High

Potential risks:

* [Risk 1]
* [Risk 2]

Mitigation:

* [Mitigation 1]
* [Mitigation 2]

---

## 7. AI Usage Declaration

AI was used for:

* [ ] Understanding existing code
* [ ] Generating code
* [ ] Refactoring
* [ ] Generating tests
* [ ] Drafting documentation
* [ ] Reviewing the diff
* [ ] Not used

Human verification:

* [ ] I understand every meaningful change in this PR
* [ ] I checked generated code manually
* [ ] I checked generated tests manually
* [ ] I removed unsupported AI assumptions
* [ ] I accept responsibility for this PR

---

## 8. Reviewer Focus

Please focus your review on:

* [ ] Correctness
* [ ] Architecture
* [ ] Security
* [ ] Performance
* [ ] Tests
* [ ] Maintainability
* [ ] Product intent
* [ ] Edge cases
