### PR TITLE
fix(mlflow): drop dead lightbridge-main-db role, sync docs for cutover

### DIFF
--- a/charts/lightbridge-db/values.yaml
+++ b/charts/lightbridge-db/values.yaml
@@ -106,26 +106,10 @@ resources:
             login: true
             passwordSecret:
               name: coder-db-role
-          # Dedicated login role for the mlops platform (ADR-0085): MLflow's
-          # LIVE traffic still uses this shared cluster (same reasoning as
-          # coder, ADR-0083) — LakeFS used to as well, but moved to a
-          # dedicated cluster (charts/mlops-db) per ADR-0123 after an
-          # incident where an unrelated tenant on THIS shared cluster
-          # exhausted its connections and took LakeFS down with it. ADR-0123
-          # also provisions a `mlflow` role/database on charts/mlops-db
-          # ahead of time, but does NOT repoint MLflow's connection yet —
-          # that needs its existing tracking data's migration explicitly
-          # cleared first, so this role/Database stay live here until then.
-          # Password from the basic-auth Secret below (ESO-provisioned).
-          - name: mlflow
-            ensure: present
-            login: true
-            passwordSecret:
-              name: mlflow-db-role
           # Dedicated login role for lightbridge-governance (ADORSYS-GIS/lightbridge-governance),
           # the AI governance platform's registry + Copilot/Foundry connectors.
-          # Reuses this shared CNPG cluster, same reasoning as coder/mlflow
-          # (ADR-0083). Owns the `governance` Database below; password from the
+          # Reuses this shared CNPG cluster, same reasoning as coder (ADR-0083).
+          # Owns the `governance` Database below; password from the
           # basic-auth Secret `lightbridge-governance-db-role` (ESO-provisioned,
           # below).
           - name: governance
@@ -482,80 +466,15 @@ resources:
           remoteRef:
             key: ai/camer/digital/prod/env
             property: coder_db_password
