### PR TITLE
fix(librechat-code-interpreter): correct redis-ha hostname (was a nonexistent hybrid)

### DIFF
--- a/charts/librechat-code-interpreter/values.yaml
+++ b/charts/librechat-code-interpreter/values.yaml
@@ -128,7 +128,17 @@ codeapi:
             OTEL_TRACING_ENABLED: "false"
             OTEL_SERVICE_NAME: aiml-codeapi-api
             CODEAPI_HARDENED_SANDBOX_MODE: "true"
-            REDIS_HOST: redis-ha-redis-haproxy.redis-system.svc.cluster.local
+            # ⚠️ Live-incident correction, 2026-08-10: was originally written
+            # as the nonexistent hybrid `redis-ha-redis-haproxy` (NXDOMAIN,
+            # confirmed live) — a typo transposing the two real redis-system
+            # Services (`redis-ha-redis`, `redis-ha-haproxy`). Fixed to the
+            # HAProxy master-router, NOT the round-robin `redis-ha-redis` —
+            # same durable fix already applied for librechat-app's own
+            # READONLY trap (redis-ha-redis load-balances master+replica, so
+            # a write connection lands on the read-only replica ~50% of the
+            # time). See charts/librechat-app/values.yaml's REDIS_URI note
+            # for the full rationale.
+            REDIS_HOST: redis-ha-haproxy.redis-system.svc.cluster.local
             REDIS_PORT: "6379"
             REDIS_PASSWORD:
               secretKeyRef: { name: codeapi-secrets, key: redis-password }
@@ -185,7 +195,7 @@ codeapi:
           image:
             repository: busybox
             tag: "1.36.1"
-          command: ["sh", "-c", "until nc -z redis-ha-redis-haproxy.redis-system.svc.cluster.local 6379; do echo waiting for redis; sleep 2; done"]
+          command: ["sh", "-c", "until nc -z redis-ha-haproxy.redis-system.svc.cluster.local 6379; do echo waiting for redis; sleep 2; done"]
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
@@ -223,7 +233,7 @@ codeapi:
             CODEAPI_HARDENED_SANDBOX_MODE: "true"
             SANDBOX_ENDPOINT: http://codeapi-sandbox-runner:2000/api/v2
             EGRESS_GATEWAY_URL: http://codeapi-egress-gateway:3190
-            REDIS_HOST: redis-ha-redis-haproxy.redis-system.svc.cluster.local
+            REDIS_HOST: redis-ha-haproxy.redis-system.svc.cluster.local
             REDIS_PORT: "6379"
             REDIS_PASSWORD:
               secretKeyRef: { name: codeapi-secrets, key: redis-password }
@@ -407,7 +417,7 @@ codeapi:
               secretKeyRef: { name: codeapi-secrets, key: minio-access-key }
             MINIO_SECRET_KEY:
               secretKeyRef: { name: codeapi-secrets, key: minio-secret-key }
-            REDIS_HOST: redis-ha-redis-haproxy.redis-system.svc.cluster.local
+            REDIS_HOST: redis-ha-haproxy.redis-system.svc.cluster.local
             REDIS_PORT: "6379"
             REDIS_PASSWORD:
               secretKeyRef: { name: codeapi-secrets, key: redis-password }
@@ -454,7 +464,7 @@ codeapi:
           env:
             OTEL_TRACING_ENABLED: "false"
             OTEL_SERVICE_NAME: aiml-codeapi-tool-call-server
-            REDIS_HOST: redis-ha-redis-haproxy.redis-system.svc.cluster.local
+            REDIS_HOST: redis-ha-haproxy.redis-system.svc.cluster.local
             REDIS_PORT: "6379"
             REDIS_PASSWORD:
               secretKeyRef: { name: codeapi-secrets, key: redis-password }
@@ -515,7 +525,7 @@ codeapi:
               secretKeyRef: { name: codeapi-secrets, key: codeapi-egress-grant-secret }
             CODEAPI_INTERNAL_SERVICE_TOKEN:
               secretKeyRef: { name: codeapi-secrets, key: codeapi-internal-service-token }
-            REDIS_HOST: redis-ha-redis-haproxy.redis-system.svc.cluster.local
+            REDIS_HOST: redis-ha-haproxy.redis-system.svc.cluster.local
             REDIS_PORT: "6379"
             REDIS_PASSWORD:
               secretKeyRef: { name: codeapi-secrets, key: redis-password }


### PR DESCRIPTION
## 1. Summary

This PR changes:

