### PR TITLE
fix(webank-training): split dataset-build image from training.image

### DIFF
--- a/charts/webank-training/ci/lint-values.yaml
+++ b/charts/webank-training/ci/lint-values.yaml
@@ -14,6 +14,8 @@ training:
       - key: nvidia.com/gpu
         operator: Exists
         effect: NoSchedule
+  datasetBuild:
+    image: ghcr.io/adorsys-gis/webank-dataset-gpu@sha256:c4ddb832deda7854bb617d422acca099001a6ec2aea1d585b8e460a53e4f6edf
 models:
   - id: document-detector
     trainer: document-detector

--- a/charts/webank-training/templates/workflowtemplate.yaml
+++ b/charts/webank-training/templates/workflowtemplate.yaml
@@ -4,6 +4,8 @@
 {{- $detector := $training.documentDetector -}}
 {{- if not $training.image }}{{ fail "webank-training: training.image must be an immutable image digest" }}{{- end }}
 {{- if not (contains "@sha256:" $training.image) }}{{ fail "webank-training: training.image must be digest-pinned" }}{{- end }}
+{{- if not $training.datasetBuild.image }}{{ fail "webank-training: training.datasetBuild.image must be an immutable image digest" }}{{- end }}
+{{- if not (contains "@sha256:" $training.datasetBuild.image) }}{{ fail "webank-training: training.datasetBuild.image must be digest-pinned" }}{{- end }}
 {{- if not $lakefs.endpoint }}{{ fail "webank-training: training.lakefs.endpoint is required" }}{{- end }}
 {{- if not $training.otel.endpoint }}{{ fail "webank-training: training.otel.endpoint is required" }}{{- end }}
 {{- if not $workflow.serviceAccountName }}{{ fail "webank-training: workflow.serviceAccountName is required" }}{{- end }}
@@ -97,7 +99,7 @@ spec:
       priorityClassName: {{ . | quote }}
       {{- end }}
       container:
-        image: {{ $training.image | quote }}
+        image: {{ $training.datasetBuild.image | quote }}
         command: ["sh", "-ceu"]
         args:
           - |

--- a/charts/webank-training/values.yaml
+++ b/charts/webank-training/values.yaml
@@ -68,6 +68,12 @@ training:
   # sizing convention; do not size either from the smaller packed-output
   # artifact.
   datasetBuild:
+    # webank-models#435 split the combined training image: `train` uses
+    # `training.image` (candle-only, no `ort`) and `dataset-build` uses this
+    # image (the CUDA image carrying `ort` plus the Python generator venvs).
+    # GPU node placement above stays shared between both — both images link
+    # `libcuda.so.1` — but the image reference itself is no longer shared.
+    image: ""
     resources:
       requests: { cpu: "4", memory: 10Gi, nvidia.com/gpu: 1 }
       limits: { cpu: "8", memory: 14Gi, nvidia.com/gpu: 1 }


### PR DESCRIPTION
## 1. Summary

This PR changes `charts/webank-training/values.yaml`,
`charts/webank-training/templates/workflowtemplate.yaml`, and
`charts/webank-training/ci/lint-values.yaml`:

- Adds `training.datasetBuild.image`, a new required, `@sha256:`-pinned
  image value nested under the existing `training.datasetBuild` map
  (sibling to the `.resources` block ai-helm#949 introduced), with the
  same fail-closed validation `training.image` already has.
- Wires only the 5 `webank-<model>-dataset-build` templates' container
  `image` field to `training.datasetBuild.image`. The 5
  `webank-<model>-train` templates are untouched and keep reading
  `training.image`.
- Adds a `training.datasetBuild.image` entry to the CI lint fixture.

It solves:

- webank-models#435 split the previously combined `webank-train-gpu` image
  into two: `webank-train-gpu` (candle-only, no `ort`) for `*-train`, and
  the new `webank-dataset-gpu` (the CUDA image carrying `ort` plus the
  Python generator venvs) for `*-dataset-build`. Since ai-helm#945 this
  chart has used one shared `training.image` for both template kinds, so
  the 5 `*-dataset-build` templates currently point at an image that no
  longer contains what they need to run.

References:

- ADORSYS-GIS/webank-models#429 (fixed `xtask` writing tracing logs to
  stdout, corrupting `BASE_REF="$(cargo xtask training-data
  bootstrap-model-repository ...)"` — the actual root cause of the only
  dataset-build run ever attempted on the cluster failing after 5s)
- ADORSYS-GIS/webank-models#435 (the image split this PR wires the chart
  to)
- ADORSYS-GIS/ai-helm#945, #949 (introduced `training.datasetBuild` and
  restored its GPU placement — both **untouched** here)

---

## 2. Intent

