### PR TITLE
fix(librechat-code-interpreter): probe port nested under spec.httpGet, not top-level

### DIFF
--- a/charts/librechat-code-interpreter/values.yaml
+++ b/charts/librechat-code-interpreter/values.yaml
@@ -164,12 +164,14 @@ codeapi:
               enabled: true
               type: HTTP
               path: /v1/health
-              spec: { httpGet: { port: http }, initialDelaySeconds: 10, periodSeconds: 30 }
+              port: http
+              spec: { initialDelaySeconds: 10, periodSeconds: 30 }
             readiness:
               enabled: true
               type: HTTP
               path: /v1/health
-              spec: { httpGet: { port: http }, initialDelaySeconds: 5, periodSeconds: 10 }
+              port: http
+              spec: { initialDelaySeconds: 5, periodSeconds: 10 }
           resources:
             requests: { cpu: 100m, memory: 256Mi }
             limits: { cpu: 500m, memory: 512Mi }
@@ -242,12 +244,14 @@ codeapi:
               enabled: true
               type: HTTP
               path: /health
-              spec: { httpGet: { port: health }, initialDelaySeconds: 30, periodSeconds: 30 }
+              port: health
+              spec: { initialDelaySeconds: 30, periodSeconds: 30 }
             readiness:
               enabled: true
               type: HTTP
               path: /ready
-              spec: { httpGet: { port: health }, initialDelaySeconds: 10, periodSeconds: 10 }
+              port: health
+              spec: { initialDelaySeconds: 10, periodSeconds: 10 }
           resources:
             requests: { cpu: 500m, memory: 1Gi }
             limits: { cpu: 2000m, memory: 3Gi }
@@ -346,7 +350,8 @@ codeapi:
               enabled: true
               type: HTTP
               path: /api/v2/health
-              spec: { httpGet: { port: sandbox }, initialDelaySeconds: 30, periodSeconds: 10, timeoutSeconds: 5 }
+              port: sandbox
+              spec: { initialDelaySeconds: 30, periodSeconds: 10, timeoutSeconds: 5 }
           resources:
             requests: { cpu: 500m, memory: 1Gi }
             limits: { cpu: 2000m, memory: 3Gi }
@@ -402,12 +407,14 @@ codeapi:
               enabled: true
               type: HTTP
               path: /health
-              spec: { httpGet: { port: http }, initialDelaySeconds: 10, periodSeconds: 30, failureThreshold: 3 }
+              port: http
+              spec: { initialDelaySeconds: 10, periodSeconds: 30, failureThreshold: 3 }
             readiness:
               enabled: true
               type: HTTP
               path: /ready
-              spec: { httpGet: { port: http }, initialDelaySeconds: 5, periodSeconds: 15, failureThreshold: 2, timeoutSeconds: 5 }
+              port: http
+              spec: { initialDelaySeconds: 5, periodSeconds: 15, failureThreshold: 2, timeoutSeconds: 5 }
           resources:
             requests: { cpu: 50m, memory: 128Mi }
             limits: { cpu: 200m, memory: 256Mi }
@@ -449,12 +456,14 @@ codeapi:
               enabled: true
               type: HTTP
               path: /health
-              spec: { httpGet: { port: http }, initialDelaySeconds: 10, periodSeconds: 30 }
+              port: http
+              spec: { initialDelaySeconds: 10, periodSeconds: 30 }
             readiness:
               enabled: true
               type: HTTP
               path: /health
-              spec: { httpGet: { port: http }, initialDelaySeconds: 5, periodSeconds: 10 }
+              port: http
+              spec: { initialDelaySeconds: 5, periodSeconds: 10 }
           resources:
             requests: { cpu: 50m, memory: 128Mi }
             limits: { cpu: 200m, memory: 256Mi }
@@ -503,12 +512,14 @@ codeapi:
               enabled: true
               type: HTTP
               path: /live
-              spec: { httpGet: { port: http }, initialDelaySeconds: 10, periodSeconds: 30 }
+              port: http
+              spec: { initialDelaySeconds: 10, periodSeconds: 30 }
             readiness:
               enabled: true
               type: HTTP
               path: /ready