- Fixes `REDIS_HOST` (and the `wait-for-sandbox-runner`/`wait-for-redis`
  initContainer's `nc` check) across all 5 Redis-consuming controllers in
  `charts/librechat-code-interpreter` — was
  `redis-ha-redis-haproxy.redis-system.svc.cluster.local` (never existed),
  now `redis-ha-haproxy.redis-system.svc.cluster.local` (the real HAProxy
  master-router Service).

It solves:

- Live `CrashLoopBackOff` on `codeapi-api` / `codeapi-tool-call-server`
  ("Failed to connect to Redis after 6 attempts") discovered right after
  #962 (AppArmor fix) synced and containers actually started running app
  code. Source of truth: #941, #962.

---

## 2. Intent

> `REDIS_HOST` was written as a typo transposing the two real
> `redis-system` Services (`redis-ha-redis`, `redis-ha-haproxy`) into a
> hostname that has never existed — confirmed live via a throwaway pod:
> `NXDOMAIN`. Rather than just fixing the typo to either real service, this
> uses `redis-ha-haproxy` specifically, matching a durable fix this repo
> already made once for `librechat-app`'s own Redis connection: the
> round-robin `redis-ha-redis` Service load-balances master+replica, so a
> write connection lands on the read-only replica ~50% of the time
> (`READONLY You can't write against a read only replica`). HAProxy
> health-checks both pods over TLS and routes all traffic to whichever is
> `role:master`, auto-following Sentinel failover. Using `redis-ha-redis`
> here would have traded one live bug for a second, harder-to-reproduce
> one that would only surface intermittently under write load.

---

## 3. Scope

### In Scope

- `charts/librechat-code-interpreter/values.yaml` — `REDIS_HOST` on `api`,
  `service-worker`, `file-server`, `tool-call-server`, `egress-gateway`
  (5 occurrences) + the `wait-for-redis` initContainer's `nc -z` check.

### Out of Scope

- `charts/librechat-app` — already correct (this is the pattern being
  matched, not changed).
- Redis TLS CA-verification gap (documented, separate, pre-existing
  limitation in `docs/patterns/self-hosted-code-interpreter.md`).

---

## 4. Verification

I verified this change by:

- [x] Running automated tests
- [x] Running manual tests
- [x] Checking logs
- [ ] Checking metrics
- [ ] Testing error cases
- [ ] Testing permissions/security behavior
- [ ] Testing rollback or failure behavior, if relevant

Commands run:

```bash
helm lint charts/librechat-code-interpreter --strict
helm template librechat-code-interpreter charts/librechat-code-interpreter --namespace librechat-sandbox | grep -c redis-ha-haproxy
grep -rn "redis-ha-redis-haproxy" charts/librechat-code-interpreter/  # only inside the explanatory comment now

# Live repro before the fix:
kubectl --context hetzner-prod -n librechat-sandbox run dns-test --image=busybox:1.36 \
  --restart=Never --rm -it --command -- sh -c \
  "nslookup redis-ha-redis-haproxy.redis-system.svc.cluster.local"
kubectl --context hetzner-prod -n redis-system get svc
```

Results:

```text
1 chart(s) linted, 0 chart(s) failed
6   (all 6 occurrences now correct)

** server can't find redis-ha-redis-haproxy.redis-system.svc.cluster.local: NXDOMAIN

NAME                         TYPE        CLUSTER-IP      PORT(S)
redis-ha-haproxy             ClusterIP   10.43.33.44     6379/TCP
redis-ha-redis               ClusterIP   10.43.104.126   6379/TCP
```

---

## 5. Screenshots / Evidence

* Logs: `codeapi-api` pod on `hetzner-prod`:

```text
DNSException: getaddrinfo ENOTFOUND
{"level":"error","message":"Failed to connect to Redis after 6 attempts","service":"service-api"}
```

---

## 6. Risk Assessment

Risk level:

* [x] Low
* [ ] Medium
* [ ] High

Potential risks:

* None beyond the fix itself not resolving connectivity for some other
  reason (network policy, auth) — but DNS resolution and the target
  Service's existence were both directly verified live before merging.

Mitigation:

* Verified the destination Service exists and its port matches
  (`redis-ha-haproxy:6379`); the NetworkPolicy egress rule for this port
  is a plain port-match with no hostname dependency, so it needed no
  change.

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [ ] Refactoring
* [ ] Generating tests
* [x] Drafting documentation
* [ ] Reviewing the diff
* [ ] Not used

Human verification:

* [x] I understand every meaningful change in this PR
* [x] I checked generated code manually
* [ ] I checked generated tests manually
* [x] I removed unsupported AI assumptions
* [x] I accept responsibility for this PR

---

## 8. Reviewer Focus

Please focus your review on:

* [x] Correctness
* [ ] Architecture
* [ ] Security
* [ ] Performance
* [ ] Tests
* [ ] Maintainability
* [ ] Product intent
* [ ] Edge cases
