### PR TITLE
fix(imageupdater): activate the CRD controller for lightbridge-governance

### DIFF
--- a/charts/apps/values.yaml
+++ b/charts/apps/values.yaml
@@ -928,6 +928,18 @@ applications:
       argocd-image-updater.argoproj.io/sync.signature-type: cosign
       argocd-image-updater.argoproj.io/sync.cosign.certificate-oidc-issuer: https://token.actions.githubusercontent.com
       argocd-image-updater.argoproj.io/sync.cosign.certificate-identity-regexp: ^https://github\.com/ADORSYS-GIS/lightbridge-governance/\.github/workflows/docker\.yml@.*$
+      # Write-back: git, to ai-helm-values, same shape as converse-ui /
+      # lightbridge-code-intelligence (ADR-0055). Without this the detected
+      # tag has nowhere to persist -- image-updater's default write-back
+      # method is `argocd` (patches the Application's own parameter
+      # overrides, not this repo), which is not what the values-repo file's
+      # own comment promises and silently diverges from GitOps. Caught in
+      # #940's review before this ever shipped a detection-only no-op.
+      argocd-image-updater.argoproj.io/write-back-method: git
+      argocd-image-updater.argoproj.io/git-repository: https://github.com/adorsys-gis/ai-helm-values.git
+      argocd-image-updater.argoproj.io/git-branch: main
+      argocd-image-updater.argoproj.io/write-back-target: helmvalues:/environments/prod/values/lightbridge-governance.yaml
+      argocd-image-updater.argoproj.io/git-credentials: secret:argocd/github-app-creds--adorsys-gis
     depsOverlay: environments/prod/deps/lightbridge-governance
     chart: lightbridge-governance
     destination:

--- a/charts/apps/values.yaml
+++ b/charts/apps/values.yaml
@@ -895,6 +895,39 @@ applications:
   - name: lightbridge-governance
     finalizers:
       - resources-finalizer.argocd.argoproj.io
+    additionalAnnotations:
+      # argocd-image-updater: float both controllers (api Deployment +
+      # copilot-sync CronJob, app-template v4 -- lightbridge-governance#56)
+      # independently onto the newest cosign-signed sha-<gitsha> tag from
+      # lightbridge-governance's own docker.yml (signing added in that
+      # repo's #60, specifically to make this possible). Both aliases point
+      # at the SAME image repo, so they resolve to the same tag on their
+      # own -- no explicit lockstep needed, unlike lightbridge-code-
+      # intelligence's role-selected same-image aliases (cp/disp/recon/...).
+      # allow-tags restricts to sha-<hex> so this can never resolve back to
+      # the floating `main` tag the values-repo file used before.
+      argocd-image-updater.argoproj.io/image-list: api=ghcr.io/adorsys-gis/lightbridge-governance,sync=ghcr.io/adorsys-gis/lightbridge-governance
+      argocd-image-updater.argoproj.io/api.update-strategy: newest-build
+      argocd-image-updater.argoproj.io/api.allow-tags: regexp:^sha-[0-9a-f]+$
+      argocd-image-updater.argoproj.io/api.force-update: "true"
+      # GHCR read cred so tag detection survives ghcr.io/adorsys-gis/* going
+      # private -- same shared secret lightbridge-code-intelligence already
+      # uses (the dockerconfigjson is keyed on the ghcr.io host, not a repo).
+      argocd-image-updater.argoproj.io/api.pull-secret: pullsecret:argocd/adorsys-gis-ghcr-pull
+      argocd-image-updater.argoproj.io/api.helm.image-name: app-template.controllers.api.containers.main.image.repository
+      argocd-image-updater.argoproj.io/api.helm.image-tag: app-template.controllers.api.containers.main.image.tag
+      argocd-image-updater.argoproj.io/api.signature-type: cosign
+      argocd-image-updater.argoproj.io/api.cosign.certificate-oidc-issuer: https://token.actions.githubusercontent.com
+      argocd-image-updater.argoproj.io/api.cosign.certificate-identity-regexp: ^https://github\.com/ADORSYS-GIS/lightbridge-governance/\.github/workflows/docker\.yml@.*$
+      argocd-image-updater.argoproj.io/sync.update-strategy: newest-build
+      argocd-image-updater.argoproj.io/sync.allow-tags: regexp:^sha-[0-9a-f]+$
+      argocd-image-updater.argoproj.io/sync.force-update: "true"
+      argocd-image-updater.argoproj.io/sync.pull-secret: pullsecret:argocd/adorsys-gis-ghcr-pull
+      argocd-image-updater.argoproj.io/sync.helm.image-name: app-template.controllers.copilot-sync.containers.main.image.repository
+      argocd-image-updater.argoproj.io/sync.helm.image-tag: app-template.controllers.copilot-sync.containers.main.image.tag
+      argocd-image-updater.argoproj.io/sync.signature-type: cosign
+      argocd-image-updater.argoproj.io/sync.cosign.certificate-oidc-issuer: https://token.actions.githubusercontent.com
+      argocd-image-updater.argoproj.io/sync.cosign.certificate-identity-regexp: ^https://github\.com/ADORSYS-GIS/lightbridge-governance/\.github/workflows/docker\.yml@.*$
     depsOverlay: environments/prod/deps/lightbridge-governance
     chart: lightbridge-governance
     destination:

