### PR TITLE
fix(librechat-code-interpreter): bump images to sha-64cdf1a (nsjail smoke-test diagnostics)

### DIFF
--- a/charts/librechat-code-interpreter/values.yaml
+++ b/charts/librechat-code-interpreter/values.yaml
@@ -113,7 +113,7 @@ codeapi:
         api:
           image:
             repository: ghcr.io/adorsys-gis/code-interpreter-api
-            tag: sha-1d37e37
+            tag: sha-64cdf1a
             pullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -216,7 +216,7 @@ codeapi:
         service-worker:
           image:
             repository: ghcr.io/adorsys-gis/code-interpreter-worker
-            tag: sha-1d37e37
+            tag: sha-64cdf1a
             pullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -282,7 +282,7 @@ codeapi:
         sandbox-runner:
           image:
             repository: ghcr.io/adorsys-gis/code-interpreter-sandbox-runner
-            tag: sha-1d37e37
+            tag: sha-64cdf1a
             pullPolicy: IfNotPresent
           securityContext:
             privileged: false
@@ -387,7 +387,7 @@ codeapi:
         file-server:
           image:
             repository: ghcr.io/adorsys-gis/code-interpreter-file-server
-            tag: sha-1d37e37
+            tag: sha-64cdf1a
             pullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -450,7 +450,7 @@ codeapi:
         tool-call-server:
           image:
             repository: ghcr.io/adorsys-gis/code-interpreter-tool-call-server
-            tag: sha-1d37e37
+            tag: sha-64cdf1a
             pullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -499,7 +499,7 @@ codeapi:
         egress-gateway:
           image:
             repository: ghcr.io/adorsys-gis/code-interpreter-egress-gateway
-            tag: sha-1d37e37
+            tag: sha-64cdf1a
             pullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -592,7 +592,7 @@ codeapi:
         package-init:
           image:
             repository: ghcr.io/adorsys-gis/code-interpreter-package-init
-            tag: sha-1d37e37
+            tag: sha-64cdf1a
             pullPolicy: IfNotPresent
           env:
             PYTHON_VERSION: "3.14.4"


### PR DESCRIPTION
## 1. Summary

This PR changes:

- Bumps every image tag in `charts/librechat-code-interpreter` from
  `sha-1d37e37` to `sha-64cdf1a` (all 7 controllers, built from the same
  fork commit).

It solves:

- `codeapi-sandbox-runner` `CrashLoopBackOff` persisting past #965's mount
  fix, now with zero diagnostic detail (`FATAL: NsJail smoke test failed`
  + an empty `--log` file). This PR bumps to a diagnostics-only fork
  commit so the *next* crash-loop cycle reveals the actual nsjail error —
  it does not itself fix the underlying nsjail failure (unknown yet).
  Source of truth: #941, #964, #965,
  [ADORSYS-GIS/code-interpreter@64cdf1a](https://github.com/ADORSYS-GIS/code-interpreter/commit/64cdf1a39085872047db0b60ef3cca4cb10e1c80).

---

## 2. Intent

> The NsJail smoke test in `api/src/entrypoint.sh` discarded nsjail's own
> stdout/stderr entirely (`> /dev/null 2>&1`), relying only on nsjail's
> `--log` file for diagnostics — confirmed live that file can come back
> completely empty on a real failure, leaving no way to determine the
> actual cause. Captures nsjail's raw stdout/stderr to a second temp file
> and prints it alongside `--log` on failure. This is a diagnostic-only
> change — the underlying nsjail failure itself is not yet understood or
> fixed; a follow-up PR will address it once the real error is visible.

---

## 3. Scope

### In Scope

- `charts/librechat-code-interpreter/values.yaml` — bump all 7 image tags
  to `sha-64cdf1a`.

### Out of Scope

- Fixing the actual nsjail smoke-test failure (unknown cause — this PR
  only makes it diagnosable).

---

## 4. Verification

I verified this change by:

- [x] Running automated tests
- [x] Running manual tests
- [x] Checking logs
- [ ] Checking metrics
- [ ] Testing error cases
- [ ] Testing permissions/security behavior
- [ ] Testing rollback or failure behavior, if relevant

Commands run:

```bash
helm lint charts/librechat-code-interpreter --strict
helm template librechat-code-interpreter charts/librechat-code-interpreter --namespace librechat-sandbox
bash -n api/src/entrypoint.sh   # in the fork, before pushing
```

Results:

```text
1 chart(s) linted, 0 chart(s) failed
(render succeeded; only image tags changed vs. the prior render)
syntax OK
```

Fork CI (`ADORSYS-GIS/code-interpreter`, commit `64cdf1a`): `Publish
images` passed; `ghcr.io/adorsys-gis/code-interpreter-*:sha-64cdf1a`
confirmed present via the GHCR packages API.

---

## 5. Screenshots / Evidence

* Logs: `codeapi-sandbox-runner` pod on `hetzner-prod`, running #965's
  fix (past all bind-mounts, nsjail smoke test now actually executes):

```text
Running NsJail smoke test...
Guest RLIMIT_NOFILE soft limit: 1048576
FATAL: NsJail smoke test failed — sandbox cannot start
NsJail log output:
```

(empty log — nothing after that line)

---

## 6. Risk Assessment

Risk level:

* [x] Low
* [ ] Medium
* [ ] High

Potential risks:

* Purely additive diagnostic logging — no behavior change to the
  pass/fail path itself.

Mitigation:

* `bash -n` syntax-checked; fork `Publish images` workflow passed.

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [ ] Refactoring
* [ ] Generating tests
* [x] Drafting documentation
* [ ] Reviewing the diff
* [ ] Not used

Human verification:

* [x] I understand every meaningful change in this PR
* [x] I checked generated code manually
* [ ] I checked generated tests manually
* [x] I removed unsupported AI assumptions
* [x] I accept responsibility for this PR

---

## 8. Reviewer Focus

Please focus your review on:

* [x] Correctness
* [ ] Architecture
* [ ] Security
* [ ] Performance
* [ ] Tests
* [ ] Maintainability
* [ ] Product intent
* [ ] Edge cases