-  # ────────────────────────────────────────────────────────────────────
-  # MLflow (ADR-0085): a `mlflow` Database owned by the managed `mlflow`
-  # role above, plus the role's basic-auth Secret (username + password)
-  # consumed by BOTH CNPG (passwordSecret) and the MLflow app (via
-  # mlflow-db-secret assembled in charts/mlflow-secrets). Mirrors the
-  # coder pattern.
-  # NOTE: the ESO `password` template braces are double-escaped so Helm's
-  # `tpl` (this whole string is tpl'd) leaves `{{ .password }}` for ESO.
-  # ────────────────────────────────────────────────────────────────────
-  - |
-    apiVersion: postgresql.cnpg.io/v1
-    kind: Database
-    metadata:
-      name: mlflow
-      namespace: converse
-      annotations:
-        argocd.argoproj.io/sync-wave: "3"
-        argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
-    spec:
-      cluster:
-        name: lightbridge-main-db
-      name: mlflow
-      owner: mlflow
-      ensure: present
-  # ────────────────────────────────────────────────────────────────────
-  # MLflow OIDC auth DB (ADR-0085): a SECOND `mlflow_oidc` Database owned by
-  # the same `mlflow` role. The mlflow-oidc-auth plugin keeps its own
-  # users/groups/permissions store and auto-migrates it (Alembic → head) on
-  # first login. It MUST NOT share the tracking store's `mlflow` DB: both use
-  # a default `alembic_version` table, so the plugin reads MLflow's tracking
-  # revision, can't resolve it against its own migration chain, aborts before
-  # any DDL, and never creates its tables → every login fails
-  # "Failed to update user/groups". A dedicated DB (empty alembic_version)
-  # lets the plugin migrate from base cleanly. Found live during ADR-0085
-  # verification. No extra Secret — reuses the `mlflow` role/password.
-  # ────────────────────────────────────────────────────────────────────
-  - |
-    apiVersion: postgresql.cnpg.io/v1
-    kind: Database
-    metadata:
-      name: mlflow-oidc
-      namespace: converse
-      annotations:
-        argocd.argoproj.io/sync-wave: "3"
-        argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
-    spec:
-      cluster:
-        name: lightbridge-main-db
-      name: mlflow_oidc
-      owner: mlflow
-      ensure: present
-  - |
-    apiVersion: external-secrets.io/v1
-    kind: ExternalSecret
-    metadata:
-      name: mlflow-db-role
-      namespace: converse
-      annotations:
-        argocd.argoproj.io/sync-wave: "1"
-    spec:
-      refreshInterval: 1h
-      secretStoreRef:
-        kind: ClusterSecretStore
-        name: ssegning-aws
-      target:
-        name: mlflow-db-role
-        creationPolicy: Owner
-        template:
-          type: kubernetes.io/basic-auth
-          data:
-            username: "mlflow"
-            password: "{{ "{{ .password }}" }}"
-      data:
-        - secretKey: password
-          remoteRef:
-            key: ai/camer/digital/prod/env
-            property: mlflow_db_password
+  # MLflow's `mlflow`/`mlflow_oidc` Database CRs + `mlflow-db-role`
+  # ExternalSecret used to live here (ADR-0085). Removed — hard cutover, no
+  # dormant parallel path — now that MLflow is cut over to mlops-main-db
+  # (ADR-0123: `mlflow` role + `mlflow`/`mlflow_oidc` Database CRs on
+  # charts/mlops-db, provisioned by ai-helm#957; connection repointed by the
+  # companion ai-helm-values PR once the owner confirmed via the
+  # authenticated MLflow UI that these databases held nothing worth
+  # migrating). Mirrors exactly how ai-helm#957 removed LakeFS's equivalent
+  # `lakefs` Database CR + `lakefs-db-role` ExternalSecret from this same
+  # file when LakeFS cut over first. The `mlflow_db_password` Secrets
+  # Manager property is unchanged and reused as-is by charts/mlops-db's own
+  # `mlflow-db-role` ExternalSecret — same credential, new cluster.

--- a/charts/mlflow/ci/mlflow-app.yaml
+++ b/charts/mlflow/ci/mlflow-app.yaml
@@ -9,8 +9,12 @@
 # 2. Documentation of the exact chart schema decisions (existingDatabaseSecret,
 #    S3 artifact store via existingSecret, native mlflow-oidc-auth plugin).
 #
-# Backend store DB: the existing lightbridge-main-db CNPG cluster (converse
-# ns), via the `mlflow` managed role/Database (charts/lightbridge-db).
+# Backend store DB: the dedicated mlops-main-db CNPG cluster (mlops ns,
+# charts/mlops-db), via the `mlflow` managed role/Database — ADR-0123,
+# supersedes the earlier lightbridge-main-db (converse ns) placement.
+# Cutover gated on the owner confirming, via the authenticated MLflow UI,
+# that lightbridge-main-db's `mlflow`/`mlflow_oidc` databases held nothing
+# worth migrating (only the default experiment, no run history).
 # Artifact store: Hetzner Object Storage (S3-compatible), prefix
 # `mlflow-artifacts/` inside the shared ssegning-k8s-state bucket, reusing
 # the platform's existing S3 credentials.
@@ -27,7 +31,7 @@ backendStore:
   databaseConnectionCheck: true
   postgres:
     enabled: true
-    host: "lightbridge-main-db-rw.converse.svc.cluster.local"
+    host: "mlops-main-db-rw.mlops.svc.cluster.local"
     port: 5432
     database: "mlflow"
     driver: "psycopg2"
@@ -48,9 +52,17 @@ artifactRoot:
 
 # Hetzner Object Storage (Ceph-RGW) endpoint + path-style addressing — this
 # chart's `extraEnvVars` is a plain MAP (key: value), not a list.
