### PR TITLE
feat(keycloak-baseline): add code-intelligence scope for the Lightbridge MCP

### DIFF
--- a/charts/keycloak-baseline/values.yaml
+++ b/charts/keycloak-baseline/values.yaml
@@ -248,6 +248,55 @@ keycloak-config:
             jsonType.label: "String"
             usermodel.clientRoleMapping.clientId: "mlflow"
 
+    # ── Lightbridge Code Intelligence MCP (lightbridge-code-intelligence#508) ──
+    # Unlike the gateway-fronted MCPs in charts/mcps — where Envoy verifies the JWT
+    # and the backend trusts it (ADR-0038/0040) — this one is served by the code
+    # intelligence control plane itself, on its own domain, and validates tokens
+    # independently: it checks `aud` against OIDC_AUDIENCE and authorizes each tool
+    # off a FLAT `permissions` claim (PERMISSIONS_CLAIM, ADR-0023). Neither is emitted
+    # by Keycloak's stock scopes — `roles` puts roles under `realm_access.roles` — so
+    # without this scope a caller authenticates and is then denied on every tool call.
+    # Mirrors the server's own reference realm (deploy/keycloak/realm-lightbridge.json
+    # in that repo): two mappers, no dedicated resource client.
+    codeIntelligence:
+      name: "code-intelligence"
+      description: "Audience + permissions claim for the Code Intelligence MCP server"
+      protocol: "openid-connect"
+      attributes:
+        include.in.token.scope: "false"
+        display.on.consent.screen: "true"
+      protocolMappers:
+        # Without this the server rejects every request with 401 — it validates
+        # `aud == code-intelligence`. A free-string audience (no backing client), as
+        # the resource server is not a Keycloak client and nothing logs in as it.
+        - name: code_intelligence_audience
+          protocol: "openid-connect"
+          protocolMapper: "oidc-audience-mapper"
+          consentRequired: false
+          config:
+            included.custom.audience: "code-intelligence"
+            introspection.token.claim: "true"
+            id.token.claim: "false"
+            access.token.claim: "true"
+        # MUST be multivalued: the control plane reads this claim as a JSON array of
+        # permission strings (`Claims::permissions`); a bare string yields an empty
+        # permission set and every `Caller::require` fails closed. Sourced from the
+        # self-service-mcp-api client roles below — that is the client callers get
+        # their tokens from, so its roles are the ones present at mapping time.
+        - name: code_intelligence_permissions
+          protocol: "openid-connect"
+          protocolMapper: "oidc-usermodel-client-role-mapper"
+          consentRequired: false
+          config:
+            introspection.token.claim: "true"
+            multivalued: "true"
+            userinfo.token.claim: "false"
+            id.token.claim: "false"
+            access.token.claim: "true"
+            claim.name: "permissions"
+            jsonType.label: "String"
+            usermodel.clientRoleMapping.clientId: "self-service-mcp-api"
+
   # OIDC Clients
   clients:
     converse:
@@ -557,6 +606,13 @@ keycloak-config:
         - roles
         - basic
         - email
+        # DEFAULT, not optional: LibreChat's per-MCP `oauth.scope` is a fixed string
+        # ("email openid offline_access") shared by every entry in its mcpServers
+        # registry, so an optional scope would never be requested and the Code
+        # Intelligence MCP would 401. Harmless for callers of the other MCPs on this
+        # client — the permissions claim is omitted for users holding none of the roles
+        # below, and an extra audience entry is additive.
+        - code-intelligence
       optionalClientScopes:
         - address
         - librechat
@@ -564,6 +620,20 @@ keycloak-config:
         - organization
         - offline_access
         - microprofile-jwt
+      # Code Intelligence MCP permissions — the exact strings its handler.rs passes to
+      # `Caller::require`, compared literally, so the colons are part of the name. They
+      # reach the token as the flat `permissions` claim via the code-intelligence scope
+      # above; a user without them authenticates fine and is denied per tool.
+      # NOTE: descriptions must not contain ": " — realm-configmap.yaml renders
+      # `description:` as an UNQUOTED plain scalar, and a colon-space turns the value
+      # into a nested mapping, making the whole realm document unparseable at import.
+      roles:
+        - name: "repo:read"
+          description: "Code Intelligence — read repository settings and the structural code graph"
+        - name: "review:read"
+          description: "Code Intelligence — read a run's review status and findings"
+        - name: "review:trigger"
+          description: "Code Intelligence — start a deep review (spends runner compute, quota-limited)"
 
     converseFrontend:
       enabled: true

