### PR TITLE
style(dashboards): ruff format the two files that have main red since Aug 6

### DIFF
--- a/tools/dashboards/src/dashboards/envoy_ai_gateway/provider_billing.py
+++ b/tools/dashboards/src/dashboards/envoy_ai_gateway/provider_billing.py
@@ -182,10 +182,7 @@ def _panel_last_success() -> object:
     # Guard: `and (gauge > 0)` drops the series while the gauge is still 0
     # (never succeeded), so the panel shows "no data" instead of a bogus
     # ~55-year value (time() - 0 = current Unix epoch).
-    expr = (
-        f"(time() - {METRIC_PROVIDER_LAST_SUCCESS}) "
-        f"and ({METRIC_PROVIDER_LAST_SUCCESS} > 0)"
-    )
+    expr = f"(time() - {METRIC_PROVIDER_LAST_SUCCESS}) and ({METRIC_PROVIDER_LAST_SUCCESS} > 0)"
     return _stat_panel(
         title="Seconds since last successful poll",
         expr=expr,

--- a/tools/dashboards/tests/test_provider_billing_poller.py
+++ b/tools/dashboards/tests/test_provider_billing_poller.py
@@ -192,6 +192,7 @@ def test_fetch_usage_uses_dot_period_format(monkeypatch) -> None:
         captured["url"] = req.full_url
         captured["auth"] = req.get_header("Authorization")
         import io
+
         return io.BytesIO(b'{"months": []}')
 
     monkeypatch.setattr(poller.urllib.request, "urlopen", _fake_urlopen)
@@ -220,8 +221,10 @@ def test_transient_errors() -> None:
 
 def test_poll_returns_transient_on_network_error(monkeypatch) -> None:
     """A network/transient failure is surfaced with permanent=False (retryable)."""
+
     def _raise(api_url, token, from_period, to_period=None):
         raise urllib.error.URLError("no network")
+
     monkeypatch.setattr(poller, "fetch_usage", _raise)
     metrics = poller.Metrics(registry=prometheus_client.CollectorRegistry())
     ok, err, permanent = poller.poll("https://api.deepinfra.com", "tok", ["2026-08"], metrics)
@@ -234,8 +237,10 @@ def test_poll_returns_transient_on_network_error(monkeypatch) -> None:
 
 def test_poll_returns_permanent_on_http_error(monkeypatch) -> None:
     """A bad token (403) is surfaced as permanent so main() logs it loudly."""
+
     def _raise(api_url, token, from_period, to_period=None):
         raise urllib.error.HTTPError(url="u", code=403, msg="Forbidden", hdrs=None, fp=None)
+
     monkeypatch.setattr(poller, "fetch_usage", _raise)
     metrics = poller.Metrics(registry=prometheus_client.CollectorRegistry())
     ok, err, permanent = poller.poll("https://api.deepinfra.com", "tok", ["2026-08"], metrics)
@@ -299,6 +304,13 @@ def test_dashboard_json_matches_generator() -> None:
     compare the query expressions (not the whole dict — the orchestrator in
     main.py additionally injects the report link and schema-version stamp).
     """
-    out = Path(__file__).resolve().parents[3] / "charts" / "observability-dashboards" / "files" / "envoy-ai-gateway" / "provider-billing.json"
+    out = (
+        Path(__file__).resolve().parents[3]
+        / "charts"
+        / "observability-dashboards"
+        / "files"
+        / "envoy-ai-gateway"
+        / "provider-billing.json"
+    )
     committed = json.loads(out.read_text())
     assert sorted(_panel_exprs(committed)) == sorted(_panel_exprs(provider_billing.build()))


### PR DESCRIPTION
## Summary

`Dashboard drift check` has been **failing on `main` since 2026-08-06** at the "Check formatting (ruff)" step. This is the two-file `ruff format` that fixes it.

```
Would reformat: src/dashboards/envoy_ai_gateway/provider_billing.py
Would reformat: tests/test_provider_billing_poller.py
2 files would be reformatted, 24 files already formatted
```

## Evidence it's pre-existing, not from #974

| Run | Result | Date |
|---|---|---|
| [31086822338](https://github.com/ADORSYS-GIS/ai-helm/actions/runs/31086822338) | ✅ last success | 2026-08-06 08:54 |
| [31093246432](https://github.com/ADORSYS-GIS/ai-helm/actions/runs/31093246432) | ❌ | 2026-08-06 |
| [31093758196](https://github.com/ADORSYS-GIS/ai-helm/actions/runs/31093758196) | ❌ | 2026-08-06 |
| [31096910913](https://github.com/ADORSYS-GIS/ai-helm/actions/runs/31096910913) | ❌ | 2026-08-06 |
| [31471821228](https://github.com/ADORSYS-GIS/ai-helm/actions/runs/31471821228) | ❌ | 2026-08-11 (post-#974 merge) |

Same two files every time; the 24 others — including the ones #974 added — are already clean.

## What changed

Pure `uv run ruff format` output, **no hand edits**, entirely cosmetic:

- one f-string joined onto a single line (byte-identical string),
- blank lines after a nested `import` and two nested `def`s,
- a long `Path(...)` expression wrapped across lines (same path).

No behaviour, no query, no dashboard JSON touched.

## Why a separate PR

I hit this in #974 and **reverted it there** rather than bury two unrelated files inside a feature diff — it would have hidden them, and the fix deserves its own reviewable change. Flagged it in that PR's body at the time.

## Verification — the exact commands CI runs

```
uv run ruff format --check .   → 26 files already formatted
uv run ruff check .            → All checks passed!
uv run dashboards check        → ok — every dashboard matches its generator
uv run pytest -q               → 20 passed
```

`dashboards check` and the tests passing is the part that matters: it confirms the reformatting changed nothing semantic.

## AI Usage Declaration

- [x] AI-assisted

Used Claude Code to: notice the failing check after #974 merged, confirm from run history that it predates that PR rather than assuming either way, apply `ruff format`, and verify with the exact CI commands.

Verified manually: read the full diff line by line to confirm every hunk is cosmetic before claiming so, and ran `dashboards check` + the test suite specifically to prove no semantic drift — not just the formatter that produced the change.

- [ ] I have reviewed all AI-generated content and take responsibility for its correctness
- [ ] I have tested/verified this change as described above

🤖 Generated with [Claude Code](https://claude.com/claude-code)
