### PR TITLE
fix(librechat-code-interpreter): bump images to sha-d3b0f05 (mkdir hash-cache fix)

### DIFF
--- a/charts/librechat-code-interpreter/values.yaml
+++ b/charts/librechat-code-interpreter/values.yaml
@@ -113,7 +113,7 @@ codeapi:
         api:
           image:
             repository: ghcr.io/adorsys-gis/code-interpreter-api
-            tag: sha-5d53fcc
+            tag: sha-d3b0f05
             pullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -216,7 +216,7 @@ codeapi:
         service-worker:
           image:
             repository: ghcr.io/adorsys-gis/code-interpreter-worker
-            tag: sha-5d53fcc
+            tag: sha-d3b0f05
             pullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -282,7 +282,7 @@ codeapi:
         sandbox-runner:
           image:
             repository: ghcr.io/adorsys-gis/code-interpreter-sandbox-runner
-            tag: sha-5d53fcc
+            tag: sha-d3b0f05
             pullPolicy: IfNotPresent
           securityContext:
             privileged: false
@@ -387,7 +387,7 @@ codeapi:
         file-server:
           image:
             repository: ghcr.io/adorsys-gis/code-interpreter-file-server
-            tag: sha-5d53fcc
+            tag: sha-d3b0f05
             pullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -450,7 +450,7 @@ codeapi:
         tool-call-server:
           image:
             repository: ghcr.io/adorsys-gis/code-interpreter-tool-call-server
-            tag: sha-5d53fcc
+            tag: sha-d3b0f05
             pullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -499,7 +499,7 @@ codeapi:
         egress-gateway:
           image:
             repository: ghcr.io/adorsys-gis/code-interpreter-egress-gateway
-            tag: sha-5d53fcc
+            tag: sha-d3b0f05
             pullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -592,7 +592,7 @@ codeapi:
         package-init:
           image:
             repository: ghcr.io/adorsys-gis/code-interpreter-package-init
-            tag: sha-5d53fcc
+            tag: sha-d3b0f05
             pullPolicy: IfNotPresent
           env:
             PYTHON_VERSION: "3.14.4"


### PR DESCRIPTION
## 1. Summary

This PR changes:

- Bumps every image tag in `charts/librechat-code-interpreter` from
  `sha-5d53fcc` to `sha-d3b0f05` (all 7 controllers, built from the same
  fork commit).

It solves:

- `codeapi-sandbox-runner` `CrashLoopBackOff` persisting through #967
  (which fixed the `/usr/sbin` symlink-shadowing bug but self-inflicted
  the exact same bash command-hashing bug class it was fixing, for a
  different command). Source of truth: #941, #966, #967,
  [ADORSYS-GIS/code-interpreter@d3b0f05](https://github.com/ADORSYS-GIS/code-interpreter/commit/d3b0f054c90936f3855c8a00169e22786787c2ba).

---

## 2. Intent

> #967 removed the `/usr/sbin -> bin` symlink and recreated it as a real
> directory before binding — but bash's cached resolution of a bare
> `mkdir` (from an earlier `mkdir` call in the same script block, which
> still saw `/usr/sbin` as a valid symlink) goes stale the instant
> `rm /usr/sbin` removes that symlink; the `mkdir` call right after it,
> still using the stale cached path, fails with `bash: line N:
> /usr/sbin/mkdir: No such file or directory`. Fix: `hash -r` between the
> `rm` and the `mkdir`, forcing bash to re-resolve `mkdir` fresh.

---

## 3. Scope

### In Scope

- `charts/librechat-code-interpreter/values.yaml` — bump all 7 image tags
  to `sha-d3b0f05`.

### Out of Scope

- Any other chart values (env vars, ports, probes — verified unchanged via
  `helm template` diff).

---

## 4. Verification

I verified this change by:

- [x] Running automated tests
- [x] Running manual tests
- [x] Checking logs
- [ ] Checking metrics
- [ ] Testing error cases
- [ ] Testing permissions/security behavior
- [ ] Testing rollback or failure behavior, if relevant

Commands run:

```bash
helm lint charts/librechat-code-interpreter --strict
helm template librechat-code-interpreter charts/librechat-code-interpreter --namespace librechat-sandbox
bash -n docker/start-direct-sandbox.sh   # in the fork, before pushing
```

Results:

```text
1 chart(s) linted, 0 chart(s) failed
(render succeeded; only image tags changed vs. the prior render)
outer/inner syntax OK
```

Fork CI (`ADORSYS-GIS/code-interpreter`, commit `d3b0f05`): both `CI` and
`Publish images` workflows passed;
`ghcr.io/adorsys-gis/code-interpreter-sandbox-runner:sha-d3b0f05`
confirmed present via the GHCR packages API.

---

## 5. Screenshots / Evidence

* Logs: `codeapi-sandbox-runner` pod on `hetzner-prod`, running #967's fix:

```text
bash: line 47: /usr/sbin/mkdir: No such file or directory
mount: /usr/sbin: mount point does not exist.
FATAL: cannot bind /usr/sbin
```

---

## 6. Risk Assessment

Risk level:

* [x] Low
* [ ] Medium
* [ ] High

Potential risks:

* Another instance of the same command-hashing bug class elsewhere in the
  script, not yet found.

Mitigation:

* Fork CI passed; the chart still carries #966's stdout/stderr capture,
  so any further failure remains fully diagnosable from the next
  crash-loop cycle.

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [ ] Refactoring
* [ ] Generating tests
* [x] Drafting documentation
* [ ] Reviewing the diff
* [ ] Not used

Human verification:

* [x] I understand every meaningful change in this PR
* [x] I checked generated code manually
* [ ] I checked generated tests manually
* [x] I removed unsupported AI assumptions
* [x] I accept responsibility for this PR

---

## 8. Reviewer Focus

Please focus your review on:

* [x] Correctness
* [ ] Architecture
* [ ] Security
* [ ] Performance
* [ ] Tests
* [ ] Maintainability
* [ ] Product intent
* [ ] Edge cases