Before this PR, `charts/webank-training` had a single shared `training.image`
used by all ten WorkflowTemplates. That was correct when one combined image
served both jobs, but webank-models#435 split the image along dependency
lines (candle vs. `ort`/Python venvs) specifically because dataset-build and
train no longer share a runtime surface. Continuing to point the 5
dataset-build templates at `training.image` after that split means they
pull an image missing the Python generator venvs and `ort` they need.

This PR gives dataset-build its own image knob, following the same pattern
`training.datasetBuild.resources` already established for CPU/memory: a
distinct value for a distinct footprint, GPU node **placement** still shared
(both images link `libcuda.so.1`, per ai-helm#948/#949 — that reasoning is
unaffected by which image the driver dependency lives in).

This chart change alone does not point anything at a real image —
`training.datasetBuild.image` defaults to `""` here and fails closed until
a values file sets it. The real digest is a separate, follow-up PR against
`ai-helm-values` (not yet mergeable until this chart releases — see
Sequencing below).

---

## 3. Scope

### In Scope

- New `training.datasetBuild.image` value, required and digest-pinned like
  `training.image`.
- Wiring the 5 `*-dataset-build` templates' `container.image` to it.
- CI lint fixture update so `helm lint --strict` continues to pass.

### Out of Scope

- Setting a real digest anywhere (that's the `ai-helm-values` follow-up
  PR).
- Anything about `push-candidate` / `fixed-candidate publish` (ai-helm#945,
  untouched).
- Anything about `lakefs.model.storageNamespace` (ai-helm#945, untouched).
- GPU node placement — `runtimeClassName: nvidia`, the
  `nvidia.com/gpu.present` nodeSelector, the `nvidia.com/gpu` toleration,
  and the `nvidia.com/gpu` request/limit on `training.datasetBuild.resources`
  (ai-helm#949, untouched) — dataset-build still needs the driver the GPU
  claim injects regardless of which of the two images that dependency now
  lives in.
- Chart docs (`docs/integrations/webank-training-deployment.md`,
  `docs/playbooks/webank-model-workflows.md`) still describe dataset-build
  as running "the pinned `webank-train-gpu` image" — now stale after the
  split. Left alone here to keep this diff to the value/template/CI-fixture
  change only; worth a fast follow-up.

---

## 4. Verification

I verified this change by:

- [x] Running automated tests
- [x] Checking logs

Commands run:

```bash
helm dependency build charts/webank-training
helm lint --strict -f charts/webank-training/ci/lint-values.yaml charts/webank-training
helm template webank-training charts/webank-training -f charts/webank-training/ci/lint-values.yaml \
  > rendered-after.yaml
git stash   # revert to pre-change working tree
helm template webank-training charts/webank-training -f charts/webank-training/ci/lint-values.yaml \
  > rendered-before.yaml
git stash pop
diff -u rendered-before.yaml rendered-after.yaml
kubeconform -strict -schema-location default \
  -schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json' \
  -summary rendered-after.yaml
```

Results:

```text
$ helm lint --strict -f charts/webank-training/ci/lint-values.yaml charts/webank-training
==> Linting charts/webank-training
[INFO] Chart.yaml: icon is recommended
1 chart(s) linted, 0 chart(s) failed

$ diff -u rendered-before.yaml rendered-after.yaml
--- exactly 5 hunks, one per *-dataset-build template, each changing only
    the `image:` line from webank-train-gpu@sha256:<lint-placeholder> to
    webank-dataset-gpu@sha256:<lint-placeholder>
--- all 5 *-train templates: zero diff
--- runtimeClassName / nodeSelector / toleration / training.datasetBuild.resources /
    fixed-candidate publish / storageNamespace: identical in both renders
    (independently grep-diffed, zero hits)

$ kubeconform -strict ... -summary rendered-after.yaml
Summary: 10 resources found in 1 file - Valid: 10, Invalid: 0, Errors: 0, Skipped: 0
```

---

## 5. Sequencing (read before merging)

**This PR must merge and the chart must release before the companion
`ai-helm-values` PR (setting the real `webank-dataset-gpu` 1.7.0 digest)
takes effect** — the values PR's new key is inert against the currently
released chart version, which has no `training.datasetBuild.image` slot to
fill. Both PRs are left **unmerged**; merging either triggers ArgoCD
auto-deploy, so this is intentionally left for a human to sequence and
merge.

---

## 6. Risk

* Chart version bump / release is handled by release-please on merge, as
  with #945/#949 — not done manually here.
* `training.datasetBuild.image` fails closed (`required` + `@sha256:`
  check) exactly like `training.image`, so a values file that doesn't set
  it will fail template rendering rather than silently falling back to the
  wrong image.

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [x] Reviewing the diff

Human verification:

* [ ] I understand every meaningful change in this PR
* [ ] I checked generated code manually
* [ ] I checked generated tests manually
* [ ] I removed unsupported AI assumptions
* [ ] I accept responsibility for this PR

---

## 8. Reviewer Focus

Please focus your review on:

* [x] Correctness
* [x] Product intent
