### PR TITLE
feat(inference): deploy Qwen3-4B (Q6_K, llama.cpp) as the fleet coding model

### DIFF
--- a/charts/ai-models/values.yaml
+++ b/charts/ai-models/values.yaml
@@ -633,24 +633,6 @@ backends:
       key: ai/camer/digital/prod/env
       property: vllm_local_api_key
 
-  # Qwen3-Coder-30B-A3B — the fleet's CODING model (vLLM, MoE 30B/3B active,
-  # AWQ INT4). Cluster-local Service created by the `qwen3-coder-30b-a3b`
-  # inference entry. Same `vllm_local_api_key` ssegning-aws property every
-  # other fleet backend uses.
-  qwen3-coder-30b-a3b-local:
-    schema: OpenAI
-    prefix: "/v1"
-    fqdn:
-      hostname: qwen3-coder-30b-a3b.inference.svc.cluster.local
-      port: 8080
-    securityType: APIKey
-    resourceName: qwen3-coder-30b-a3b-local-svc
-    secretRef:
-      name: qwen3-coder-30b-a3b-api-key
-    externalSecret:
-      key: ai/camer/digital/prod/env
-      property: vllm_local_api_key
-
 # Models — each entry becomes one child Application using the `ai-model`
 # leaf chart. Setting `enabled: false` on a model skips its Application
 # (the AppSet controller will delete a previously-generated child).
@@ -685,8 +667,8 @@ models:
 #  something that could come back, and these cannot: the servers no longer exist.
 #
 #  Today `-local` is exactly: z-image-turbo-local (image generation) — one per
-#  fleet card. Both text tiers (openmythos-27b-local, qwen3-8b-fast-local) are
-#  disabled. If you add another, it is on the fleet or it does not carry -local.
+#  fleet card. The text tiers (openmythos-27b-local, qwen3-8b-fast-local) are
+#  all disabled. If you add another, it is on the fleet or it does not carry -local.
 # ═══════════════════════════════════════════════════════════════════════════════
 
 # ⚠️ INTERNAL-ONLY MODELS CARRY AN `-internal` SUFFIX (2026-07-28).
@@ -758,66 +740,6 @@ models:
         ref: qwen3-8b-fast-local
         priority: 0
         modelNameOverride: "qwen3-8b-fast"   # = --served-model-name