+#
+# Connection-pool cap (ADR-0123 follow-up, now confirmed — not guessed):
+# MLFLOW_SQLALCHEMYSTORE_POOL_SIZE / _MAX_OVERFLOW, read by MLflow's own
+# store/db/utils.py straight into sqlalchemy.create_engine(). pool_size=3 +
+# max_overflow=2 = 5/worker x 2 gunicorn workers = 10 total, well inside the
+# 30-connection worst case charts/mlops-db's max_connections="80" budgeted.
 extraEnvVars:
   MLFLOW_S3_ENDPOINT_URL: "https://nbg1.your-objectstorage.com"
   AWS_DEFAULT_REGION: "us-east-1"
+  MLFLOW_SQLALCHEMYSTORE_POOL_SIZE: "3"
+  MLFLOW_SQLALCHEMYSTORE_MAX_OVERFLOW: "2"
 
 # Basic-auth (the chart default) stays OFF — oidcAuth is the auth mechanism.
 auth:
@@ -111,15 +123,15 @@ oidcAuth:
   # verification). Two earlier wrong states, same class of bug: default
   # `sqlite:///auth.db` (read-only fs → "unable to open database file"), then
   # the shared `mlflow` DB (alembic revision collision above).
-  # Point it at a DEDICATED `mlflow_oidc` DB on the same lightbridge-main-db
-  # server (owned by the same `mlflow` role — charts/lightbridge-db Database
-  # CR); the plugin then finds an empty alembic_version and migrates from
-  # base. No new egress / no new Secret — same host:port + role as the
+  # Point it at a DEDICATED `mlflow_oidc` DB on the same mlops-main-db
+  # server (owned by the same `mlflow` role — charts/mlops-db Database CR,
+  # ADR-0123); the plugin then finds an empty alembic_version and migrates
+  # from base. No new egress / no new Secret — same host:port + role as the
   # tracking store.
   database:
     postgres:
       enabled: true
-      host: "lightbridge-main-db-rw.converse.svc.cluster.local"
+      host: "mlops-main-db-rw.mlops.svc.cluster.local"
       port: 5432
       database: "mlflow_oidc"
       driver: "psycopg2"

--- a/charts/mlflow/templates/applications.yaml
+++ b/charts/mlflow/templates/applications.yaml
@@ -7,12 +7,21 @@ mlflow App-of-Apps orchestrator — renders two child Application CRs:
 No auth-proxy child — the upstream chart bundles the mlflow-oidc-auth plugin
 natively (auth.oidcAuth in the app's values), giving real per-user Keycloak
 identity + group RBAC inside MLflow itself. See ADR-0085.
-(The mlflow-db child is disabled — MLflow uses the existing lightbridge-main-db
-CNPG cluster. See ADR-0085.)
+(The mlflow-db child stays disabled — NOT because MLflow lacks a dedicated
+CNPG cluster any more. MLflow is cut over to mlops-main-db (ADR-0123): its
+`mlflow`/`mlflow_oidc` role/Database were provisioned by ai-helm#957 and its
+connection actually repointed by the follow-up ai-helm-values PR once the
+owner confirmed, via the authenticated MLflow UI, that lightbridge-main-db
+held nothing worth migrating. mlops-db (charts/mlops-db) is that dedicated
+cluster; it stays a child of the lakefs orchestrator, not this one, and
+this chart's own db child stays disabled purely to avoid deploying the
+SAME Cluster resource twice from two different Applications — see
+charts/mlops-db and charts/lakefs/values.yaml.)
 All target home-remote (ADR-0017 guard via mlflow.argocd.destinationClusterRef).
 Rendered as direct Application CRs rather than an ApplicationSet because the
 children are fixed + heterogeneous — see ADR-0019 (lightbridge is the canonical
-example). See ADR-0085 for the MLflow-specific auth/DB/S3 decisions.
+example). See ADR-0085 for the MLflow-specific auth/S3 decisions (still
+current) and ADR-0123 for the DB decision (supersedes ADR-0085's for MLflow).
 */ -}}
 {{- $a := .Values.argocd -}}
 {{- if .Values.secrets.enabled }}

