### PR TITLE
feat: deploy lightbridge-governance (AI governance platform)

### DIFF
--- a/charts/apps/values.yaml
+++ b/charts/apps/values.yaml
@@ -863,6 +863,47 @@ applications:
     destination:
       namespace: converse
 
+  # --- lightbridge-governance ---
+  # The AI governance platform (repo: ADORSYS-GIS/lightbridge-governance): a
+  # tenant/application/integration registry plus two connectors — GitHub
+  # Copilot (pull, RFC-0001, the copilot-sync CronJob) and Microsoft Foundry
+  # (push over OTLP, RFC-0002). One image, two binaries. Own namespace
+  # (`governance`), separate from `converse` — this is not part of the
+  # Lightbridge authz stack.
+  #
+  # OCI mode (ADR-0055): the chart lives WITH the app code (charts live here
+  # and publish to OCI on merge, matching lightbridge-authz's convention —
+  # not vendored into ai-helm). The chart renders its OWN CronJob egress
+  # CiliumNetworkPolicy (GitHub + the S3 raw archive, scoped to the
+  # copilot-sync pods), so no depsOverlay is needed for that half. depsOverlay
+  # below adds the piece the chart can't own itself: DB egress to the shared
+  # lightbridge-main-db CNPG cluster in `converse` (ADR-0083 reuse, same as
+  # coder/lakefs/mlflow — see charts/lightbridge-db) plus the DNS baseline
+  # under this namespace's default-deny-egress.
+  #
+  # Postgres role/database (`governance`) provisioned in charts/lightbridge-db
+  # (this repo). GHCR package is public (no imagePullSecret needed — verified
+  # via `gh repo view` visibility; re-check if that ever changes).
+  #
+  # ⚠️ NOT YET LIVE-READY: the chart's ExternalSecret property names
+  # (governance_database_url, governance_internal_resolve_token,
+  # governance_internal_ingest_token, governance_github_app_id,
+  # governance_github_app_private_key) are unverified against the real
+  # ssegning-aws store, copilot.tenantId + externalSecret.s3RemoteKey are
+  # empty until an operator sets them in the values-repo file below, and no
+  # ingress-side CiliumNetworkPolicy exists yet (core-gateway's Authorino
+  # calling /internal/v1/resolve and the OTel Collector calling
+  # /internal/v1/ingest need their exact live Service selectors verified
+  # before a restrictive ingress policy can be added safely — see this
+  # chart's README). See the PR description for the full pre-merge checklist.
+  - name: lightbridge-governance
+    finalizers:
+      - resources-finalizer.argocd.argoproj.io
+    depsOverlay: environments/prod/deps/lightbridge-governance
+    chart: lightbridge-governance
+    destination:
+      namespace: governance
+
   # ── Lightbridge observability — Grafana dashboards-as-code (ADR-0046) ──
   # Deploys the dashboards-as-code chart that lives in the APPLICATION repo
   # (ADORSYS-GIS/lightbridge-code-intelligence, PUBLIC → no repo-creds needed), NOT in

--- a/charts/apps/values.yaml
+++ b/charts/apps/values.yaml
@@ -587,18 +587,14 @@ applications:
       # untouched. No depsOverlay on this app, so it renders as a single source.
       repoURL: oci://ghcr.io/adorsys-gis/charts/core-gateway
       chart: "."
-      # ⚠️ TEMPORARY ROLLBACK PIN (2026-08-03 incident): 0.3.146 is the last
-      # published chart WITHOUT the ADR-0116 redact-extproc sidecar at all
-      # (0.3.147 = e7ea902/#900, the first commit that adds it). Live traffic
-      # was seeing near-half of ext_proc streams get an ImmediateResponse
-      # after #905 switched response.body to Buffered as a stopgap for the
-      # UTF-8 chunk-split bug — a bug already fixed properly upstream
-      # (lightbridge-governance#47, sha-b3c0a2e) but not yet re-verified live
-      # under that stopgap. Pinning below the whole feature is the fastest
-      # correct kill switch while the chart is reworked so Buffered/Streamed
-      # is a value, not a template literal (see redactExtproc.processingMode
-      # once that lands) — re-float to ">=0.0.0" once verified fixed.
-      targetRevision: "0.3.146"
+      # Re-floated 2026-08-06: the 2026-08-03 incident's rollback pin
+      # (0.3.146, the last chart WITHOUT the ADR-0116 redact-extproc sidecar)
+      # is lifted. The UTF-8 chunk-split bug in streaming ext_proc responses
+      # is fixed upstream (lightbridge-governance#47, sha-b3c0a2e -- already
+      # the pinned redactExtproc.image.tag in this repo's
+      # environments/prod/values/core-gateway.yaml) and has been re-verified
+      # live under production traffic. Back to the normal chart-float range.
+      targetRevision: ">=0.0.0"
       helm:
         releaseName: core-gateway
     destination:

--- a/charts/lightbridge-db/values.yaml
+++ b/charts/lightbridge-db/values.yaml
@@ -103,6 +103,17 @@ resources:
             login: true
             passwordSecret:
               name: mlflow-db-role
+          # Dedicated login role for lightbridge-governance (ADORSYS-GIS/lightbridge-governance),
+          # the AI governance platform's registry + Copilot/Foundry connectors.
+          # Reuses this shared CNPG cluster, same reasoning as coder/lakefs/mlflow
+          # (ADR-0083). Owns the `governance` Database below; password from the
+          # basic-auth Secret `lightbridge-governance-db-role` (ESO-provisioned,
+          # below).
+          - name: governance
+            ensure: present
+            login: true
+            passwordSecret:
+              name: lightbridge-governance-db-role
   # ────────────────────────────────────────────────────────────────────
   # barman-cloud ObjectStore — MODERNISED TO HETZNER OBJECT STORAGE.
   #
