### PR TITLE
feat(apps): float lightbridge-governance's images via argocd-image-updater

### DIFF
--- a/charts/apps/values.yaml
+++ b/charts/apps/values.yaml
@@ -895,6 +895,39 @@ applications:
   - name: lightbridge-governance
     finalizers:
       - resources-finalizer.argocd.argoproj.io
+    additionalAnnotations:
+      # argocd-image-updater: float both controllers (api Deployment +
+      # copilot-sync CronJob, app-template v4 -- lightbridge-governance#56)
+      # independently onto the newest cosign-signed sha-<gitsha> tag from
+      # lightbridge-governance's own docker.yml (signing added in that
+      # repo's #60, specifically to make this possible). Both aliases point
+      # at the SAME image repo, so they resolve to the same tag on their
+      # own -- no explicit lockstep needed, unlike lightbridge-code-
+      # intelligence's role-selected same-image aliases (cp/disp/recon/...).
+      # allow-tags restricts to sha-<hex> so this can never resolve back to
+      # the floating `main` tag the values-repo file used before.
+      argocd-image-updater.argoproj.io/image-list: api=ghcr.io/adorsys-gis/lightbridge-governance,sync=ghcr.io/adorsys-gis/lightbridge-governance
+      argocd-image-updater.argoproj.io/api.update-strategy: newest-build
+      argocd-image-updater.argoproj.io/api.allow-tags: regexp:^sha-[0-9a-f]+$
+      argocd-image-updater.argoproj.io/api.force-update: "true"
+      # GHCR read cred so tag detection survives ghcr.io/adorsys-gis/* going
+      # private -- same shared secret lightbridge-code-intelligence already
+      # uses (the dockerconfigjson is keyed on the ghcr.io host, not a repo).
+      argocd-image-updater.argoproj.io/api.pull-secret: pullsecret:argocd/adorsys-gis-ghcr-pull
+      argocd-image-updater.argoproj.io/api.helm.image-name: app-template.controllers.api.containers.main.image.repository
+      argocd-image-updater.argoproj.io/api.helm.image-tag: app-template.controllers.api.containers.main.image.tag
+      argocd-image-updater.argoproj.io/api.signature-type: cosign
+      argocd-image-updater.argoproj.io/api.cosign.certificate-oidc-issuer: https://token.actions.githubusercontent.com
+      argocd-image-updater.argoproj.io/api.cosign.certificate-identity-regexp: ^https://github\.com/ADORSYS-GIS/lightbridge-governance/\.github/workflows/docker\.yml@.*$
+      argocd-image-updater.argoproj.io/sync.update-strategy: newest-build
+      argocd-image-updater.argoproj.io/sync.allow-tags: regexp:^sha-[0-9a-f]+$
+      argocd-image-updater.argoproj.io/sync.force-update: "true"
+      argocd-image-updater.argoproj.io/sync.pull-secret: pullsecret:argocd/adorsys-gis-ghcr-pull
+      argocd-image-updater.argoproj.io/sync.helm.image-name: app-template.controllers.copilot-sync.containers.main.image.repository
+      argocd-image-updater.argoproj.io/sync.helm.image-tag: app-template.controllers.copilot-sync.containers.main.image.tag
+      argocd-image-updater.argoproj.io/sync.signature-type: cosign
+      argocd-image-updater.argoproj.io/sync.cosign.certificate-oidc-issuer: https://token.actions.githubusercontent.com
+      argocd-image-updater.argoproj.io/sync.cosign.certificate-identity-regexp: ^https://github\.com/ADORSYS-GIS/lightbridge-governance/\.github/workflows/docker\.yml@.*$
     depsOverlay: environments/prod/deps/lightbridge-governance
     chart: lightbridge-governance
     destination:


### PR DESCRIPTION
## What

Configures `argocd-image-updater` for `lightbridge-governance`'s two app-template controllers (api Deployment, copilot-sync CronJob), replacing the floating `main` tag currently in `ai-helm-values` with automatic promotion to the newest **cosign-signed** `sha-<gitsha>` tag.

Companion PR (pins the current tag as the starting point): ai-helm-values (link once opened).

## Why

- `main` is a mutable tag + `imagePullPolicy: IfNotPresent` — a node that already cached an older `main` layer silently serves stale code even after a fix merges and republishes. Hit this exact trap yesterday verifying lightbridge-governance#62.
- `sha-<gitsha>` tags are immutable — once image-updater pins one, a pod always gets the exact bytes that tag was signed for.
- Provenance-verified: `signature-type: cosign` requires the image to be signed by lightbridge-governance's own `docker.yml` workflow (lightbridge-governance#60 added that signing specifically to make this possible), matching how every other auto-updated image on this platform (lightbridge-code-intelligence) is verified.

## Changes

- `charts/apps/values.yaml`: added `additionalAnnotations` to the `lightbridge-governance` app entry — two aliases (`api`, `sync`), same image repo, each independently resolving to the newest signed `sha-` tag (`allow-tags: regexp:^sha-[0-9a-f]+$`). No explicit lockstep needed since both aliases query the same repo and will independently arrive at the same answer.

## Verification

```
helm dependency build charts/apps
helm template charts/apps -f charts/apps/values.yaml --show-only templates/applications.yaml | grep -A25 'name: aii-lightbridge-governance$'
```
Confirmed both aliases' full annotation set renders correctly (image-name/image-tag paths, cosign issuer/identity regexp, allow-tags, pull-secret).

## Assumptions carried over from the established pattern

- `pullsecret:argocd/adorsys-gis-ghcr-pull` already exists (same secret `lightbridge-code-intelligence`'s own image-updater annotations reference) — not re-verified here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)