--- a/charts/mlflow/values.yaml
+++ b/charts/mlflow/values.yaml
@@ -5,16 +5,20 @@
 # native Keycloak OIDC + group RBAC inside MLflow itself. The chart owns no
 # workload resources; it owns the two child Applications.
 #
-# MLflow uses the existing lightbridge-main-db CNPG cluster (charts/lightbridge-db)
-# for its backend store — no separate CNPG cluster (ADR-0085, same reasoning
-# as coder in ADR-0083). STILL TRUE for MLflow's live traffic as of ADR-0123:
-# that ADR gives the mlops namespace its own dedicated CNPG cluster
-# (charts/mlops-db, a child of charts/lakefs — see that chart) and
-# provisions a `mlflow` role/Database there ahead of time, but MLflow's
-# actual connection (charts/mlflow-secrets) is NOT repointed yet — doing so
-# would abandon MLflow's existing tracking data with no migration, which
-# ADR-0123 explicitly did not clear. Repointing this app to charts/mlops-db
-# is a separate, explicitly-approved follow-up.
+# MLflow is CUT OVER to mlops-main-db, the mlops namespace's own dedicated
+# CNPG cluster (charts/mlops-db, a child of charts/lakefs — see that chart),
+# per ADR-0123 — superseding ADR-0085 decision #3's original shared
+# lightbridge-main-db placement for MLflow, same as it already did for
+# LakeFS. The `mlflow`/`mlflow_oidc` role/Database on mlops-main-db were
+# provisioned ahead of time by ai-helm#957; the actual connection repoint
+# (ai-helm-values `environments/prod/values/mlflow-app.yaml`) landed once
+# the owner confirmed, via the authenticated MLflow UI, that
+# lightbridge-main-db's `mlflow`/`mlflow_oidc` databases held nothing worth
+# migrating (only the default experiment, no run history) — clearing the
+# gate ADR-0123 explicitly left open. The now-dead role/Database on
+# lightbridge-main-db (charts/lightbridge-db) are dropped in this same PR,
+# once that connection repoint is merged and verified — hard cutover, no
+# dormant parallel path.
 
 # ────────────────────────────────────────────────────────────────────────
 # Shared ArgoCD wiring for all child Applications.
@@ -56,15 +60,15 @@ secrets:
   syncWave: "0"
 
 # ────────────────────────────────────────────────────────────────────────
-# mlflow-db child — STILL DISABLED (ADR-0123). MLflow's live traffic still
-# uses lightbridge-main-db (charts/lightbridge-db) for its backend store — a
-# managed `mlflow` role + `mlflow`/`mlflow_oidc` Database CRs stay there for
-# now. This child staying disabled is NOT the same as "no dedicated cluster
-# exists" any more: charts/mlops-db (a child of charts/lakefs, ADR-0123) IS
-# a dedicated CNPG cluster and already provisions a `mlflow` role/database on
-# it, ready for MLflow to actually use once its existing tracking data's
-# migration is explicitly cleared. Left disabled here rather than enabled to
-# avoid deploying the SAME Cluster twice from two different Applications.
+# mlflow-db child — stays DISABLED even now that MLflow is cut over
+# (ADR-0123). This does NOT mean MLflow lacks a dedicated cluster: it uses
+# mlops-main-db, provisioned by charts/mlops-db (a child of the lakefs
+# orchestrator, not this one) — the `mlflow`/`mlflow_oidc` role/Database
+# CRs already live there. This child stays disabled purely to avoid
+# deploying the SAME Cluster resource twice from two different
+# Applications; ownership of mlops-main-db isn't LakeFS- or MLflow-
+# specific, same as lightbridge-main-db being a child of
+# charts/lightbridge doesn't make Lightbridge own coder's/governance's data.
 # ────────────────────────────────────────────────────────────────────────
 db:
   enabled: false

