### PR TITLE
fix(inference): disable LMCache for qwen3-5-2b (hybrid KV manager crash)

### DIFF
--- a/charts/inference/templates/_helpers.tpl
+++ b/charts/inference/templates/_helpers.tpl
@@ -209,9 +209,10 @@ Output: a YAML list of strings.
          since v0.6, but we pin it EXPLICITLY so a nightly image bump cannot
          silently flip it off. This is the engine-internal prefix cache (GPU KV
          reuse) — NO host-RAM offload. LMCache (`--kv-transfer-config`, opt-in
-         per model via the `lmcache:` block) is a separate, offload-based path,
-         currently ON for qwen3-5-2b (ticket #973) with kvCacheDtype `auto` per
-         ADR-0118 (fp8 + LMCache unverified on the hybrid Gated DeltaNet arch). */ -}}
+         per model via the `lmcache:` block) is a separate, offload-based path
+         that is OFF for qwen3-5-2b: it disables vLLM's hybrid KV cache manager,
+         which the hybrid Gated DeltaNet + Mamba architecture requires (verified
+         crash, ticket #973). */ -}}
   {{- $args = concat $args (list "--enable-prefix-caching") -}}
   {{- with $s.quantization -}}
     {{- $args = concat $args (list "--quantization" .) -}}

--- a/charts/inference/values.yaml
+++ b/charts/inference/values.yaml
@@ -737,12 +737,13 @@ models:
    # architecture (DeltaNet layers have no classic KV cache). Measure at the
    # load gate, then try fp8_e4m3 (÷2 KV).
    #
-   # ⚠️ LMCache ON (decision 2026-08-11, ticket #973): LMCache serializes KV
-   # tensors as stored on the GPU; its behaviour with the hybrid architecture
-   # was UNVERIFIED. Enabled at the owner's request to test prefix reuse;
-   # kvCacheDtype MUST stay `auto` (ADR-0118). The load gate measures
-   # hit-rate/VRAM; if the hybrid arch misbehaves, roll back = delete the
-   # `lmcache:` block.
+   # ⚠️ LMCache OFF (verified 2026-08-11, ticket #973): LMCache (`--kv-transfer-config`)
+   # forces vLLM to disable its hybrid KV cache manager, which Qwen3.5-2B's hybrid
+   # Gated DeltaNet + Mamba architecture REQUIRES to unify the attention/mamba KV
+   # cache specs — the engine crashes at KV-cache init ("Hybrid KV cache manager is
+   # disabled but failed to convert the KV cache specs to one unified type"). This is
+   # the ADR-0118 risk confirmed in prod. Prefix reuse is still provided by vLLM's
+   # built-in APC (`--enable-prefix-caching`), which is independent of LMCache.
    qwen3-5-2b:
       enabled: true
       engine: vllm
@@ -762,7 +763,7 @@ models:
         parallel: 4
         dtype: bfloat16
         toolCallParser: qwen3_coder
-        kvCacheDtype: auto            # REQUIRED with LMCache (ADR-0118: fp8+LMCache unverified)
+        kvCacheDtype: auto            # fp8 unverified on the hybrid architecture (ADR-0118)
         reasoning: "off"              # non-thinking default; clients opt in per request
         # Multimodal: the model has a vision tower (Qwen3_5ForConditionalGeneration,
         # same multimodal family as the retired qwen3-vl-4b, ADR-0094). vLLM accepts
@@ -771,13 +772,11 @@ models:
         # object (--limit-mm-per-prompt is typed json.loads).
         limitMmPerPrompt:
           image: 4                    # up to 4 images per request
-      lmcache:
-        enabled: true                 # KV offload L0 GPU → L1 host RAM for prefix reuse
       resources:
         cpuRequest: "2"
         cpuLimit: "8"
         memoryRequest: 8Gi
-        memoryLimit: 16Gi             # above LMCACHE_MAX_LOCAL_CPU_SIZE (4 GiB) + vLLM overhead
+        memoryLimit: 16Gi
 
    # ─────────────────────────────────────────────────────────────────────────
    # Z-Image-Turbo — IMAGE GENERATION, served by LocalAI (ADR-0102/0103/0105).


### PR DESCRIPTION
## Summary

Hotfix for a production incident (ticket #973): `qwen3-5-2b` pod crash-loops at KV-cache init.

**Root cause:** with `--kv-transfer-config` set (LMCache), vLLM disables its **hybrid KV cache manager**, which Qwen3.5-2B's hybrid **Gated DeltaNet + Mamba** architecture requires to unify the attention/mamba KV cache specs. The engine crashes:
```
ValueError: Hybrid KV cache manager is disabled but failed to convert the KV cache specs to one unified type.
```
This confirms the ADR-0118 risk (LMCache unverified/incompatible on the hybrid architecture).

**Fix:** remove the `lmcache:` block from the `qwen3-5-2b` entry. Prefix reuse is still provided by vLLM's built-in APC (`--enable-prefix-caching`), which is independent of LMCache. Vision (`--limit-mm-per-prompt {"image":4}`) and 256k context are unchanged.

## Verification

- [x] YAML parse OK
- [x] `helm lint --strict` → 0 failed
- [x] `--kv-transfer-config` no longer rendered (0 occurrences); `--enable-prefix-caching` + `--limit-mm-per-prompt {"image":4}` still present

```text
$ helm template chk charts/inference --dry-run | grep -c kv-transfer-config
0
$ helm template chk charts/inference --dry-run | grep -A1 -e enable-prefix-caching -e limit-mm-per-prompt
- "--enable-prefix-caching"
- "--limit-mm-per-prompt"
- "{\"image\":4}"
```

## Risk Assessment

**Low** — restores the hybrid KV cache manager the model needs to start. LMCache (host-RAM offload) is lost, but GPU prefix reuse (APC) is retained; the load gate (ticket #973) still validates hit-rate + VRAM + vision.

## AI Usage Declaration

- [x] Drafting the PR description and commit message (assistant)
- [ ] Generating code — config removal, reviewed by the human owner

## Reviewer Focus

- Confirm LMCache is incompatible with the hybrid KV cache manager in this vLLM nightly (ADR-0118).
