### PR TITLE
fix(lightbridge-db): raise max_connections and memory headroom

### DIFF
--- a/charts/lakefs/ci/lakefs-app.yaml
+++ b/charts/lakefs/ci/lakefs-app.yaml
@@ -36,6 +36,24 @@ secretKeys:
 lakefsConfig: |
   database:
     type: postgres
+    # Incident (2026-08-08/09): lightbridge-main-db is a SHARED CNPG cluster
+    # (converse ns, ADR-0085) with no PgBouncer in front of it. LakeFS's
+    # unconfigured client fell back to the binary's own default pool
+    # (max_open_connections=25, max_idle_connections=25 — confirmed from the
+    # pod's own "Config loaded" startup log line, not guessed), which alone
+    # is a quarter of CNPG's default max_connections=100 and, combined with
+    # every other tenant's own pool (coder/mlflow/governance/codeintel/
+    # grafana_ro), exhausted it: `FATAL: sorry, too many clients already`
+    # (SQLSTATE 53300). LakeFS then fell back to rendering its first-run
+    # /setup page and returned repository-not-found/auth errors.
+    # Capped hard here — LakeFS's KV access pattern is short, low-concurrency
+    # point reads/writes, not a connection-heavy workload — so it can never
+    # again be the tenant that exhausts the shared cluster. Key names verified
+    # against the same startup log (`database.postgres.max_open_connections`,
+    # `database.postgres.max_idle_connections`), not guessed against docs.
+    postgres:
+      max_open_connections: 5
+      max_idle_connections: 2
   blockstore:
     type: s3
     s3:

--- a/charts/lightbridge-db/values.yaml
+++ b/charts/lightbridge-db/values.yaml
@@ -42,13 +42,30 @@ resources:
       postgresql:
         parameters:
           archive_timeout: "30min"
+          # Incident (2026-08-08/09): max_connections was left UNSET, so CNPG
+          # applied its own default of 100 — too little for a cluster shared
+          # by 7 tenant roles (repoauth/codeintel/grafana_ro/coder/lakefs/
+          # mlflow/governance) each holding their own client-side pool, plus
+          # the reserved superuser/replication/monitoring-exporter slots.
+          # LakeFS alone defaults to a 25-connection pool (see charts/lakefs
+          # lakefs-app.yaml, now capped to 5) — a quarter of the old ceiling
+          # from one tenant. Doubled explicitly to 200 rather than left
+          # implicit, paired with the memory bump below so it isn't a bare
+          # number with no headroom behind it. Sized for max_connections ×
+          # work_mem (Postgres default work_mem=4MiB, unset here): worst case
+          # (every connection concurrently sorting) is 200 × 4MiB ≈ 800MiB,
+          # plus per-backend base overhead (roughly 200 × ~2MiB ≈ 400MiB) and
+          # CNPG's own shared_buffers default (128MiB) — call it ~1.3GiB
+          # worst-case, which the 2Gi limit below covers with headroom without
+          # requiring the node to reserve that much (500Mi→1Gi request only).
+          max_connections: "200"
       resources:
         limits:
           cpu: 300m
-          memory: 1Gi
+          memory: 2Gi
         requests:
           cpu: 200m
-          memory: 500Mi
+          memory: 1Gi
       # Declarative role for lightbridge-repo-auth (ADR-0047): a dedicated login
       # role, isolated from the bootstrap `app` role. Password from the
       # basic-auth Secret below (ESO-provisioned); CNPG creates/maintains the


### PR DESCRIPTION
## 1. Summary

This PR changes:

- `charts/lightbridge-db/values.yaml`: sets `postgresql.parameters.max_connections: "200"`
  explicitly on the `lightbridge-main-db` CNPG Cluster (was unset → CNPG default 100), and
  raises its `resources` from `limits: {cpu: 300m, memory: 1Gi}` / `requests: {cpu: 200m,
  memory: 500Mi}` to `limits: {cpu: 300m, memory: 2Gi}` / `requests: {cpu: 200m, memory: 1Gi}`.