-
-  # ─────────────────────────────────────────────────────────────────────────
-  # Qwen3-Coder-30B-A3B — CODING model on the GPU fleet (vLLM, MoE 30B/3B
-  # active, AWQ INT4).
-  #
-  # Serving spec: charts/inference/values.yaml `qwen3-coder-30b-a3b`.
-  #
-  # ⚠️ FEDERATED WITHOUT ITS LOAD GATE (ADR-0101) — deliberate, at the
-  # operator's request, so a real coding request can be exercised through the
-  # gateway end to end. The gate is still REQUIRED before this entry is
-  # trusted with real traffic: measure tok/s, VRAM headroom and answer
-  # QUALITY (ONE lossy layer: AWQ INT4 — the FP8 KV cache risk is gone, the
-  # serving spec opts OUT of the fleet fp8 default with `kvCacheDtype: auto`,
-  # so the KV cache is 16-bit, unquantized). Update this comment with the
-  # measured numbers when done.
-  #
-  # ⚠️ PRICING IS A PLACEHOLDER. Derived from the ADR-0104 node cost at an
-  # ASSUMED 35 tok/s decode (never measured; the 8B dense measured 45 tok/s
-  # with LMCache + CUDA graphs, this model is eager-mode):
-  #   €0.2968/h ÷ 3600 ÷ 35 tok/s = €2.36/1M output at saturation
-  #   × 3.45 duty-cycle uplift     = €8.13/1M ≈ $8.85/M (1 : 0.15 : 0.03 split)
-  # RE-DERIVE from the measured rate before relying on cost boards — never
-  # scale a placeholder (same rule as every corrected price in this file).
-  #
-  # ⚠️ Context raised to 12288 input window (2026-08-05): at 8192 the
-  # catalog's own maxOutputTokens (4096) is additive on top of the input
-  # window, so a 4097-token prompt + 4096 output = 8193 > 8192 → vLLM refused
-  # (same failure as #919). The serving spec window is 16384 (see inference),
-  # exactly the advertised contextLength (12288) + maxOutputTokens (4096) — a
-  # client honouring the catalog can never exceed it. The serving spec runs
-  # the 16-bit KV cache (`kvCacheDtype: auto`, NOT the fp8 fleet default) with
-  # `parallel: 1`, so 16384 ≈ 1.50 GiB KV leaves ~1.83 GiB of the ~3.33 GiB
-  # budget (0.95 util) for activations — re-verify at the load gate, not assumed.
-  #
-  # ⚠️ Thinking is OFF at the server (`reasoning: "off"` in the serving spec),
-  # so `supportedParameters` does NOT advertise `reasoning` — same policy as
-  # z-image-turbo. Clients opt in per request via chat_template_kwargs.
-  qwen3-coder-30b-a3b-local:
-    enabled: true
-    kind: text
-    minBackends: 1                   # one GPU, one backend, by design
-    timeout:
-      requestTimeout: 600s
-      connectionIdleTimeout: 1h
-    info:
-      displayName: "Qwen3-Coder-30B (self-hosted)"
-      contextLength: 12288           # = advertised INPUT window (clients add maxOutputTokens on top; serving window is 16384)
-      maxOutputTokens: 4096
-      supportedParameters: *spStandard
-    pricing:
-      strategy: weighted
-      standard:
-        inputPer1M: 1.34
-        cachedInputPer1M: 0.27
-        outputPer1M: 8.85
-    backends:
-      qwen3-coder-30b-a3b-local:
-        ref: qwen3-coder-30b-a3b-local
-        priority: 0
-        modelNameOverride: "qwen3-coder-30b-a3b"   # = --served-model-name
 
   # ─────────────────────────────────────────────────────────────────────────
   # Z-Image-Turbo — IMAGE GENERATION, on the GPU fleet (ADR-0100).

--- a/charts/inference/values.yaml
+++ b/charts/inference/values.yaml
@@ -644,159 +644,40 @@ defaults:
 models:
 
    # ─────────────────────────────────────────────────────────────────────────
-   # Qwen3-Coder-30B-A3B (MoE, AWQ INT4, vLLM) — CODING MODEL, takes the GPU
-   # fleet card that used to run qwen3-vl-4b-thinking.
+   # Qwen3-4B (Q6_K GGUF, llama.cpp) — the fleet's coding model.
    #
-   # QuantTrio/Qwen3-Coder-30B-A3B-Instruct-AWQ: 30B MoE (128 experts, 8 active),
-   # AWQ INT4 safetensors, ~16.8 GB on disk (6 shards). Apache-2.0.
-   # Base model: Qwen/Qwen3-Coder-30B-A3B-Instruct (official Qwen, 1.5M downloads).
+   # Full deployment plan + sizing:
+   #   inference-ops docs/benchmarks/2026-08-06-qwen3-4b-q6k-rtx4000-ada-deployment.md
    #
-   # ⚠️ NOT LOAD-GATED, and NOT FEDERATED (ADR-0101). `enabled: true` here only
-   # deploys it onto a GPU so it CAN be measured — federating it into
-   # charts/ai-models/values.yaml is a separate step, after someone has
-   # actually sent it a coding request and measured tok/s, VRAM and quality.
+   # ⚠️ NOT FEDERATED until the load gate measures it (ADR-0101 — a model must
+   # be measured before any user can route to it). Predictions are in the plan
+   # above; the gate's own report is separate and immuable.
    #