@@ -310,6 +321,64 @@ resources:
           remoteRef:
             key: ai/camer/digital/prod/env
             property: codeintel_db_password
+  # ────────────────────────────────────────────────────────────────────
+  # lightbridge-governance: a `governance` Database owned by the managed
+  # `governance` role above, plus the role's basic-auth Secret (username +
+  # password) consumed by CNPG (passwordSecret). Mirrors the codeintel
+  # pattern above. No extensions needed -- ADR-0009: cratestack is the sole
+  # persistence layer, plain tables only.
+  #
+  # NOTE: the lightbridge-governance chart's own ExternalSecret takes ONE
+  # opaque `governance_database_url` property (a pre-assembled connection
+  # string), not username+password assembled at the pod (unlike codeintel's
+  # bjw-template $(DB_PASSWORD) substitution). An operator must construct
+  # postgresql://governance:<governance_db_password>@lightbridge-main-db-rw.converse.svc.cluster.local:5432/governance
+  # and write it into ai/camer/digital/prod/env as governance_database_url
+  # once this role's password (below) is known -- see
+  # charts/lightbridge-governance's own README in the lightbridge-governance
+  # repo for the full property list this depends on.
+  # ────────────────────────────────────────────────────────────────────
+  - |
+    apiVersion: postgresql.cnpg.io/v1
+    kind: Database
+    metadata:
+      name: governance
+      namespace: converse
+      annotations:
+        argocd.argoproj.io/sync-wave: "3"
+        argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    spec:
+      cluster:
+        name: lightbridge-main-db
+      name: governance
+      owner: governance
+      ensure: present
+  - |
+    apiVersion: external-secrets.io/v1
+    kind: ExternalSecret
+    metadata:
+      name: lightbridge-governance-db-role
+      namespace: converse
+      annotations:
+        argocd.argoproj.io/sync-wave: "1"
+    spec:
+      refreshInterval: 1h
+      secretStoreRef:
+        kind: ClusterSecretStore
+        name: ssegning-aws
+      target:
+        name: lightbridge-governance-db-role
+        creationPolicy: Owner
+        template:
+          type: kubernetes.io/basic-auth
+          data:
+            username: "governance"
+            password: "{{ "{{ .password }}" }}"
+      data:
+        - secretKey: password
+          remoteRef:
+            key: ai/camer/digital/prod/env
+            property: governance_db_password
   # ────────────────────────────────────────────────────────────────────
   # grafana_ro role password (read-only DB user for the Grafana dashboards).
   # basic-auth Secret consumed by CNPG (passwordSecret on the managed role above)


### PR DESCRIPTION
## AI Usage Declaration

Companion PRs: [lightbridge-governance#57](https://github.com/ADORSYS-GIS/lightbridge-governance/pull/57) (a real chart bug found while scoping this) and [ai-helm-values](https://github.com/ADORSYS-GIS/ai-helm-values/compare/claude/deploy-lightbridge-governance) (**must merge first or land alongside** — `ignoreMissingValueFiles` silently falls back to chart defaults otherwise).

## What

Registers [ADORSYS-GIS/lightbridge-governance](https://github.com/ADORSYS-GIS/lightbridge-governance) — the tenant/application/integration registry plus the GitHub Copilot connector (RFC-0001) — as a new app in its own `governance` namespace.

## Changes

- **`charts/lightbridge-db`**: adds the `governance` managed CNPG role, its `Database` CR, and the role-password `ExternalSecret` — same shape as `codeintel`/`coder`/`lakefs`/`mlflow` reusing the shared `lightbridge-main-db` cluster (ADR-0083).
- **`charts/apps`**: registers `lightbridge-governance`, OCI-mode (`chart: lightbridge-governance`, matching `same-origin-proxy`'s self-contained-chart shape), namespace `governance`, with `depsOverlay: environments/prod/deps/lightbridge-governance` for what the chart can't own itself (DB egress).
- **`charts/apps`** (separate commit): re-floats `core-gateway` off the 2026-08-03 redact-extproc incident rollback pin (`0.3.146` → `>=0.0.0`) — confirmed by the requester that the upstream UTF-8 chunk-split fix (`lightbridge-governance#47`, `sha-b3c0a2e`) has been re-verified live.

## Verification

```
helm lint charts/lightbridge-db charts/apps
helm template charts/apps -f charts/apps/values.yaml --show-only templates/applications.yaml
```
Confirmed the generated `Application` CR has the correct OCI source, $values ref, and deps source; `Database`/`ExternalSecret` blocks render correctly in `lightbridge-db`.

## Known gaps — NOT yet live-ready

- `copilot.tenantId` ships as an explicit TODO placeholder in the values-repo file — needs a real tenant id created via `governance-ctl` (ADR-0001). Confirmed with the requester to ship as-is.
- ExternalSecret property names on `ai/camer/digital/prod/env` (`governance_database_url`, `governance_internal_resolve_token`, `governance_internal_ingest_token`, `governance_github_app_id`, `governance_github_app_private_key`) are the chart's own unverified assumption — needs an operator to confirm/create them.
- The `governance` role's password must be set at `ai/camer/digital/prod/env` → `governance_db_password`, and the assembled connection string written to `governance_database_url`.
- No ingress-side `CiliumNetworkPolicy` yet: core-gateway's Authorino (`/internal/v1/resolve`) and the OTel Collector (`/internal/v1/ingest`) need their live Service selectors verified first (see `charts/redact-gateway`'s own CNP comment on why guessing here is unsafe — a wrong selector fails closed silently). Ingress is open by default in the new namespace today (same as `mlflow`/`lakefs`, not a regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)