### PR TITLE
fix(webank-training): disable ungated dataset-build publish by default

### DIFF
--- a/charts/webank-training/ci/lint-values.yaml
+++ b/charts/webank-training/ci/lint-values.yaml
@@ -20,6 +20,10 @@ models:
   - id: document-detector
     trainer: document-detector
     datasetBuild:
+      # Only model kept `enabled: true` in this CI fixture so `helm
+      # template`/`helm lint` still render-cover the dataset-build
+      # WorkflowTemplate branch itself, not just its default-off state.
+      enabled: true
       target:
         repository: ds-document-detector
         branch: main

--- a/charts/webank-training/templates/workflowtemplate.yaml
+++ b/charts/webank-training/templates/workflowtemplate.yaml
@@ -22,6 +22,19 @@
 {{- $id := required "webank-training: models[].id is required" $model.id -}}
 {{- $trainer := required (printf "webank-training: %s trainer is required" $id) $model.trainer -}}
 {{- $datasetBuild := required (printf "webank-training: %s datasetBuild is required" $id) $model.datasetBuild -}}
+{{- /*
+Interim governance gate (webank-models issue #482, ADR-0046): every
+dataset-build publish call in this template lacks a readiness-gate step
+because dataset-build produces none of the /workspace/governance/* evidence
+the gate needs to check. Until each dataset has a source manifest and a
+readiness attestation, its WorkflowTemplate must not exist in the cluster, so
+it cannot be `argo submit`-able. Default OFF and safe: an entry that omits
+`datasetBuild.enabled` renders no `<id>-dataset-build` WorkflowTemplate at
+all. Flip to `true` per model only once that model's dataset-build path can
+satisfy the gate; this does not touch the *-train templates, which are
+already gated.
+*/ -}}
+{{- $datasetBuildEnabled := $datasetBuild.enabled | default false -}}
 {{- $datasetTarget := required (printf "webank-training: %s datasetBuild.target is required" $id) $datasetBuild.target -}}
 {{- $datasetSource := required (printf "webank-training: %s datasetBuild.source is required" $id) $datasetBuild.source -}}
 {{- $sourceStrategy := required (printf "webank-training: %s datasetBuild.source.strategy is required" $id) $datasetSource.strategy -}}
@@ -54,6 +67,7 @@
 {{- if or (eq $sourceRepository $datasetTargetRepository) (eq $sourceRepository $candidateRepository) }}{{ fail (printf "webank-training: %s governed source repository must be distinct from its targets" $id) }}{{- end }}
 {{- end }}
 {{- if not (has $trainer (list "document-detector" "document-recognizer" "face-detector" "sface" "pad-liveness-pending")) }}{{ fail (printf "webank-training: %s has an unknown trainer" $id) }}{{- end }}
+{{- if $datasetBuildEnabled }}
 ---
 apiVersion: argoproj.io/v1alpha1
 kind: WorkflowTemplate
@@ -231,6 +245,7 @@ spec:
             mountPath: /workspace
         resources:
           {{- toYaml $training.datasetBuild.resources | nindent 10 }}
+{{- end }}
 ---
 apiVersion: argoproj.io/v1alpha1
 kind: WorkflowTemplate

--- a/charts/webank-training/values.yaml
+++ b/charts/webank-training/values.yaml
@@ -122,8 +122,20 @@ training:
     learningRate: 0.001
     shrinkRatio: 0.6
 
-# One entry produces exactly two public WorkflowTemplates: `<id>-dataset-build`
-# and `<id>-train`. `datasetBuild` selects one closed source strategy and fixes
-# its target route; `lakefs` retains the fixed training input/candidate routes.
-# Values never provide executable shell text.
+# One entry produces up to two public WorkflowTemplates: `<id>-dataset-build`
+# (only when `datasetBuild.enabled: true`) and `<id>-train`. `datasetBuild`
+# selects one closed source strategy and fixes its target route; `lakefs`
+# retains the fixed training input/candidate routes. Values never provide
+# executable shell text.
+#
+# `datasetBuild.enabled` (bool, default `false` when omitted): interim
+# governance gate (webank-models issue #482, ADR-0046). No dataset-build
+# publish call in templates/workflowtemplate.yaml is preceded by a
+# readiness-gate step, because dataset-build produces none of the
+# /workspace/governance/* evidence the gate needs — unlike `<id>-train`,
+# which already enforces it. Until a model's dataset has a source manifest
+# and readiness attestation, leave this unset/false so its
+# `<id>-dataset-build` WorkflowTemplate does not exist in the cluster at all
+# and cannot be `argo submit`-able. Flip to `true` per model only once that
+# gate can be satisfied.
 models: []