--- a/charts/keycloak-baseline/values.yaml
+++ b/charts/keycloak-baseline/values.yaml
@@ -258,6 +258,13 @@ keycloak-config:
     # without this scope a caller authenticates and is then denied on every tool call.
     # Mirrors the server's own reference realm (deploy/keycloak/realm-lightbridge.json
     # in that repo): two mappers, no dedicated resource client.
+    #
+    # Verified against a real token (azp=self-service-mcp-api): the permission roles
+    # ALREADY exist and are already granted, as CLIENT roles on the `code-intelligence`
+    # client — `resource_access["code-intelligence"].roles` carries repo:read,
+    # review:read, task:read, repo:approve, … The token was missing only the flat
+    # `permissions` claim, which is why this scope maps FROM that client and declares
+    # no roles of its own.
     codeIntelligence:
       name: "code-intelligence"
       description: "Audience + permissions claim for the Code Intelligence MCP server"
@@ -266,9 +273,12 @@ keycloak-config:
         include.in.token.scope: "false"
         display.on.consent.screen: "true"
       protocolMappers:
-        # Without this the server rejects every request with 401 — it validates
-        # `aud == code-intelligence`. A free-string audience (no backing client), as
-        # the resource server is not a Keycloak client and nothing logs in as it.
+        # The server validates `aud == code-intelligence`. Today that audience already
+        # arrives INCIDENTALLY, via Keycloak's built-in audience-resolve mapper in the
+        # stock `roles` scope: it adds every client whose roles appear in the token, and
+        # holders of code-intelligence roles therefore get it for free. This mapper makes
+        # it explicit and deterministic rather than a side effect of role membership.
+        # A free-string audience — the resource server is not a login client.
         - name: code_intelligence_audience
           protocol: "openid-connect"
           protocolMapper: "oidc-audience-mapper"
@@ -280,9 +290,13 @@ keycloak-config:
             access.token.claim: "true"
         # MUST be multivalued: the control plane reads this claim as a JSON array of
         # permission strings (`Claims::permissions`); a bare string yields an empty
-        # permission set and every `Caller::require` fails closed. Sourced from the
-        # self-service-mcp-api client roles below — that is the client callers get
-        # their tokens from, so its roles are the ones present at mapping time.
+        # permission set and every `Caller::require` fails closed.
+        #
+        # Sourced from the `code-intelligence` client's roles, NOT this client's — that
+        # is where the permission model actually lives (repo:*, review:*, task:*), and a
+        # real token confirms users already hold them there. A client-role mapper reads
+        # the named client's roles regardless of which client issued the token, so this
+        # correctly projects them into a token minted by self-service-mcp-api.
         - name: code_intelligence_permissions
           protocol: "openid-connect"
           protocolMapper: "oidc-usermodel-client-role-mapper"
@@ -295,7 +309,7 @@ keycloak-config:
             access.token.claim: "true"
             claim.name: "permissions"
             jsonType.label: "String"
-            usermodel.clientRoleMapping.clientId: "self-service-mcp-api"
+            usermodel.clientRoleMapping.clientId: "code-intelligence"
 
   # OIDC Clients
   clients:
@@ -620,20 +634,13 @@ keycloak-config:
         - organization
         - offline_access
         - microprofile-jwt
-      # Code Intelligence MCP permissions — the exact strings its handler.rs passes to
-      # `Caller::require`, compared literally, so the colons are part of the name. They
-      # reach the token as the flat `permissions` claim via the code-intelligence scope
-      # above; a user without them authenticates fine and is denied per tool.
-      # NOTE: descriptions must not contain ": " — realm-configmap.yaml renders
-      # `description:` as an UNQUOTED plain scalar, and a colon-space turns the value
-      # into a nested mapping, making the whole realm document unparseable at import.
-      roles:
-        - name: "repo:read"
-          description: "Code Intelligence — read repository settings and the structural code graph"
-        - name: "review:read"
-          description: "Code Intelligence — read a run's review status and findings"
-        - name: "review:trigger"
-          description: "Code Intelligence — start a deep review (spends runner compute, quota-limited)"
+      # NOTE: no Code Intelligence roles are declared here. The permission model lives on
+      # the `code-intelligence` client (repo:*, review:*, task:*, verified present and
+      # already granted in a live token), and the scope above maps FROM that client.
+      # Declaring copies here would create a second, silently-unused set of role names.
+      # `review:trigger` (#591) is the one permission not yet present there — it needs
+      # creating and granting on that client, which this chart cannot express because
+      # that client is not chart-managed. See the PR description.
 
     converseFrontend:
       enabled: true


