### PR TITLE
fix(core-gateway): responseHoldBackBytes silently overrode the upstream redact-extproc fix

### DIFF
--- a/charts/core-gateway/values.yaml
+++ b/charts/core-gateway/values.yaml
@@ -398,7 +398,20 @@ redactExtproc:
   # container env (a bare number renders as a YAML float/int that Kubernetes'
   # string-typed EnvVar.value rejects — the same class of bug as ADR-0109's
   # `"n": 1` trap and the MAX_BODY_BYTES scientific-notation one).
-  responseHoldBackBytes: 1024
+  #
+  # ⚠️ 2026-08-06 incident: this MUST track governance_redact::holdback::DEFAULT_WINDOW
+  # in the deployed image, not just be "a reasonable-looking number". The
+  # 2026-08-03 fix (lightbridge-governance#47, sha-b3c0a2e) shipped with
+  # DEFAULT_WINDOW still at 1024; a follow-up review pass (main@29ae332,
+  # "window size ... 1024 -> 4096 bytes, exceeds longest Block entity")
+  # raised the CODE's own default to 4096 -- but this chart value is an
+  # explicit env override, so it kept forcing 1024 regardless of which image
+  # was deployed. Re-enabling redactExtproc with only the image bumped, and
+  # NOT this value, would have silently reintroduced the exact bug the image
+  # bump was meant to fix. Verify against governance_redact::holdback::DEFAULT_WINDOW
+  # at whatever commit `redactExtproc.image.tag` (ai-helm-values) points to
+  # before changing either one without the other.
+  responseHoldBackBytes: 4096
   # Per-message ext_proc budget. The CRD default (200ms) is the whole
   # redaction budget per chunk; regex/validator recognizers fit comfortably
   # inside it, an NER pass would not (ADR-0115 — NER is a separate service).


### PR DESCRIPTION
## AI Usage Declaration

Investigating the 2026-08-06 redact-extproc incident (500s on normal traffic, 422s on PII/secrets — see [ai-helm-values#197](https://github.com/ADORSYS-GIS/ai-helm-values/pull/197), the emergency disable). **Must merge together with the companion image bump**: [ai-helm-values (redact-extproc-upgrade branch)](https://github.com/ADORSYS-GIS/ai-helm-values/compare/claude/redact-extproc-upgrade) — bumping the image alone would not have fixed this.

## Root cause (git archaeology — a live repro is in progress to confirm)

Two compounding bugs:

1. **Stale image.** The deployed tag `sha-b3c0a2e` (2026-08-03) predates a follow-up review pass on `lightbridge-governance`'s `main` (`29ae332`: "add fail_closed", "carry partial UTF-8 codepoints across chunks") and a real-SSE-streaming rewrite (`c900cc0`: "deliver real SSE streaming") that both shipped *after* it. Fixed in the companion ai-helm-values PR (bumps to `sha-6baa6d1`).
2. **This chart silently overrides the fix regardless of image.** `charts/core-gateway/values.yaml` hardcodes `responseHoldBackBytes: 1024`, rendered straight into the container's `RESPONSE_HOLD_BACK_BYTES` env var (`templates/envoy-proxy.yaml:73`). The redact-extproc binary's own default (`governance_redact::holdback::DEFAULT_WINDOW`) was raised from `1024` to `4096` in that same `29ae332` commit — "exceeds longest Block entity" — but env-var precedence means **this chart value keeps forcing 1024 no matter which image is deployed**. Bumping the image without this fix would have silently reintroduced the exact bug the image bump was meant to fix.

## Change

`responseHoldBackBytes: 1024` → `4096` in `charts/core-gateway/values.yaml`, with a comment explaining the coupling to the image tag so this doesn't drift again.

## Verification

```
helm dependency build charts/core-gateway && helm lint charts/core-gateway
helm template charts/core-gateway --set redactExtproc.enabled=true | grep -A2 RESPONSE_HOLD_BACK_BYTES
```
Renders `value: "4096"` (still string-typed, per the existing quoting-trap comment). Also end-to-end rendered against the companion ai-helm-values file with `--set redactExtproc.enabled=true` to confirm both fixes compose correctly.

## Scope

`redactExtproc.enabled` stays `false` (set in ai-helm-values#197). This PR + its companion are prep for re-enabling, not a re-enable — a live repro (multipass/k3s) is running independently to confirm before anyone flips that back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)