### PR TITLE
fix(librechat-code-interpreter): bump images to sha-5d53fcc (usr/sbin symlink-shadowing fix)

### DIFF
--- a/charts/librechat-code-interpreter/values.yaml
+++ b/charts/librechat-code-interpreter/values.yaml
@@ -113,7 +113,7 @@ codeapi:
         api:
           image:
             repository: ghcr.io/adorsys-gis/code-interpreter-api
-            tag: sha-64cdf1a
+            tag: sha-5d53fcc
             pullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -216,7 +216,7 @@ codeapi:
         service-worker:
           image:
             repository: ghcr.io/adorsys-gis/code-interpreter-worker
-            tag: sha-64cdf1a
+            tag: sha-5d53fcc
             pullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -282,7 +282,7 @@ codeapi:
         sandbox-runner:
           image:
             repository: ghcr.io/adorsys-gis/code-interpreter-sandbox-runner
-            tag: sha-64cdf1a
+            tag: sha-5d53fcc
             pullPolicy: IfNotPresent
           securityContext:
             privileged: false
@@ -387,7 +387,7 @@ codeapi:
         file-server:
           image:
             repository: ghcr.io/adorsys-gis/code-interpreter-file-server
-            tag: sha-64cdf1a
+            tag: sha-5d53fcc
             pullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -450,7 +450,7 @@ codeapi:
         tool-call-server:
           image:
             repository: ghcr.io/adorsys-gis/code-interpreter-tool-call-server
-            tag: sha-64cdf1a
+            tag: sha-5d53fcc
             pullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -499,7 +499,7 @@ codeapi:
         egress-gateway:
           image:
             repository: ghcr.io/adorsys-gis/code-interpreter-egress-gateway
-            tag: sha-64cdf1a
+            tag: sha-5d53fcc
             pullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -592,7 +592,7 @@ codeapi:
         package-init:
           image:
             repository: ghcr.io/adorsys-gis/code-interpreter-package-init
-            tag: sha-64cdf1a
+            tag: sha-5d53fcc
             pullPolicy: IfNotPresent
           env:
             PYTHON_VERSION: "3.14.4"


### PR DESCRIPTION
## 1. Summary

This PR changes:

- Bumps every image tag in `charts/librechat-code-interpreter` from
  `sha-64cdf1a` to `sha-5d53fcc` (all 7 controllers, built from the same
  fork commit).

It solves:

- `codeapi-sandbox-runner` `CrashLoopBackOff`, root-caused with #966's
  diagnostics: `timeout: failed to run command '/usr/sbin/nsjail': No
  such file or directory`. Source of truth: #941, #965, #966,
  [ADORSYS-GIS/code-interpreter@5d53fcc](https://github.com/ADORSYS-GIS/code-interpreter/commit/5d53fcc945b9184c4c6e5c5ed37cfe6682a76c5e).

---

## 2. Intent

> Root cause, confirmed live via manual reproduction in a debug pod using
> the built image (`unshare --mount` + replaying each bind-mount step by
> step, checking `nsjail`'s presence after each one): on this image's base
> (`fedora:43`), `/usr/sbin` is a SYMLINK to `bin` — i.e. `/usr/sbin` and
> `/usr/bin` are the same underlying directory. Binding `$ROOTFS/usr/sbin`
> onto `/usr/sbin` therefore actually lands the bind on `/usr/bin` (mount
> resolves the symlink target); the LATER bind of `$ROOTFS/usr/bin` onto
> `/usr/bin` then stacks on top and shadows it — so `nsjail`, which lives
> only in `$ROOTFS/usr/sbin` on the target rootfs (a real, separate
> directory there, e.g. Debian), silently disappears again by the time the
> smoke test runs. Confirmed exactly: `nsjail` present + executable
> immediately after the `/usr/sbin` bind, gone after the subsequent
> `/usr/lib`, `/usr/local`, `/usr/bin` binds. Fix: if `/usr/sbin` is a
> symlink, replace it with a real (empty) directory inside the private
> `unshare` mount namespace before binding, so it becomes an independent
> mount point the later `/usr/bin` bind cannot shadow — entirely
> namespace-local, never touches the actual node or any other container.

---

## 3. Scope

### In Scope

- `charts/librechat-code-interpreter/values.yaml` — bump all 7 image tags
  to `sha-5d53fcc`.

### Out of Scope

- Any other chart values (env vars, ports, probes — verified unchanged via
  `helm template` diff).

---

## 4. Verification

I verified this change by:

- [x] Running automated tests
- [x] Running manual tests
- [x] Checking logs
- [ ] Checking metrics
- [ ] Testing error cases
- [ ] Testing permissions/security behavior
- [ ] Testing rollback or failure behavior, if relevant

Commands run:

```bash
helm lint charts/librechat-code-interpreter --strict
helm template librechat-code-interpreter charts/librechat-code-interpreter --namespace librechat-sandbox
bash -n docker/start-direct-sandbox.sh   # in the fork, before pushing

# Live root-cause reproduction (debug pod on hetzner-prod, same image,
# matching securityContext, sleep-override command):
kubectl -n librechat-sandbox exec debug-sandbox-runner -- unshare --mount sh -c '
  ... replicate each bind-mount step ...
  [ -f /usr/sbin/nsjail ] && echo EXISTS || echo MISSING
'
# → EXISTS right after the /usr/sbin bind, MISSING after usr/lib+usr/local+usr/bin binds
# → confirmed /usr/sbin -> bin symlink on host; real dir on rootfs
# → with the fix (replace symlink with real dir first): EXISTS + EXECUTABLE
#   after all binds
```

Results:

```text
1 chart(s) linted, 0 chart(s) failed
(render succeeded; only image tags changed vs. the prior render)
outer/inner syntax OK
```

Fork CI (`ADORSYS-GIS/code-interpreter`, commit `5d53fcc`): `Publish
images` passed; `ghcr.io/adorsys-gis/code-interpreter-*:sha-5d53fcc`
confirmed present via the GHCR packages API.

---

## 5. Screenshots / Evidence

* Logs: `codeapi-sandbox-runner` pod on `hetzner-prod`, running #966's
  diagnostic-instrumented image:

```text
FATAL: NsJail smoke test failed — sandbox cannot start
NsJail log output (--log):
NsJail stdout/stderr:
timeout: failed to run command '/usr/sbin/nsjail': No such file or directory
```

---

## 6. Risk Assessment

Risk level:

* [x] Low
* [ ] Medium
* [ ] High

Potential risks:

* A remaining, separate library-loading issue was also observed during
  manual reproduction (`libprotobuf.so.32` missing when the multiarch
  `LD_LIBRARY_PATH` setup wasn't replicated in a simplified manual test) —
  not yet confirmed present or absent in the real, full script path (which
  DOES set that up before nsjail runs). If it recurs, it's a distinct,
  separate follow-up.

Mitigation:

* This fix addresses the confirmed, reproduced root cause (the symlink
  shadowing) precisely; the chart still carries #966's stdout/stderr
  capture, so any further failure remains fully diagnosable from the next
  crash-loop cycle.

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [ ] Refactoring
* [ ] Generating tests
* [x] Drafting documentation
* [ ] Reviewing the diff
* [ ] Not used

Human verification:

* [x] I understand every meaningful change in this PR
* [x] I checked generated code manually
* [ ] I checked generated tests manually
* [x] I removed unsupported AI assumptions
* [x] I accept responsibility for this PR

---

## 8. Reviewer Focus

Please focus your review on:

* [x] Correctness
* [ ] Architecture
* [ ] Security
* [ ] Performance
* [ ] Tests
* [ ] Maintainability
* [ ] Product intent
* [ ] Edge cases