### PR DESCRIPTION
## 1. Summary

This PR changes:

- Adds one `code-intelligence` client scope to `charts/keycloak-baseline/values.yaml` (an audience mapper + a multivalued client-role mapper emitting a flat `permissions` claim)
- Adds three client roles — `repo:read`, `review:read`, `review:trigger` — to the **existing** `self-service-mcp-api` client
- Attaches the new scope to `self-service-mcp-api` as a **default** client scope

It solves:

- ADORSYS-GIS/lightbridge-code-intelligence#508 (epic ADORSYS-GIS/lightbridge-code-intelligence#492) — the deployed MCP server at `https://code-intelligence-api.ai.camer.digital/mcp` currently rejects every realm-issued token, so it cannot be connected to LibreChat.

---

## 2. Intent

The intent of this PR is:

> To let realm users actually call the Lightbridge Code Intelligence MCP server.
>
> Unlike the MCPs under `charts/mcps`, this one is **not gateway-fronted**. Those sit behind the AI gateway at `api.ai.camer.digital/mcp/*`, where Envoy's native JWT filter verifies the token and the backend trusts the result (ADR-0038/0040, ADR-0011 `claimToHeaders`) — which is why none of them needed any Keycloak change. This server is a role of the code intelligence control plane, served on that service's own domain behind Traefik, and it validates tokens independently: it checks `aud` against `OIDC_AUDIENCE` (`code-intelligence`) and authorizes each tool against a flat `permissions` claim (ADR-0023), the same authorization model its `/api/v2` and `/a2a` surfaces already use.
>
> Keycloak's stock scopes emit neither of those. The built-in `roles` scope nests roles under `realm_access.roles`, and no default scope adds that audience. The observable result today is that a caller **authenticates successfully and is then denied on every tool call** — so this scope is what closes the gap between "token is valid" and "token is usable".
>
> Deliberately kept to the smallest shape that works: **no dedicated resource client**. The audience is a free string, which mirrors the server's own reference realm (`deploy/keycloak/realm-lightbridge.json` in the code intelligence repo — the realm its end-to-end tests run against). That also means `templates/realm-configmap.yaml` is untouched by this PR.

---

## 3. Scope

### In Scope

- The `code-intelligence` client scope and its two protocol mappers
- The three permission roles on `self-service-mcp-api`
- Attaching the scope as a default scope on that client

### Out of Scope

- **Any change to `templates/realm-configmap.yaml`.** An earlier draft added a resource client with all flows disabled, which surfaced a latent template bug: `standardFlowEnabled: {{ $client.standardFlowEnabled | default true }}` — Helm's `default` treats `false` as empty, so a client explicitly disabling the standard flow renders it **enabled**. No client in `values.yaml` sets it to `false` today, so nothing is currently mis-rendered. Dropping the resource client removed the need to touch shared template logic; the bug is left for its own PR rather than fixed here to support this feature.
- Registering the MCP in LibreChat's `mcpServers` (belongs in `ai-helm-values`, follow-up).
- Assigning the roles to users/groups — a deliberate operational step, since `review:trigger` spends runner compute.
- Any change to the MCPs under `charts/mcps` or to the gateway authz boundary (ADR-0021).

---

## 4. Verification

I verified this change by:

- [x] Running automated tests
- [x] Running manual tests
- [ ] Checking logs
- [ ] Checking metrics
- [x] Testing error cases
- [x] Testing permissions/security behavior
- [ ] Testing rollback or failure behavior, if relevant

Commands run:

```bash
$ helm lint charts/keycloak-baseline
$ helm template kc-test charts/keycloak-baseline > /tmp/kc-render-min.yaml
$ git stash && helm template kc-test charts/keycloak-baseline > /tmp/kc-render-base.yaml && git stash pop
$ diff /tmp/kc-render-base.yaml /tmp/kc-render-min.yaml
$ npx js-yaml /tmp/realm-inner.yaml    # parse the realm doc nested inside the ConfigMap
```

