### PR TITLE
fix(librechat-code-interpreter): pin packages PVC + package-init Job to Replace=false

### DIFF
--- a/charts/librechat-code-interpreter/values.yaml
+++ b/charts/librechat-code-interpreter/values.yaml
@@ -554,6 +554,19 @@ codeapi:
     # securityContext on this container at all.
     package-init:
       type: job
+      # ⚠️ Replace=false override (live-incident correction, 2026-08-08): the
+      # repo-wide default syncPolicy (charts/apps) uses ArgoCD's Replace=true
+      # sync option (`kubectl replace` instead of `apply`). Once this Job's
+      # pod is created, `spec.selector` is server-populated and immutable —
+      # every subsequent sync then fails with `spec.selector: Required
+      # value`/`field is immutable` and the Application sits Failed/OutOfSync
+      # forever, even though the running Job itself is perfectly healthy.
+      # Confirmed live across 5+ retried sync attempts. This per-resource
+      # annotation overrides just this Job back to `kubectl apply`, which
+      # handles the immutable-selector case fine (apply only patches fields
+      # that changed). Nothing else in the repo is affected.
+      annotations:
+        argocd.argoproj.io/sync-options: Replace=false
       pod:
         restartPolicy: Never
       containers:
@@ -628,6 +641,16 @@ codeapi:
       # completion of hook /PersistentVolumeClaim/codeapi", forever. Plain
       # resource now — binds normally once package-init's pod (or any other
       # consumer) is scheduled.
+      # ⚠️ Replace=false override (live-incident correction, 2026-08-08):
+      # once Bound, a PVC's spec is immutable except resources.requests —
+      # the repo-wide Replace=true sync option (`kubectl replace`) fails
+      # every subsequent sync with `spec is immutable after creation`,
+      # forever, even though the PVC itself is perfectly healthy. Confirmed
+      # live across 5+ retried sync attempts. This per-resource annotation
+      # overrides just this PVC back to `kubectl apply`. Nothing else in the
+      # repo is affected.
+      annotations:
+        argocd.argoproj.io/sync-options: Replace=false
       advancedMounts:
         sandbox-runner:
           sandbox-runner:


### PR DESCRIPTION
## 1. Summary

This PR changes:

- Adds `argocd.argoproj.io/sync-options: Replace=false` as a per-resource
  annotation to the `packages` PVC and the `package-init` Job in
  `charts/librechat-code-interpreter`.

It solves:

- A live, structural ArgoCD sync failure on `aii-librechat-code-interpreter`
  discovered while driving #941 (self-hosted LibreChat Code Interpreter,
  ADR-0122) to a healthy live deploy. Source of truth: #941, #944, #947.

---

## 2. Intent

> The repo-wide default `syncPolicy` (`charts/apps`) uses ArgoCD's
> `Replace=true` sync option (`kubectl replace` instead of `apply`). Two
> resources in this chart develop server-populated **immutable** fields once
> they exist in their normal running state: the `packages` PVC, once `Bound`
> (`spec` becomes immutable except `resources.requests`), and the
> `package-init` Job, once its pod is created (`spec.selector` becomes
> server-populated and immutable). Every subsequent sync then fails with
> `spec is immutable after creation` / `spec.selector: Required value ...
> field is immutable`, and the Application sits `Failed`/`OutOfSync`
> **forever** — confirmed live: after clearing a stuck PVC+Job from an
> earlier incident and letting ArgoCD recreate them fresh, the very next
> sync hit this exact conflict again. Not a one-off; guaranteed to recur
> every time these two resources are in their normal state.

---

## 3. Scope

### In Scope

- `charts/librechat-code-interpreter/values.yaml` — per-resource
  `argocd.argoproj.io/sync-options: Replace=false` annotation on the
  `packages` PVC and `package-init` Job only.

### Out of Scope

- Changing the repo-wide `Replace=true` default in `charts/apps` (would
  affect every other app in the repo — out of scope for this fix).
- The `codeapi-secrets` ExternalSecret `SecretSyncedError` (missing
  `ssegning-aws` properties) — separate, pre-existing, tracked in
  `docs/patterns/self-hosted-code-interpreter.md`.

---

## 4. Verification

I verified this change by:

- [x] Running automated tests
- [x] Running manual tests
- [x] Checking logs
- [ ] Checking metrics
- [ ] Testing error cases
- [ ] Testing permissions/security behavior
- [ ] Testing rollback or failure behavior, if relevant

Commands run:

```bash
helm lint charts/librechat-code-interpreter --strict
helm template librechat-code-interpreter charts/librechat-code-interpreter --namespace librechat-sandbox
```

Results:

```text
1 chart(s) linted, 0 chart(s) failed

# Rendered PVC now carries:
metadata:
  annotations:
    argocd.argoproj.io/sync-options: Replace=false
    helm.sh/resource-policy: keep

# Rendered Job now carries:
metadata:
  annotations:
    argocd.argoproj.io/sync-options: Replace=false
```

---

## 5. Screenshots / Evidence

* Logs: live `kubectl` diagnosis on `hetzner-prod` / `admin@homeos` (ArgoCD),
  captured during the #941 live-deploy follow-through:

```text
$ kubectl --context admin@homeos -n argocd get application aii-librechat-code-interpreter \
    -o jsonpath="{.status.operationState.message}"
one or more synchronization tasks completed unsuccessfully, reason: error when
replacing "/dev/shm/...": PersistentVolumeClaim "codeapi" is invalid: spec:
Forbidden: spec is immutable after creation except resources.requests and
volumeAttributesClassName for bound claims
...,error when replacing "/dev/shm/...": Job.batch "codeapi-package-init" is
invalid: [spec.selector: Required value, ... field is immutable] (retried 5 times).
```

Reproduced twice independently (once against a stale PVC from an earlier
incident, once against a freshly-recreated, genuinely `Bound` PVC + `Running`
Job) — confirming this is structural, not transient/cache-related.

---

## 6. Risk Assessment

Risk level:

* [x] Low
* [ ] Medium
* [ ] High

Potential risks:

* An annotation typo/wrong key would silently no-op (ArgoCD would just keep
  using `Replace=true`, i.e. no worse than the current broken state).

Mitigation:

* Verified via `helm template` that the annotation renders with the exact
  key ArgoCD documents (`argocd.argoproj.io/sync-options: Replace=false`),
  scoped to only these two resources — every other resource in the chart
  and every other app in the repo keeps the `Replace=true` default.

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [ ] Refactoring
* [ ] Generating tests
* [x] Drafting documentation
* [ ] Reviewing the diff
* [ ] Not used

Human verification:

* [x] I understand every meaningful change in this PR
* [x] I checked generated code manually
* [ ] I checked generated tests manually
* [x] I removed unsupported AI assumptions
* [x] I accept responsibility for this PR

---

## 8. Reviewer Focus

Please focus your review on:

* [x] Correctness
* [x] Architecture
* [ ] Security
* [ ] Performance
* [ ] Tests
* [ ] Maintainability
* [ ] Product intent
* [ ] Edge cases
