### PR TITLE
fix(librechat-code-interpreter): move Replace=false override to app-level syncPolicy

### DIFF
--- a/charts/apps/values.yaml
+++ b/charts/apps/values.yaml
@@ -1120,6 +1120,26 @@ applications:
     depsOverlay: environments/prod/deps/librechat-code-interpreter
     destination:
       namespace: librechat-sandbox
+    # ⚠️ Override, NOT the repo-wide Replace=true default (live-incident
+    # correction, 2026-08-08): this chart's `packages` PVC and
+    # `package-init` Job both develop server-populated immutable fields
+    # once they exist in their normal running state (a Bound PVC's spec;
+    # a Job's spec.selector) — Replace=true (`kubectl replace`) then fails
+    # every subsequent sync forever with "spec is immutable"/"field is
+    # immutable", even once the workload itself is healthy. Confirmed live
+    # across 10+ retried sync attempts, including a per-resource
+    # `argocd.argoproj.io/sync-options: Replace=false` annotation attempt
+    # (charts/librechat-code-interpreter/values.yaml git history) that did
+    # NOT override the app-level default. Same pattern already used by
+    # other apps in this file (e.g. same-origin-proxy, apprise-api,
+    # opencode-k8s-agent) — just the two known-safe options, no Replace.
+    syncPolicy:
+      syncOptions:
+        - CreateNamespace=true
+        - ServerSideApply=true
+      automated:
+        prune: true
+        selfHeal: true
 
   # --- Models ---
   - name: models

--- a/charts/librechat-code-interpreter/values.yaml
+++ b/charts/librechat-code-interpreter/values.yaml
@@ -554,19 +554,15 @@ codeapi:
     # securityContext on this container at all.
     package-init:
       type: job
-      # ⚠️ Replace=false override (live-incident correction, 2026-08-08): the
-      # repo-wide default syncPolicy (charts/apps) uses ArgoCD's Replace=true
-      # sync option (`kubectl replace` instead of `apply`). Once this Job's
-      # pod is created, `spec.selector` is server-populated and immutable —
-      # every subsequent sync then fails with `spec.selector: Required
-      # value`/`field is immutable` and the Application sits Failed/OutOfSync
-      # forever, even though the running Job itself is perfectly healthy.
-      # Confirmed live across 5+ retried sync attempts. This per-resource
-      # annotation overrides just this Job back to `kubectl apply`, which
-      # handles the immutable-selector case fine (apply only patches fields
-      # that changed). Nothing else in the repo is affected.
-      annotations:
-        argocd.argoproj.io/sync-options: Replace=false
+      # ⚠️ Replace=true (repo-wide default syncPolicy) vs. this Job's
+      # server-populated immutable spec.selector: see the syncPolicy
+      # override on this app's entry in charts/apps/values.yaml — a
+      # per-resource `argocd.argoproj.io/sync-options: Replace=false`
+      # annotation here was tried first and does NOT work (confirmed live:
+      # ArgoCD still replaced and failed identically with the annotation
+      # present) — Replace, unlike Prune/Validate, isn't documented as
+      # resource-level-overridable and empirically isn't in this ArgoCD
+      # version. Fixed at the Application level instead.
       pod:
         restartPolicy: Never
       containers:
@@ -641,16 +637,15 @@ codeapi:
       # completion of hook /PersistentVolumeClaim/codeapi", forever. Plain
       # resource now — binds normally once package-init's pod (or any other
       # consumer) is scheduled.
-      # ⚠️ Replace=false override (live-incident correction, 2026-08-08):
-      # once Bound, a PVC's spec is immutable except resources.requests —
-      # the repo-wide Replace=true sync option (`kubectl replace`) fails
-      # every subsequent sync with `spec is immutable after creation`,
-      # forever, even though the PVC itself is perfectly healthy. Confirmed
-      # live across 5+ retried sync attempts. This per-resource annotation
-      # overrides just this PVC back to `kubectl apply`. Nothing else in the
-      # repo is affected.
-      annotations:
-        argocd.argoproj.io/sync-options: Replace=false
+      # ⚠️ Replace=true (repo-wide default syncPolicy) vs. a Bound PVC's
+      # immutable spec: see the syncPolicy override on this app's entry in
+      # charts/apps/values.yaml — a per-resource
+      # `argocd.argoproj.io/sync-options: Replace=false` annotation here was
+      # tried first and does NOT work (confirmed live: ArgoCD still
+      # replaced and failed identically with the annotation present) —
+      # Replace, unlike Prune/Validate, isn't documented as
+      # resource-level-overridable and empirically isn't in this ArgoCD
+      # version. Fixed at the Application level instead.
       advancedMounts:
         sandbox-runner:
           sandbox-runner:


### PR DESCRIPTION
## 1. Summary

This PR changes:

- Overrides the `librechat-code-interpreter` app entry's `syncPolicy` in
  `charts/apps/values.yaml` to drop `Replace=true` (keeping
  `CreateNamespace=true` + `ServerSideApply=true` + automated
  `prune`/`selfHeal`), matching the pattern already used by several other
  apps in that file.
