### PR TITLE
fix(webank-training)!: repoint push-candidate at fixed-candidate publish, drop dataset-build GPU

### DIFF
--- a/charts/webank-training/ci/lint-values.yaml
+++ b/charts/webank-training/ci/lint-values.yaml
@@ -28,7 +28,7 @@ models:
         repository: ds-document-detector
         branch: main
         storageNamespace: s3://governed-ci/datasets/ds-document-detector
-      model: { repository: model-document-detector, branch: main }
+      model: { repository: model-document-detector, branch: main, storageNamespace: s3://governed-ci/models/model-document-detector }
   - id: document-recognizer
     trainer: document-recognizer
     datasetBuild:
@@ -39,7 +39,7 @@ models:
       source: { strategy: hermetic-synthetic }
     lakefs:
       dataset: { repository: ds-document-recognizer, branch: main }
-      model: { repository: model-document-recognizer, branch: main }
+      model: { repository: model-document-recognizer, branch: main, storageNamespace: s3://governed-ci/models/model-document-recognizer }
   - id: face-detector
     trainer: face-detector
     datasetBuild:
@@ -50,7 +50,7 @@ models:
       source: { strategy: hermetic-synthetic }
     lakefs:
       dataset: { repository: ds-face-detector, branch: main }
-      model: { repository: model-face-detector, branch: main }
+      model: { repository: model-face-detector, branch: main, storageNamespace: s3://governed-ci/models/model-face-detector }
   - id: sface
     trainer: sface
     datasetBuild:
@@ -64,7 +64,7 @@ models:
         branch: main
     lakefs:
       dataset: { repository: ds-sface, branch: main }
-      model: { repository: model-sface, branch: main }
+      model: { repository: model-sface, branch: main, storageNamespace: s3://governed-ci/models/model-sface }
   - id: pad-liveness
     trainer: pad-liveness-pending
     datasetBuild:
@@ -78,4 +78,4 @@ models:
         branch: main
     lakefs:
       dataset: { repository: ds-pad-liveness, branch: main }
-      model: { repository: model-pad-liveness, branch: main }
+      model: { repository: model-pad-liveness, branch: main, storageNamespace: s3://governed-ci/models/model-pad-liveness }

--- a/charts/webank-training/templates/workflowtemplate.yaml
+++ b/charts/webank-training/templates/workflowtemplate.yaml
@@ -33,6 +33,7 @@
 {{- $datasetStorageNamespace := required (printf "webank-training: %s datasetBuild.target.storageNamespace is required" $id) $datasetTarget.storageNamespace -}}
 {{- $candidateRepository := required (printf "webank-training: %s lakefs.model.repository is required" $id) $candidateLakefs.repository -}}
 {{- $candidateBranch := required (printf "webank-training: %s lakefs.model.branch is required" $id) $candidateLakefs.branch -}}
+{{- $candidateStorageNamespace := required (printf "webank-training: %s lakefs.model.storageNamespace is required" $id) $candidateLakefs.storageNamespace -}}
 {{- if ne $datasetRepository (printf "ds-%s" $id) }}{{ fail (printf "webank-training: %s dataset repository must be ds-%s" $id $id) }}{{- end }}
 {{- if ne $datasetTargetRepository $datasetRepository }}{{ fail (printf "webank-training: %s datasetBuild target must match its training dataset repository" $id) }}{{- end }}
 {{- if ne $candidateRepository (printf "model-%s" $id) }}{{ fail (printf "webank-training: %s model repository must be model-%s" $id $id) }}{{- end }}
@@ -84,14 +85,6 @@ spec:
   {{- end }}
   templates:
     - name: build
-      podSpecPatch: |
-        runtimeClassName: {{ $training.gpu.runtimeClassName | quote }}
-      nodeSelector:
-        {{- toYaml $training.gpu.nodeSelector | nindent 8 }}
-      {{- with $training.gpu.tolerations }}
-      tolerations:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
       {{- with $training.gpu.priorityClassName }}
       priorityClassName: {{ . | quote }}
       {{- end }}
@@ -218,7 +211,7 @@ spec:
           - name: OTEL_SERVICE_NAME
             value: {{ printf "webank-%s-dataset-build" $id | quote }}
         resources:
-          {{- toYaml $training.gpu.resources | nindent 10 }}
+          {{- toYaml $training.datasetBuild.resources | nindent 10 }}
 ---
 apiVersion: argoproj.io/v1alpha1
 kind: WorkflowTemplate
@@ -315,15 +308,13 @@ spec:
               --learning-rate {{ $detector.learningRate }} \
               --shrink-ratio {{ $detector.shrinkRatio }}
             . /workspace/document-detector/governance/lineage.env
-            cargo xtask training-data push \
-              --destination training-data-lake \
-              --path "$CANDIDATE_PATH" \
-              --manifest /workspace/document-detector/governance/source-manifest.json \
-              --lakefs-ref "$LAKEFS_SOURCE_REF" \
-              --readiness /workspace/document-detector/governance/readiness.json \
-              --lakefs-branch "$WEBANK_MODEL_LAKEFS_BRANCH" \
+            cargo xtask training-data fixed-candidate publish \
+              --model document-detector \
+              --artifact "$CANDIDATE_PATH" \
+              --dataset-ref "$LAKEFS_SOURCE_REF" \
               --lakefs-endpoint "$WEBANK_LAKEFS_ENDPOINT" \
-              --lakefs-repository "$WEBANK_MODEL_LAKEFS_REPOSITORY"
+              --lakefs-repository "$WEBANK_MODEL_LAKEFS_REPOSITORY" \
+              --lakefs-storage-namespace "$WEBANK_MODEL_LAKEFS_STORAGE_NAMESPACE"
 {{- else if eq $trainer "document-recognizer" }}
             cargo xtask training-data readiness-gate \
               --manifest /workspace/governance/source-manifest.json \
@@ -333,15 +324,13 @@ spec:
               --data /workspace/dataset \
               --output "$CANDIDATE_PATH" \
               --epochs 10
-            cargo xtask training-data push \
-              --destination training-data-lake \
-              --path "$CANDIDATE_PATH" \
-              --manifest /workspace/governance/source-manifest.json \
-              --lakefs-ref "$LAKEFS_REF" \
-              --readiness /workspace/governance/readiness.json \
-              --lakefs-branch "$WEBANK_MODEL_LAKEFS_BRANCH" \
+            cargo xtask training-data fixed-candidate publish \
+              --model document-recognizer \
+              --artifact "$CANDIDATE_PATH" \
+              --dataset-ref "$LAKEFS_REF" \
               --lakefs-endpoint "$WEBANK_LAKEFS_ENDPOINT" \
-              --lakefs-repository "$WEBANK_MODEL_LAKEFS_REPOSITORY"
+              --lakefs-repository "$WEBANK_MODEL_LAKEFS_REPOSITORY" \
+              --lakefs-storage-namespace "$WEBANK_MODEL_LAKEFS_STORAGE_NAMESPACE"
 {{- else if eq $trainer "face-detector" }}
             cargo xtask training-data readiness-gate \
               --manifest /workspace/governance/source-manifest.json \
@@ -351,15 +340,13 @@ spec:
               --data /workspace/dataset \
               --output "$CANDIDATE_PATH" \
               --epochs 10
-            cargo xtask training-data push \
-              --destination training-data-lake \
-              --path "$CANDIDATE_PATH" \
-              --manifest /workspace/governance/source-manifest.json \
-              --lakefs-ref "$LAKEFS_REF" \
-              --readiness /workspace/governance/readiness.json \
-              --lakefs-branch "$WEBANK_MODEL_LAKEFS_BRANCH" \
+            cargo xtask training-data fixed-candidate publish \
+              --model face-detector \
+              --artifact "$CANDIDATE_PATH" \
+              --dataset-ref "$LAKEFS_REF" \
               --lakefs-endpoint "$WEBANK_LAKEFS_ENDPOINT" \
-              --lakefs-repository "$WEBANK_MODEL_LAKEFS_REPOSITORY"
+              --lakefs-repository "$WEBANK_MODEL_LAKEFS_REPOSITORY" \
+              --lakefs-storage-namespace "$WEBANK_MODEL_LAKEFS_STORAGE_NAMESPACE"
 {{- else if eq $trainer "sface" }}
             cargo xtask training-data readiness-gate \
               --manifest /workspace/governance/source-manifest.json \
@@ -369,15 +356,13 @@ spec:
               --data /workspace/dataset \
               --output "$CANDIDATE_PATH" \
               --epochs 10
-            cargo xtask training-data push \
-              --destination training-data-lake \
-              --path "$CANDIDATE_PATH" \
-              --manifest /workspace/governance/source-manifest.json \
-              --lakefs-ref "$LAKEFS_REF" \
-              --readiness /workspace/governance/readiness.json \
-              --lakefs-branch "$WEBANK_MODEL_LAKEFS_BRANCH" \
+            cargo xtask training-data fixed-candidate publish \
+              --model sface \
+              --artifact "$CANDIDATE_PATH" \
+              --dataset-ref "$LAKEFS_REF" \
               --lakefs-endpoint "$WEBANK_LAKEFS_ENDPOINT" \
-              --lakefs-repository "$WEBANK_MODEL_LAKEFS_REPOSITORY"
+              --lakefs-repository "$WEBANK_MODEL_LAKEFS_REPOSITORY" \
+              --lakefs-storage-namespace "$WEBANK_MODEL_LAKEFS_STORAGE_NAMESPACE"
 {{- else }}
             echo "PAD liveness candidate training is unavailable: the governed PAD dataset descriptor exists, but no PAD optimizer/trainer has landed. Refusing to fabricate a candidate." >&2
             exit 2
@@ -404,8 +389,8 @@ spec:
             value: {{ $datasetBranch | quote }}
           - name: WEBANK_MODEL_LAKEFS_REPOSITORY
             value: {{ $candidateRepository | quote }}
-          - name: WEBANK_MODEL_LAKEFS_BRANCH
-            value: {{ $candidateBranch | quote }}
+          - name: WEBANK_MODEL_LAKEFS_STORAGE_NAMESPACE
+            value: {{ $candidateStorageNamespace | quote }}
           - name: LAKEFS_ACCESS_KEY_ID
             valueFrom: { secretKeyRef: { name: {{ $lakefs.secretName | quote }}, key: {{ $lakefs.accessKey | quote }} } }
           - name: LAKEFS_SECRET_ACCESS_KEY

--- a/charts/webank-training/values.yaml
+++ b/charts/webank-training/values.yaml
@@ -41,6 +41,19 @@ training:
     resources:
       requests: { cpu: "4", memory: 16Gi, nvidia.com/gpu: 1 }
       limits: { cpu: "8", memory: 16Gi, nvidia.com/gpu: 1 }
+  # Dataset-build steps run generation, image decode/resize, tensor packing,
+  # and an HTTP upload — no forward pass, no CUDA (webank-models#415). They
+  # request no accelerator and carry no GPU node placement; only `train`
+  # steps use `training.gpu` above. Sized from a real local run of this
+  # pipeline: 13,393 crops in 2:55, materialize-synthetic-source 12,799 rows
+  # in 11s (peak 13.2 GiB RSS, measured with `/usr/bin/time -v` — the working
+  # set is one `Vec<f32>` tensor plus a copy, not the packed output size),
+  # pack 4.4 GB in 14s. The memory limit keeps ~50% headroom above that
+  # measured peak; do not size it from the smaller output artifact.
+  datasetBuild:
+    resources:
+      requests: { cpu: "4", memory: 16Gi }
+      limits: { cpu: "8", memory: 20Gi }
   documentDetector:
     stemChannels: 32
     epochs: 10

--- a/docs/integrations/webank-training-deployment.md
+++ b/docs/integrations/webank-training-deployment.md
@@ -21,12 +21,14 @@ stage into an alternative public operation.
 
 ## Dataset-build templates
 
-`*-dataset-build` templates are restricted-plane operations placed on
-`nvidia.com/gpu.present=true` nodes (the live GPU node label, matching
-`charts/inference`), tolerating `nvidia.com/gpu:NoSchedule` (Exists), and
-using `runtimeClassName: nvidia` so the host CUDA driver libraries are mounted.
-They request the same reviewed CPU, memory, and one-GPU resource profile as
-candidate training (ADR-0114).
+`*-dataset-build` templates are restricted-plane operations that run on
+ordinary CPU nodes — no GPU node placement, toleration, or `runtimeClassName`
+(webank-models#415). The work is generation, image decode/resize, tensor
+packing, and a LakeFS upload: no forward pass, no CUDA device. Their CPU and
+memory request/limit come from `training.datasetBuild.resources`, sized from a
+real local run of this pipeline (13,393 crops in 2:55; `materialize-synthetic-
+source` peaking at 13.2 GiB RSS, not the smaller packed-output size), separate
+from `training.gpu` (ADR-0114), which candidate training alone still uses.
 Every Dataset Build form has **no inputs**. Its target repository, `main`
 branch, reviewed storage namespace, and closed source strategy come only from
 `ai-helm-values`; the dashboard cannot choose a LakeFS reference, source
@@ -65,8 +67,8 @@ The recognizer, face-detector, and SFace
 templates take a governed `dataset`, `manifest`, and `readiness` artifact plus
 the matching `lakefs_ref`; they run their closed, model-specific Rust trainer
 only after the readiness gate passes. All successful trainers write candidates
-back only through `training-data push` into the fixed per-model `model-*`
-repository, never to the model registry.
+back only through `training-data fixed-candidate publish` into the fixed
+per-model `model-*` repository, never to the model registry.
 
 `run_name` is optional on every training template. Its default includes the
 generated Argo workflow name, so it is unique even when the operator leaves

--- a/docs/playbooks/webank-model-workflows.md
+++ b/docs/playbooks/webank-model-workflows.md
@@ -10,7 +10,7 @@ Start with the model-specific operation you actually need:
 
 | Need | Template pattern | Compute |
 | --- | --- | --- |
-| Build and publish a fixed training dataset | `webank-<model>-dataset-build` | one GPU |
+| Build and publish a fixed training dataset | `webank-<model>-dataset-build` | CPU only (webank-models#415) |
 | Train a governed candidate | `webank-<model>-train` | one GPU |
 
 There is one template of each kind for document detector, document recognizer,
@@ -42,11 +42,13 @@ A successful run writes one validated training bundle through the fixed
 LakeFS boundary into that model's `ds-<model>/main` repository and reports the
 server-issued immutable commit.
 
-All dataset-build pods select `nvidia.com/gpu.present=true`, tolerate
-`nvidia.com/gpu:NoSchedule` (Exists), use `runtimeClassName: nvidia`, and request
-the reviewed one-GPU CPU/memory resource profile. This guarantees that dataset
-materialization has the same GPU-node allocation and CUDA driver injection as
-candidate training.
+Dataset-build pods request no GPU: no `nvidia.com/gpu` limit/request, no
+`nvidia.com/gpu.present=true` node selector, no `nvidia.com/gpu:NoSchedule`
+toleration, and no `runtimeClassName: nvidia` (webank-models#415). The work is
+generation, image decode/resize, tensor packing, and a LakeFS upload — no
+forward pass, no CUDA device — and runs on ordinary CPU nodes with the reviewed
+`training.datasetBuild.resources` CPU/memory profile. Do not expect it to
+compete with candidate training for one of the fleet's two GPU cards.
 
 If an SFace or PAD governed-source repository is empty, the operation fails
 before materialization. Do not use fixtures or placeholder evidence as a
@@ -84,6 +86,6 @@ as PAD training and do not create a candidate manually.
 | --- | --- | --- |
 | Argo rejects a missing dataset field | The data contract is intentionally required. | Supply the approved ref/version or artifacts; never fake a value. |
 | `readiness-gate` fails | Source manifest, readiness attestation, and pinned commit disagree or are not eligible. | Repair/reapprove data in its source repository. |
-| Pod remains Pending | GPU placement requirements cannot currently be met, or MLOps is preempted by serving (ADR-0114). | Check an `nvidia.com/gpu.present=true` node and its allocatable GPU; do not remove placement constraints. |
-| `libcuda.so.1` cannot be opened | The pod did not use the NVIDIA runtime handler, so host driver libraries were not injected. | Confirm the rendered template and pod both have `runtimeClassName: nvidia`; do not copy CUDA driver files into the image. |
+| `*-train` pod remains Pending | GPU placement requirements cannot currently be met, or MLOps is preempted by serving (ADR-0114). | Check an `nvidia.com/gpu.present=true` node and its allocatable GPU; do not remove placement constraints. |
+| `libcuda.so.1` cannot be opened | The pod did not use the NVIDIA runtime handler, so host driver libraries were not injected. Only `*-train` pods use the NVIDIA runtime; `*-dataset-build` pods do not and should never need it. | Confirm the rendered `*-train` template and pod both have `runtimeClassName: nvidia`; do not copy CUDA driver files into the image. |
 | PAD train exits immediately | There is no PAD trainer. | Keep it blocked until a model-specific trainer lands. |


### PR DESCRIPTION
## 1. Summary

This PR changes `charts/webank-training/templates/workflowtemplate.yaml` (both
defects live in this one template file) plus its supporting `values.yaml`,
`ci/lint-values.yaml`, and two docs:

- `webank-<model>-train`'s `push-candidate` step (document-detector,
  document-recognizer, face-detector, sface — not pad-liveness, a stub):
  replaces the removed `cargo xtask training-data push --destination
  training-data-lake --path ... --manifest ... --lakefs-ref ... --readiness
  ...` with the real current replacement, `cargo xtask training-data
  fixed-candidate publish --model --artifact --dataset-ref --lakefs-endpoint
  --lakefs-repository --lakefs-storage-namespace` (`--lakefs-branch` left to
  its own `main` default). Adds the new required `models[].lakefs.model.
  storageNamespace` value the templates now need.
- All 5 `webank-<model>-dataset-build` templates: removes the
  `nvidia.com/gpu` request/limit, `nvidia.com/gpu.present` nodeSelector,
  nvidia toleration, and `runtimeClassName: nvidia` — this step is
  generation, image decode/resize, tensor packing, and upload, not a forward
  pass. Adds a new `training.datasetBuild.resources` (CPU/memory only) block,
  sized from a real local pipeline run. `webank-<model>-train`'s own GPU
  claims are untouched.
- `docs/integrations/webank-training-deployment.md` and
  `docs/playbooks/webank-model-workflows.md`: corrects the now-stale
  dataset-build GPU description and `training-data push` mentions.

It solves:

- ADORSYS-GIS/ai-helm#942
- References ADORSYS-GIS/webank-models#415 (filed against the source repo;
  the fix belongs here since these WorkflowTemplates are Helm/ArgoCD-managed
  from this chart, not from `webank-models`)

---

## 2. Intent

Both defects were verified live, not inferred:

- `push-candidate`'s CLI invocation fails closed with `error: unrecognized
  subcommand 'push'` on a real `webank-models` release build — the
  subcommand was demoted to `training-data legacy push` (documented as
  migration-only) once PR #347 landed the fixed-route commands. The deployed
  `webank-sface-train` and `webank-document-recognizer-train`
  WorkflowTemplates (`hetzner-prod`/`mlops`, chart `webank-training-0.2.17`)
  are still on the exact stale command — confirmed with a read-only `kubectl
  get`.
- The 5 `*-dataset-build` templates claim a whole GPU (`nvidia.com/gpu: 1`,
  GPU node placement) for CPU/IO-bound work, on a pool of only two GPU nodes,
  for up to 6h (`activeDeadlineSeconds: 21600`) at `priorityClassName:
  mlops-training`. Confirmed live on `webank-sface-dataset-build`.

---

## 3. Scope

### In Scope

- Fixing the 4 affected `*-train` templates' `push-candidate` invocation and
  plumbing the new required flags/values it needs.
- Confirming `pad-liveness-train` is an intentional stub (unaffected) and
  `readiness-gate` is unaffected (unchanged).
- Removing GPU request/limit/nodeSelector/toleration/runtimeClassName from
  all 5 `*-dataset-build` templates; sizing their CPU/memory from measurement.
- Correcting the two chart docs describing the pre-fix behavior as current.

### Out of Scope

- Unifying `fixed-candidate publish --model`'s `DatasetModel` taxonomy
  (`sface`) with `training-workflow submit --model`'s `face-embedder` — a
  distinct, deliberate naming domain flagged in ai-helm#942 and in
  ADORSYS-GIS/webank-models#416, not invented or resolved here. This chart's
  `$id` already matches `DatasetModel`, so no mapping was needed.
- Any change to the `ai-helm-values` repo. That repo's `environments/prod/
  values/webank-training.yaml` will need a `lakefs.model.storageNamespace`
  added per model before this chart version can deploy cleanly — flagged in
  the Risk Assessment below, not made here (different repo, out of scope).
- Anything on the live cluster. Every cluster command run was `get`, never
  `apply`/`patch`/`delete`; no Secret was read.
- Publishing a new chart OCI release or bumping `Chart.yaml`'s version by
  hand — this repo's `release-please` config (`release-please-config.json`)
  attributes the `MAJOR.MINOR` floor bump to commits touching
  `charts/webank-training/**` automatically; the commit is `fix(webank-
  training)!: …` (breaking, see below) so the automated release PR will do
  the version/changelog bump on merge, not this PR.

---

## 4. Verification

I verified this change by:

- [x] Running automated tests
- [ ] Running manual tests
- [ ] Checking logs
- [ ] Checking metrics
- [x] Testing error cases
- [ ] Testing permissions/security behavior
- [ ] Testing rollback or failure behavior, if relevant

Commands run:

```bash
helm dependency build charts/webank-training
helm lint charts/webank-training --strict -f charts/webank-training/ci/lint-values.yaml
helm template webank-training charts/webank-training -f charts/webank-training/ci/lint-values.yaml > rendered-after.yaml
kubeconform -summary -strict -schema-location default \
  -schema-location 'https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/{{.ResourceKind}}{{.KindSuffix}}.json' \
  -schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json' \
  rendered-after.yaml

# before/after diff of the rendered manifests, on the pre-change commit vs this one
diff -u rendered-before.yaml rendered-after.yaml

# read-only cross-check against the live cluster
kubectl --context hetzner-prod -n mlops get workflowtemplate webank-sface-train -o yaml
kubectl --context hetzner-prod -n mlops get workflowtemplate webank-sface-dataset-build -o yaml
```

Results:

```text
helm lint --strict  -> 1 chart(s) linted, 0 chart(s) failed
kubeconform         -> Summary: 10 resources found in 1 file - Valid: 10, Invalid: 0, Errors: 0, Skipped: 0

diff before/after -> exactly:
  - 5x dataset-build blocks: podSpecPatch/nodeSelector/tolerations block removed,
    nvidia.com/gpu request+limit removed, memory limit 16Gi -> 20Gi (new
    training.datasetBuild.resources default)
  - 4x train blocks (document-detector/document-recognizer/face-detector/sface):
    `training-data push ...` -> `training-data fixed-candidate publish ...`,
    WEBANK_MODEL_LAKEFS_BRANCH env -> WEBANK_MODEL_LAKEFS_STORAGE_NAMESPACE
  - all 5 *-train templates' own GPU nodeSelector/toleration/runtimeClassName/
    resources blocks: unchanged (grep-verified zero diff lines there)
  - all 10 WorkflowTemplate names render identically before and after

live kubectl get (read-only, no apply/patch/delete, no Secrets read):
  webank-sface-train: confirms the exact stale `training-data push --destination
    training-data-lake ...` command this PR replaces, still deployed today
  webank-sface-dataset-build: confirms the exact GPU request/limit/nodeSelector/
    toleration/runtimeClassName this PR removes, still deployed today
```

---

## 5. Screenshots / Evidence

Add evidence here:

* Screenshot: n/a (chart-only change)
* Logs: `helm lint`/`helm template`/`kubeconform` output above
* Metrics: n/a
* Recording: n/a

---

## 6. Risk Assessment

Risk level:

* [ ] Low
* [x] Medium
* [ ] High

Potential risks:

* `models[].lakefs.model.storageNamespace` is now a required value
  (`required` fails the render if absent). `ai-helm-values`'
  `environments/prod/values/webank-training.yaml` almost certainly does not
  set it yet (it predates this fix) and will need it added, per model,
  before this chart version can sync — otherwise ArgoCD will show the
  Application as `Degraded`/render-failed rather than silently deploying a
  broken template. This is a **fail-closed** failure mode, not silent
  breakage, and is called out as a `BREAKING CHANGE:` footer in the commit.
* Dataset-build steps no longer read `training.gpu.resources`/
  `nodeSelector`/`tolerations`/`runtimeClassName` at all — any existing
  `ai-helm-values` override aimed at dataset-build sizing (e.g. the current
  live 16 CPU/48Gi/1-GPU profile visible in `kubectl get
  workflowtemplate webank-sface-dataset-build`) will silently stop applying
  to dataset-build once this deploys, falling back to this chart's new
  `training.datasetBuild.resources` default (4 CPU/16Gi request, 8 CPU/20Gi
  limit) unless `ai-helm-values` adds its own override. That default is
  sized from a real measured pipeline run (peak 13.2 GiB RSS +50%
  headroom), so even the unmodified default should be safe, but it is a
  smaller allocation than what is live today.
* This PR only makes the chart correct; it was **not** applied to the
  cluster (no `helm upgrade`/`argocd sync` run). Whether/when it deploys is
  ArgoCD's normal sync process, outside this PR's control.

Mitigation:

* The new required field fails closed with a clear `required(...)` error
  message naming the exact missing path per model — an operator upgrading
  without the matching `ai-helm-values` change gets a loud render failure,
  not a silent misconfiguration.
* The new `datasetBuild.resources` default is derived from the same
  measurement cited in webank-models#415 (13.2 GiB RSS peak,
  `/usr/bin/time -v`), with ~50% memory headroom, not guessed.
* `pad-liveness-train`'s stub behavior (`exit 2`, "no PAD optimizer/trainer
  has landed") is unchanged — verified by rendering and diffing that
  template specifically.

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [x] Refactoring
* [ ] Generating tests
* [x] Drafting documentation
* [x] Reviewing the diff
* [ ] Not used

Human verification:

* [ ] I understand every meaningful change in this PR
* [ ] I checked generated code manually
* [ ] I checked generated tests manually
* [ ] I removed unsupported AI assumptions
* [ ] I accept responsibility for this PR

---

## 8. Reviewer Focus

Please focus your review on:

* [x] Correctness
* [x] Architecture
* [ ] Security
* [x] Performance
* [ ] Tests
* [x] Maintainability
* [ ] Product intent
* [x] Edge cases

Fixes ADORSYS-GIS/ai-helm#942
Refs ADORSYS-GIS/webank-models#415

🤖 Generated with [Claude Code](https://claude.com/claude-code)
