### PR TITLE
feat(webank-training): gate dataset-build publish on a real readiness-gate step

### DIFF
--- a/charts/webank-training/ci/lint-values.yaml
+++ b/charts/webank-training/ci/lint-values.yaml
@@ -20,9 +20,12 @@ models:
   - id: document-detector
     trainer: document-detector
     datasetBuild:
-      # Only model kept `enabled: true` in this CI fixture so `helm
-      # template`/`helm lint` still render-cover the dataset-build
-      # WorkflowTemplate branch itself, not just its default-off state.
+      # All three hermetic-synthetic models are kept `enabled: true` in this
+      # CI fixture (matching production, ai-helm-values
+      # environments/prod/values/webank-training.yaml) so `helm
+      # template`/`helm lint` render-cover every dataset-build
+      # WorkflowTemplate branch, including each one's readiness-gate step,
+      # not just document-detector's.
       enabled: true
       target:
         repository: ds-document-detector
@@ -38,6 +41,7 @@ models:
   - id: document-recognizer
     trainer: document-recognizer
     datasetBuild:
+      enabled: true
       target:
         repository: ds-document-recognizer
         branch: main
@@ -49,6 +53,7 @@ models:
   - id: face-detector
     trainer: face-detector
     datasetBuild:
+      enabled: true
       target:
         repository: ds-face-detector
         branch: main

--- a/charts/webank-training/templates/workflowtemplate.yaml
+++ b/charts/webank-training/templates/workflowtemplate.yaml
@@ -23,16 +23,21 @@
 {{- $trainer := required (printf "webank-training: %s trainer is required" $id) $model.trainer -}}
 {{- $datasetBuild := required (printf "webank-training: %s datasetBuild is required" $id) $model.datasetBuild -}}
 {{- /*
-Interim governance gate (webank-models issue #482, ADR-0046): every
-dataset-build publish call in this template lacks a readiness-gate step
-because dataset-build produces none of the /workspace/governance/* evidence
-the gate needs to check. Until each dataset has a source manifest and a
-readiness attestation, its WorkflowTemplate must not exist in the cluster, so
-it cannot be `argo submit`-able. Default OFF and safe: an entry that omits
-`datasetBuild.enabled` renders no `<id>-dataset-build` WorkflowTemplate at
-all. Flip to `true` per model only once that model's dataset-build path can
-satisfy the gate; this does not touch the *-train templates, which are
-already gated.
+Interim governance gate (webank-models issue #482, ADR-0046). Historically,
+no dataset-build publish call in this template ran a readiness-gate step,
+because dataset-build produced none of the /workspace/governance/* evidence
+the gate needs to check, so a `datasetBuild.enabled` entry stayed default-OFF
+until its path could satisfy the gate. As of this change, the three
+hermetic-synthetic builders (document-detector, document-recognizer,
+face-detector) write a real governance/source-manifest.json and
+governance/readiness.json next to their raw output, and each of their
+dataset-build DAGs below runs `cargo xtask training-data readiness-gate`
+against those files before packing/publishing (ADR-0046's accepted option
+(c); webank-models#482). `sface` and `pad-liveness` use the governed-lakefs
+strategy and remain out of scope: they have no consented source data and stay
+ungated. `datasetBuild.enabled` still guards whether a model's
+`<id>-dataset-build` WorkflowTemplate renders at all; this does not touch the
+*-train templates, which were already gated.
 */ -}}
 {{- $datasetBuildEnabled := $datasetBuild.enabled | default false -}}
 {{- $datasetTarget := required (printf "webank-training: %s datasetBuild.target is required" $id) $datasetBuild.target -}}
@@ -138,18 +143,39 @@ spec:
               --lakefs-repository "$WEBANK_DATASET_LAKEFS_REPOSITORY" \
               --code-revision "$WEBANK_SOURCE_REVISION" \
               --policy /opt/webank-document-detector-dataset/bootstrap-policy.json
+            cargo xtask training-data readiness-gate \
+              --manifest /workspace/output/document-detector-bootstrap/governance/source-manifest.json \
+              --lakefs-ref "$BASE_REF" \
+              --readiness /workspace/output/document-detector-bootstrap/governance/readiness.json
             cargo xtask training-data fixed-dataset publish \
               --model document-detector \
               --bundle /workspace/output/document-detector-bootstrap/document-detector-training-v1.tar \
               --lakefs-branch "$WEBANK_DATASET_LAKEFS_BRANCH" \
               --lakefs-endpoint "$WEBANK_LAKEFS_ENDPOINT" \
               --lakefs-repository "$WEBANK_DATASET_LAKEFS_REPOSITORY" \