-   # ⚠️ `gpuMemoryUtilization: 0.95` caps vLLM's budget at 18.99 GiB
-   # (0.95 × 19.99). Weights are ~15.66 GiB, leaving ~3.33 GiB for KV cache +
-   # CUDA graphs + activations. FP8 KV cache (defaults.kvCacheDtype) halves the
-   # KV footprint (~0.38 GiB at 8K). CUDA graphs capture memory is larger on
-   # this 48-layer / 128-expert MoE than on dense models, so `--enforce-eager`
-   # is PRE-DECLARED in serving.extraArgs below (review finding) — CUDA graphs
-   # off until the load gate measures real headroom, then re-check.
-   # Context raised to 16384 (2026-08-05): at 12288 the catalog's own
-   # maxOutputTokens (4096) is additive on top of the input window, so a
-   # 12288-token prompt + 4096 output = 16384 > 12288 → vLLM refused — the
-   # same failure as the 8193 > 8192 refusal, one step higher. 16384 is the
-   # smallest window where the advertised contextLength (12288) + maxOutputTokens
-   # (4096) fit, so a client honouring the catalog can never exceed it. With the
-   # 16-bit KV cache (kvCacheDtype: auto — NO quantization) and `parallel: 1`
-   # (see below), 16384 needs ~1.50 GiB KV (≈2× the fp8 footprint), leaving
-   # ~1.83 GiB of the ~3.33 GiB budget for activations — still comfortable,
-   # but the non-fp8 KV footprint must be re-verified at the load gate.
-   #
-   # ⚠️ MoE architecture: 128 experts, 8 active per token. vLLM supports
-   # qwen3_moe natively. AWQ Marlin kernels for the expert linear layers;
-   # gate/router layers kept in FP16 — baked into the model's HF config
-   # (quantization_config.modules_to_not_convert: ['.mlp.gate']), not wired
-   # by the chart. vLLM reads it automatically from config.json.
-   #
-   # ⚠️ RISK (review finding): lossy layers on a model whose entire value is
-   # correctness. (1) AWQ INT4 — the pinned quant's own card warns "significant
-   # loss under 4-bit quantization, use with caution". (2) The fleet default
-   # FP8 KV cache (defaults.kvCacheDtype) with uncalibrated scales — this model
-   # OPPTS OUT with `serving.kvCacheDtype: auto` below (16-bit KV cache, NO
-   # quantization), which removes the fp8-KV quality risk; only the AWQ-INT4
-   # weight loss remains. The load gate must still measure quality (not just
-   # tok/s and VRAM) BEFORE this model is federated — see ADR-0118.
-   qwen3-coder-30b-a3b:
+   # contextSize 32768 / parallel 1: every request gets the FULL native
+   # window (the per-request window is the load-bearing number). parallel: 2 @
+   # ctx 65536 (two full-window slots) is a load-gate comparison, not the
+   # initial setting — it implies rope scaling.
+   qwen3-4b:
      enabled: true
-     engine: vllm
+     engine: llamacpp
      weights:
-       hfRepo: QuantTrio/Qwen3-Coder-30B-A3B-Instruct-AWQ
-       # Pinned via `curl -s https://huggingface.co/api/models/QuantTrio/Qwen3-Coder-30B-A3B-Instruct-AWQ | jq -r .sha`
-       revision: c58857a7f41c0920f73d1b56678640f9c02017d7
-       # ⚠️ PROVENANCE (review finding, 2026-08-05): this repo's config.json
-       # differs from the official base model's — `intermediate_size` 5472 vs 6144,
-       # `max_window_layers` 28 vs 48, `use_qk_norm: true`, and `name_or_path:
-       # tclf90/Qwen3-Coder-30B-A3B-Instruct-AWQ` (a third-party quant, republished
-       # by QuantTrio). The SHA pin makes the bytes reproducible, and vLLM reads
-       # this config against these weights so it is self-consistent — but confirm
-       # at the load gate that the AWQ was quantized from the exact official
-       # checkpoint before trusting it with real traffic.
-       # No `include`: vLLM needs the whole repo (6 safetensors shards + config
-       # + tokenizer + tool parser), not a single file.
-       #
-       # 16.8 GB on disk; staging in .cache peaks at ~2x = ~33.6 GB. 35 GiB
-       # gives margin above that. Longhorn grows a PVC in place but never
-       # shrinks one, so err high.
-       sizeGi: 35
-       # 6 shards of ~2.8 GB each; with 8-way fan-out, peak memory could hit
-       # ~22 GB. Cap fan-out and raise the margin (same lesson as the
-       # Z-Image-Turbo incident #802).
-       seedMaxWorkers: 2
-       seedMemoryLimit: 10Gi
+       hfRepo: Qwen/Qwen3-4B-GGUF
+       # Pinned via `curl -s https://huggingface.co/api/models/Qwen/Qwen3-4B-GGUF | jq -r .sha`
+       revision: bc640142c66e1fdd12af0bd68f40445458f3869b
+       include: "Qwen3-4B-Q6_K.gguf"
+       sizeGi: 10
      serving:
-       # Conservative start (model native: 262144). For agentic coding through
-       # opencode, system prompt + tool schemas + file context can exceed 8K on
-       # turn one — raised to 16384 (2026-08-05) so the catalog's advertised
-       # input window (12288) + maxOutputTokens (4096) both fit the window,
-       # after the 12289 > 12288 refusal at 16384's predecessor step. With
-       # ~15.6 GiB weights and the 16-bit KV cache (kvCacheDtype: auto,
-       # NO quantization), 16384 fits: ~1.50 GiB KV, ~1.83 GiB left for
-       # activations at the 0.95 util budget.
-       contextSize: 16384
-       # ⚠️ parallel: 1, NOT 2 (review finding, 2026-08-05). vLLM PRE-ALLOCATES
-       # the KV cache for `--max-num-seqs × --max-model-len` tokens, not one
-       # sequence. At parallel: 2 that is 2 × 16384 = 32768 tokens × 96 KiB (fp16)
-       # = ~3.00 GiB of KV — which consumes most of the ~3.33 GiB headroom
-       # (18.99 GiB budget − ~15.66 GiB weights) and leaves ~0.33 GiB for
-       # activations, a thin margin for a 48-layer MoE and the exact "no memory
-       # for KV blocks" startup abort the --enforce-eager note below fears. At
-       # parallel: 1 the KV prealloc is 1 × 16384 = ~1.50 GiB, leaving the
-       # ~1.83 GiB for activations the comments above assume. One GPU, one
-       # backend (minBackends: 1) — a single concurrent coding request is the
-       # honest capacity here. Re-raise only after the load gate measures real
-       # headroom.
+       contextSize: 32768
        parallel: 1
-       quantization: awq
-       # float16, not bfloat16: AWQ weights are INT4 with FP16 scales; the
-       # model's torch_dtype is bfloat16 but vLLM's AWQ path uses float16
-       # for non-quantized layers (embedding, lm_head, gate/router). This
-       # is the repo's AWQ convention — same as qwen3-8b-fast.
-       dtype: float16
-       # ⚠️ qwen3_xml, NOT hermes. Qwen3-Coder uses XML function-call format
-       # (the model ships its own qwen3coder_tool_parser.py). hermes is correct
-       # for Qwen3 base models but produces plain-text tool calls on Coder.
-       # Ref: https://docs.vllm.ai/en/stable/features/tool_calling/
-       toolCallParser: qwen3_xml
-       # Fleet convention for Qwen3 text models (same as qwen3-8b-fast,
-       # openmythos-27b): thinking OFF at the server. Without a configured
-       # `--reasoning-parser`, vLLM's Qwen3 default emits the trace as RAW
-       # `<think>` tags inside `content` — visible markup in every answer.
-       # Thinking also eats the tight 16K window + output budget at the eager
-       # mode this model is forced into. Clients opt in per request with
-       # `chat_template_kwargs.enable_thinking=true` (vLLM merges request
-       # kwargs over --default-chat-template-kwargs).
+       # Fleet convention for Qwen3 text models (same as openmythos-27b,
+       # qwen3-8b-fast): thinking OFF at the server. Clients opt in per
+       # request; the catalog does NOT advertise reasoning.
        reasoning: "off"
