### PR TITLE
feat(inference): serve qwen3-5-2b at full 256k native context

### DIFF
--- a/charts/ai-models/values.yaml
+++ b/charts/ai-models/values.yaml
@@ -975,7 +975,7 @@ models:
       connectionIdleTimeout: 1h
     info:
       displayName: "Qwen3.5-2B (self-hosted)"
-      contextLength: 131072          # 128k = vLLM --max-model-len (GDN → KV cheap, fleet precedent qwen3-5-4b)
+      contextLength: 262144          # 256k = full native context (model_max_length), = vLLM --max-model-len
       maxOutputTokens: 8192
       supportedParameters: *spStandard
     pricing:

--- a/charts/inference/values.yaml
+++ b/charts/inference/values.yaml
@@ -749,12 +749,13 @@ models:
         revision: 15852e8c16360a2fea060d615a32b45270f8a8fc
         sizeGi: 10
       serving:
-        # 128k initial: matches the fleet's GDN precedent (qwen3-5-4b-local used
-        # contextLength 131072 — linear attention → KV cheap) and the review
-        # conclusion on this PR. Native is 262,144; stretch to 262144 only after
-        # the load-gate VRAM measurement (plan §6.2). >32k avoids the prompt
-        # too-long error loop that 32768 caused for coding workloads.
-        contextSize: 131072
+        # 256k = the model's FULL native context (verified: tokenizer_config
+        # model_max_length 262144). Decision: serve the max window — the hybrid
+        # Gated DeltaNet architecture makes KV nearly free (fleet GDN precedent
+        # qwen3-5-4b-local: "KV cheap"), and agentic clients (OpenCode) need the
+        # headroom. VRAM is confirmed at the load gate (ticket #973); if the
+        # gate shows pressure, drop back to 131072.
+        contextSize: 262144
         parallel: 4
         dtype: bfloat16
         toolCallParser: qwen3_coder


### PR DESCRIPTION
## Summary

- Bumps Qwen3.5-2B's context window from **128k → 256k (262,144)** — the model's **full native context** (verified at source: HF `tokenizer_config.json` `model_max_length: 262144`).
- `charts/inference/values.yaml`: `serving.contextSize: 131072 → 262144` (→ `--max-model-len 262144`)
- `charts/ai-models/values.yaml`: `info.contextLength: 131072 → 262144` (catalog = served window)

## Intent

Serve the model at its maximum native window. The hybrid Gated DeltaNet architecture makes KV nearly free (fleet GDN precedent: `qwen3-5-4b-local` "KV cheap"), and agentic clients (OpenCode) need the headroom — this is the direct follow-up to the context fix from PR #970 and the review conclusion.

## Scope

**In:** the two chart values + comments.
**Out:** no engine/flag changes beyond the window, no pricing changes, no plan/doc changes (tracked in ticket #973).

## Verification

- [x] `./tools/check-model-catalogs.sh` → OK (2 served, 2 federated)
- [x] `helm lint --strict` both charts → 0 failed
- [x] `helm template --dry-run` both charts → OK; rendered `--max-model-len` + `contextLength: 262144` confirmed

```text
$ ./tools/check-model-catalogs.sh
check-model-catalogs: OK (2 served on the GPU fleet, 2 federated cluster-local)

$ helm lint charts/inference --strict
1 chart(s) linted, 0 chart(s) failed

$ helm lint charts/ai-models --strict
1 chart(s) linted, 0 chart(s) failed

$ helm template chk charts/inference --dry-run | grep -A1 max-model-len
- "--max-model-len"
- "262144"
```

## Risk Assessment

**Medium** — VRAM at 256k is unmeasured (the load gate in ticket #973 is the measurement). Mitigation: the DeltaNet architecture keeps KV near-constant; if the gate shows pressure, fall back to 131072 (documented in the chart comment).

## AI Usage Declaration

- [x] Drafting the PR description and commit message (assistant)
- [ ] Generating code — the change is a two-value config bump, reviewed by the human owner

## Reviewer Focus

- Confirm 256k is the intended window (vs keeping 128k until the load gate).
- VRAM risk acceptance for the full native window.
