### PR TITLE
fix(webank-training): mount a writable /workspace on dataset-build and train pods

### DIFF
--- a/charts/webank-training/templates/workflowtemplate.yaml
+++ b/charts/webank-training/templates/workflowtemplate.yaml
@@ -98,6 +98,12 @@ spec:
       {{- with $training.gpu.priorityClassName }}
       priorityClassName: {{ . | quote }}
       {{- end }}
+      securityContext:
+        fsGroup: 10001
+      volumes:
+        - name: workspace
+          emptyDir:
+            sizeLimit: {{ $training.datasetBuild.workspaceSizeLimit | quote }}
       container:
         image: {{ $training.datasetBuild.image | quote }}
         command: ["sh", "-ceu"]
@@ -220,6 +226,9 @@ spec:
             value: {{ $training.otel.endpoint | quote }}
           - name: OTEL_SERVICE_NAME
             value: {{ printf "webank-%s-dataset-build" $id | quote }}
+        volumeMounts:
+          - name: workspace
+            mountPath: /workspace
         resources:
           {{- toYaml $training.datasetBuild.resources | nindent 10 }}
 ---
@@ -298,6 +307,12 @@ spec:
       {{- with $training.gpu.priorityClassName }}
       priorityClassName: {{ . | quote }}
       {{- end }}
+      securityContext:
+        fsGroup: 10001
+      volumes:
+        - name: workspace
+          emptyDir:
+            sizeLimit: {{ $training.workspaceSizeLimit | quote }}
       container:
         image: {{ $training.image | quote }}
         command: ["sh", "-ceu"]
@@ -409,6 +424,9 @@ spec:
             value: {{ $training.otel.endpoint | quote }}
           - name: OTEL_SERVICE_NAME
             value: {{ printf "webank-%s-train" $id | quote }}
+        volumeMounts:
+          - name: workspace
+            mountPath: /workspace
         resources:
           {{- toYaml $training.gpu.resources | nindent 10 }}
 {{- end }}

--- a/charts/webank-training/values.yaml
+++ b/charts/webank-training/values.yaml
@@ -43,6 +43,32 @@ training:
     resources:
       requests: { cpu: "4", memory: 16Gi, nvidia.com/gpu: 1 }
       limits: { cpu: "8", memory: 16Gi, nvidia.com/gpu: 1 }
+  # Both `webank-dataset-gpu` and `webank-train-gpu` run as a fixed non-root
+  # UID:GID 10001:10001 baked into the image (Dockerfile.dataset-build:74,
+  # Dockerfile.train-gpu:123 in ADORSYS-GIS/webank-models) -- not an
+  # environment literal, so this fact lives in the chart, not ai-helm-values.
+  # Every `*-dataset-build`/`*-train` pod mounts an `emptyDir` at /workspace
+  # (see templates/workflowtemplate.yaml) sized below, plus
+  # `securityContext.fsGroup: 10001` so that non-root UID can actually write
+  # it: an emptyDir/PVC volume's mount-point is chowned root:root by default
+  # on attach, and `fsGroup` is the documented, portable mechanism (works for
+  # both emptyDir and a future PVC storage class alike) that makes the
+  # kubelet chown it to that GID with the setgid bit set, instead of relying
+  # on emptyDir's undocumented default permissions. `train` also needs this
+  # for its Argo input artifacts (`inputs.artifacts[].path` under /workspace)
+  # to land somewhere the main container can actually read.
+  #
+  # `emptyDir`, not a PVC: unlike webank-models' own (undeployed,
+  # documentation-by-example) deploy/argo-workflows/dataset-build-workflowtemplate.yaml,
+  # every `build`/`train` template here runs as ONE container in ONE pod --
+  # no multi-step DAG spanning separate pods -- so nothing needs the volume
+  # to outlive that single pod or be attached from a second one. Both GPU
+  # nodes have ~1.7Ti allocatable ephemeral-storage and exactly 1
+  # `nvidia.com/gpu` each (verified live against hetzner-prod 2026-08-08), so
+  # the GPU claim itself already caps concurrency to one workflow pod per
+  # node -- a `sizeLimit` far under that headroom needs no PVC/StorageClass
+  # provisioning latency to be safe.
+  workspaceSizeLimit: 8Gi
   # webank-models#415 argued dataset-build performs no forward pass so it
   # needs no GPU. That reasoning was correct but incomplete (ai-helm#948):
   # every subcommand of the pinned `webank-train-gpu` image — including a
@@ -77,6 +103,18 @@ training:
     resources:
       requests: { cpu: "4", memory: 10Gi, nvidia.com/gpu: 1 }
       limits: { cpu: "8", memory: 14Gi, nvidia.com/gpu: 1 }