--- a/charts/mlops-db/values.yaml
+++ b/charts/mlops-db/values.yaml
@@ -13,15 +13,17 @@
 #
 # Namespace is `mlops` — the same namespace both tenants' workloads run in.
 #
-# ⚠️ TWO TENANTS, TWO DIFFERENT STATES as of this chart's introduction:
-#   - LakeFS: fully cut over (charts/lakefs-secrets points here now).
-#   - MLflow: role + Database provisioned and READY, but MLflow's actual
-#     connection string (charts/mlflow-secrets) still points at
-#     lightbridge-main-db. Repointing it means MLflow starts against an
-#     EMPTY database on this cluster — nothing here migrates MLflow's
-#     existing tracking data from lightbridge-main-db. That is a separate,
-#     explicitly-cleared follow-up, not part of the incident-response cutover
-#     this chart's introduction was. See ADR-0123.
+# BOTH TENANTS NOW CUT OVER:
+#   - LakeFS: charts/lakefs-secrets points here (ADR-0123's original
+#     incident-response cutover).
+#   - MLflow: ai-helm-values environments/prod/values/mlflow-app.yaml
+#     (backendStore.postgres.host / oidcAuth.database.postgres.host) points
+#     here too, as the explicitly-gated follow-up ADR-0123 left open —
+#     cleared once the owner confirmed, via the authenticated MLflow UI,
+#     that lightbridge-main-db's `mlflow`/`mlflow_oidc` databases held
+#     nothing worth migrating (only the default experiment, no run
+#     history). MLflow started against this cluster's empty `mlflow`/
+#     `mlflow_oidc` databases; nothing was migrated, by design.
 
 resources:
   # ────────────────────────────────────────────────────────────────────
@@ -81,17 +83,26 @@ resources:
           # (that cluster carries 7 unbounded tenants) nor left at this
           # cluster's earlier LakeFS-only 50. LakeFS: hard-capped 5-connection
           # pool (charts/lakefs lakefs-app.yaml). MLflow: 1 replica × 2
-          # gunicorn workers (environments/prod/values/mlflow-app.yaml),
-          # each holding its own SQLAlchemy pool — the upstream
-          # community-charts/mlflow chart exposes no documented pool-size
-          # value in this repo's fixtures to cap it explicitly (unlike
-          # LakeFS's documented database.postgres.max_open_connections), so
-          # this is sized for a generous WORST-CASE per-worker pool (~15
-          # connections) rather than a verified cap: 2 × 15 = 30. LakeFS (5)
-          # + MLflow worst case (30) + admin/monitoring/backup headroom
-          # (~15) + margin ⇒ 80. Capping MLflow's own pool explicitly is a
-          # follow-up once its chart's actual pool-size knob is confirmed
-          # (not guessed) — see ADR-0123.
+          # gunicorn workers (environments/prod/values/mlflow-app.yaml), each
+          # holding its own SQLAlchemy pool. This 80 figure predates
+          # confirming MLflow's actual pool-size knob and was deliberately
+          # sized for a generous WORST-CASE per-worker pool (~15 connections,
+          # SQLAlchemy's own QueuePool default) rather than a verified cap:
+          # 2 x 15 = 30. LakeFS (5) + MLflow worst case (30) +
+          # admin/monitoring/backup headroom (~15) + margin => 80.
+          #
+          # MLflow's pool knob is now confirmed and capped (ADR-0123
+          # follow-up, closed): MLFLOW_SQLALCHEMYSTORE_POOL_SIZE=3 /
+          # _MAX_OVERFLOW=2 in environments/prod/values/mlflow-app.yaml, read
+          # straight into sqlalchemy.create_engine() by MLflow's own
+          # store/db/utils.py — verified against mlflow/environment_
+          # variables.py for the deployed image (burakince/mlflow:3.14.0),
+          # not guessed. Actual MLflow ceiling is 5/worker x 2 = 10, a third
+          # of the 30 this 80 budgeted — left at 80 rather than re-sized
+          # down: preserves headroom already proven safe, and re-deriving it
+          # tighter isn't this follow-up's job (see the file this note is
+          # in — sizing changes aren't bundled with the connection-string
+          # cutover PR).
           max_connections: "80"
       resources:
         # Sized for max_connections × work_mem: worst case with Postgres's

