### PR TITLE
fix(librechat-code-interpreter): package-init needs its full capability set

### DIFF
--- a/charts/librechat-code-interpreter/values.yaml
+++ b/charts/librechat-code-interpreter/values.yaml
@@ -528,6 +528,19 @@ codeapi:
     # sandbox-runner may start before this Job finishes populating /pkgs on
     # a fresh install, which is a real but bounded/self-healing risk (its
     # readinessProbe fails until packages are usable), not a hard failure.
+    #
+    # ⚠️ NO securityContext at all (live-incident correction, 2026-08-08):
+    # `capabilities.drop: [ALL]` broke Node.js archive extraction — `tar`
+    # (run as root, but with CAP_CHOWN dropped) failed `chown()`ing files to
+    # the upstream tarball's embedded uid/gid ("Cannot change ownership to
+    # uid 1000, gid 1000: Operation not permitted"), which the init script
+    # treats as fatal (`ERROR: Failed to extract Node.js archive`), so the
+    # whole run reported FAILED even though most of the multi-package-manager
+    # install had already succeeded. This container genuinely needs broad
+    # root capabilities for its job (compiling Python from source, extracting
+    # archives with arbitrary embedded ownership, installing across several
+    # package managers) — matches upstream's own chart, which never put a
+    # securityContext on this container at all.
     package-init:
       type: job
       pod:
@@ -538,10 +551,6 @@ codeapi:
             repository: ghcr.io/adorsys-gis/code-interpreter-package-init
             tag: sha-93172e7
             pullPolicy: IfNotPresent
-          securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop: [ALL]
           env:
             PYTHON_VERSION: "3.14.4"
             NODE_VERSION: "24.15.0"


### PR DESCRIPTION
## 1. Summary

This PR changes:

- Removes `securityContext` (`allowPrivilegeEscalation: false`, `capabilities.drop: [ALL]`) entirely from `package-init`'s container in `charts/librechat-code-interpreter/values.yaml`.

It solves:

- Live-incident fix (third in this sequence, after runAsNonRoot #943 and the PVC-hook deadlock #944, all following from #941/ADR-0122): once the PVC bound and `package-init` actually started, it still failed extracting the Node.js archive — `tar: ... Cannot change ownership to uid 1000, gid 1000: Operation not permitted` — because `capabilities.drop: [ALL]` dropped `CAP_CHOWN`, which `tar` needs even running as root to preserve the archive's embedded file ownership.

---

## 2. Intent

The intent of this PR is:

> Let `package-init` actually do its job — compiling Python from source, extracting archives with arbitrary embedded ownership, installing across three package managers — which genuinely needs broad root capabilities, same category of exception as `sandbox-runner` (though far narrower — no `SYS_ADMIN` or similar).

---

## 3. Scope

### In Scope

- Removing `package-init`'s container `securityContext` block.

### Out of Scope

- The other 5 controllers (api, file-server, tool-call-server, egress-gateway, service-worker) keep their hardened `securityContext` — they're simple stateless HTTP services, not doing system-level installs, so this specific failure mode doesn't apply to them. They haven't gotten far enough at runtime yet (blocked on the still-missing `ssegning-aws` secret properties) to confirm they're fully clean, but there's no reason to expect the same issue.

---

## 4. Verification

I verified this change by:

- [x] Running automated tests
- [ ] Running manual tests
- [x] Checking logs
- [ ] Checking metrics
- [ ] Testing error cases
- [ ] Testing permissions/security behavior
- [ ] Testing rollback or failure behavior, if relevant

Commands run:

```bash
helm dep build charts/librechat-code-interpreter
helm lint charts/librechat-code-interpreter --strict
helm template codeapi charts/librechat-code-interpreter -n librechat-sandbox --dry-run
kubectl --context hetzner-prod -n librechat-sandbox logs pod/codeapi-package-init-n2pfc --tail=300
```

Results:

```text
0 chart(s) failed. Re-rendered and confirmed package-init's container carries no
securityContext block at all now (pod-level seccompProfile:RuntimeDefault from
defaultPodOptions is unaffected). Root cause confirmed directly from the live
pod's logs: Bun and Bash package registration had already succeeded earlier in
the same run; only the Node.js archive extraction step failed with the chown
permission error, but the init script treats any failed step as fatal for the
whole run ("ERROR: Package initialization FAILED").
```

---

## 5. Screenshots / Evidence

* Logs: live `kubectl logs` output from the maintainer's cluster, pasted into this PR's discussion / the linked incident thread (#941, #943, #944).

---

## 6. Risk Assessment

Risk level:

* [ ] Low
* [x] Medium
* [ ] High

Potential risks:

* `package-init` now runs with full default root capabilities (no `capabilities.drop`), a real regression on defense-in-depth for this one container.

Mitigation:

* Matches upstream's own chart, which never hardened this container either — not a novel risk, just reverting to the known-working posture for a container whose whole job is system-level package installation.
* Scoped to `package-init` only; every other controller in the chart keeps its hardened `securityContext` unchanged.

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [x] Drafting documentation
* [ ] Refactoring
* [ ] Generating tests
* [ ] Reviewing the diff
* [ ] Not used

Human verification:

* [ ] I understand every meaningful change in this PR
* [ ] I checked generated code manually
* [ ] I checked generated tests manually
* [ ] I removed unsupported AI assumptions
* [ ] I accept responsibility for this PR

*(This PR was authored end-to-end by Claude Code, diagnosing a live failure directly against the cluster with the maintainer's explicit go-ahead to use kubectl; the human maintainer should complete the verification checklist above before merging.)*

---

## 8. Reviewer Focus

Please focus your review on:

* [x] Correctness
* [ ] Architecture
* [x] Security
* [ ] Performance
* [ ] Tests
* [ ] Maintainability
* [ ] Product intent
* [ ] Edge cases

Specifically: whether dropping the securityContext entirely (vs. adding back just `CHOWN`/`FOWNER`) is the right call given this container's actual job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