-              spec: { httpGet: { port: http }, initialDelaySeconds: 5, periodSeconds: 10 }
+              port: http
+              spec: { initialDelaySeconds: 5, periodSeconds: 10 }
           resources:
             requests: { cpu: 50m, memory: 128Mi }
             limits: { cpu: 200m, memory: 256Mi }


### PR DESCRIPTION
## 1. Summary

This PR changes:

- Moves `port:` from inside `spec.httpGet` to the top level of each probe object (a sibling of `type`/`path`) across all 11 HTTP/exec-adjacent probes in `charts/librechat-code-interpreter/values.yaml`.

It solves:

- Live-incident fix (fourth in this sequence, following #941/#943/#944/#946): a forced ArgoCD sync rejected `codeapi-service-worker` with `livenessProbe.httpGet.port: Invalid value: 0`.

---

## 2. Intent

The intent of this PR is:

> Fix a schema misunderstanding: `bjw-template`'s non-custom probe builder reads `port` as a field directly on the probe object, not nested inside `spec.httpGet` (which mimics a literal Kubernetes probe shape this template doesn't actually accept there). Every HTTP probe in this chart had it in the wrong place; it only "worked" for 4 of 6 controllers because bjw's fallback-to-primary-Service-port happened to resolve correctly for those — `service-worker` has no Service by design, so its fallback resolved to nothing and rendered `port: 0`.

---

## 3. Scope

### In Scope

- Correcting `port:` placement on all 11 probes (api, service-worker, sandbox-runner's readiness, file-server, tool-call-server, egress-gateway).

### Out of Scope

- The `Replace=true` ArgoCD sync-strategy conflict with the now-`Bound` packages PVC and the `package-init` Job's server-generated `selector` — a separate, cluster-side issue (not a chart bug) still being worked through directly with the maintainer.

---

## 4. Verification

I verified this change by:

- [x] Running automated tests
- [ ] Running manual tests
- [x] Checking logs
- [ ] Checking metrics
- [ ] Testing error cases
- [ ] Testing permissions/security behavior
- [ ] Testing rollback or failure behavior, if relevant

Commands run:

```bash
helm dep build charts/librechat-code-interpreter
helm lint charts/librechat-code-interpreter --strict
helm template codeapi charts/librechat-code-interpreter -n librechat-sandbox --dry-run
grep -B1 "port: 0" <rendered output>
awk '/httpGet:/{print; getline; print; getline; print}' <rendered output>
```

Results:

```text
0 chart(s) failed. Zero "port: 0" matches anywhere in the rendered manifest.
All 11 httpGet probes confirmed resolving to their correct named container
port (http, sandbox, health). Root cause confirmed directly from the live
ArgoCD sync error message (Deployment.apps "codeapi-service-worker" is
invalid: livenessProbe.httpGet.port: Invalid value: 0).
```

---

## 5. Screenshots / Evidence

* Logs: live ArgoCD `operationState.message` output pasted into this PR's discussion / the linked incident thread (#941, #943, #944, #946).

---

## 6. Risk Assessment

Risk level:

* [x] Low
* [ ] Medium
* [ ] High

Potential risks:

* None beyond the probes themselves — this only corrects port resolution, no behavioral change to the 4 controllers whose probes already happened to resolve correctly via the fallback path.

Mitigation:

* N/A — straightforward correctness fix, verified by direct render inspection.

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [x] Drafting documentation
* [ ] Refactoring
* [ ] Generating tests
* [ ] Reviewing the diff
* [ ] Not used

Human verification:

* [ ] I understand every meaningful change in this PR
* [ ] I checked generated code manually
* [ ] I checked generated tests manually
* [ ] I removed unsupported AI assumptions
* [ ] I accept responsibility for this PR

*(This PR was authored end-to-end by Claude Code, diagnosing a live failure directly against the cluster with the maintainer's explicit go-ahead to use kubectl; the human maintainer should complete the verification checklist above before merging.)*

---

## 8. Reviewer Focus

Please focus your review on:

* [x] Correctness
* [ ] Architecture
* [ ] Security
* [ ] Performance
* [ ] Tests
* [ ] Maintainability
* [ ] Product intent
* [ ] Edge cases

Specifically: confirming the probe port for each of the 6 controllers matches its actual container port name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