--- a/docs/adr/0085-mlops-platform-lakefs-argo-workflows-mlflow.md
+++ b/docs/adr/0085-mlops-platform-lakefs-argo-workflows-mlflow.md
@@ -12,12 +12,16 @@
 > outage where an unrelated tenant on the shared cluster exhausted its
 > Postgres connections and took LakeFS down with it showed the coupling was
 > a real production risk for LakeFS's data-versioning role specifically.
-> **MLflow's role/database are provisioned on the new cluster too but its
-> live connection has NOT been repointed** — ADR-0123 explicitly did not
-> clear abandoning MLflow's existing tracking data, so decision #3 stays in
-> force for MLflow until a separate, explicitly-cleared migration lands.
-> Decisions #1 (S3 backend) and #2 (per-app auth strategy) below are
-> unaffected and remain in force as originally decided here.
+> **MLflow is now cut over too (2026-08-09, same day):** the owner checked
+> the authenticated MLflow UI directly and confirmed `lightbridge-main-db`'s
+> `mlflow`/`mlflow_oidc` databases held nothing worth migrating (only the
+> default experiment, no run history) — clearing the gate ADR-0123 left
+> open. MLflow's connection (`environments/prod/values/mlflow-app.yaml` in
+> `ai-helm-values`) now points at `mlops-main-db`; its old role/Database on
+> `lightbridge-main-db` are removed (`charts/lightbridge-db`). Decision #3
+> below is now fully superseded by ADR-0123 for both `mlops`-namespace
+> tenants. Decisions #1 (S3 backend) and #2 (per-app auth strategy) below
+> are unaffected and remain in force as originally decided here.
 
 ## Context
 

--- a/docs/adr/0123-mlops-dedicated-cnpg-cluster.md
+++ b/docs/adr/0123-mlops-dedicated-cnpg-cluster.md
@@ -4,6 +4,39 @@
 **Date:** 2026-08-09
 **Deciders:** @stephane-segning
 
+> **Update (2026-08-09, same day):** the two items this ADR left as
+> "Follow-up required before MLflow's cutover" are both now resolved and
+> MLflow's cutover has executed:
+> 1. **Data-safety gate** — this ADR's authors could not confirm via
+>    database access whether `lightbridge-main-db`'s `mlflow`/`mlflow_oidc`
+>    databases held anything worth migrating. The owner has since checked
+>    the authenticated MLflow UI directly and confirmed: only the default
+>    experiment exists, no run history. Nothing is abandoned by cutting
+>    over with no migration.
+> 2. **Pool-size knob** — this ADR's `max_connections: "80"` sizing used an
+>    unverified worst-case estimate (~15 connections/gunicorn-worker)
+>    because "the upstream community-charts/mlflow chart exposes no
+>    documented pool-size value in this repo's fixtures to cap it
+>    explicitly." It does: `MLFLOW_SQLALCHEMYSTORE_POOL_SIZE` /
+>    `_MAX_OVERFLOW`, read straight into `sqlalchemy.create_engine()` by
+>    MLflow's own `store/db/utils.py` (verified against
+>    `mlflow/environment_variables.py` for the deployed image,
+>    `burakince/mlflow:3.14.0`). Now set to `pool_size=3` /
+>    `max_overflow=2` (10 connections total across MLflow's 2 gunicorn
+>    workers) in `environments/prod/values/mlflow-app.yaml`.
+>
+> MLflow's connection now points at `mlops-main-db`
+> (`environments/prod/values/mlflow-app.yaml`, `ai-helm-values`); its old
+> role/Database on `lightbridge-main-db` are removed (`charts/lightbridge-db`,
+> this repo, same PR as this note) — hard cutover, no dormant parallel
+> path, mirroring exactly how LakeFS's own role/Database were removed from
+> `lightbridge-main-db` when it cut over first. `charts/mlops-db`'s
+> `max_connections: "80"` sizing is left as-is (real usage is now ~15 of
+> 80, not re-derived tighter as part of this follow-up). This is a status
+> update per this repo's ADR-immutability convention, not an edit to the
+> Decision/Sizing/Follow-up sections below, which remain the historical
+> record of what was known and decided on 2026-08-09.
+
 ## Context
 
 Incident, `hetzner-prod`, 2026-08-08/09: LakeFS's HTTP API started returning