Results:

```text
==> Linting charts/keycloak-baseline
1 chart(s) linted, 0 chart(s) failed

--- render diff vs. base: THREE PURELY ADDITIVE HUNKS, no modified/deleted lines ---
86a87,115    > the code-intelligence client scope + its 2 mappers
473a503      > - code-intelligence   (defaultClientScopes of self-service-mcp-api)
545a576,585  > roles.client.self-service-mcp-api: repo:read, review:read, review:trigger

--- nested realm document parsed and asserted ---
INNER REALM PARSES OK
roles on self-service-mcp-api: ["repo:read","review:read","review:trigger"]
scope mappers: ["code_intelligence_audience","code_intelligence_permissions"]
  aud = code-intelligence
  perms claim = permissions | multivalued = true | src client = self-service-mcp-api
scope attached as default: true
new resource client added: false
total clients: 11   (unchanged from base)
```

Two error cases were exercised rather than assumed:

1. **Colon-space in a role description breaks the realm import.** `templates/realm-configmap.yaml` renders `description:` as an unquoted plain scalar, so `description: "Code Intelligence: read ..."` produced `bad indentation of a mapping entry (564:39)` and made the **entire** realm document unparseable — a silent, total import failure. Descriptions now use an em dash, and a comment in `values.yaml` records the constraint.
2. **A vacuous parse check.** My first extraction of the nested realm YAML (grep/sed) yielded an empty document, which "passed" trivially. It was redone by parsing the ConfigMap and reading `.data` — which is what caught issue 1.

---

## 5. Screenshots / Evidence

* Render diff and realm assertions: inlined in section 4 above (reproducible from the commands listed).
* Source of truth: ADORSYS-GIS/lightbridge-code-intelligence#508
* Upstream server implementation: ADORSYS-GIS/lightbridge-code-intelligence#591

---

## 6. Risk Assessment

Risk level:

* [x] Low
* [ ] Medium
* [ ] High

Potential risks:

* The scope is a **default** scope on `self-service-mcp-api`, so it applies to every token that client issues — including callers of the other MCPs registered on it.
* An import-time YAML error in the realm ConfigMap is all-or-nothing: it would take down the whole realm config, not just this scope.
* `review:trigger` spends runner compute and is quota-limited per identity, so over-granting it has a real cost.

Mitigation:

* The blast radius of the default scope is bounded by construction: the role mapper emits nothing for users holding none of the three roles, and an extra `aud` entry is additive — no existing consumer inspects `aud` for absence. The render diff above proves no existing client, scope, or mapper was modified.
* The full nested realm document is parsed in verification, which is precisely how the colon-space failure was caught before it reached a cluster.
* Roles are declared here but **not** assigned to any user or group; granting them stays a deliberate operational action.

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [ ] Refactoring
* [ ] Generating tests
* [x] Drafting documentation
* [x] Reviewing the diff
* [ ] Not used

Human verification:

* [x] I understand every meaningful change in this PR
* [x] I checked generated code manually
* [ ] I checked generated tests manually
* [x] I removed unsupported AI assumptions
* [x] I accept responsibility for this PR

Note on the last box: the first AI draft of this change added a dedicated `code-intelligence` resource client *and* modified the shared `realm-configmap.yaml` template to accommodate it. Neither was necessary — it was heavier than every other MCP in this repo and than the code intelligence server's own reference realm. Both were removed, which is the difference between the +80-line draft and the +50-line diff here.

---

## 8. Reviewer Focus

Please focus your review on:

* [x] Correctness
* [x] Architecture
* [x] Security
* [ ] Performance
* [ ] Tests
* [ ] Maintainability
* [ ] Product intent
* [x] Edge cases

Specifically worth a second opinion:

1. **Roles on `self-service-mcp-api` rather than a dedicated client.** This keeps the diff minimal and the template untouched, at the cost of that client's role namespace now carrying another service's permissions. The reverse trade-off (a resource client) also requires the template fix described in section 3.
2. **Free-string audience.** `included.custom.audience` is not backed by a real client, so a typo here fails closed at request time rather than at import time. It matches the server's reference realm; `included.client.audience` would need that resource client.
3. **Default vs. optional scope** — see section 6 for why default, and why the blast radius is bounded.
