### PR TITLE
fix(inference): render --limit-mm-per-prompt as JSON

### DIFF
--- a/charts/inference/templates/_helpers.tpl
+++ b/charts/inference/templates/_helpers.tpl
@@ -244,10 +244,12 @@ Output: a YAML list of strings.
          accepts OpenAI `image_url` content parts natively (fleet precedent
          qwen3-vl-4b, ADR-0094) — this knob EXPLICITLY caps media per prompt
          (`--limit-mm-per-prompt`) so a model or image default change cannot
-         silently reject or unbounded-accept images. `image=N` = up to N images
-         per request. */ -}}
+         silently reject or unbounded-accept images. ⚠️ The flag is typed
+         `json.loads`, so the value MUST be a JSON object (e.g. {"image": 4}) —
+         a bare `image=4` is rejected by the parser and crash-loops the pod
+         (same gotcha as --allowed-origins). `toJson` produces the object form. */ -}}
   {{- with $s.limitMmPerPrompt -}}
-    {{- $args = concat $args (list "--limit-mm-per-prompt" .) -}}
+    {{- $args = concat $args (list "--limit-mm-per-prompt" (toJson .)) -}}
   {{- end -}}
   {{- if .lmcache -}}
     {{- $args = concat $args (list "--kv-transfer-config" "{\"kv_connector\":\"LMCacheConnectorV1\",\"kv_role\":\"kv_both\"}") -}}

--- a/charts/inference/values.yaml
+++ b/charts/inference/values.yaml
@@ -767,8 +767,10 @@ models:
         # Multimodal: the model has a vision tower (Qwen3_5ForConditionalGeneration,
         # same multimodal family as the retired qwen3-vl-4b, ADR-0094). vLLM accepts
         # OpenAI `image_url` content parts natively; the cap below is explicit so an
-        # image default change cannot silently reject inputs.
-        limitMmPerPrompt: "image=4"   # up to 4 images per request
+        # image default change cannot silently reject inputs. Rendered as a JSON
+        # object (--limit-mm-per-prompt is typed json.loads).
+        limitMmPerPrompt:
+          image: 4                    # up to 4 images per request
       lmcache:
         enabled: true                 # KV offload L0 GPU → L1 host RAM for prefix reuse
       resources:


### PR DESCRIPTION
## Summary

Hotfix for a production incident (ticket #973): `qwen3-5-2b` pod in **CrashLoopBackOff** (exit 2).

**Root cause:** `--limit-mm-per-prompt image=4` — vLLM types this flag as `json.loads` (the same gotcha as `--allowed-origins`, already documented in `_helpers.tpl`), so a bare `image=4` is rejected at start-up:
```
vllm serve: error: argument --limit-mm-per-prompt: Value image=4 cannot be converted to <function loads at ...>
```

**Fix:** the `serving.limitMmPerPrompt` knob is now a dict rendered via `toJson` → `--limit-mm-per-prompt {"image":4}` (valid JSON object).

## Verification

- [x] YAML parse OK
- [x] `helm lint --strict` → 0 failed
- [x] Rendered arg confirmed: `--limit-mm-per-prompt {"image":4}`

```text
$ helm template chk charts/inference --dry-run | grep -A1 limit-mm-per-prompt
- "--limit-mm-per-prompt"
- "{\"image\":4}"
```

## Risk Assessment

**Low** — restores the intended vision cap (4 images/request) in the JSON form vLLM actually accepts. ArgoCD sync will restart the pod; the load gate (ticket #973) still validates vision + LMCache + hit-rate.

## AI Usage Declaration

- [x] Drafting the PR description and commit message (assistant)
- [ ] Generating code — config/knob fix, reviewed by the human owner

## Reviewer Focus

- Confirm the JSON object form is the correct vLLM `--limit-mm-per-prompt` syntax.