### PR DESCRIPTION
## What

Completes the MLflow `mlops-main-db` cutover on the ai-helm side, now
that the connection-string half
(ai-helm-values#214, **merged and verified live**) is confirmed healthy.

1. Drops the now-dead `mlflow`/`mlflow_oidc` role+Database+Secret on
   `lightbridge-main-db` (`charts/lightbridge-db`) — hard cutover, no
   dormant parallel path, exactly mirroring how `ai-helm#957` removed
   LakeFS's equivalent role/Database from this same file.
2. Syncs stale "not repointed yet" comments across
   `charts/mlflow/{values.yaml,templates/applications.yaml}`,
   `charts/mlops-db/values.yaml`, and `charts/mlflow/ci/mlflow-app.yaml`
   — the exact doc-sync pattern `ai-helm#958` established for LakeFS's
   own cutover.
3. Adds dated status-update notes (not body edits — this repo's
   ADR-immutability convention) to `docs/adr/0123-...md` and
   `docs/adr/0085-...md` closing out ADR-0123's two explicit follow-up
   items.

It solves: ADR-0123's own "Follow-up required before MLflow's cutover"
(`docs/adr/0123-mlops-dedicated-cnpg-cluster.md`) — the data-safety gate
and the pool-size-knob confirmation.

## Source of truth

**#961** is the durable record for the data-safety confirmation that
unblocks this PR: the repository owner checked the authenticated MLflow
UI directly and confirmed `lightbridge-main-db`'s `mlflow`/`mlflow_oidc`
databases held nothing worth migrating. That confirmation reached this
PR via an AI agent session rather than a first-hand GitHub comment, so
#961 exists specifically to make it durable, dated, and correctable —
please read its provenance note, and @stephane-segning: a 👍 or comment
there closes the loop before this merges.

Independent of that confirmation, this PR's specific action is *not*
destructive on its own: both `mlflow`/`mlflow_oidc` `Database` CRs
being removed carry `databaseReclaimPolicy: retain` (confirmed live,
see Verification below) — removing the CR stops CNPG from managing the
role/database declaratively, it does not drop the underlying PostgreSQL
database or data. #961 has the full reasoning.

## Why sequenced as its own PR, after ai-helm-values#214

MLflow's connection target (host/port/database) lives in
**ai-helm-values** (`environments/prod/values/mlflow-app.yaml`); its
CNPG role/Database live **here**, in ai-helm's
`charts/lightbridge-db`. These are two independently-syncing ArgoCD
sources in two separate repos. Dropping the role here before the new
connection was confirmed working would have broken the *live* pod's
auth against its *current* database mid-transition. Opened only after
ai-helm-values#214 merged and I verified the pod live:

```
$ kubectl -n mlops get pod -l app.kubernetes.io/instance=mlflow
mlflow-67544d857c-mdc6t   1/1   Running   0   <fresh>

$ kubectl -n mlops get configmap mlflow-env-configmap -o yaml
PGHOST: mlops-main-db-rw.mlops.svc.cluster.local
...

$ kubectl -n mlops logs <pod> -c mlflow | grep pool
2026/08/09 10:28:42 INFO mlflow.store.db.utils: Create SQLAlchemy engine
  with pool options {'pool_size': 3, 'max_overflow': 2}

# A real owner OIDC login succeeded end to end against the new
# mlflow_oidc database (fresh alembic migration from base), and
# experiments/search returned 200 with real data.
# Zero restarts, zero connection errors, /health 200 throughout.
```

This is a straight port of the exact precedent `ai-helm#957`/`#958`
already set for LakeFS's own cutover (single-repo role removal +
doc-sync as a fast-follow, after the connection-string side proved
out) — just applied on MLflow's turn instead of doing it eagerly and
racing the two repos' independent syncs.

