### PR TITLE
chore: set native issue types in the issue forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/dev-ticket.yml
+++ b/.github/ISSUE_TEMPLATE/dev-ticket.yml
@@ -2,6 +2,7 @@ name: Development Ticket
 description: Implementation work, bugs, refactors, technical tasks, spikes, or operational work.
 title: "[Ticket]: "
 labels: ["ticket"]
+type: Task
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/epic.yml
+++ b/.github/ISSUE_TEMPLATE/epic.yml
@@ -2,6 +2,7 @@ name: Epic
 description: A large initiative spanning multiple stories with a meaningful business or technical objective.
 title: "[Epic]: "
 labels: ["epic"]
+type: Epic
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/user-story.yml
+++ b/.github/ISSUE_TEMPLATE/user-story.yml
@@ -2,6 +2,7 @@ name: User Story
 description: A user need or a valuable capability, with testable acceptance criteria.
 title: "[Story]: "
 labels: ["user-story"]
+type: Story
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
## Summary

Adds a native GitHub issue `type:` key (`Epic`, `Story`, `Task`) to each of the
three issue forms (`epic.yml`, `user-story.yml`, `dev-ticket.yml`), alongside
the title prefix and label they already set.

## Intent

Source of truth: [`ADORSYS-GIS/ai-helm#1002`](https://github.com/ADORSYS-GIS/ai-helm/issues/1002) — the tracking epic for the 2026-08-13 cross-repo backlog consolidation, which found
153 open issues needed manual typing precisely because the forms never set a
type. This PR is part 1 of a 3-agent effort to make the ticket-taxonomy rule
self-enforcing — every new issue must automatically get (a) a title prefix,
(b) a label, and (c) the native GitHub issue type. Today the templates set
(a) and (b) but not (c), so newly-filed tickets land untyped and the
Epic/Story hierarchy decays.

## Scope

- `.github/ISSUE_TEMPLATE/epic.yml`: add `type: Epic`
- `.github/ISSUE_TEMPLATE/user-story.yml`: add `type: Story`
- `.github/ISSUE_TEMPLATE/dev-ticket.yml`: add `type: Task`

Each addition is a single top-level line inserted immediately after the
existing `labels:` line. No `body:` block, `title:`, or `labels:` value was
touched — this repo's forms already had the correct `title:`/`labels:`
values, so no fix was needed there.

## Verification

- [x] `Epic`, `Story`, and `Task` confirmed as live issue types in the
  ADORSYS-GIS org via `gh api orgs/ADORSYS-GIS/issue-types` — these values
  resolve.
- [x] `git diff` reviewed by hand for all three files before committing — each
  diff is exactly one added line, no other content changed.
- [x] YAML structure of all three files otherwise unchanged (form-schema fields,
  `body:` blocks, field ids/validations untouched) — confirmed as part of the
  same diff review.

Not verified live end-to-end (would require filing a real issue against this
repo); reviewer should confirm the type renders correctly on the next issue
filed from these forms once merged, or test in a scratch issue on this
branch's SHA if GitHub's editor preview is preferred.

## Risk Assessment

Low risk. Additive-only change to issue-form YAML; does not touch any
application code, chart, or CI-gated path. Worst case if a `type:` value ever
stopped resolving (e.g. the org issue type were renamed/removed) is that
issue creation from the form would fail with a clear GitHub-side validation
error, not a silent misclassification.

## AI Usage Declaration

- [x] AI (Claude) drafted this change and PR description.
- [x] A human (the repo maintainer) owns verification and reviews this PR
      before merge; AI did not merge or self-approve.

AI was used to: identify the missing `type:` key across the org's shared
issue-template shape, confirm the corresponding org-level issue types exist,
apply the same surgical one-line-per-file edit across repos, and draft this
PR body per the governance template.

## Reviewer Focus

- Confirm the `type:` values (`Epic`/`Story`/`Task`) match the intended
  mapping and the org's current issue-type names.
- Confirm no `body:` content or field ids changed (diff should show exactly
  one added line per file).
- This PR is intentionally **not** merged by AI — merge is left to a human
  reviewer.
