### PR TITLE
feat(inference): LMCache + vision for qwen3-5-2b

### DIFF
--- a/charts/inference/templates/_helpers.tpl
+++ b/charts/inference/templates/_helpers.tpl
@@ -209,9 +209,9 @@ Output: a YAML list of strings.
          since v0.6, but we pin it EXPLICITLY so a nightly image bump cannot
          silently flip it off. This is the engine-internal prefix cache (GPU KV
          reuse) — NO host-RAM offload. LMCache (`--kv-transfer-config`, opt-in
-         per model via the `lmcache:` block) is a separate, offload-based path
-         and stays OFF for qwen3-5-2b (ADR-0118: unverified on the hybrid Gated
-         DeltaNet architecture; requires kvCacheDtype auto). */ -}}
+         per model via the `lmcache:` block) is a separate, offload-based path,
+         currently ON for qwen3-5-2b (ticket #973) with kvCacheDtype `auto` per
+         ADR-0118 (fp8 + LMCache unverified on the hybrid Gated DeltaNet arch). */ -}}
   {{- $args = concat $args (list "--enable-prefix-caching") -}}
   {{- with $s.quantization -}}
     {{- $args = concat $args (list "--quantization" .) -}}

--- a/charts/inference/templates/_helpers.tpl
+++ b/charts/inference/templates/_helpers.tpl
@@ -205,6 +205,14 @@ Output: a YAML list of strings.
       "--max-model-len" (toString (required "serving.contextSize is required" $s.contextSize))
       "--max-num-seqs" (toString (default 4 $s.parallel))
       "--gpu-memory-utilization" (toString (default 0.90 $s.gpuMemoryUtilization))) -}}
+  {{- /* Prefix caching. vLLM's Automatic Prefix Caching (APC) has been default-ON
+         since v0.6, but we pin it EXPLICITLY so a nightly image bump cannot
+         silently flip it off. This is the engine-internal prefix cache (GPU KV
+         reuse) — NO host-RAM offload. LMCache (`--kv-transfer-config`, opt-in
+         per model via the `lmcache:` block) is a separate, offload-based path
+         and stays OFF for qwen3-5-2b (ADR-0118: unverified on the hybrid Gated
+         DeltaNet architecture; requires kvCacheDtype auto). */ -}}
+  {{- $args = concat $args (list "--enable-prefix-caching") -}}
   {{- with $s.quantization -}}
     {{- $args = concat $args (list "--quantization" .) -}}
   {{- end -}}

--- a/charts/inference/templates/_helpers.tpl
+++ b/charts/inference/templates/_helpers.tpl
@@ -240,6 +240,15 @@ Output: a YAML list of strings.
   {{- with $s.toolCallParser -}}
     {{- $args = concat $args (list "--enable-auto-tool-choice" "--tool-call-parser" .) -}}
   {{- end -}}
+  {{- /* Multimodal (vision) input. vLLM auto-detects the model's vision tower and
+         accepts OpenAI `image_url` content parts natively (fleet precedent
+         qwen3-vl-4b, ADR-0094) — this knob EXPLICITLY caps media per prompt
+         (`--limit-mm-per-prompt`) so a model or image default change cannot
+         silently reject or unbounded-accept images. `image=N` = up to N images
+         per request. */ -}}
+  {{- with $s.limitMmPerPrompt -}}
+    {{- $args = concat $args (list "--limit-mm-per-prompt" .) -}}
+  {{- end -}}
   {{- if .lmcache -}}
     {{- $args = concat $args (list "--kv-transfer-config" "{\"kv_connector\":\"LMCacheConnectorV1\",\"kv_role\":\"kv_both\"}") -}}
   {{- end -}}

--- a/charts/inference/values.yaml
+++ b/charts/inference/values.yaml
@@ -764,6 +764,11 @@ models:
         toolCallParser: qwen3_coder
         kvCacheDtype: auto            # REQUIRED with LMCache (ADR-0118: fp8+LMCache unverified)
         reasoning: "off"              # non-thinking default; clients opt in per request
+        # Multimodal: the model has a vision tower (Qwen3_5ForConditionalGeneration,
+        # same multimodal family as the retired qwen3-vl-4b, ADR-0094). vLLM accepts
+        # OpenAI `image_url` content parts natively; the cap below is explicit so an
+        # image default change cannot silently reject inputs.
+        limitMmPerPrompt: "image=4"   # up to 4 images per request
       lmcache:
         enabled: true                 # KV offload L0 GPU → L1 host RAM for prefix reuse
       resources:

--- a/charts/inference/values.yaml
+++ b/charts/inference/values.yaml
@@ -737,9 +737,12 @@ models:
    # architecture (DeltaNet layers have no classic KV cache). Measure at the
    # load gate, then try fp8_e4m3 (÷2 KV).
    #
-   # ⚠️ LMCache OFF: LMCache serializes KV tensors as stored on the GPU; its
-   # behaviour with the hybrid architecture is UNVERIFIED. Enable only after
-   # measurement (and then kvCacheDtype MUST stay `auto` — ADR-0118).
+   # ⚠️ LMCache ON (decision 2026-08-11, ticket #973): LMCache serializes KV
+   # tensors as stored on the GPU; its behaviour with the hybrid architecture
+   # was UNVERIFIED. Enabled at the owner's request to test prefix reuse;
+   # kvCacheDtype MUST stay `auto` (ADR-0118). The load gate measures
+   # hit-rate/VRAM; if the hybrid arch misbehaves, roll back = delete the
+   # `lmcache:` block.
    qwen3-5-2b:
       enabled: true
       engine: vllm
