### PR TITLE
fix(librechat-code-interpreter): bump images to sha-1279a65 (sandbox-runner bash hashing fix)

### DIFF
--- a/charts/librechat-code-interpreter/values.yaml
+++ b/charts/librechat-code-interpreter/values.yaml
@@ -113,7 +113,7 @@ codeapi:
         api:
           image:
             repository: ghcr.io/adorsys-gis/code-interpreter-api
-            tag: sha-93172e7
+            tag: sha-1279a65
             pullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -216,7 +216,7 @@ codeapi:
         service-worker:
           image:
             repository: ghcr.io/adorsys-gis/code-interpreter-worker
-            tag: sha-93172e7
+            tag: sha-1279a65
             pullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -282,7 +282,7 @@ codeapi:
         sandbox-runner:
           image:
             repository: ghcr.io/adorsys-gis/code-interpreter-sandbox-runner
-            tag: sha-93172e7
+            tag: sha-1279a65
             pullPolicy: IfNotPresent
           securityContext:
             privileged: false
@@ -387,7 +387,7 @@ codeapi:
         file-server:
           image:
             repository: ghcr.io/adorsys-gis/code-interpreter-file-server
-            tag: sha-93172e7
+            tag: sha-1279a65
             pullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -450,7 +450,7 @@ codeapi:
         tool-call-server:
           image:
             repository: ghcr.io/adorsys-gis/code-interpreter-tool-call-server
-            tag: sha-93172e7
+            tag: sha-1279a65
             pullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -499,7 +499,7 @@ codeapi:
         egress-gateway:
           image:
             repository: ghcr.io/adorsys-gis/code-interpreter-egress-gateway
-            tag: sha-93172e7
+            tag: sha-1279a65
             pullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -592,7 +592,7 @@ codeapi:
         package-init:
           image:
             repository: ghcr.io/adorsys-gis/code-interpreter-package-init
-            tag: sha-93172e7
+            tag: sha-1279a65
             pullPolicy: IfNotPresent
           env:
             PYTHON_VERSION: "3.14.4"


### PR DESCRIPTION
## 1. Summary

This PR changes:

- Bumps every image tag in `charts/librechat-code-interpreter` from
  `sha-93172e7` to `sha-1279a65` (all 7 controllers, built from the same
  fork commit).

It solves:

- `codeapi-sandbox-runner` `CrashLoopBackOff`, discovered one step past the
  AppArmor fix (#962): `bash: line 5: /usr/sbin/mount: No such file or
  directory`. Source of truth: #941, #962, #963,
  [ADORSYS-GIS/code-interpreter@1279a65](https://github.com/ADORSYS-GIS/code-interpreter/commit/1279a65481f331af60e8f727aef1eb28e23ca2ac).

---

## 2. Intent

> `docker/start-direct-sandbox.sh`'s inner `unshare` block bind-mounts
> `$ROOTFS/usr/sbin` over `/usr/sbin` as its first step, then keeps calling
> the bare `mount` command for every later bind (`usr/lib`, `usr/lib64`,
> `usr/local`, `sandbox_api`, `pkgs`, `host-packages`, `usr/bin`). Bash
> caches a bare command word to the absolute path it first resolved via
> `$PATH` (its hash table) and does NOT re-search `$PATH` on later
> invocations. The very first bind-mount replaces `/usr/sbin`'s *content*
> with the target rootfs's own `usr/sbin` (built from a different base
> image — Debian, which doesn't ship `mount` at that exact path). Every
> subsequent bare `mount` call still resolves via the stale cached path,
> and fails once that path no longer points at a real binary. Fixed
> upstream in our fork by resolving `mount` to an absolute path once via
> `command -v mount` before any bind-mount runs, and using that resolved
> path for every subsequent call.

---

## 3. Scope

### In Scope

- `charts/librechat-code-interpreter/values.yaml` — bump all 7 image tags
  to `sha-1279a65` (keeps the fleet built from one fork commit, per this
  chart's own bump-the-image-version convention).

### Out of Scope

- Any other chart values (env vars, ports, probes — verified unchanged via
  `helm template` diff).

---

## 4. Verification

I verified this change by:

- [x] Running automated tests
- [x] Running manual tests
- [x] Checking logs
- [ ] Checking metrics
- [ ] Testing error cases
- [ ] Testing permissions/security behavior
- [ ] Testing rollback or failure behavior, if relevant

Commands run:

```bash
helm lint charts/librechat-code-interpreter --strict
helm template librechat-code-interpreter charts/librechat-code-interpreter --namespace librechat-sandbox
bash -n docker/start-direct-sandbox.sh   # (in the fork, before pushing)
```

Results:

```text
1 chart(s) linted, 0 chart(s) failed
(render succeeded; only image tags changed vs. the prior render — no env
 var/port/probe shape changes)
syntax OK
```

Fork CI (`ADORSYS-GIS/code-interpreter`, commit `1279a65`): both `CI` and
`Publish images` workflows passed; `ghcr.io/adorsys-gis/code-interpreter-
sandbox-runner:sha-1279a65` confirmed present via the GHCR packages API.

---

## 5. Screenshots / Evidence

* Logs: `codeapi-sandbox-runner` pod on `hetzner-prod`, before this fix
  (after #962's AppArmor fix had already landed):

```text
Starting Sandbox (direct NsJail, no microVM) on port 2000...
[sandbox] Remounted cgroupfs as rw
...
[sandbox] All /proc submounts removed
bash: line 5: /usr/sbin/mount: No such file or directory
FATAL: cannot bind /usr/lib
```

---

## 6. Risk Assessment

Risk level:

* [x] Low
* [ ] Medium
* [ ] High

Potential risks:

* An image build issue in the fork's CI could ship a broken tag.

Mitigation:

* Fork's `CI` and `Publish images` workflows both passed for this commit;
  image existence confirmed directly via the GHCR API before bumping the
  chart tag; `helm template` diff confirmed no other shape change.

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [ ] Refactoring
* [ ] Generating tests
* [x] Drafting documentation
* [ ] Reviewing the diff
* [ ] Not used

Human verification:

* [x] I understand every meaningful change in this PR
* [x] I checked generated code manually
* [ ] I checked generated tests manually
* [x] I removed unsupported AI assumptions
* [x] I accept responsibility for this PR

---

## 8. Reviewer Focus

Please focus your review on:

* [x] Correctness
* [ ] Architecture
* [ ] Security
* [ ] Performance
* [ ] Tests
* [ ] Maintainability
* [ ] Product intent
* [ ] Edge cases
