### PR TITLE
fix(librechat-code-interpreter): drop runAsNonRoot, no controller image supports it

### DIFF
--- a/charts/librechat-code-interpreter/values.yaml
+++ b/charts/librechat-code-interpreter/values.yaml
@@ -84,12 +84,23 @@ codeapi:
   global:
     fullnameOverride: codeapi
 
-  # Hardened by default for every controller except sandbox-runner, which
-  # explicitly overrides this (NsJail needs to start as root — see its own
-  # container securityContext below).
+  # NO runAsNonRoot here (live-deploy correction, 2026-08-08): confirmed via
+  # a real rollout that NONE of the ADORSYS-GIS/code-interpreter fork's
+  # images declare a non-root USER (checked every Dockerfile — all `FROM
+  # oven/bun:1.3.14`/`buildpack-deps:bookworm` production stages, no `USER`
+  # directive) — every one of them runs as root by design/default. Asserting
+  # runAsNonRoot:true here made kubelet refuse to start ANY controller
+  # (`CreateContainerConfigError: container has runAsNonRoot and image will
+  # run as root`) — first hit on package-init specifically because it's a
+  # pre-install hook Job that blocks the rest of the release, so nothing else
+  # even got a chance to run before this was caught. `allowPrivilegeEscalation:
+  # false`/`capabilities.drop: [ALL]`/`readOnlyRootFilesystem`/seccomp still
+  # apply per-container below — running as root is a real regression on
+  # defense-in-depth, tracked in the ADR as a follow-up (patch the fork's
+  # Dockerfiles to add non-root USERs, which needs care: /pkgs and other
+  # writable paths would need matching ownership).
   defaultPodOptions:
     securityContext:
-      runAsNonRoot: true
       seccompProfile:
         type: RuntimeDefault
 

--- a/docs/adr/0122-self-hosted-code-interpreter.md
+++ b/docs/adr/0122-self-hosted-code-interpreter.md
@@ -215,6 +215,19 @@ copied — see also the correction note above):
   here rather than fixed in this PR).
 - Programmatic Tool Calling (routing MCP tool calls through the sandbox) is
   available upstream but not wired here yet.
+- **Every controller runs as root** — caught live on first deploy (2026-08-08):
+  none of the `ADORSYS-GIS/code-interpreter` fork's Dockerfiles declare a
+  non-root `USER` (checked all 7 — every production stage is `FROM
+  oven/bun:1.3.14`/`buildpack-deps:bookworm` with no `USER` directive), so
+  `defaultPodOptions.securityContext.runAsNonRoot: true` made kubelet refuse
+  to start every controller (`CreateContainerConfigError`). Removed; every
+  container still gets `allowPrivilegeEscalation: false` /
+  `capabilities.drop: [ALL]` / `readOnlyRootFilesystem` (where tolerated) /
+  seccomp `RuntimeDefault`, but running as root is a real regression on
+  defense-in-depth versus this repo's usual posture. Proper fix is patching
+  the fork's Dockerfiles to add non-root `USER`s — needs care (matching
+  ownership on `/pkgs` and other writable mounts) — tracked here rather than
+  attempted under live-incident pressure.
 
 ## Alternatives considered
 


### PR DESCRIPTION
## 1. Summary

This PR changes:

- Removes `defaultPodOptions.securityContext.runAsNonRoot: true` from `charts/librechat-code-interpreter/values.yaml`.
- Updates ADR-0122 with a new follow-up documenting the root cause and the proper fix (non-root `USER`s in the fork's Dockerfiles).

It solves:

- Live-incident fix following the merge of #941: the `package-init` pre-install hook Job CrashLooped with `CreateContainerConfigError: container has runAsNonRoot and image will run as root`, blocking the entire ArgoCD sync (Application `OutOfSync`/`Degraded`).

---

## 2. Intent

The intent of this PR is:

> Unblock the live deployment of the self-hosted Code Interpreter (ADR-0122) by removing a chart-wide `securityContext` assertion that no image in the `ADORSYS-GIS/code-interpreter` fork actually satisfies.

---

## 3. Scope

### In Scope

- Dropping `runAsNonRoot: true` from `defaultPodOptions`.
- Documenting the root cause and the proper follow-up fix in ADR-0122.

### Out of Scope

- Patching the fork's Dockerfiles to add non-root `USER`s (the actually-correct fix) — needs care around `/pkgs` and other writable-mount ownership, not something to attempt under live-incident pressure. Tracked as a follow-up in the ADR.
- The other known, already-tracked limitations (Redis TLS not CA-verified, single replica per controller, etc.) — unchanged by this PR.

---

## 4. Verification

I verified this change by:

- [x] Running automated tests
- [ ] Running manual tests
- [x] Checking logs
- [ ] Checking metrics
- [ ] Testing error cases
- [ ] Testing permissions/security behavior
- [ ] Testing rollback or failure behavior, if relevant

Commands run:

```bash
helm dep build charts/librechat-code-interpreter
helm lint charts/librechat-code-interpreter --strict
helm template codeapi charts/librechat-code-interpreter -n librechat-sandbox --dry-run
```

Results:

```text
0 chart(s) failed. Re-rendered and confirmed exactly one `runAsNonRoot` assertion
remains in the whole manifest (sandbox-runner's own explicit `false`); every other
controller now has no runAsNonRoot assertion at all, matching what their images
actually support. Root cause confirmed against live cluster logs from the
maintainer (kubectl describe pod/codeapi-package-init-*):
  Warning  Failed  ...  Error: container has runAsNonRoot and image will run as
  root (pod: "codeapi-package-init-...", container: "package-init")
and against the ADORSYS-GIS/code-interpreter fork's own Dockerfiles (checked all
7 — service/Dockerfile{,.api,.worker,.tool-call-server,.egress-gateway} and
docker/Dockerfile.package-init — none declare a `USER`).
```

---

## 5. Screenshots / Evidence

* Logs: live `kubectl describe pod` output from the maintainer showing the
  `CreateContainerConfigError`, pasted into this PR's discussion.

---

## 6. Risk Assessment

Risk level:

* [ ] Low
* [x] Medium
* [ ] High

Potential risks:

* Every controller in this chart now runs as root instead of asserting non-root — a real regression on defense-in-depth versus this repo's usual `securityContext` posture, even though `allowPrivilegeEscalation:false`/`capabilities.drop:[ALL]`/`readOnlyRootFilesystem` (where tolerated)/seccomp all still apply.

Mitigation:

* Tracked explicitly in ADR-0122's Neutral/follow-ups as the correct fix to do properly (non-root `USER`s in the fork's Dockerfiles) rather than rushed here.
* No change to the sandbox-runner's own elevated capability set (already a documented, necessary exception) or to any network policy.

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [x] Drafting documentation
* [ ] Refactoring
* [ ] Generating tests
* [ ] Reviewing the diff
* [ ] Not used

Human verification:

* [ ] I understand every meaningful change in this PR
* [ ] I checked generated code manually
* [ ] I checked generated tests manually
* [ ] I removed unsupported AI assumptions
* [ ] I accept responsibility for this PR

*(This PR was authored end-to-end by Claude Code, diagnosing a live incident reported directly by the maintainer with real `kubectl` output; the human maintainer should complete the verification checklist above before merging.)*

---

## 8. Reviewer Focus

Please focus your review on:

* [x] Correctness
* [ ] Architecture
* [x] Security
* [ ] Performance
* [ ] Tests
* [ ] Maintainability
* [ ] Product intent
* [ ] Edge cases

Specifically: whether dropping `runAsNonRoot` chart-wide (vs. some narrower fix) is the right call, and whether the tracked follow-up (non-root images) is prioritized appropriately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