- `charts/lakefs/ci/lakefs-app.yaml`: syncs the doc-reference/render-test copy of the
  actually-deployed private `ai-helm-values` file with the LakeFS Postgres pool cap
  landing in [ai-helm-values#210](https://github.com/ADORSYS-GIS/ai-helm-values/pull/210).

It solves:

- Live production outage — LakeFS on `hetzner-prod` cannot open its metadata KV store:
  `FATAL: sorry, too many clients already` (SQLSTATE 53300) against `lightbridge-main-db`.

---

## 2. Intent

`lightbridge-main-db` (converse ns) is a CNPG cluster **shared** by 7 tenant roles
(`repoauth`, `codeintel`, `grafana_ro`, `coder`, `lakefs`, `mlflow`, `governance` —
ADR-0083/ADR-0085), each holding its own client-side connection pool, with no PgBouncer
in front, and `max_connections` left at CNPG's implicit default of 100. LakeFS alone
defaulted to a 25-connection pool (see the companion `ai-helm-values` PR, which caps it
to 5) — a quarter of the ceiling from one tenant. Combined, the shared pool exhausted
Postgres's connection budget and LakeFS's KV store became unreachable — not lost, just
unreachable (LakeFS has no PVC; all state is in this Postgres cluster).

This PR is the CNPG-side half of the smallest fix that ends the outage: raise the
ceiling explicitly (rather than leaving it as an undocumented default) and back it with
enough memory, paired with the `ai-helm-values` PR that stops LakeFS from being the
tenant that exhausts it.

---

## 3. Scope

### In Scope

- `lightbridge-main-db`'s `max_connections` and `resources.limits/requests.memory`.
- Keeping `charts/lakefs/ci/lakefs-app.yaml` in sync with the deployed LakeFS values
  (its own header comment requires this; not otherwise picked up by this repo's lint
  loop since the fixture is named `*-app.yaml`, not `*-values.yaml`).

### Out of Scope

- Any resource belonging to the `converse`/lightbridge application beyond this shared
  cluster's capacity parameters.
- Adding a CNPG `Pooler` (PgBouncer) in front of this shared cluster — considered and
  explicitly deferred (see the CNPG-headroom commit body): this cluster is shared by
  tenants (mlflow, coder, governance, lightbridge-code-intelligence) this incident
  response has no evidence about w.r.t. session-level Postgres features that
  transaction-mode pooling can break. Not a risk worth taking in the smallest fix for
  an active outage.
- Giving LakeFS its own dedicated CNPG cluster — that's the **follow-up PR** (Stage 2),
  opened once this PR is verified to have restored service.

---

## 4. Verification

I verified this change by:

- [x] Running automated tests (`helm lint --strict`, `helm template --dry-run`)
- [ ] Running manual tests
- [x] Checking logs
- [ ] Checking metrics
- [ ] Testing error cases
- [ ] Testing permissions/security behavior
- [ ] Testing rollback or failure behavior, if relevant

Commands run:

```bash
kubectl --context hetzner-prod -n mlops logs lakefs-<pod> --tail=60   # confirmed the FATAL/setup-page symptoms live
kubectl --context hetzner-prod -n converse get cluster lightbridge-main-db -o yaml  # confirmed max_connections unset, resources 300m/1Gi
helm lint charts/lightbridge-db --strict
helm template lightbridge-db charts/lightbridge-db --dry-run > after.yaml
git stash && helm template lightbridge-db charts/lightbridge-db --dry-run > before.yaml && git stash pop
diff -u before.yaml after.yaml
kubeconform -summary -schema-location default \
  -schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json' \
  -ignore-missing-schemas after.yaml
```

Results:

```text
1 chart(s) linted, 0 chart(s) failed
Summary: 18 resources found in 1 file - Valid: 18, Invalid: 0, Errors: 0, Skipped: 0
diff shows ONLY the new max_connections comment block + "200" and the memory
limit/request change (1Gi→2Gi, 500Mi→1Gi) — no other resource in the render changed.
```

---

## 5. Screenshots / Evidence

* Logs: LakeFS pod startup log (read-only `kubectl logs`, no Secret contents) showed
  the actual default pool (`database.postgres.max_open_connections=25
  max_idle_connections=25`) and, in the HTTP-layer symptoms, the setup-page fallback
  (`Setup email validation failed`, `authentication error ... invalid token`) matching
  the reported outage.
* CNPG Cluster spec (read-only `kubectl get cluster -o yaml`): confirmed
  `resources: {limits: {cpu: 300m, memory: 1Gi}, requests: {cpu: 200m, memory: 500Mi}}`
  and no `max_connections` in `postgresql.parameters` before this change.

---

## 6. Risk Assessment

Risk level:

* [x] Low

Potential risks:

* Raising `max_connections` without matching memory could pressure the node under
  worst-case concurrent load.
* The Deployment's `checksum/config`-equivalent for CNPG is a `Cluster` spec change —
  CNPG applies `postgresql.parameters` via `postgres.conf` + reload where possible;
  `max_connections` specifically requires a Postgres **restart** to take effect (it is
  not reloadable), so CNPG will roll the instances one at a time (`primaryUpdateStrategy:
  unsupervised`) to apply it — brief per-instance unavailability during rollout, masked
  by the 2-instance HA topology.

Mitigation:

* Sized the memory limit explicitly for the new `max_connections` ceiling (see the
  commit body for the `max_connections × work_mem` + per-backend-overhead + `shared_buffers`
  arithmetic) rather than raising one without the other.
* This cluster already runs 2 instances with `podAntiAffinityType: preferred` and
  `enablePDB: true` — a rolling restart to apply `max_connections` is the cluster's
  normal supported update path, not a new risk introduced here.

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [ ] Refactoring
* [ ] Generating tests
* [x] Drafting documentation
* [x] Reviewing the diff
* [ ] Not used

Human verification:

* [ ] I understand every meaningful change in this PR
* [ ] I checked generated code manually
* [ ] I checked generated tests manually
* [ ] I removed unsupported AI assumptions
* [ ] I accept responsibility for this PR

---

## 8. Reviewer Focus

Please focus your review on:

* [x] Correctness
* [ ] Architecture
* [ ] Security
* [x] Performance
* [ ] Tests
* [ ] Maintainability
* [ ] Product intent
* [x] Edge cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)