- Removes the now-confirmed-ineffective per-resource
  `argocd.argoproj.io/sync-options: Replace=false` annotations from
  `charts/librechat-code-interpreter/values.yaml` (added in #951).

It solves:

- The same live ArgoCD sync failure #951 attempted to fix, which turned out
  to need an app-level fix instead of a per-resource one. Source of truth:
  #941, #944, #947, #951.

---

## 2. Intent

> #951's per-resource `argocd.argoproj.io/sync-options: Replace=false`
> annotation does **not** actually override the app-level `Replace=true`
> default — confirmed live: after #951 merged and published (chart 0.1.6),
> ArgoCD still attempted `kubectl replace` on both the `packages` PVC and
> the `package-init` Job and failed identically (`spec is immutable after
> creation` / `spec.selector: Required value ... field is immutable`).
> Unlike `Prune`/`Validate`, ArgoCD's docs don't state that `Replace` is
> resource-level overridable, and empirically it isn't in this cluster's
> ArgoCD version — the app-level `Replace=true` always wins regardless of a
> resource's own annotation. The fix has to live at the Application level.

---

## 3. Scope

### In Scope

- `charts/apps/values.yaml` — `syncPolicy` override on the
  `librechat-code-interpreter` app entry only.
- `charts/librechat-code-interpreter/values.yaml` — remove the dead
  per-resource annotations from #951 (comments updated to explain why).

### Out of Scope

- Changing the repo-wide `Replace=true` default for any other app.
- The `codeapi-secrets` ExternalSecret `SecretSyncedError` (missing
  `ssegning-aws` properties) — separate, pre-existing, tracked in
  `docs/patterns/self-hosted-code-interpreter.md`.

---

## 4. Verification

I verified this change by:

- [x] Running automated tests
- [x] Running manual tests
- [x] Checking logs
- [ ] Checking metrics
- [ ] Testing error cases
- [ ] Testing permissions/security behavior
- [ ] Testing rollback or failure behavior, if relevant

Commands run:

```bash
helm lint charts/librechat-code-interpreter --strict
helm lint charts/apps
helm template aii charts/apps | grep -A 30 "name: aii-librechat-code-interpreter$"
```

Results:

```text
1 chart(s) linted, 0 chart(s) failed   (librechat-code-interpreter)
1 chart(s) linted, 0 chart(s) failed   (apps)

# Rendered Application now carries:
spec:
  syncPolicy:
    managedNamespaceMetadata:
      labels:
        pod-security.kubernetes.io/enforce: "privileged"
    automated:
      prune: true
      selfHeal: true
    syncOptions:
    - CreateNamespace=true
    - ServerSideApply=true
# (Replace=true no longer present; automation preserved)
```

---

## 5. Screenshots / Evidence

* Logs: live `kubectl` on `hetzner-prod` / `admin@homeos` (ArgoCD), captured
  AFTER #951's per-resource annotation fix had already merged and
  published as chart 0.1.6 — proving the per-resource approach didn't work:

```text
$ kubectl --context admin@homeos -n argocd get application aii-librechat-code-interpreter \
    -o jsonpath="{.status.operationState.message}"
one or more synchronization tasks completed unsuccessfully, reason: error when
replacing "/dev/shm/...": PersistentVolumeClaim "codeapi" is invalid: spec:
Forbidden: spec is immutable after creation except resources.requests and
volumeAttributesClassName for bound claims
...,error when replacing "/dev/shm/...": Job.batch "codeapi-package-init" is
invalid: [spec.selector: Required value, ... field is immutable] (retried 5 times).
```

Identical failure to before #951, with the per-resource annotation
confirmed present in the synced manifest — isolating the fix to the
Application level.

---

## 6. Risk Assessment

Risk level:

* [x] Low
* [ ] Medium
* [ ] High

Potential risks:

* Losing `Replace=true` for this one app could theoretically leave stale
  fields on a resource whose shape changed in a way `apply`'s
  strategic-merge can't reconcile (e.g. a removed field from a list).

Mitigation:

* Scoped to this single app only (matches the pattern already proven safe
  for `same-origin-proxy`, `apprise-api`, `opencode-k8s-agent` in the same
  file); `automated.prune`/`selfHeal` are preserved so drift still
  self-heals; verified via rendered manifest diff above.

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [ ] Refactoring
* [ ] Generating tests
* [x] Drafting documentation
* [ ] Reviewing the diff
* [ ] Not used

Human verification:

* [x] I understand every meaningful change in this PR
* [x] I checked generated code manually
* [ ] I checked generated tests manually
* [x] I removed unsupported AI assumptions
* [x] I accept responsibility for this PR

---

## 8. Reviewer Focus

Please focus your review on:

* [x] Correctness
* [x] Architecture
* [ ] Security
* [ ] Performance
* [ ] Tests
* [ ] Maintainability
* [ ] Product intent
* [ ] Edge cases
