### PR TITLE
fix(webank-training): restore dataset-build GPU placement

### DIFF
--- a/charts/webank-training/templates/workflowtemplate.yaml
+++ b/charts/webank-training/templates/workflowtemplate.yaml
@@ -85,6 +85,14 @@ spec:
   {{- end }}
   templates:
     - name: build
+      podSpecPatch: |
+        runtimeClassName: {{ $training.gpu.runtimeClassName | quote }}
+      nodeSelector:
+        {{- toYaml $training.gpu.nodeSelector | nindent 8 }}
+      {{- with $training.gpu.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with $training.gpu.priorityClassName }}
       priorityClassName: {{ . | quote }}
       {{- end }}

--- a/charts/webank-training/values.yaml
+++ b/charts/webank-training/values.yaml
@@ -18,14 +18,16 @@ training:
     secretKey: secret-access-key
   otel:
     endpoint: ""
-  # Every dataset-build and training template uses this GPU-node placement and
-  # resource profile: `nvidia.com/gpu.present=true` (the live GPU node label,
-  # matching charts/inference's `defaults.gpu` — see ADR-0114), an
-  # matching toleration and runtime class, and an explicit positive accelerator
-  # request and limit. Every cluster-specific name and placement value is
-  # supplied by ai-helm-values; this chart owns only the rendering contract.
-  # Dataset construction receives the same reviewed CPU, memory, and accelerator
-  # allocation as candidate training.
+  # Every dataset-build and training template uses this GPU-node placement:
+  # `nvidia.com/gpu.present=true` (the live GPU node label, matching
+  # charts/inference's `defaults.gpu` — see ADR-0114), a matching toleration,
+  # and `runtimeClassName`. Every cluster-specific name and placement value
+  # is supplied by ai-helm-values; this chart owns only the rendering
+  # contract. `train` also takes its CPU/memory/accelerator quantities from
+  # `resources` below; `dataset-build` uses the same placement but its own
+  # measured `training.datasetBuild.resources` quantities (see below) —
+  # placement is shared because both need the driver library the GPU claim
+  # injects (ai-helm#948), not because their resource footprints match.
   #
   # ⚠️ Prior to ADR-0114 this contract was `role: gpu`, which no node in the
   # cluster has ever carried — every GPU-requesting workflow pod was
@@ -41,19 +43,34 @@ training:
     resources:
       requests: { cpu: "4", memory: 16Gi, nvidia.com/gpu: 1 }
       limits: { cpu: "8", memory: 16Gi, nvidia.com/gpu: 1 }
-  # Dataset-build steps run generation, image decode/resize, tensor packing,
-  # and an HTTP upload — no forward pass, no CUDA (webank-models#415). They
-  # request no accelerator and carry no GPU node placement; only `train`
-  # steps use `training.gpu` above. Sized from a real local run of this
-  # pipeline: 13,393 crops in 2:55, materialize-synthetic-source 12,799 rows
-  # in 11s (peak 13.2 GiB RSS, measured with `/usr/bin/time -v` — the working
-  # set is one `Vec<f32>` tensor plus a copy, not the packed output size),
-  # pack 4.4 GB in 14s. The memory limit keeps ~50% headroom above that
-  # measured peak; do not size it from the smaller output artifact.
+  # webank-models#415 argued dataset-build performs no forward pass so it
+  # needs no GPU. That reasoning was correct but incomplete (ai-helm#948):
+  # every subcommand of the pinned `webank-train-gpu` image — including a
+  # pure-CLI one like `training-data bootstrap-model-repository` — links
+  # `libcuda.so.1` as a hard ELF DT_NEEDED dependency, because candle's
+  # `cuda` feature pulls in ~30 `cu*` driver symbols at load time. The
+  # process fails at start (exit 127, "cannot open shared object file")
+  # unless the NVIDIA driver library is injected, which only happens via
+  # the GPU resource claim plus `runtimeClassName: nvidia`. Dataset-build
+  # therefore keeps the same GPU node placement as `train` (`training.gpu`
+  # nodeSelector/toleration/runtimeClassName), even though it runs no
+  # kernel — the accelerator claim exists to provision the driver, not
+  # compute.
+  #
+  # CPU/memory stay their own knob, distinct from `training.gpu.resources`,
+  # because dataset-build's measured footprint differs from training's and
+  # has already changed once: webank-models#424 measured
+  # `materialize-synthetic-source` peaking at 13.20 GiB RSS (12,799 rows,
+  # `/usr/bin/time -v`); webank-models#425 removed a redundant tensor copy
+  # and cut that peak to 8.81 GiB RSS (9,234,140 KB), byte-identical output
+  # verified by SHA-256. The request sits just above that new peak and the
+  # limit keeps ~50%+ headroom above it, consistent with the original
+  # sizing convention; do not size either from the smaller packed-output
+  # artifact.
   datasetBuild:
     resources:
-      requests: { cpu: "4", memory: 16Gi }
-      limits: { cpu: "8", memory: 20Gi }
+      requests: { cpu: "4", memory: 10Gi, nvidia.com/gpu: 1 }
+      limits: { cpu: "8", memory: 14Gi, nvidia.com/gpu: 1 }
   documentDetector:
     stemChannels: 32
     epochs: 10

--- a/docs/integrations/webank-training-deployment.md
+++ b/docs/integrations/webank-training-deployment.md
@@ -21,14 +21,20 @@ stage into an alternative public operation.
 
 ## Dataset-build templates
 
-`*-dataset-build` templates are restricted-plane operations that run on
-ordinary CPU nodes — no GPU node placement, toleration, or `runtimeClassName`
-(webank-models#415). The work is generation, image decode/resize, tensor
-packing, and a LakeFS upload: no forward pass, no CUDA device. Their CPU and
-memory request/limit come from `training.datasetBuild.resources`, sized from a
-real local run of this pipeline (13,393 crops in 2:55; `materialize-synthetic-
-source` peaking at 13.2 GiB RSS, not the smaller packed-output size), separate
-from `training.gpu` (ADR-0114), which candidate training alone still uses.
+`*-dataset-build` templates are restricted-plane operations placed on
+`nvidia.com/gpu.present=true` nodes (the live GPU node label, matching
+`charts/inference`), tolerating `nvidia.com/gpu:NoSchedule` (Exists), and
+using `runtimeClassName: nvidia`. The work itself — generation, image
+decode/resize, tensor packing, and a LakeFS upload — performs no forward pass
+and needs no GPU compute (webank-models#415); the GPU node placement is kept
+anyway because the pinned `webank-train-gpu` image links `libcuda.so.1` as a
+hard dependency, so every subcommand fails to start (exit 127) without the
+driver library the GPU claim injects (ai-helm#948). Their CPU and memory
+request/limit come from `training.datasetBuild.resources`, sized from a real
+local run of this pipeline (13,393 crops in 2:55; `materialize-synthetic-
+source` peaking at 8.81 GiB RSS after webank-models#425, down from 13.20 GiB
+— not the smaller packed-output size), kept separate from `training.gpu`
+(ADR-0114) because the two footprints differ even though placement is shared.
 Every Dataset Build form has **no inputs**. Its target repository, `main`
 branch, reviewed storage namespace, and closed source strategy come only from
 `ai-helm-values`; the dashboard cannot choose a LakeFS reference, source

--- a/docs/playbooks/webank-model-workflows.md
+++ b/docs/playbooks/webank-model-workflows.md
@@ -10,7 +10,7 @@ Start with the model-specific operation you actually need:
 
 | Need | Template pattern | Compute |
 | --- | --- | --- |
-| Build and publish a fixed training dataset | `webank-<model>-dataset-build` | CPU only (webank-models#415) |
+| Build and publish a fixed training dataset | `webank-<model>-dataset-build` | one GPU (placement only — ai-helm#948) |
 | Train a governed candidate | `webank-<model>-train` | one GPU |
 
 There is one template of each kind for document detector, document recognizer,
@@ -42,13 +42,17 @@ A successful run writes one validated training bundle through the fixed
 LakeFS boundary into that model's `ds-<model>/main` repository and reports the
 server-issued immutable commit.
 
-Dataset-build pods request no GPU: no `nvidia.com/gpu` limit/request, no
-`nvidia.com/gpu.present=true` node selector, no `nvidia.com/gpu:NoSchedule`
-toleration, and no `runtimeClassName: nvidia` (webank-models#415). The work is
-generation, image decode/resize, tensor packing, and a LakeFS upload — no
-forward pass, no CUDA device — and runs on ordinary CPU nodes with the reviewed
-`training.datasetBuild.resources` CPU/memory profile. Do not expect it to
-compete with candidate training for one of the fleet's two GPU cards.
+Dataset-build pods select `nvidia.com/gpu.present=true`, tolerate
+`nvidia.com/gpu:NoSchedule` (Exists), and use `runtimeClassName: nvidia`, the
+same GPU node placement as candidate training. The work itself — generation,
+image decode/resize, tensor packing, and a LakeFS upload — performs no forward
+pass and needs no GPU compute (webank-models#415), but the pinned
+`webank-train-gpu` image links `libcuda.so.1` as a hard dependency, so every
+subcommand fails to start without the driver library the GPU claim injects
+(ai-helm#948); dataset-build therefore competes with candidate training for
+one of the fleet's two GPU cards even though it runs no kernel. Its CPU and
+memory come from the reviewed `training.datasetBuild.resources` profile, not
+`training.gpu.resources` — the two footprints are measured separately.
 
 If an SFace or PAD governed-source repository is empty, the operation fails
 before materialization. Do not use fixtures or placeholder evidence as a
@@ -86,6 +90,6 @@ as PAD training and do not create a candidate manually.
 | --- | --- | --- |
 | Argo rejects a missing dataset field | The data contract is intentionally required. | Supply the approved ref/version or artifacts; never fake a value. |
 | `readiness-gate` fails | Source manifest, readiness attestation, and pinned commit disagree or are not eligible. | Repair/reapprove data in its source repository. |
-| `*-train` pod remains Pending | GPU placement requirements cannot currently be met, or MLOps is preempted by serving (ADR-0114). | Check an `nvidia.com/gpu.present=true` node and its allocatable GPU; do not remove placement constraints. |
-| `libcuda.so.1` cannot be opened | The pod did not use the NVIDIA runtime handler, so host driver libraries were not injected. Only `*-train` pods use the NVIDIA runtime; `*-dataset-build` pods do not and should never need it. | Confirm the rendered `*-train` template and pod both have `runtimeClassName: nvidia`; do not copy CUDA driver files into the image. |
+| `*-train` or `*-dataset-build` pod remains Pending | GPU placement requirements cannot currently be met, or MLOps is preempted by serving (ADR-0114). Both template kinds request GPU node placement. | Check an `nvidia.com/gpu.present=true` node and its allocatable GPU; do not remove placement constraints. |
+| `libcuda.so.1` cannot be opened | The pod did not use the NVIDIA runtime handler, so host driver libraries were not injected. Every subcommand in the pinned image needs this, including `*-dataset-build`'s (ai-helm#948) — it is not `*-train`-only. | Confirm the rendered template and pod both have `runtimeClassName: nvidia`; do not copy CUDA driver files into the image. |
 | PAD train exits immediately | There is no PAD trainer. | Keep it blocked until a model-specific trainer lands. |


### PR DESCRIPTION
## 1. Summary

This PR changes `charts/webank-training/templates/workflowtemplate.yaml`,
`charts/webank-training/values.yaml`,
`docs/integrations/webank-training-deployment.md`, and
`docs/playbooks/webank-model-workflows.md`:

- Restores, on all five `webank-<model>-dataset-build` templates, the GPU
  node placement PR #945 removed: the `podSpecPatch: runtimeClassName:
  "nvidia"`, the `nvidia.com/gpu.present: "true"` nodeSelector, and the
  `nvidia.com/gpu:NoSchedule` (Exists) toleration.
- Adds `nvidia.com/gpu: 1` back to `training.datasetBuild.resources`'
  requests and limits (a separate block from `training.gpu.resources`,
  unlike before #945 — see Intent).
- Lowers `training.datasetBuild.resources.memory` (16Gi/20Gi → 10Gi/14Gi),
  because webank-models#425 has since cut the measured
  `materialize-synthetic-source` peak RSS from 13.20 GiB to 8.81 GiB.
- Corrects the two chart docs and a stale `values.yaml` comment describing
  dataset-build as CPU-only, to explain why GPU placement is back.

It solves:

- ADORSYS-GIS/ai-helm#948

References:

- ADORSYS-GIS/ai-helm#945 (the PR being partially reverted — its
  `push-candidate` → `fixed-candidate publish` fix and
  `lakefs.model.storageNamespace` plumbing are correct and **not** touched
  here)
- ADORSYS-GIS/webank-models#415 (the original, incomplete reasoning)

---

## 2. Intent

#945 removed dataset-build's GPU placement because dataset-build performs no
forward pass — generation, image decode/resize, tensor packing, and a LakeFS
upload, no CUDA kernel. **That reasoning was correct but incomplete, and the
change is unsafe.** The pinned `ghcr.io/adorsys-gis/webank-train-gpu` image
links `libcuda.so.1` as a hard ELF `DT_NEEDED` dependency — candle's `cuda`
feature pulls in ~30 `cu*` driver symbols at load time — so **every**
subcommand in that image, including pure-CLI ones like `training-data
bootstrap-model-repository`, fails at process start (exit 127, `cannot open
shared object file`) when the driver library is absent. The driver is only
injected by the GPU resource claim plus `runtimeClassName: nvidia`. Removing
the claim while keeping the CUDA-linked image strands the binary before it
can even parse its arguments.

The owner's decision: GPU nodes exist and are faster; both dataset building
and training run on GPU. CPU-only is a constraint specific to production
inference (the 2vCPU/2GiB no-GPU serving case), not a general principle for
batch work on a GPU-equipped cluster. The correct fix for ai-helm#948 is to
restore GPU placement, not to publish a CPU-only image.

`training.datasetBuild.resources` — the separate CPU/memory (now also GPU
quantity) block #945 introduced — is kept rather than reverted back to
sharing `training.gpu.resources` wholesale. Its CPU/memory sizing is real,
measured data (13.20 GiB → 8.81 GiB peak RSS after webank-models#425) that
has already proven useful and has already changed once; collapsing it back
into the generic `training.gpu.resources` profile would throw that
measurement away and re-couple dataset-build's memory limit to whatever
`train` needs. Placement (`nodeSelector`/`toleration`/`runtimeClassName`) is
shared between `train` and `dataset-build` because both need the same driver
injection; resource *quantities* are not, because the two workloads have
different, independently measured footprints.

---

## 3. Scope

### In Scope

- Restoring `nvidia.com/gpu.present` nodeSelector, the nvidia toleration,
  and `runtimeClassName: nvidia` on all 5 `*-dataset-build` templates.
- Adding `nvidia.com/gpu: 1` to `training.datasetBuild.resources`' requests
  and limits, and lowering its memory request/limit using the
  webank-models#425 measurement.
- Updating the two chart docs and the `training.gpu` values.yaml comment
  that described (or implied) dataset-build as CPU-only or resource-sharing
  with `train`, so they match the restored manifest.

### Out of Scope

- #945's `push-candidate` → `cargo xtask training-data fixed-candidate
  publish` fix and its `lakefs.model.storageNamespace` value/env plumbing.
  Both are correct and unrelated to the GPU question; left untouched and
  verified byte-for-byte unchanged in the rendered output (see Verification).
- The matching `ai-helm-values` change (ai-helm-values#208) — already merged,
  no action needed there for this revert.
- Publishing a CPU-only image variant. Explicitly rejected per the owner's
  decision (see Intent).
- Any cluster action. Cluster is read-only and currently unauthenticated
  (OIDC expired); nothing here was applied anywhere.

---

## 4. Verification

I verified this change by:

- [x] Running automated tests
- [ ] Running manual tests
- [ ] Checking logs
- [ ] Checking metrics
- [ ] Testing error cases
- [ ] Testing permissions/security behavior
- [ ] Testing rollback or failure behavior, if relevant

Commands run:

```bash
helm dependency build charts/webank-training
helm lint --strict -f charts/webank-training/ci/lint-values.yaml charts/webank-training

# render before (origin/main, #945 still merged) and after (this branch) in
# separate worktrees, same lint-values.yaml
helm template charts/webank-training -f charts/webank-training/ci/lint-values.yaml > rendered-before.yaml   # origin/main
helm template charts/webank-training -f charts/webank-training/ci/lint-values.yaml > rendered-after.yaml    # this branch
diff -u rendered-before.yaml rendered-after.yaml

kubeconform -strict -summary \
  -schema-location default \
  -schema-location 'https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/{{.ResourceKind}}{{.KindSuffix}}.json' \
  -schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json' \
  rendered-after.yaml
```

Results:

```text
helm lint --strict  -> 1 chart(s) linted, 0 chart(s) failed
kubeconform          -> Summary: 10 resources found in 1 file - Valid: 10, Invalid: 0, Errors: 0, Skipped: 0

diff before/after -> exactly, in each of the 5 *-dataset-build blocks:
  + podSpecPatch: runtimeClassName: "nvidia"
  + nodeSelector: nvidia.com/gpu.present: "true"
  + tolerations: [nvidia.com/gpu, NoSchedule, Exists]
  - resources.limits.memory: 20Gi  -> + 14Gi
  - resources.requests.memory: 16Gi -> + 10Gi
  + resources.limits["nvidia.com/gpu"]: 1
  + resources.requests["nvidia.com/gpu"]: 1
No other lines differ anywhere in the 10-resource render: all 5 *-train
templates' push-candidate command (`fixed-candidate publish`, 4 occurrences
both sides), WEBANK_MODEL_LAKEFS_STORAGE_NAMESPACE env (9 occurrences both
sides), and every WorkflowTemplate name are byte-identical before and after.
```

---

## 5. Screenshots / Evidence

Add evidence here:

* Screenshot: n/a (chart-only change)
* Logs: `helm lint`/`helm template`/`kubeconform` output above
* Metrics: n/a
* Recording: n/a

---

## 6. Risk Assessment

Risk level:

* [x] Low
* [ ] Medium
* [ ] High

Potential risks:

* Dataset-build pods again compete with `*-train` pods for one of the
  fleet's two GPU nodes, which can queue dataset-build behind an
  in-progress training run. This is the accepted tradeoff of the owner's
  decision (GPU placement is correct for batch work on this cluster), not
  an oversight.
* The lowered `training.datasetBuild.resources.memory` (16Gi/20Gi →
  10Gi/14Gi) is sized from a peak RSS measurement
  (webank-models#425, 9,234,140 KB = 8.81 GiB) with headroom, not a guess,
  but it is a real reduction from what #945 shipped; if a future model's
  dataset-build has a different memory footprint than
  document-recognizer's measured pipeline, this default may need
  per-model override in `ai-helm-values`.
* This PR only makes the chart correct; it is **not** applied to the
  cluster. Whether/when it deploys is ArgoCD's normal sync process.

Mitigation:

* The GPU placement restore exactly matches what was live and working
  before #945 (confirmed via `git show` on the pre-#945 commit, not
  reconstructed from memory).
* The new memory figures are derived from a cited, byte-for-byte-verified
  measurement (webank-models#425's PR body), with the same ~50%+ headroom
  convention #945 itself used.

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [ ] Refactoring
* [ ] Generating tests
* [x] Drafting documentation
* [x] Reviewing the diff
* [ ] Not used

Human verification:

* [ ] I understand every meaningful change in this PR
* [ ] I checked generated code manually
* [ ] I checked generated tests manually
* [ ] I removed unsupported AI assumptions
* [ ] I accept responsibility for this PR

---

## 8. Reviewer Focus

Please focus your review on:

* [x] Correctness
* [x] Architecture
* [ ] Security
* [x] Performance
* [ ] Tests
* [x] Maintainability
* [x] Product intent
* [ ] Edge cases

Fixes ADORSYS-GIS/ai-helm#948
Refs ADORSYS-GIS/ai-helm#945
Refs ADORSYS-GIS/webank-models#415

🤖 Generated with [Claude Code](https://claude.com/claude-code)