--- a/docs/playbooks/webank-model-workflows.md
+++ b/docs/playbooks/webank-model-workflows.md
@@ -17,6 +17,18 @@ There is one template of each kind for document detector, document recognizer,
 face detector, SFace, and PAD liveness. Do not choose a different entrypoint:
 the displayed `build` or `train` entrypoint is fixed by the selected template.
 
+> **All five `webank-<model>-dataset-build` templates are currently disabled**
+> (`datasetBuild.enabled` unset/`false` in `ai-helm-values`) and will not
+> appear in the Argo Workflows dashboard. None of their publish calls is
+> preceded by a `readiness-gate` step — dataset-build produces none of the
+> `/workspace/governance/*` evidence that gate needs — so, per webank-models
+> [ADR-0046](https://github.com/ADORSYS-GIS/webank-models/blob/main/docs/adr/0046-fixed-dataset-publish-governance-gate.md)
+> and issue [#482](https://github.com/ADORSYS-GIS/webank-models/issues/482),
+> they must not be able to publish ungoverned data. `*-train` is unaffected
+> and already enforces the gate. Re-enabling a given model's dataset-build
+> template is gated on that model having a source manifest and a readiness
+> attestation.
+
 Each template's LakeFS routes are fixed in reviewed `ai-helm-values`, not in
 the Argo form. Dataset builds use `ds-<model>/main`; training candidates use
 `model-<model>/main`. Every Dataset Build target may be created from its


### PR DESCRIPTION
## 1. Summary

This PR changes:

- Adds a per-model `datasetBuild.enabled` toggle (bool, default `false` when
  omitted) in `charts/webank-training` that gates whether the
  `webank-<model>-dataset-build` WorkflowTemplate renders at all.
- No existing model entry sets `datasetBuild.enabled`, so merging this PR
  alone — no companion `ai-helm-values` change required — removes all five
  `webank-<model>-dataset-build` WorkflowTemplate objects
  (document-detector, document-recognizer, face-detector, sface,
  pad-liveness) from the next ArgoCD sync in namespace `mlops` on
  `hetzner-prod`.
- `webank-<model>-train` templates are completely untouched and remain
  unconditional.
- Updates `charts/webank-training/ci/lint-values.yaml` so CI still
  render-covers the `enabled: true` branch (not just the new default-off
  state), and `docs/playbooks/webank-model-workflows.md` so operators
  aren't surprised the templates no longer appear in the dashboard.

It solves:

- webank-models issue [#482](https://github.com/ADORSYS-GIS/webank-models/issues/482)
- Binding requirement in webank-models
  [ADR-0046](https://github.com/ADORSYS-GIS/webank-models/blob/main/docs/adr/0046-fixed-dataset-publish-governance-gate.md):
  no dataset-build DAG may reach a publish step without a `readiness-gate`
  task first.

---

## 2. Intent

**This is an interim, reversible governance fix, not a permanent removal.**

`charts/webank-training/templates/workflowtemplate.yaml` renders five
`webank-<model>-dataset-build` WorkflowTemplates. I verified (read-only
`kubectl get workflowtemplate`) all ten template names exist live on
`hetzner-prod`, namespace `mlops`, chart `webank-training-0.2.21`, and that
every `fixed-dataset publish` call site in the dataset-build branch of this
template passes exactly:

```
--model --bundle --lakefs-branch --lakefs-endpoint --lakefs-repository --lakefs-storage-namespace
```

— **no `--manifest`, no `--readiness`, no `--lakefs-ref`, and no
`readiness-gate` step anywhere in the dataset-build branch.** They publish to
LakeFS ungated and are `argo submit`-able right now.

By contrast the **training** path in the same file *is* gated: a separate
`cargo xtask training-data readiness-gate --manifest … --lakefs-ref …
--readiness …` step precedes training (lines 344, 360, 376 pre-change) for
document-recognizer/face-detector/sface, and `document-detector` sources
`/workspace/document-detector/governance/lineage.env` written by
`checkout-document-detector`, which runs the same gate internally. The chart
already implements gate-as-DAG-step correctly for training and simply omits
it for dataset builds.

**Why disable rather than add the gate directly:** dataset-build steps
produce none of the `/workspace/governance/*` artifacts a `readiness-gate`
step needs to check — that directory is populated only on the candidate/train
path. Adding a gate step today would give it nothing to check. MIDV-2020
cannot produce qualifying evidence today, and `sface`/`pad-liveness` have no
governed source repository at all. So the templates cannot be made compliant
right now; the honest interim is to disable them so they cannot publish
ungoverned data into the registry of record.

**Why a values-level toggle rather than deleting the template blocks:** a
toggle is reversible in one line (`datasetBuild.enabled: true`) once a given
model's dataset actually has a source manifest and readiness attestation. A
deletion would have to be rewritten from scratch. The chart already uses this
exact `enabled` convention elsewhere (`children: [{name, chartPath,
syncWave, enabled}]`, see `CONTRIBUTING.md`'s orchestrator-plus-leaves
pattern), so this isn't new machinery.

---

## 3. Scope

### In Scope

- `charts/webank-training/templates/workflowtemplate.yaml`: wrap the
  `<id>-dataset-build` `WorkflowTemplate` manifest in
  `{{- if $datasetBuildEnabled }}` / `{{- end }}`, where
  `$datasetBuildEnabled := $datasetBuild.enabled | default false`.
- `charts/webank-training/values.yaml`: document the new field.
- `charts/webank-training/ci/lint-values.yaml`: exercise both the enabled and
  default-off render branches.
- `docs/playbooks/webank-model-workflows.md`: note the current disabled
  state for operators.

### Out of Scope

- `webank-<model>-train` templates — untouched, already gated.
- Adding a real `readiness-gate` step to dataset-build — not possible yet
  (see Intent); tracked by re-enabling per model once each has governance
  evidence.
- Any `ai-helm-values` change — not required for this PR to take effect,
  since no existing model entry sets the new field and the default is
  `false`.
- Chart version bump — this repo's `release-please` derives it from
  Conventional Commit type on merge (see `CONTRIBUTING.md`); not hand-edited
  here.

---

## 4. Verification

I verified this change by:

- [x] Running automated tests
- [x] Running manual tests
- [ ] Checking logs
- [ ] Checking metrics
- [ ] Testing error cases
- [x] Testing permissions/security behavior
- [x] Testing rollback or failure behavior, if relevant

Commands run:

```bash
cd charts/webank-training
helm dependency update .
helm lint . --strict -f ci/lint-values.yaml
helm template webank-training . -f ci/lint-values.yaml --dry-run
# second render with a synthetic single-model values file that never sets
# datasetBuild.enabled at all (the real-world default state)
helm template webank-training . -f <all-default-values> --dry-run
./tools/commit-lint.sh --file <this commit's message>
```

Results:

```text
helm lint: 1 chart(s) linted, 0 chart(s) failed
helm template (ci/lint-values.yaml, document-detector has enabled: true):
  renders exactly 1 dataset-build WorkflowTemplate (webank-document-detector-dataset-build)
  + 5 train WorkflowTemplates (document-detector, document-recognizer,
    face-detector, sface, pad-liveness) — all unconditional, unaffected.
helm template (no model sets datasetBuild.enabled — the real hetzner-prod
  state today, since the field is new):
  renders 0 dataset-build WorkflowTemplates + that model's train template only.
commit-lint.sh: exit 0
```

I also confirmed, read-only, that no `Workflow` objects currently exist for
any of the five (`kubectl get workflows -A` returned none) — disabling
interrupts nothing in flight. This is *consistent with*, not *proof of*,
never having run: post-outage GC would look identical.

I did **not** run `kubectl apply`, `helm upgrade`, or `argocd sync` against
`hetzner-prod` at any point — every check above was read-only
(`kubectl get`) or local (`helm lint`/`helm template`).

---

## 5. Screenshots / Evidence

* Rendered manifests (local `helm template` output, not applied): described
  above, available on request.

---

## 6. Risk Assessment

Risk level:

* [x] Low

Potential risks:

* An operator or automation was relying on submitting one of these five
  templates directly (bypassing the intended workflow). Mitigated: verified
  no in-flight `Workflow` objects exist for any of the five.
* `ai-helm-values` might already carry a conflicting `datasetBuild.enabled`
  value I couldn't see (that repo isn't touched by this PR). Mitigated: the
  field is new — no prior commit could have set it — so every existing model
  entry falls through to the new `false` default.

Mitigation:

* The change is a one-line-per-model, values-only toggle — re-enabling any
  single model takes one PR touching only `ai-helm-values`, no chart change.
* `*-train` — the only templates that can currently reach a governed
  publish — is completely untouched.

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [x] Drafting documentation
* [x] Reviewing the diff

Human verification:

* [ ] I understand every meaningful change in this PR
* [ ] I checked generated code manually
* [ ] I checked generated tests manually
* [ ] I removed unsupported AI assumptions
* [ ] I accept responsibility for this PR

---

## 8. Reviewer Focus

Please focus your review on:

* [x] Correctness
* [x] Security
* [x] Product intent
* [x] Edge cases

Specifically: please confirm whether `ai-helm-values` needs a companion
change, or whether (as verified above) the new field's absence there is
sufficient to disable all five templates on the next sync.