+    # Overrides `training.workspaceSizeLimit` above for dataset-build's
+    # larger /workspace: a real local run of the document-recognizer
+    # hermetic-synthetic pipeline (source archive 823 MB + raw crops
+    # ~360 MB + materialized 4.4 GB + packed 4.4 GB ≈ 10 GB measured, this
+    # template's `sh`/`xtask` steps -- no unpack-round-trip step runs here,
+    # unlike the reference manifest cited below) needs headroom above that
+    # ~10 GB. Sized to the same 24Gi
+    # deploy/argo-workflows/dataset-build-workflowtemplate.yaml (webank-models,
+    # story #328) already uses for this same pipeline's PVC, so a
+    # governed-lakefs model (sface, pad-liveness) with a differently sized
+    # source checkout stays covered by the same generous margin.
+    workspaceSizeLimit: 24Gi
   documentDetector:
     stemChannels: 32
     epochs: 10


### PR DESCRIPTION
## 1. Summary

This PR changes:

- Mounts an `emptyDir` volume at `/workspace` on every `webank-*-dataset-build` and `webank-*-train` template in `charts/webank-training/templates/workflowtemplate.yaml` (10 rendered WorkflowTemplates total: 5 models × {dataset-build, train}).
- Sets `securityContext.fsGroup: 10001` on the same templates so the non-root container (`USER 10001:10001` in both `Dockerfile.dataset-build` and `Dockerfile.train-gpu`) can actually write the mounted volume.
- Adds `training.workspaceSizeLimit` (`8Gi`, for `train`) and `training.datasetBuild.workspaceSizeLimit` (`24Gi`, for `dataset-build`) to `charts/webank-training/values.yaml`, with the measured sizing reasoning inline.

It solves:

- Every `*-dataset-build` WorkflowTemplate writes under `/workspace/output/...` but declared no volume for it, so `/workspace` lived on the container's own root filesystem — which a non-root UID cannot create a top-level directory under. This blocked **every** Argo dataset build.

---

## 2. Intent

Verified live against `hetzner-prod`/`mlops`: workflow `webank-document-recognizer-dataset-build-dthgb` (submitted 2026-08-08T18:56) failed in ~10s, exit code 2, with:

```
document-recognizer synthetic build refused: [Errno 13] Permission denied: '/workspace'
```

