### PR TITLE
fix(librechat-code-interpreter): unconfine sandbox-runner AppArmor profile

### DIFF
--- a/charts/librechat-code-interpreter/values.yaml
+++ b/charts/librechat-code-interpreter/values.yaml
@@ -279,6 +279,19 @@ codeapi:
             runAsNonRoot: false
             seccompProfile:
               type: Unconfined
+            # ⚠️ Live-incident correction, 2026-08-10: without an explicit
+            # appArmorProfile, this cluster's kubelet (v1.35.3, native
+            # AppArmor field) defaults the container to the `RuntimeDefault`
+            # AppArmor profile on this AppArmor-enabled node (Ubuntu 24.04).
+            # That profile blocks the mount-propagation syscall NsJail needs
+            # at startup EVEN WITH SYS_ADMIN granted below — confirmed live:
+            # `unshare: cannot change root filesystem propagation:
+            # Permission denied`, CrashLoopBackOff. seccompProfile:Unconfined
+            # (above) does not also disable AppArmor confinement — they're
+            # independent LSMs. Same permanent-exception rationale as the
+            # capability list below (NsJail's namespace/mount/chroot setup).
+            appArmorProfile:
+              type: Unconfined
             capabilities:
               add:
                 - SYS_ADMIN


### PR DESCRIPTION
## 1. Summary

This PR changes:

- Adds `appArmorProfile: { type: Unconfined }` to the `sandbox-runner`
  container's `securityContext` in `charts/librechat-code-interpreter`.

It solves:

- A live `CrashLoopBackOff` on `codeapi-sandbox-runner` discovered right
  after the `codeapi-secrets`/`librechat-codeapi-jwt` ExternalSecrets
  finished syncing (the last outstanding blocker from #941/#951/#952).
  Source of truth: #941, #952.

---

## 2. Intent

> Now that secrets are synced and containers are actually starting,
> `sandbox-runner` crashloops on startup:
> `unshare: cannot change root filesystem propagation: Permission denied`.
> Without an explicit `appArmorProfile`, this cluster's kubelet (v1.35.3,
> native AppArmor securityContext field) defaults new containers to the
> `RuntimeDefault` AppArmor profile on this AppArmor-enabled node (Ubuntu
> 24.04 LTS worker). That profile blocks the mount-propagation syscall
> NsJail needs at startup even with `SYS_ADMIN` already granted —
> `seccompProfile: Unconfined` (already set) only disables seccomp
> filtering, not AppArmor confinement; they're independent LSMs enforced
> separately by the kernel.

---

## 3. Scope

### In Scope

- `charts/librechat-code-interpreter/values.yaml` — `appArmorProfile`
  override on the `sandbox-runner` container only.

### Out of Scope

- Any other container in the chart (all remain hardened/confined as-is).

---

## 4. Verification

I verified this change by:

- [x] Running automated tests
- [x] Running manual tests
- [x] Checking logs
- [ ] Checking metrics
- [ ] Testing error cases
- [ ] Testing permissions/security behavior
- [ ] Testing rollback or failure behavior, if relevant

Commands run:

```bash
helm lint charts/librechat-code-interpreter --strict
helm template librechat-code-interpreter charts/librechat-code-interpreter --namespace librechat-sandbox | grep -A3 appArmorProfile
```

Results:

```text
1 chart(s) linted, 0 chart(s) failed

appArmorProfile:
  type: Unconfined
capabilities:
  add:
  - SYS_ADMIN
```

---

## 5. Screenshots / Evidence

* Logs: live pod logs on `hetzner-prod`, `librechat-sandbox` namespace:

```text
$ kubectl --context hetzner-prod -n librechat-sandbox logs codeapi-sandbox-runner-<pod>
Starting Sandbox (direct NsJail, no microVM) on port 2000...
[sandbox] Remounted cgroupfs as rw
[sandbox] Draining root cgroup (3 procs) into init/...
[sandbox] Root cgroup procs after drain: 0
[sandbox] Enabled +memory +pids on root cgroup.subtree_control
[sandbox] Removing 12 /proc submounts for fresh procfs support...
[sandbox] All /proc submounts removed
unshare: cannot change root filesystem propagation: Permission denied
```

`kubectl get pod ... -o jsonpath='{.spec.containers[0].securityContext}'`
confirmed `SYS_ADMIN` and every other capability from ADR-0122 already
present, and the namespace already carries the `privileged` Pod Security
Standard label — isolating the cause to AppArmor, not capabilities or PSS.

---

## 6. Risk Assessment

Risk level:

* [x] Low
* [ ] Medium
* [ ] High

Potential risks:

* Disabling AppArmor confinement on this container widens its kernel
  attack surface further, on top of the already-broad capability set.

Mitigation:

* Scoped to `sandbox-runner` only — the one deliberately un-hardened
  component in the chart by design (ADR-0122: NsJail needs broad root
  capabilities and namespace/mount/chroot access; this is the same
  permanent-exception category as its existing capability list). No other
  container in the chart or repo is affected.

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [ ] Refactoring
* [ ] Generating tests
* [x] Drafting documentation
* [ ] Reviewing the diff
* [ ] Not used

Human verification:

* [x] I understand every meaningful change in this PR
* [x] I checked generated code manually
* [ ] I checked generated tests manually
* [x] I removed unsupported AI assumptions
* [x] I accept responsibility for this PR

---

## 8. Reviewer Focus

Please focus your review on:

* [x] Correctness
* [x] Security
* [ ] Architecture
* [ ] Performance
* [ ] Tests
* [ ] Maintainability
* [ ] Product intent
* [ ] Edge cases