@@ -759,13 +762,15 @@ models:
         parallel: 4
         dtype: bfloat16
         toolCallParser: qwen3_coder
-        kvCacheDtype: auto            # fp8 unverified on the hybrid architecture
+        kvCacheDtype: auto            # REQUIRED with LMCache (ADR-0118: fp8+LMCache unverified)
         reasoning: "off"              # non-thinking default; clients opt in per request
+      lmcache:
+        enabled: true                 # KV offload L0 GPU → L1 host RAM for prefix reuse
       resources:
-       cpuRequest: "2"
-       cpuLimit: "8"
-       memoryRequest: 8Gi
-       memoryLimit: 16Gi
+        cpuRequest: "2"
+        cpuLimit: "8"
+        memoryRequest: 8Gi
+        memoryLimit: 16Gi             # above LMCACHE_MAX_LOCAL_CPU_SIZE (4 GiB) + vLLM overhead
 
    # ─────────────────────────────────────────────────────────────────────────
    # Z-Image-Turbo — IMAGE GENERATION, served by LocalAI (ADR-0102/0103/0105).


### PR DESCRIPTION
## Summary

Cache + vision enablement for `qwen3-5-2b` (ticket #973), stacked on `feat/qwen3-5-2b-256k-context` (context = max 262144).

Three commits:

1. **`fix(inference): pin --enable-prefix-caching for vLLM`** (`_helpers.tpl`) — APC is default-on since v0.6, but the fleet image is a nightly; pinned explicitly so a bump cannot silently flip it off. Engine-internal GPU KV reuse; LMCache stays a separate opt-in path.

2. **`feat(inference): enable LMCache KV offload for qwen3-5-2b`** (`values.yaml`) — adds the `lmcache:` block → `--kv-transfer-config {"kv_connector":"LMCacheConnectorV1","kv_role":"kv_both"}` (L0 GPU → L1 host RAM prefix reuse). `kvCacheDtype` stays `auto` (ADR-0118: fp8 + LMCache UNVERIFIED — guarded). `memoryLimit: 16Gi` > `LMCACHE_MAX_LOCAL_CPU_SIZE` (4GiB). Rollback = delete the block.

3. **`feat(inference): enable vision input for qwen3-5-2b`** (`values.yaml` + `_helpers.tpl`) — Qwen3.5-2B is multimodal (Qwen3_5ForConditionalGeneration vision tower, same family as the retired qwen3-vl-4b / ADR-0094). New `serving.limitMmPerPrompt` knob → `--limit-mm-per-prompt image=4` (up to 4 images per request), explicit so an image default change cannot silently reject inputs.

## Scope

**In:** the two files above. **Out:** no federation/pricing changes, no llm-d routing (separate decision, ticket #973), no docs (inference-ops benchmark pending the load gate).

## Verification

- [x] YAML parse OK (both charts)
- [x] `helm lint --strict` both charts → 0 failed
- [x] `check-model-catalogs.sh` → OK (2 served, 2 federated)
- [x] Rendered args confirmed: `--max-model-len 262144`, `--enable-prefix-caching`, `--kv-cache-dtype auto`, `--limit-mm-per-prompt image=4`, `--kv-transfer-config` (LMCacheConnectorV1)

```text
$ helm template chk charts/inference --dry-run | grep -A1 -e max-model-len -e kv-cache-dtype -e limit-mm-per-prompt -e kv-transfer-config
- "--max-model-len"
- "262144"
- "--kv-cache-dtype"
- "auto"
- "--limit-mm-per-prompt"
- "image=4"
- "--kv-transfer-config"
- "{\"kv_connector\":\"LMCacheConnectorV1\",\"kv_role\":\"kv_both\"}"

$ ./tools/check-model-catalogs.sh
check-model-catalogs: OK (2 served on the GPU fleet, 2 federated cluster-local)
```

## Risk Assessment

**Medium-High** — LMCache has never been validated on the hybrid Gated DeltaNet architecture (ADR-0118); vision on this model is untested in prod. Mitigations: `kvCacheDtype` stays `auto`; rollback = one-line deletion of the `lmcache:` block (vision = remove `limitMmPerPrompt`); the load gate (ticket #973) measures prefix hit-rate (> 50 %), VRAM, and a real image through `/v1/chat/completions` (the qwen3-vl-4b load-gate protocol).

## Merge order

1. #976 (`feat/qwen3-5-2b-256k-context`) → main
2. This PR → `feat/qwen3-5-2b-256k-context`

## AI Usage Declaration

- [x] Drafting the PR description and commit messages (assistant)
- [ ] Generating code — config bump + one flag pin + one new knob, reviewed by the human owner

## Reviewer Focus

- Accept LMCache-on-hybrid-architecture + vision risk for this model?
- `image=4` cap sane for the coding/agentic workload?