-              --lakefs-storage-namespace "$WEBANK_DATASET_LAKEFS_STORAGE_NAMESPACE"
+              --lakefs-storage-namespace "$WEBANK_DATASET_LAKEFS_STORAGE_NAMESPACE" \
+              --manifest /workspace/output/document-detector-bootstrap/governance/source-manifest.json \
+              --readiness /workspace/output/document-detector-bootstrap/governance/readiness.json \
+              --lakefs-ref "$BASE_REF"
 {{- else if eq $id "document-recognizer" }}
+            BASE_REF="$(cargo xtask training-data bootstrap-model-repository \
+              --model document-recognizer \
+              --role dataset \
+              --lakefs-branch "$WEBANK_DATASET_LAKEFS_BRANCH" \
+              --lakefs-endpoint "$WEBANK_LAKEFS_ENDPOINT" \
+              --lakefs-repository "$WEBANK_DATASET_LAKEFS_REPOSITORY" \
+              --lakefs-storage-namespace "$WEBANK_DATASET_LAKEFS_STORAGE_NAMESPACE")"
             PYTHONPATH=/opt/webank-document-recognizer-dataset/src \
               /opt/webank-document-detector-dataset/venv/bin/python \
               -m webank_document_recognizer_dataset \
-              --output /workspace/output/document-recognizer-raw
+              --output /workspace/output/document-recognizer-raw \
+              --lakefs-ref "$BASE_REF" \
+              --lakefs-repository "$WEBANK_DATASET_LAKEFS_REPOSITORY" \
+              --code-revision "$WEBANK_SOURCE_REVISION"
+            cargo xtask training-data readiness-gate \
+              --manifest /workspace/output/document-recognizer-raw/governance/source-manifest.json \
+              --lakefs-ref "$BASE_REF" \
+              --readiness /workspace/output/document-recognizer-raw/governance/readiness.json
             cargo xtask training-data materialize-synthetic-source \
               --model document-recognizer \
               --source /workspace/output/document-recognizer-raw \
@@ -164,12 +190,29 @@ spec:
               --lakefs-branch "$WEBANK_DATASET_LAKEFS_BRANCH" \
               --lakefs-endpoint "$WEBANK_LAKEFS_ENDPOINT" \
               --lakefs-repository "$WEBANK_DATASET_LAKEFS_REPOSITORY" \
-              --lakefs-storage-namespace "$WEBANK_DATASET_LAKEFS_STORAGE_NAMESPACE"
+              --lakefs-storage-namespace "$WEBANK_DATASET_LAKEFS_STORAGE_NAMESPACE" \
+              --manifest /workspace/output/document-recognizer-raw/governance/source-manifest.json \
+              --readiness /workspace/output/document-recognizer-raw/governance/readiness.json \
+              --lakefs-ref "$BASE_REF"
 {{- else if eq $id "face-detector" }}
+            BASE_REF="$(cargo xtask training-data bootstrap-model-repository \
+              --model face-detector \
+              --role dataset \
+              --lakefs-branch "$WEBANK_DATASET_LAKEFS_BRANCH" \
+              --lakefs-endpoint "$WEBANK_LAKEFS_ENDPOINT" \
+              --lakefs-repository "$WEBANK_DATASET_LAKEFS_REPOSITORY" \
+              --lakefs-storage-namespace "$WEBANK_DATASET_LAKEFS_STORAGE_NAMESPACE")"
             PYTHONPATH=/opt/webank-face-detector-dataset/src \
               /opt/webank-document-detector-dataset/venv/bin/python \
               -m webank_face_detector_dataset \
-              --output /workspace/output/face-detector-raw
+              --output /workspace/output/face-detector-raw \
+              --lakefs-ref "$BASE_REF" \
+              --lakefs-repository "$WEBANK_DATASET_LAKEFS_REPOSITORY" \
+              --code-revision "$WEBANK_SOURCE_REVISION"
+            cargo xtask training-data readiness-gate \
+              --manifest /workspace/output/face-detector-raw/governance/source-manifest.json \
+              --lakefs-ref "$BASE_REF" \
+              --readiness /workspace/output/face-detector-raw/governance/readiness.json
             cargo xtask training-data materialize-synthetic-source \
               --model face-detector \
               --source /workspace/output/face-detector-raw \
@@ -184,7 +227,10 @@ spec:
               --lakefs-branch "$WEBANK_DATASET_LAKEFS_BRANCH" \
               --lakefs-endpoint "$WEBANK_LAKEFS_ENDPOINT" \
               --lakefs-repository "$WEBANK_DATASET_LAKEFS_REPOSITORY" \
