### PR TITLE
fix(librechat-code-interpreter): PVC as a pre-install hook deadlocks ArgoCD

### DIFF
--- a/charts/librechat-code-interpreter/values.yaml
+++ b/charts/librechat-code-interpreter/values.yaml
@@ -513,18 +513,23 @@ codeapi:
             requests: { cpu: 50m, memory: 128Mi }
             limits: { cpu: 200m, memory: 256Mi }
 
-    # ── PACKAGE-INIT (Helm pre-install/pre-upgrade hook Job) ────────────
+    # ── PACKAGE-INIT (plain Job, NOT a Helm/ArgoCD hook) ─────────────────
     # Compiles Python from source and installs Node/Bun/Bash into the shared
-    # packages PVC before sandbox-runner/service-worker start. No
-    # readOnlyRootFilesystem (compiles into system paths — same class of
-    # container as the `seed` weight-download Jobs elsewhere in this repo,
-    # see .trivyignore.yaml KSV-0014).
+    # packages PVC. No readOnlyRootFilesystem (compiles into system paths —
+    # same class of container as the `seed` weight-download Jobs elsewhere
+    # in this repo, see .trivyignore.yaml KSV-0014).
+    #
+    # ⚠️ NOT a `helm.sh/hook: pre-install` Job (live-incident correction,
+    # 2026-08-08 — see the `packages` persistence entry below for the full
+    # story): a hook Job here needs the packages PVC to exist and be Bound
+    # BEFORE ArgoCD runs it, but the PVC can only bind once THIS Job's own
+    # pod is scheduled (WaitForFirstConsumer on hcloud-volumes) — a
+    # structural deadlock, not a race. Runs as an ordinary resource instead;
+    # sandbox-runner may start before this Job finishes populating /pkgs on
+    # a fresh install, which is a real but bounded/self-healing risk (its
+    # readinessProbe fails until packages are usable), not a hard failure.
     package-init:
       type: job
-      annotations:
-        helm.sh/hook: pre-install,pre-upgrade
-        helm.sh/hook-weight: "-5"
-        helm.sh/hook-delete-policy: before-hook-creation
       pod:
         restartPolicy: Never
       containers:
@@ -592,9 +597,17 @@ codeapi:
       # cluster default storage class (hcloud-volumes on home-remote)
       storageClass: ""
       retain: true # helm.sh/resource-policy: keep — don't lose compiled packages on upgrade
-      annotations:
-        helm.sh/hook: pre-install,pre-upgrade
-        helm.sh/hook-weight: "-10" # before package-init (-5)
+      # ⚠️ NOT a `helm.sh/hook: pre-install` PVC (live-incident correction,
+      # 2026-08-08). This cluster's default storage class (hcloud-volumes) is
+      # WaitForFirstConsumer — the PVC only binds once a pod referencing it
+      # is SCHEDULED. As a pre-install hook at an earlier wave than
+      # package-init's Job, ArgoCD blocked waiting for this PVC to become
+      # Healthy/Bound before it would even create that Job's pod — the only
+      # thing that could ever trigger the bind. Confirmed live: Application
+      # stuck OutOfSync/Degraded, operationState.message "waiting for
+      # completion of hook /PersistentVolumeClaim/codeapi", forever. Plain
+      # resource now — binds normally once package-init's pod (or any other
+      # consumer) is scheduled.
       advancedMounts:
         sandbox-runner:
           sandbox-runner:


### PR DESCRIPTION
## 1. Summary

This PR changes:

- Removes `helm.sh/hook: pre-install,pre-upgrade` (and the related weight/delete-policy annotations) from both the `packages` PersistentVolumeClaim and the `package-init` Job in `charts/librechat-code-interpreter/values.yaml`. Both are now ordinary resources.

It solves:

- Live-incident fix: after #943 merged and synced, the ArgoCD Application `aii-librechat-code-interpreter` stayed stuck `OutOfSync`/`Degraded` forever, `operationState.message`: `"waiting for completion of hook /PersistentVolumeClaim/codeapi"`.

---

## 2. Intent

The intent of this PR is:

> Break a structural ArgoCD sync deadlock: the packages PVC was a `pre-install` hook at an earlier wave than the `package-init` Job that's its only consumer, but this cluster's `hcloud-volumes` storage class is `WaitForFirstConsumer` — the PVC can only bind once a pod referencing it is scheduled. ArgoCD blocks each hook wave until it's Healthy before starting the next, so it waited forever for a bind that could never happen without the very pod it was blocking.

---

## 3. Scope

### In Scope

- Dropping the hook annotations from the `packages` PVC and `package-init` Job.

### Out of Scope

- Re-adding strict ordering between `package-init` and the other controllers (e.g. an initContainer on `sandbox-runner` that waits for the Job) — noted as a straightforward future improvement in the commit message, not attempted here under live-incident pressure.
- Everything else already tracked in ADR-0122 (Redis TLS, root-user images, etc.) — unchanged.

---

## 4. Verification

I verified this change by:

- [x] Running automated tests
- [ ] Running manual tests
- [x] Checking logs
- [ ] Checking metrics
- [ ] Testing error cases
- [ ] Testing permissions/security behavior
- [ ] Testing rollback or failure behavior, if relevant

Commands run:

```bash
helm dep build charts/librechat-code-interpreter
helm lint charts/librechat-code-interpreter --strict
helm template codeapi charts/librechat-code-interpreter -n librechat-sandbox --dry-run
grep -n "helm.sh/hook" /tmp/fix2-render.yaml   # confirms zero matches
kubectl --context admin@homeos -n argocd get application aii-librechat-code-interpreter -o jsonpath='{.status.operationState.message}'
kubectl --context hetzner-prod -n librechat-sandbox describe pvc codeapi
kubectl --context hetzner-prod get storageclass hcloud-volumes -o jsonpath='{.volumeBindingMode}'
```

Results:

```text
0 chart(s) failed. Zero helm.sh/hook annotations remain anywhere in the rendered
chart; the PVC still carries helm.sh/resource-policy: keep. Root cause confirmed
directly against the live cluster: operationState.message was literally
"waiting for completion of hook /PersistentVolumeClaim/codeapi"; kubectl
describe pvc showed repeated "waiting for first consumer to be created before
binding" events; storage class volumeBindingMode confirmed WaitForFirstConsumer.
```

---

## 5. Screenshots / Evidence

* Logs: live `kubectl` output pasted into this PR's discussion and the linked incident thread (PR #943 / #941).

---

## 6. Risk Assessment

Risk level:

* [ ] Low
* [x] Medium
* [ ] High

Potential risks:

* Without PreSync ordering, `sandbox-runner`/other controllers could start before `package-init` finishes populating the shared `/pkgs` volume on a fresh install.

Mitigation:

* Bounded and self-healing: `sandbox-runner`'s readinessProbe fails until packages are actually usable, so it won't serve traffic prematurely — it just won't be Ready for a short window on first install, not broken.
* A tighter fix (e.g. an initContainer waiting on the Job) is a straightforward follow-up, not attempted here to avoid adding more moving parts during an active incident.

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [x] Drafting documentation
* [ ] Refactoring
* [ ] Generating tests
* [ ] Reviewing the diff
* [ ] Not used

Human verification:

* [ ] I understand every meaningful change in this PR
* [ ] I checked generated code manually
* [ ] I checked generated tests manually
* [ ] I removed unsupported AI assumptions
* [ ] I accept responsibility for this PR

*(This PR was authored end-to-end by Claude Code, diagnosing a live ArgoCD deadlock directly against the cluster with the maintainer's explicit go-ahead to use kubectl; the human maintainer should complete the verification checklist above before merging.)*

---

## 8. Reviewer Focus

Please focus your review on:

* [x] Correctness
* [ ] Architecture
* [ ] Security
* [ ] Performance
* [ ] Tests
* [ ] Maintainability
* [ ] Product intent
* [x] Edge cases

Specifically: whether dropping ordering entirely (vs. some other hook-wave arrangement) is the right call, and whether the self-healing argument for the race risk holds up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
