### PR TITLE
feat(inference): enable thinking mode for qwen3-5-2b

### DIFF
--- a/charts/inference/values.yaml
+++ b/charts/inference/values.yaml
@@ -764,7 +764,7 @@ models:
         dtype: bfloat16
         toolCallParser: qwen3_coder
         kvCacheDtype: auto            # fp8 unverified on the hybrid architecture (ADR-0118)
-        reasoning: "off"              # non-thinking default; clients opt in per request
+        reasoning: "on"               # thinking enabled by default
         # Multimodal: the model has a vision tower (Qwen3_5ForConditionalGeneration,
         # same multimodal family as the retired qwen3-vl-4b, ADR-0094). vLLM accepts
         # OpenAI `image_url` content parts natively; the cap below is explicit so an


### PR DESCRIPTION
## Summary

Enables **thinking mode** for `qwen3-5-2b` (ticket #973): `serving.reasoning: "off"` → `"on"`, which renders `--default-chat-template-kwargs {"enable_thinking": true}`.

## Scope

**In:** one line in `charts/inference/values.yaml` (the qwen3-5-2b entry only).
**Out:** no `reasoningParser` added, no catalog/`supportedParameters` change, no other model touched — a minimal, single-value change as requested.

## Verification

- [x] YAML parse OK
- [x] `helm lint --strict` → 0 failed
- [x] Rendered arg: `--default-chat-template-kwargs {"enable_thinking": true}`
- [x] No `--reasoning-parser` added (minimal change)

```text
$ helm template chk charts/inference --dry-run | grep -A1 default-chat-template-kwargs
- "--default-chat-template-kwargs"
- "{\"enable_thinking\": true}"
```

## Risk Assessment

**Medium** — Qwen3.5-2B is documented as prone to thinking loops (model card), and without a `reasoningParser` the thinking trace lands in `content` rather than `reasoning_content`. This is the minimal change requested; adding `reasoningParser: qwen3` and advertising `reasoning` in the catalog are separate follow-ups (tracked in ticket #973).

## AI Usage Declaration

- [x] Drafting the PR description and commit message (assistant)
- [ ] Generating code — one-value config change, reviewed by the human owner

## Reviewer Focus

- Confirm thinking-on-by-default is intended for this coding model.
- Note the missing `reasoningParser` consequence (trace in `content`) — acceptable for now?