--- a/charts/imageupdater/values.yaml
+++ b/charts/imageupdater/values.yaml
@@ -37,3 +37,16 @@ imageUpdaters:
     applicationRefs:
       - namePattern: lightbridge-app
         useAnnotations: true
+  # lightbridge-governance API + copilot-sync image write-back to
+  # ai-helm-values (ai-helm#939, COSIGN-signed). The write-back annotations
+  # live on the aii-lightbridge-governance Application (charts/apps/values.yaml)
+  # -- adding those annotations alone does nothing without this CR: the
+  # CRD-based controller only scans Applications an ImageUpdater actually
+  # references. Confirmed missing 2026-08-07: #939 shipped the annotations
+  # but not this entry, so the controller's reconcile loop never once
+  # considered lightbridge-governance despite the Application carrying valid
+  # image-updater config for 6+ hours.
+  - name: lightbridge-governance
+    applicationRefs:
+      - namePattern: aii-lightbridge-governance
+        useAnnotations: true


### PR DESCRIPTION
## 1. Summary

This PR changes:

- Adds a missing `ImageUpdater` CR entry for `lightbridge-governance` in `charts/imageupdater/values.yaml`, activating the CRD-based image-updater controller for that Application.
- Adds the missing git write-back annotations (`write-back-method`, `git-repository`, `git-branch`, `write-back-target`, `git-credentials`) to the `lightbridge-governance` app entry in `charts/apps/values.yaml`.

It solves:

- `argocd-image-updater` never once reconciled `lightbridge-governance` despite #939 shipping detection annotations 6+ hours earlier — the live cluster stayed pinned to `sha-a2401a8` while a newer, cosign-signed image (`sha-f537552`, containing lightbridge-governance#63's fix) sat published and unused.
- Even once the controller does watch the app, without the write-back annotations added in the second commit here, the detected tag would have had nowhere to persist (defaulting to `argocd`-parameter write-back instead of a git commit to `ai-helm-values`) — a second, independent bug in #939 caught by this PR's own automated review.

---

## 2. Intent

The intent of this PR is:

> #939 added `argocd-image-updater` write-back annotations to the `aii-lightbridge-governance` Application but missed two things this cluster's CRD-based controller (ADR-0055) actually requires: (1) an `ImageUpdater` CR that references the Application by name, and (2) the git write-back annotations that tell the controller where to commit a detected tag. Neither omission produced an error — the controller simply never looked, and would have silently used the wrong write-back method if it had. This PR closes both gaps so lightbridge-governance actually gets continuous image promotion, matching the converse-ui / lightbridge-code-intelligence pattern.

---

## 3. Scope

### In Scope

- `charts/imageupdater/values.yaml`: new `lightbridge-governance` entry under `imageUpdaters`.
- `charts/apps/values.yaml`: git write-back annotations on the existing `lightbridge-governance` app entry.

### Out of Scope

- Any change to the images themselves, or to `lightbridge-governance`'s own chart/repo.
- Retroactively triggering a write-back for the currently-published `sha-f537552` — the controller will pick it up on its next reconcile once this merges.

---

## 4. Verification

I verified this change by:

- [x] Running manual tests
- [x] Checking logs

Commands run:

```bash
helm template charts/imageupdater --namespace argocd
kubectl --context admin@homeos -n argocd get applications.argoproj.io | grep governance
kubectl --context admin@homeos -n argocd-image-updater logs deploy/argocd-image-updater-controller --since=30m
python3 -c "import yaml; yaml.safe_load(open('charts/apps/values.yaml'))"
```

Results:

```text
- helm template renders the new ImageUpdater CR with namePattern: aii-lightbridge-governance
- `aii-lightbridge-governance  Synced  Healthy` confirms the real Application name matches
- controller logs before this fix show reconcile passes only for vymalo/converse-ui/
  lightbridge-app/lightbridge-code-intelligence/opfs-webauthn -- lightbridge-governance
  never appears, confirming the root cause
- charts/apps/values.yaml parses as valid YAML after the write-back annotations were added
```

---

## 5. Screenshots / Evidence

Add evidence here:

* Logs: `argocd-image-updater-controller` reconcile-pass log lines (see PR discussion) showing `lightbridge-governance` absent from every cycle prior to this fix.

---

## 6. Risk Assessment

Risk level:

* [x] Low

Potential risks:

* Once the controller starts reconciling this app, it will immediately write back a commit to `ai-helm-values` pinning both controllers to the newest signed `sha-<gitsha>` (currently `sha-f537552` or newer) — a real, user-visible change to the live cluster's running image, not just config.

Mitigation:

* This is the intended, requested behavior (image-updater was explicitly asked for to replace manual sha-pinning). The target tag is cosign-signature-verified and `allow-tags` is regexp-scoped to `sha-[0-9a-f]+`, so it can never resolve to an unsigned or floating tag.

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [x] Reviewing the diff

Human verification:

* [x] I understand every meaningful change in this PR
* [x] I checked generated code manually
* [x] I removed unsupported AI assumptions
* [x] I accept responsibility for this PR

---

## 8. Reviewer Focus

Please focus your review on:

* [x] Correctness
* [x] Architecture

🤖 Generated with [Claude Code](https://claude.com/claude-code)