## Verification

```
$ helm lint --strict charts/{lightbridge-db,mlflow,mlops-db,lakefs}
4 chart(s) linted, 0 chart(s) failed   (each, individually)
```

`helm template` before/after diffs:
- `charts/lightbridge-db`: only the `mlflow` Database, `mlflow_oidc`
  Database, and `mlflow-db-role` ExternalSecret disappear from the
  rendered manifest set. Nothing else changes.
- `charts/mlflow` (orchestrator) and `charts/mlops-db`: rendered output
  byte-identical to `main`, except the comment text embedded inside
  `mlops-db`'s Cluster `postgresql.parameters` block (still valid YAML,
  no functional field changed — `max_connections: "80"` unchanged).

```
$ kubeconform -strict -summary <lightbridge-db after>
Summary: 13 resources found in 1 file - Valid: 13, Invalid: 0, Errors: 0, Skipped: 0

$ kubeconform -strict -summary <mlops-db after>
Summary: 10 resources found in 1 file - Valid: 10, Invalid: 0, Errors: 0, Skipped: 0

$ helm template mlflow community-charts/mlflow --version 1.11.2 -n mlops \
    -f charts/mlflow/ci/mlflow-app.yaml   # mirrors this repo's own
                                            # helm-lint.yaml CI step
$ kubeconform -strict -summary <that output>
Summary: 9 resources found in 1 file - Valid: 9, Invalid: 0, Errors: 0, Skipped: 0
```

Data-safety net for the removed `Database` CRs, checked live before
opening this PR:

```
$ kubectl -n converse get database mlflow -o yaml | grep databaseReclaimPolicy
databaseReclaimPolicy: retain
$ kubectl -n converse get database mlflow-oidc -o yaml | grep databaseReclaimPolicy
databaseReclaimPolicy: retain
```

## Not touched

`ai-helm-values` (already merged, #214) — LakeFS's DSN/pool cap,
`mlops-main-db`'s sizing (`max_connections: "80"` left as-is; real
MLflow usage is now ~10 of the 80 headroom budgeted, not re-derived
tighter here), and everything under `charts/webank-training` from
today are all preserved untouched.

## AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [x] Drafting documentation
* [x] Reviewing the diff
* [ ] Refactoring
* [ ] Generating tests
* [ ] Not used

Human verification:

* [ ] I understand every meaningful change in this PR
* [ ] I checked generated code manually
* [ ] I checked generated tests manually
* [ ] I removed unsupported AI assumptions
* [ ] I accept responsibility for this PR

(Left unchecked deliberately — this PR was opened by an AI agent
session; human verification is pending and tracked in #961 and the
checklist below, not pre-attested here.)

## Verification checklist

- [ ] Human: confirmed the #961 data-safety confirmation is accurate
- [ ] Human: confirmed dropping the lightbridge-main-db role did not
      affect any other tenant on that shared cluster
- [ ] Human: spot-checked MLflow UI shows expected experiment(s) post-
      cutover

🤖 Generated with [Claude Code](https://claude.com/claude-code)