-       # Fleet default: 0.90 → 17.99 GiB budget (0.90 × 19.99). Weights are
-       # ~15.66 GiB, leaving ~2.33 GiB for KV cache + CUDA graphs + activations.
-       # ⚠️ Raised to 0.95 (2026-08-05): 18.99 GiB budget → ~3.33 GiB for KV +
-       # activations. With the 16-bit KV cache (kvCacheDtype: auto) at 16384
-       # (~1.50 GiB) that leaves ~1.83 GiB for activations — ~0.4 GiB more than
-       # at 0.90, with no quality cost. 0.95 is safe on a dedicated GPU (the
-       # ~1 GiB left is driver/display overhead); re-check at the load gate.
-       gpuMemoryUtilization: 0.95
-       # ⚠️ --enforce-eager PRE-DECLARED (review finding): CUDA graphs capture
-       # memory is materially larger on this 48-layer / 128-expert MoE than on
-       # the 4B this knob was sized against, and ~3.33 GiB of headroom (0.95
-       # util) is still too tight to gamble on it — the most likely first
-       # failure is vLLM aborting at startup with no memory for KV blocks.
-       # Costs: no CUDA-graph speedup for this model until measured. Remove
-       # once the load gate has measured real headroom and confirmed eager mode
-       # is not needed (then re-check quality).
-       extraArgs:
-         - "--enforce-eager"
-       # KV cache: PER-MODEL OPT-OUT of the fleet default (defaults.kvCacheDtype
-       # = fp8_e4m3). `kvCacheDtype: auto` restores the STANDARD 16-bit
-       # (bf16/fp16) cache — NO quantization — at the cost of ≈2× the KV
-       # footprint vs fp8 (hence the ~1.83 GiB activation headroom note above).
-       # Deliberate, local choice for this coding model (correctness-sensitive,
-       # one lossy layer only: AWQ INT4); the rest of the fleet keeps the fp8
-       # default (ADR-0118). fp8 is the option if the load gate wants the extra
-       # context headroom back — measure quality first, like every knob here.
-       kvCacheDtype: auto
      resources:
        cpuRequest: "2"
        cpuLimit: "8"
-       # RAM, not VRAM. 17 Gi was too tight: vLLM stages the 16.8 GB of AWQ
-       # weights in RAM while loading (and the 30B/128-expert MoE engine init
-       # holds sizeable CPU-side structures on top), so the load OOM-killed
-       # before the port ever opened — pod never Ready, killed at the 30-min
-       # startup budget. Aligned with z-image-turbo (32 Gi), the fleet
-       # precedent for similarly-sized weights. Re-check after the load gate
-       # measures real headroom.
-       memoryRequest: 12Gi
-       memoryLimit: 32Gi
+       memoryRequest: 4Gi
+       memoryLimit: 16Gi
 
    # ─────────────────────────────────────────────────────────────────────────
    # Z-Image-Turbo — IMAGE GENERATION, served by LocalAI (ADR-0102/0103/0105).
@@ -920,8 +801,9 @@ models:
    # OpenMythos-27B (Q4_K GGUF, llama.cpp) — DISABLED.
    # Was the first model on the Hetzner GPU fleet, load-gated at 15.05 tok/s
    # decode / 625 tok/s prefill / 16748 MiB and served to users. Disabled because