`.spec.templates[0].container.volumeMounts` and `.spec.volumes` were both empty on the live `webank-document-recognizer-dataset-build` template — confirmed again directly against the cluster while preparing this fix. This was previously masked by an unrelated stdout-corruption bug (webank-models#429, fixed in image 1.7.0); today's run is the first to reach the write.

The `*-train` templates were suspected to share the same gap and, on inspection, do: `webank-document-recognizer-train`'s live template also has empty `volumeMounts`/`volumes`, and every trainer writes under `/workspace` (checkout output, `CANDIDATE_PATH`, and Argo `inputs.artifacts[].path` for document-recognizer/face-detector/sface).

---

## 3. Scope

### In Scope

- Adding the missing volume/mount/securityContext to all 10 templates this chart renders.
- Sizing the volume from measured pipeline disk usage, not a guess.

### Out of Scope

- `deploy/argo-workflows/dataset-build-workflowtemplate.yaml` in `webank-models` (a separate, undeployed, documentation-by-example manifest — not touched by this PR, only read for its sizing rationale).
- Any change to `fixed-candidate publish` (#945), `lakefs.model.storageNamespace`, the GPU placement from #949, or the `training.datasetBuild.image` split from #953 — all confirmed untouched by a `helm template` before/after diff (see below).

---

## 4. Verification

I verified this change by:

- [ ] Running automated tests
- [ ] Running manual tests
- [ ] Checking logs
- [ ] Checking metrics
- [ ] Testing error cases
- [ ] Testing permissions/security behavior
- [ ] Testing rollback or failure behavior, if relevant

Commands run:

```bash
helm dependency update charts/webank-training
helm lint --strict -f charts/webank-training/ci/lint-values.yaml charts/webank-training

# before/after render diff
git stash
helm template webank-training charts/webank-training -f charts/webank-training/ci/lint-values.yaml > before.yaml
git stash pop
helm template webank-training charts/webank-training -f charts/webank-training/ci/lint-values.yaml > after.yaml
diff -u before.yaml after.yaml

kubeconform -strict -summary \
  -schema-location default \
  -schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json' \
  after.yaml

# read-only, live cluster (never apply/patch/delete)
kubectl --context hetzner-prod -n mlops get workflowtemplate \
  webank-document-recognizer-dataset-build -o jsonpath='{.spec.templates[0].container.volumeMounts}{"\n"}{.spec.volumes}{"\n"}'
kubectl --context hetzner-prod -n mlops get workflowtemplate \
  webank-document-recognizer-train -o jsonpath='{.spec.templates[0].container.volumeMounts}{"\n"}{.spec.volumes}{"\n"}'
kubectl --context hetzner-prod -n mlops logs webank-document-recognizer-dataset-build-dthgb --all-containers --tail=30
kubectl --context hetzner-prod get storageclass
kubectl --context hetzner-prod describe node hetzner-k8s-gpu-1 hetzner-k8s-gpu-2 | grep -A5 'Allocatable:'
kubectl --context hetzner-prod get nodes hetzner-k8s-gpu-1 hetzner-k8s-gpu-2 -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.status.allocatable.nvidia\.com/gpu}{"\n"}{end}'
```

Results:

```text
helm lint: 1 chart(s) linted, 0 chart(s) failed
kubeconform: Summary: 10 resources found in 1 file - Valid: 10, Invalid: 0, Errors: 0, Skipped: 0
diff before/after: only securityContext (fsGroup: 10001), volumes (emptyDir workspace),
  and container.volumeMounts blocks added, across all 10 rendered WorkflowTemplates --
  nothing else moved.
live webank-document-recognizer-dataset-build: volumeMounts=<empty> volumes=<empty> (confirms report)
live webank-document-recognizer-train: volumeMounts=<empty> volumes=<empty> (confirms *-train shares the defect)
live pod log: "document-recognizer synthetic build refused: [Errno 13] Permission denied: '/workspace'"
storageclasses: hcloud-volumes (default, WaitForFirstConsumer), longhorn, longhorn-static
GPU nodes: hetzner-k8s-gpu-1 / hetzner-k8s-gpu-2, each Capacity ephemeral-storage ~1.81Ti,
  Allocatable ~1.76Ti (bytes), each Allocatable nvidia.com/gpu: 1
```

---

## 5. Screenshots / Evidence

Add evidence here:

* Screenshot: n/a (CLI/manifest change)
* Logs: pod log and live-template inspection captured above, from `hetzner-prod`/`mlops`, read-only
* Metrics: n/a
* Recording: n/a

---

## 6. Risk Assessment

Risk level:

* [ ] Low
* [ ] Medium
* [ ] High

Potential risks:

* `emptyDir` consumes node ephemeral storage rather than persisting past the pod — acceptable here because every affected template runs as one container in one pod (no multi-step DAG spanning pods), so nothing needs the volume to outlive that pod.
* `fsGroup: 10001` is a new pod-level `securityContext` field on GPU workload pods; it only affects ownership of the newly-added `workspace` volume mount and does not relax any other pod security setting.
* `sizeLimit` (24Gi dataset-build / 8Gi train) is a hard ceiling: a run that exceeds it gets evicted rather than silently filling the node. Sized with headroom over the measured ~10 GB working set (dataset-build) and the smaller train working set (one fetched dataset artifact + one candidate checkpoint).

Mitigation:

* Chose `emptyDir` deliberately over a PVC after confirming (live, read-only) that both GPU nodes have ~1.7Ti allocatable ephemeral-storage and exactly one `nvidia.com/gpu` each, so the GPU claim itself caps concurrency to one workflow pod per node — far under the `sizeLimit`s chosen, with no PVC/StorageClass provisioning latency added.
* `fsGroup` was chosen over relying on `emptyDir`'s undocumented default permissions, or a root init-container chown, specifically because it is the documented Kubernetes mechanism and works identically if a future change moves to a PVC.

---

## 7. AI Usage Declaration

AI was used for:

* [ ] Understanding existing code
* [ ] Generating code
* [ ] Refactoring
* [ ] Generating tests
* [ ] Drafting documentation
* [ ] Reviewing the diff
* [ ] Not used

Human verification:

* [ ] I understand every meaningful change in this PR
* [ ] I checked generated code manually
* [ ] I checked generated tests manually
* [ ] I removed unsupported AI assumptions
* [ ] I accept responsibility for this PR

---

## 8. Reviewer Focus

Please focus your review on:

* [ ] Correctness
* [ ] Architecture
* [ ] Security
* [ ] Performance
* [ ] Tests
* [ ] Maintainability
* [ ] Product intent
* [ ] Edge cases

---

Source of truth: cluster evidence captured 2026-08-08 against `hetzner-prod`/`mlops` (workflow `webank-document-recognizer-dataset-build-dthgb`), reference sizing/reasoning in `ADORSYS-GIS/webank-models` `deploy/argo-workflows/dataset-build-workflowtemplate.yaml`.

Do **not** merge — chart changes here auto-deploy via ArgoCD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
