### PR TITLE
fix(librechat-code-interpreter): bump images to sha-1d37e37 (real sandbox-runner mount fix)

### DIFF
--- a/charts/librechat-code-interpreter/values.yaml
+++ b/charts/librechat-code-interpreter/values.yaml
@@ -113,7 +113,7 @@ codeapi:
         api:
           image:
             repository: ghcr.io/adorsys-gis/code-interpreter-api
-            tag: sha-1279a65
+            tag: sha-1d37e37
             pullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -216,7 +216,7 @@ codeapi:
         service-worker:
           image:
             repository: ghcr.io/adorsys-gis/code-interpreter-worker
-            tag: sha-1279a65
+            tag: sha-1d37e37
             pullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -282,7 +282,7 @@ codeapi:
         sandbox-runner:
           image:
             repository: ghcr.io/adorsys-gis/code-interpreter-sandbox-runner
-            tag: sha-1279a65
+            tag: sha-1d37e37
             pullPolicy: IfNotPresent
           securityContext:
             privileged: false
@@ -387,7 +387,7 @@ codeapi:
         file-server:
           image:
             repository: ghcr.io/adorsys-gis/code-interpreter-file-server
-            tag: sha-1279a65
+            tag: sha-1d37e37
             pullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -450,7 +450,7 @@ codeapi:
         tool-call-server:
           image:
             repository: ghcr.io/adorsys-gis/code-interpreter-tool-call-server
-            tag: sha-1279a65
+            tag: sha-1d37e37
             pullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -499,7 +499,7 @@ codeapi:
         egress-gateway:
           image:
             repository: ghcr.io/adorsys-gis/code-interpreter-egress-gateway
-            tag: sha-1279a65
+            tag: sha-1d37e37
             pullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -592,7 +592,7 @@ codeapi:
         package-init:
           image:
             repository: ghcr.io/adorsys-gis/code-interpreter-package-init
-            tag: sha-1279a65
+            tag: sha-1d37e37
             pullPolicy: IfNotPresent
           env:
             PYTHON_VERSION: "3.14.4"


### PR DESCRIPTION
## 1. Summary

This PR changes:

- Bumps every image tag in `charts/librechat-code-interpreter` from
  `sha-1279a65` to `sha-1d37e37` (all 7 controllers, built from the same
  fork commit).

It solves:

- `codeapi-sandbox-runner` `CrashLoopBackOff` persisting through #964
  (which turned out to be an ineffective fix, discovered by re-testing
  live after that PR's image actually rolled out). Source of truth:
  #941, #963, #964,
  [ADORSYS-GIS/code-interpreter@1d37e37](https://github.com/ADORSYS-GIS/code-interpreter/commit/1d37e37c5bc6b194309b400ceb55d312b77cdd49).

---

## 2. Intent

> #964's fix resolved `mount` to an absolute path once via
> `command -v mount` and reused that variable for every bind-mount call —
> confirmed live this does NOT actually fix anything: a bind-mount
> replaces the file *content* visible at a path system-wide, not just
> bash's belief about where a command lives. Once the first bind-mount
> replaces `/usr/sbin`'s content, the pinned variable (still holding the
> literal path `/usr/sbin/mount`) breaks identically — reproduced live
> with the exact same failure, just at a shifted line number. Real fix:
> copy the `mount` binary AND its full shared-library closure (via `ldd`)
> to a path none of the bind-mounts ever touch, before the first
> bind-mount runs, and use that copy for every subsequent call.
> `LD_LIBRARY_PATH` is scoped to only the duration of the host-side mount
> calls and explicitly unset before the sandboxed entrypoint sets its own,
> so the copied host libraries never shadow the guest rootfs's own
> libraries for sandboxed user code.

---

## 3. Scope

### In Scope

- `charts/librechat-code-interpreter/values.yaml` — bump all 7 image tags
  to `sha-1d37e37`.

### Out of Scope

- Any other chart values (env vars, ports, probes — verified unchanged via
  `helm template` diff).

---

## 4. Verification

I verified this change by:

- [x] Running automated tests
- [x] Running manual tests
- [x] Checking logs
- [ ] Checking metrics
- [ ] Testing error cases
- [ ] Testing permissions/security behavior
- [ ] Testing rollback or failure behavior, if relevant

Commands run:

```bash
helm lint charts/librechat-code-interpreter --strict
helm template librechat-code-interpreter charts/librechat-code-interpreter --namespace librechat-sandbox
bash -n docker/start-direct-sandbox.sh   # both outer script and the inner
                                          # unshare heredoc, in the fork,
                                          # before pushing
# Local dry-run of the copy-binary-plus-ldd-closure mechanics (shell logic
# only, not the actual bind-mount dance which needs a privileged NsJail
# container):
cp "$(command -v mount)" /tmp/host-tools-test/mount && chmod +x ...
for lib in $(ldd ... | awk '{print $3}' | grep '^/'); do cp -n "$lib" ...; done
/tmp/host-tools-test/mount --version   # ran successfully
```

Results:

```text
1 chart(s) linted, 0 chart(s) failed
(render succeeded; only image tags changed vs. the prior render)
outer syntax OK / inner syntax OK
mount from util-linux 2.41.3 (...)   # copied binary ran fine
```

Fork CI (`ADORSYS-GIS/code-interpreter`, commit `1d37e37`): both `CI` and
`Publish images` workflows passed;
`ghcr.io/adorsys-gis/code-interpreter-sandbox-runner:sha-1d37e37`
confirmed present via the GHCR packages API.

---

## 5. Screenshots / Evidence

* Logs: `codeapi-sandbox-runner` pod on `hetzner-prod`, running #964's
  (ineffective) fix:

```text
bash: line 17: /usr/sbin/mount: No such file or directory
FATAL: cannot bind /usr/lib
```

Identical to the pre-#964 failure — only the line number shifted (from
the added comment lines), confirming the earlier fix hadn't changed
behavior at all.

---

## 6. Risk Assessment

Risk level:

* [x] Low
* [ ] Medium
* [ ] High

Potential risks:

* Same class of risk as #964: an image build issue could ship a broken
  tag.
* A library-closure copy could theoretically miss a dependency `ldd`
  doesn't report (e.g. `dlopen`-only plugins) — `mount`'s own plugins
  (filesystem helpers) are typically statically registered, not
  dynamically loaded at runtime for the plain bind-mount usage here.

Mitigation:

* Fork's `CI` and `Publish images` workflows both passed; image existence
  confirmed via GHCR API; `helm template` diff confirmed no other shape
  change; the copy-and-relink mechanics were dry-run tested locally before
  pushing.

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [ ] Refactoring
* [ ] Generating tests
* [x] Drafting documentation
* [ ] Reviewing the diff
* [ ] Not used

Human verification:

* [x] I understand every meaningful change in this PR
* [x] I checked generated code manually
* [ ] I checked generated tests manually
* [x] I removed unsupported AI assumptions
* [x] I accept responsibility for this PR

---

## 8. Reviewer Focus

Please focus your review on:

* [x] Correctness
* [ ] Architecture
* [ ] Security
* [ ] Performance
* [ ] Tests
* [ ] Maintainability
* [ ] Product intent
* [ ] Edge cases
