### PR TITLE
docs(lakefs): fix stale DB comments left by #957

### DIFF
--- a/charts/lakefs/ci/lakefs-app.yaml
+++ b/charts/lakefs/ci/lakefs-app.yaml
@@ -8,9 +8,12 @@
 # 2. Documentation of the exact chart schema decisions (existingSecret +
 #    secretKeys, S3 blockstore via extraEnvVars, no chart-owned ingress).
 #
-# Metadata DB: the existing lightbridge-main-db CNPG cluster (converse ns),
-# via the `lakefs` managed role/Database (charts/lightbridge-db). Blockstore:
-# Hetzner Object Storage (S3-compatible), prefix `lakefs/` inside the shared
+# Metadata DB: the dedicated mlops-main-db CNPG cluster (mlops ns,
+# charts/mlops-db), via the `lakefs` managed role/Database — ADR-0123,
+# supersedes the earlier lightbridge-main-db (converse ns) placement after
+# an incident where an unrelated shared-cluster tenant exhausted its
+# connections and took LakeFS down with it. Blockstore: Hetzner Object
+# Storage (S3-compatible), prefix `lakefs/` inside the shared
 # ssegning-k8s-state bucket, reusing the platform's existing S3 credentials
 # (same material CNPG backups + LibreChat's S3 file storage use).
 #
@@ -87,6 +90,15 @@ extraEnvVars:
     value: "s3://ssegning-k8s-state/lakefs"
 
 replicaCount: 1
+
+# GitOps-clean rollout trigger. This chart's Deployment computes
+# checksum/config from the ConfigMap only (verified from the upstream
+# template source) — a Secret-only value change (e.g. the ADR-0123 DB
+# cutover's database_connection_string) does not trigger a rollout on its
+# own, and nothing here opts into Stakater Reloader either. Bump this dated,
+# otherwise-inert entry whenever such a change needs an explicit rollout.
+podAnnotations:
+  ai-helm.adorsys-gis.github.io/rollout-trigger: "2026-08-09-mlops-db-cutover"
 
 # Chart defaults (delay=0s, period=10s, failureThreshold=3 => killed after
 # only 30s) are too tight for LakeFS's first-boot DB migration — the pod

--- a/charts/lakefs/templates/applications.yaml
+++ b/charts/lakefs/templates/applications.yaml
@@ -11,13 +11,18 @@ lakefs App-of-Apps orchestrator — renders FOUR child Application CRs:
                     mode, whose `--upstream` is lakefs-proxy (second source: $values).
 
 Request path: browser → lakefs-auth (Keycloak OIDC) → lakefs-proxy → lakefs.
-(The lakefs-db child is disabled — LakeFS uses the existing lightbridge-main-db
-CNPG cluster. See ADR-0085.)
+(The db child — appName mlops-db — deploys the dedicated mlops-namespace CNPG
+cluster, charts/mlops-db. Renamed from an earlier LakeFS-only lakefs-db and
+now enabled: LakeFS is cut over to it, and MLflow has a role/database
+provisioned there pending its own separately-cleared cutover. See ADR-0123,
+which supersedes ADR-0085's original shared-lightbridge-main-db decision for
+these two tenants.)
 All target home-remote (ADR-0017 guard via lakefs.argocd.destinationClusterRef).
 Rendered as direct Application CRs rather than an ApplicationSet because the
 children are fixed + heterogeneous — see ADR-0019 (lightbridge is the canonical
-example). See ADR-0085 for the LakeFS-specific DB/S3 decisions and ADR-0090 for
-the SSO shim.
+example). See ADR-0085 for the LakeFS-specific auth/S3 decisions (still
+current), ADR-0123 for the DB decision (supersedes ADR-0085's), and ADR-0090
+for the SSO shim.
 */ -}}
 {{- $a := .Values.argocd -}}
 {{- if .Values.secrets.enabled }}


### PR DESCRIPTION
## 1. Summary

This PR changes:

- `charts/lakefs/templates/applications.yaml`: fixes a stale top-comment
  claiming the `db` child is disabled and points at `lightbridge-main-db`
  (ADR-0085) — it's enabled now, renamed `mlops-db`, and covered by
  ADR-0123.
- `charts/lakefs/ci/lakefs-app.yaml`: fixes the same stale "Metadata DB"
  reference, and syncs in the `podAnnotations` rollout-trigger added to the
  real private values file in `ai-helm-values#213`, per this fixture's own
  header comment (kept structurally in sync with that file).

It solves:

- Doc drift left by [#957](https://github.com/ADORSYS-GIS/ai-helm/pull/957)
  (ADR-0123), found during peer review of that PR — comments contradicting
  the chart's own values.yaml and live cluster state.

---

## 2. Intent

A future reader of `charts/lakefs/templates/applications.yaml` or the ci
fixture should not see instructions/context that contradict what the chart
actually does. No functional behavior changes — this is purely aligning
comments and a render-only-tested fixture with the code that already
shipped in #957.

---

## 3. Scope

### In Scope
- The two stale comments named above.
- Syncing the ci fixture's `podAnnotations` with the real deployed file.

### Out of Scope
- Any functional/template change (none needed here).

---

## 4. Verification

I verified this change by:

- [x] Running automated tests (`helm lint --strict`, `helm template --dry-run`)
- [ ] Running manual tests
- [ ] Checking logs
- [ ] Checking metrics
- [ ] Testing error cases
- [ ] Testing permissions/security behavior
- [ ] Testing rollback or failure behavior, if relevant

Commands run:

```bash
helm dependency update charts/lakefs
helm lint charts/lakefs --strict
helm template lakefs charts/lakefs --dry-run > /dev/null
helm template lakefs lakefs/lakefs --version 1.12.13 -f charts/lakefs/ci/lakefs-app.yaml > /dev/null
```

Results:

```text
1 chart(s) linted, 0 chart(s) failed
Both helm template invocations exited 0, no stderr.
```

---

## 5. Screenshots / Evidence

* Docs: the two comment blocks now read `mlops-main-db`/ADR-0123 instead of
  `lightbridge-main-db`/ADR-0085, matching `charts/lakefs/values.yaml`
  (`db.enabled: true`, `appName: mlops-db`) and the live `mlops-db` ArgoCD
  Application on `hetzner-prod`.

---

## 6. Risk Assessment

Risk level:

* [x] Low
* [ ] Medium
* [ ] High

Potential risks:

* None — comments and a render-only-tested fixture only, no template or
  values logic changed.

Mitigation:

* N/A.

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [ ] Refactoring
* [ ] Generating tests
* [x] Drafting documentation
* [x] Reviewing the diff
* [ ] Not used

Human verification:

* [ ] I understand every meaningful change in this PR
* [ ] I checked generated code manually
* [ ] I checked generated tests manually
* [ ] I removed unsupported AI assumptions
* [ ] I accept responsibility for this PR

---

## 8. Reviewer Focus

Please focus your review on:

* [ ] Correctness
* [ ] Architecture
* [ ] Security
* [ ] Performance
* [ ] Tests
* [x] Maintainability
* [ ] Product intent
* [ ] Edge cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)