-              --lakefs-storage-namespace "$WEBANK_DATASET_LAKEFS_STORAGE_NAMESPACE"
+              --lakefs-storage-namespace "$WEBANK_DATASET_LAKEFS_STORAGE_NAMESPACE" \
+              --manifest /workspace/output/face-detector-raw/governance/source-manifest.json \
+              --readiness /workspace/output/face-detector-raw/governance/readiness.json \
+              --lakefs-ref "$BASE_REF"
 {{- else }}
             SOURCE_REF="$(cargo xtask training-data resolve-governed-source-branch \
               --model {{ $id }} \


### PR DESCRIPTION
## ⚠️ Deployment-sequencing finding — read before merging

**This chart change cannot be merged safely on its own against the image currently pinned in production.** I verified directly (not assumed) that the live `training.datasetBuild.image` digest —
`ghcr.io/adorsys-gis/webank-dataset-gpu@sha256:c6c4a4b562fec1f05d96aba61f8f7aa910b6cb6e9dc013b270acad5423a784c1` (tag `1.8.0`, built from `ADORSYS-GIS/webank-models@66266fce8513883db68db8fc2e69a53ba5a1638a`) — predates all four of `webank-models` #493–#496:

- `tools/document-recognizer-dataset/.../__main__.py` at that commit defines only `--output`/`--samples`/`--seed` (no `--lakefs-ref`/`--lakefs-repository`/`--code-revision`).
- `tools/face-detector-dataset/.../__main__.py` at that commit defines only `--output`/`--policy`.
- `xtask/src/training_data/fixed_dataset_command.rs`'s `Publish` variant at that commit has no `--manifest`/`--readiness`/`--lakefs-ref`.

Python's `argparse` and Rust's `clap` both reject unrecognized flags by default. That means:

- **This PR merged alone** (chart passes the new flags, image doesn't know them) → all three `*-dataset-build` WorkflowTemplates break immediately on the next run: `document-recognizer`/`face-detector` fail at Python `argparse` ("unrecognized arguments"), and **all three**, including `document-detector`, fail at the new `fixed-dataset publish --manifest/--readiness/--lakefs-ref` flags (`clap` "unexpected argument").
- **webank-models #494/#495/#496 merged alone**, with a new image built and its digest bumped in `ai-helm-values`, but this chart *not* updated → the mirror failure: the new Python CLIs now *require* `--lakefs-ref`/`--lakefs-repository`/`--code-revision` (`required=True`) that the old chart never sends, and `fixed-dataset publish` refuses to resolve `source_class` (ADR-0050 Decision 4.2) with no `--manifest`/`--readiness` supplied.

**There is no safe non-atomic ordering.** This PR and a new `webank-dataset-gpu` image digest (built from `webank-models` *after* #493, #494, #495, and #496 all land) must reach `hetzner-prod` together — practically, that means: merge all four `webank-models` PRs first, build+publish the new image, then merge this PR and the corresponding `ai-helm-values` image-digest bump PR back-to-back, accepting a short window where a dataset-build run during that gap can fail. **I did not open the `ai-helm-values` PR** — this task was scoped to `ai-helm` only, and the new image digest does not exist yet (it can only be cut after the four `webank-models` PRs merge). Please treat that bump as a required follow-up before merging this one, not as already handled.

This does not change what the chart *should* contain once that image exists — the diff below is the correct target state — only when it is safe to apply it.

---

## 1. Summary

This PR changes:

- Adds a real `cargo xtask training-data readiness-gate` step to all three **hermetic-synthetic** dataset-build DAGs (`document-detector`, `document-recognizer`, `face-detector`) in `charts/webank-training/templates/workflowtemplate.yaml`, run before `pack`/`publish`, reading the `governance/source-manifest.json` and `governance/readiness.json` files each Python builder genuinely writes next to its raw output.
- Adds a `bootstrap-model-repository` call (mirroring `document-detector`'s existing pattern) to the `document-recognizer` and `face-detector` branches to obtain `BASE_REF`, and passes it plus the image-baked `WEBANK_SOURCE_REVISION` as the three new required arguments (`--lakefs-ref`, `--lakefs-repository`, `--code-revision`) those builders' Python CLIs require once webank-models#494/#495 land.
- Passes `--manifest`/`--readiness`/`--lakefs-ref` explicitly to `fixed-dataset publish` in all three branches, so `source_class` resolves per webank-models#496 (ADR-0050 Decision 4.2) instead of refusing on the (empty) `WEBANK_GOVERNANCE_LAKEFS_REF` default.
- Extends `ci/lint-values.yaml` to keep `datasetBuild.enabled: true` for all three hermetic-synthetic models (previously only `document-detector`), so CI's own `helm lint --strict` / `helm template` render-cover the two branches this change modifies most.

It solves:

- webank-models#482 / ADR-0046's accepted "Open question 1" resolution, option (c): the dataset-build DAGs must run a readiness gate against real, builder-produced governance evidence, not a static assertion or an absent step.
- Once landed in the coordinated window described above, unblocks `webank-models` #493, #494, #495, #496 without breaking the live chart at argparse/clap or at the ADR-0050 `source_class` refusal.

---

## 2. Intent

> `hetzner-prod`'s `aii-webank-training` ArgoCD app (auto-sync + selfHeal) renders this chart directly onto the cluster. Four `webank-models` PRs are open: #494 and #495 add three new *required* CLI arguments to the `document-recognizer` and `face-detector` Python dataset builders, and #496 makes `fixed-dataset publish` refuse to write LakeFS commit metadata unless `source_class` resolves from a governed manifest/readiness pair. All three hermetic-synthetic models currently have `datasetBuild.enabled: true` in production, so any contract mismatch between the chart and the deployed image is a live-traffic risk, not a hypothetical one — see the sequencing finding above for why that risk exists in **both** directions, not just "merge the chart first."
>
> This PR closes the interim governance gap the chart's own comment (webank-models#482, ADR-0046) documented: `readiness-gate` previously never ran in any dataset-build DAG because no builder produced the evidence it needs on disk. As of webank-models#493/#494/#495, all three hermetic-synthetic builders do — this PR wires the gate to read exactly those real files.

---

## 3. Scope

### In Scope

- The three `hermetic-synthetic` dataset-build DAG branches (`document-detector`, `document-recognizer`, `face-detector`) in `charts/webank-training/templates/workflowtemplate.yaml`.
- `charts/webank-training/ci/lint-values.yaml` CI-fixture coverage for the two newly-touched branches.

### Out of Scope

- The `governed-lakefs` dataset-build branches (`sface`, `pad-liveness`): explicitly untouched — they have no consented source data yet, so they stay ungated.
- The `<id>-train` WorkflowTemplates: untouched. They already call `readiness-gate` against `/workspace/governance/*.json` Argo input artifacts supplied by the *train* workflow's own caller — a separate mechanism from this PR's dataset-build change.
- Any change to `ADORSYS-GIS/webank-models` itself (PRs #493–#496 are reviewed, not authored, here).
- The `ai-helm-values` image-digest bump this PR depends on — not opened, per the sequencing finding above.
- GPU placement (`nodeSelector`/`tolerations`/`runtimeClassName`/`resources`): read but not modified — preserved exactly, since `xtask` links `libcuda.so.1` as a hard `DT_NEEDED` dependency (ai-helm#948/#949).

---

## 4. Verification

I verified this change by:

- [x] Running automated tests
- [ ] Running manual tests
- [ ] Checking logs
- [ ] Checking metrics
- [ ] Testing error cases
- [ ] Testing permissions/security behavior
- [ ] Testing rollback or failure behavior, if relevant

Commands run:

```bash
helm dependency update charts/webank-training
helm lint charts/webank-training -f charts/webank-training/ci/lint-values.yaml --strict
helm template webank-training charts/webank-training -f charts/webank-training/ci/lint-values.yaml --dry-run
helm lint charts/webank-training -f <decoded prod values from ai-helm-values>
helm template webank-training charts/webank-training -f <decoded prod values from ai-helm-values>

# Deployed-image compatibility check (the finding above):
gh api orgs/ADORSYS-GIS/packages/container/webank-dataset-gpu/versions
gh api repos/ADORSYS-GIS/webank-models/releases   # resolved v1.8.0 -> commit 66266fce...
gh api "repos/ADORSYS-GIS/webank-models/contents/.../__main__.py?ref=66266fce..."
gh api "repos/ADORSYS-GIS/webank-models/contents/xtask/.../fixed_dataset_command.rs?ref=66266fce..."
```

Results:

```text
==> Linting charts/webank-training (both fixture sets)
[INFO] Chart.yaml: icon is recommended
1 chart(s) linted, 0 chart(s) failed

$ helm template ... --dry-run   →  exit 0, 8 WorkflowTemplate documents render,
  all parse as valid YAML (python3 yaml.safe_load_all confirmed 8/8, both
  against ci/lint-values.yaml and the real decoded prod values.yaml).

$ diff against the live chart content (fetched via `gh api
  repos/ADORSYS-GIS/ai-helm/contents/.../workflowtemplate.yaml`) confirms the
  rendered diff is scoped to exactly: the three hermetic-synthetic
  dataset-build branches (new bootstrap-model-repository call + new CLI args
  + new readiness-gate step + new publish flags) and one doc-comment update.
  webank-sface-train, webank-pad-liveness-train, and both *-train templates
  for document-recognizer/face-detector are byte-identical to before.

$ image-compatibility check: confirmed the pinned webank-dataset-gpu digest
  (v1.8.0, commit 66266fce8513883db68db8fc2e69a53ba5a1638a) predates #494,
  #495, and #496 — its document-recognizer/face-detector __main__.py and
  xtask fixed_dataset_command.rs::Publish do not define the new flags this
  PR's chart change now sends. See the sequencing finding at the top.
```

I could not run this repository's actual CI workflow (`.github/workflows/helm-lint.yaml`) remotely; the commands above reproduce it exactly (same `helm lint --strict` / `helm template --dry-run` invocations against `ci/lint-values.yaml`), run locally against the real chart. No `kubectl apply` or other mutating cluster command was run against `hetzner-prod`; only read-only `gh api` calls against GHCR package metadata and GitHub Releases.

---

## 5. Screenshots / Evidence

* Screenshot: n/a (chart template change; rendered YAML and image-metadata evidence above)
* Logs: n/a
* Metrics: n/a
* Recording: n/a

---

## 6. Risk Assessment

Risk level:

* [ ] Low
* [ ] Medium
* [x] High

Potential risks:

* **Merging this PR by itself breaks all three live `*-dataset-build` WorkflowTemplates within ~3 minutes** (ArgoCD auto-sync), because the currently-pinned `webank-dataset-gpu@sha256:c6c4a4b5...` image predates the CLI/xtask contracts this chart now assumes. See the sequencing finding at the top — this is not a hypothetical, it is a verified fact about the currently-deployed image.
* Symmetric risk in the other direction: merging `webank-models` #494/#495/#496 and bumping the image digest in `ai-helm-values` *without* this chart PR would also break all three dataset-build DAGs (missing required flags / unresolved `source_class`).
* Once correctly sequenced, `readiness-gate` is a new, real fail-closed step: if a builder's regeneration check or governance emission ever regresses, the dataset-build workflow will now correctly fail instead of silently publishing an unattested bundle — intended behavior, but worth reviewer awareness.

Mitigation:

* Do not merge this PR until a new `webank-dataset-gpu` image (built after #493/#494/#495/#496 all merge) exists and an `ai-helm-values` PR bumping `training.datasetBuild.image` to that digest is ready to merge immediately alongside this one.
* No cluster-mutating command was run as part of this verification; only `helm lint`/`helm template` and read-only `gh api` calls.

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [ ] Refactoring
* [ ] Generating tests
* [ ] Drafting documentation
* [x] Reviewing the diff
* [ ] Not used

Human verification:

* [ ] I understand every meaningful change in this PR
* [ ] I checked generated code manually
* [ ] I checked generated tests manually
* [ ] I removed unsupported AI assumptions
* [ ] I accept responsibility for this PR

---

## 8. Reviewer Focus

Please focus your review on:

* [x] Correctness
* [x] Architecture
* [ ] Security
* [ ] Performance
* [ ] Tests
* [x] Maintainability
* [x] Product intent
* [x] Edge cases

---

## Merge order (must be followed exactly — corrected from the original ask)

1. `ADORSYS-GIS/webank-models#493` (document-detector `regeneration_spot_check`) — CLI contract unchanged; safe to land any time.
2. `ADORSYS-GIS/webank-models#494` and `#495` (document-recognizer / face-detector governance emitters + new required CLI args).
3. `ADORSYS-GIS/webank-models#496` (`fixed-dataset publish` resolves `source_class`).
4. Build and publish a new `webank-dataset-gpu` image from the resulting `webank-models` `main`.
5. **This PR** and an `ai-helm-values` PR bumping `training.datasetBuild.image` to that new digest — merge these two together, back-to-back, not independently. This PR alone, merged before step 5's image-digest bump, breaks production immediately (see the sequencing finding above); the image-digest bump alone, merged before this PR, breaks production identically.

This closes the ADR-0046 accepted option (c) guardrail and addresses `ADORSYS-GIS/webank-models#482`. `sface`/`pad-liveness` remain ungated and out of scope — they have no consented source data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