-   # the fleet has two cards and they now hold qwen3-coder-30b-a3b and
-   # z-image-turbo. The pinned SHA still resolves, so re-enabling re-seeds
+   # the fleet has two cards and they now hold z-image-turbo (and the coding
+   # model that briefly took the other card was retired 2026-08-06 — the card is
+   # free). The pinned SHA still resolves, so re-enabling re-seeds
    # byte-identical weights. Report: inference-ops
    # docs/benchmarks/2026-07-26-openmythos-27b-q4k-rtx4000-ada.md
    # ─────────────────────────────────────────────────────────────────────────
@@ -946,7 +828,8 @@ models:
    # ─────────────────────────────────────────────────────────────────────────
    # Qwen3-8B-AWQ (vLLM + LMCache) — DISABLED.
    # Was the SPEED tier on the second GPU. Disabled because the fleet has two
-   # cards and they now hold qwen3-coder-30b-a3b and z-image-turbo. Never
+   # cards and they now hold z-image-turbo (the coding model that briefly took
+   # the other card was retired 2026-08-06 — the card is free). Never
    # load-gated, so it was never federated. Re-enable to roll back.
    # ─────────────────────────────────────────────────────────────────────────
    qwen3-8b-fast:

--- a/charts/librechat-opencode-wellknown/values.yaml
+++ b/charts/librechat-opencode-wellknown/values.yaml
@@ -329,20 +329,6 @@ wellKnown:
             variants:
               thinking:
                 reasoningEffort: high
-          # The fleet coding model (charts/inference `qwen3-coder-30b-a3b`).
-          # ⚠️ NO `thinking` variant: the server runs with
-          # `--default-chat-template-kwargs {"enable_thinking": false}` (reasoning
-          # OFF at the server, fleet convention for Qwen3 text models), so a
-          # `thinking` variant here would advertise a reasoning channel that
-          # cannot produce a trace. `reasoningEffort: low` is harmless (vLLM
-          # ignores the OpenAI graded knob; native knob is enable_thinking).
-          # Context/output limits come from the catalog (ai-models-info):
-          # contextLength 12288 / maxOutputTokens 4096 — the serving window is
-          # 16384 total, so input + max_tokens must not exceed 16384
-          # (12288 input + 4096 output = 16384; beyond → vLLM 400).
-          qwen3-coder-30b-a3b-local:
-            options:
-              reasoningEffort: low
           deepseek-v4-flash-0731:
             options:
               reasoningEffort: low

--- a/docs/adr/0118-fp8-kv-cache-fleet-default.md
+++ b/docs/adr/0118-fp8-kv-cache-fleet-default.md
@@ -9,7 +9,7 @@
 Self-hosted models on the Hetzner GPU fleet (RTX 4000 SFF Ada, 20475 MiB) are
 VRAM-bound: the whole budget for a model is `gpuMemoryUtilization` × 19.99 GiB,
 and weights consume most of it, leaving a small remainder for the KV cache,
-CUDA graphs and activations (for `qwen3-coder-30b-a3b` at 0.90: ~2.33 GiB after
+CUDA graphs and activations (for a 30B-A3B MoE at 0.90: ~2.33 GiB after
 ~15.66 GiB of AWQ weights). vLLM's default KV-cache dtype is 16-bit (bf16/fp16),
 which limits how many tokens fit in that remainder.
 
@@ -56,13 +56,11 @@ Scope is vLLM-only, enforced by render-time guards:
 - fp8 KV cache is lossy; the quality cost is small but must be **measured per
   model, not assumed** (ADR-0101 discipline). A model whose KV headroom was
   measured in BF16 changes its baseline silently the moment it is re-enabled.
-- Today the blast radius is one enabled model (`qwen3-coder-30b-a3b`;
-  `qwen3-vl-4b-thinking`/`qwen3-8b-fast`/`openmythos-27b` are disabled and
-  `z-image-turbo` is LocalAI) — but the default persists for any model
-  re-enabled later. ⚠️ Note: `qwen3-coder-30b-a3b` is the one enabled vLLM
-  model and it **opts out** of the fp8 default (`serving.kvCacheDtype: auto`,
-  16-bit), so today no live model actually runs fp8 KV. The default still
-  applies to any vLLM model that does not override it.
+- Today the blast radius is one enabled vLLM model — but the default persists
+  for any model re-enabled later. ⚠️ Note: that model **opts out** of the fp8
+  default (`serving.kvCacheDtype: auto`, 16-bit), so today no live model
+  actually runs fp8 KV. The default still applies to any vLLM model that does
+  not override it.
 - `fp8_e5m2`/`fp8_e4m3` are passed verbatim to `--kv-cache-dtype`; a future
   vLLM version that renames the accepted set requires the guard list to move
   in lockstep.


### PR DESCRIPTION
## 1. Summary

**Source of truth:** [inference-ops PR #4 — Qwen3-4B deployment plan + 30B retirement report](https://github.com/ADORSYS-GIS/inference-ops/pull/4) (merged) documents the full deployment plan, sizing arithmetic, engine selection and per-knob audit.

This PR changes:

- **Adds `qwen3-4b`** — Qwen3-4B (Q6_K GGUF, llama.cpp) on the GPU fleet — the new coding model, deployed on the card freed by the retirement of `qwen3-coder-30b-a3b`
- **Removes every reference to `qwen3-coder-30b-a3b`** (deleted, not disabled — it no longer exists): serving entry in `charts/inference/values.yaml`, backend + federated model in `charts/ai-models/values.yaml`, picker entry in `charts/librechat-opencode-wellknown/values.yaml`, and the references in `docs/adr/0118`
- **Serving spec**: `llamacpp`, `Qwen/Qwen3-4B-GGUF` @ `bc640142c66e1fdd12af0bd68f40445458f3869b` (SHA-pinned), `Qwen3-4B-Q6_K.gguf`, `contextSize 32768` / `parallel 1` (full native window per request), `reasoning off` at the server, cpu 2/8, memory 4/16 Gi

It solves:

- Deploys the replacement coding model on the card freed by the 30B retirement (the 30B could not fit an agentic session's context window on a 20 GiB card)

---

## 2. Intent

The intent of this PR is:

> Serve a dense coding model small enough that the card is not the constraint, replacing the retired 30B-A3B MoE. Qwen3-4B at Q6_K is ~3.31 GB (≈34 % of the card), decodes at a predicted 60–75 tok/s, and fits the full native 32768 window with the KV cache not being the constraint — for the first time on this fleet.

---

## 3. Scope

### In Scope

- New model entry `qwen3-4b` in `charts/inference/values.yaml` (llamacpp, Q6_K, SHA-pinned, ctx 32768, parallel 1, reasoning off)
- Remove `qwen3-coder-30b-a3b` serving entry from `charts/inference/values.yaml`
- Remove `qwen3-coder-30b-a3b-local` backend + federated model from `charts/ai-models/values.yaml`
- Remove `qwen3-coder-30b-a3b-local` picker entry from `charts/librechat-opencode-wellknown/values.yaml`
- Reword `docs/adr/0118` to drop the retired model's name (technical substance kept)

### Out of Scope

- Federating the coding model into the gateway (requires load gate first — ADR-0101)
- Benchmark report on inference-ops (separate PR, already opened)
- The load-gate measurement itself (post-merge, on the live card)

---

## 4. Verification

I verified this change by:

- [x] Running automated tests
- [ ] Running manual tests
- [x] Checking logs
- [ ] Checking metrics
- [x] Testing error cases
- [ ] Testing permissions/security behavior
- [ ] Testing rollback or failure behavior, if relevant

Commands run:

```bash
helm lint charts/inference --strict
helm lint charts/ai-models --strict
helm lint charts/librechat-opencode-wellknown --strict
helm template chk charts/inference --dry-run > /dev/null
./tools/check-model-catalogs.sh
```

Results:

```text
$ helm lint charts/inference --strict
1 chart(s) linted, 0 chart(s) failed

$ helm lint charts/ai-models --strict
1 chart(s) linted, 0 chart(s) failed

$ helm lint charts/librechat-opencode-wellknown --strict
1 chart(s) linted, 0 chart(s) failed

$ helm template chk charts/inference --dry-run
OK

$ ./tools/check-model-catalogs.sh
check-model-catalogs: OK (2 served on the GPU fleet, 1 federated cluster-local)
  note: 'qwen3-4b' is served but not federated — no user can route to it yet.
```

The `check-model-catalogs` note is the **expected intermediate state** (ADR-0101): the model is served but not federated until the load gate passes. CI will flag the served-but-not-federated mismatch by design until the federated entry lands.

Rendered engine args (verified against the child chart):

```text
llama-server --model /models/Qwen3-4B-GGUF/model.gguf --alias qwen3-4b \
  --host 0.0.0.0 --port 8080 -ngl 99 --ctx-size 32768 --parallel 1 \
  --metrics --jinja --reasoning off --api-key-file /etc/model-api-key/api_key \
  --no-webui --cors-origins https://api.ai.camer.digital
```

---

## 5. Screenshots / Evidence

* Model source: `Qwen/Qwen3-4B-GGUF` @ `bc640142c66e1fdd12af0bd68f40445458f3869b` (SHA verified against the Hub)
* Weights: `Qwen3-4B-Q6_K.gguf`, 3.31 GB, PVC 10 GiB
* VRAM estimate: ~6.7 GiB ≈ 34 % of the 19.99 GiB card (weights 3.08 + KV@32k f16 2.81 + compute ~0.8)
* Throughput prediction: 60–75 tok/s (bandwidth-bound: 280 GB/s ÷ 3.31 GB = 84.6 tok/s ceiling)
* Scheduling: `runtimeClassName: nvidia`, `nodeSelector: nvidia.com/gpu.present: "true"`, `nvidia.com/gpu: 1`, `priorityClassName: inference-serving`, `storageClassName: longhorn`, probes on `/health`
* Seed Job: SHA-pinned download, symlink `model.gguf`, staging cleanup, no GPU requested

---

## 6. Risk Assessment

Risk level:

* [x] Low
* [ ] Medium
* [ ] High

Potential risks:

* **Not yet measured**: throughput (60–75 tok/s) and VRAM (~6.7 GiB) are predictions, not measurements — the load gate must confirm them before federation (ADR-0101)
* **Q6_K quality**: ~99 % fidelity (Qwen's own card calls it imperceptible); a side-by-side vs BF16 is possible at the gate but not planned (we are not VRAM-bound)
* **llama.cpp image tag**: `server-cuda` is a floating tag — a digest pin is an open hardening item (pre-existing, applies to all llama.cpp models)

Mitigation:

- NOT federated until the load gate measures it (ADR-0101) — no user can route to it yet
- SHA-pinned weights — reproducible seed, byte-identical on re-seed
- Conservative `parallel: 1` — the two-slot comparison (ctx 65536) is a load-gate follow-up, not the initial setting
- Rollback = `git revert` the merge commit (weights survive via `reclaimPolicy: Retain` on the Longhorn PV)

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [ ] Refactoring
* [ ] Generating tests
* [x] Drafting documentation
* [ ] Reviewing the diff
* [ ] Not used

Human verification:

* [x] I understand every meaningful change in this PR
* [x] I checked generated code manually
* [ ] I checked generated tests manually
* [x] I removed unsupported AI assumptions
* [x] I accept responsibility for this PR

---

## 8. Reviewer Focus

Please focus your review on:

* [x] Correctness — does the model entry produce the right llama-server command?
* [ ] Architecture
* [ ] Security
* [ ] Performance
* [ ] Tests
* [x] Maintainability — is the removal of the retired model complete and clean?
* [x] Product intent — does this deploy the right replacement coding model?
* [x] Edge cases — is the served-but-not-federated state handled correctly (ADR-0101)?
