### PR TITLE
chore(librechat-opencode-wellknown): bump @vymalo/opencode* plugins to 0.14.0

### DIFF
--- a/charts/librechat-opencode-wellknown/values.yaml
+++ b/charts/librechat-opencode-wellknown/values.yaml
@@ -58,6 +58,31 @@ wellKnown:
       # reset it fails fast — see the per-model-scoped `rateLimit.tiers`
       # under the provider options below.
       - "@vymalo/opencode-ratelimit@0.12.0"
+      # OpenTelemetry export for OpenCode — the same maintainer's counterpart
+      # to Claude Code's native OTLP monitoring and Codex's `[otel]` block
+      # ([[ai-usage-telemetry-vendors]]). Ships cost (real USD, from
+      # `AssistantMessage.cost` — no price table to maintain), all five
+      # token types (input/output/reasoning/cache_read/cache_write), tool
+      # results, permission decisions, API errors and lines-of-code as OTLP
+      # traces/metrics/logs. NO CONTENT is captured — prompts/responses/tool
+      # args/API bodies are never read, only shape (lengths, counts,
+      # durations, outcomes). Resource attributes identify machine + project,
+      # never the developer, by design (no git-author-email collection).
+      # OTLP/HTTP+protobuf only (no gRPC — Bun compatibility).
+      #
+      # `endpoint` points at the governance OTLP ingestion host
+      # (`otel.ai.camer.digital`) — the same public core-gateway endpoint
+      # the Foundry/Copilot governance connectors are designed to land on
+      # (`plans/microsoft-foundry-governance.md` §2: Authorino AuthConfig →
+      # OTel Collector). ⚠️ That gateway listener + AuthConfig are still a
+      # PROPOSED plan, not yet deployed — until it ships, exported spans just
+      # fail to send (the plugin logs `otel_traces_init_failed`/etc. and
+      # keeps every other signal independent; nothing in opencode breaks).
+      # Once the listener is live, traffic starts flowing with zero opencode-
+      # side change. NOT pinned to the 0.12.0 vymalo line above (own release
+      # cadence) — bump deliberately, same rule as every other plugin here.
+      - - "@vymalo/opencode-otel@0.13.0"
+        - endpoint: "https://otel.ai.camer.digital"
       # Gives an agent a real browser: registers `browser_*` tools (open
       # tabs, click, type, scroll, screenshot — in named tab groups) backed
       # by a localhost WebSocket bridge a companion browser EXTENSION dials

--- a/charts/librechat-opencode-wellknown/values.yaml
+++ b/charts/librechat-opencode-wellknown/values.yaml
@@ -70,38 +70,34 @@ wellKnown:
       # never the developer, by design (no git-author-email collection).
       # OTLP/HTTP+protobuf only (no gRPC — Bun compatibility).
       #
-      # `endpoint` points at the governance OTLP ingestion host
-      # (`otel.ai.camer.digital`) — `OpenTelemetryCollector/lightbridge-governance-ai-cli-otel`
-      # in `governance` on the Hetzner cluster, per lightbridge-opencode-toolbeit#89.
-      # ⚠️ VERIFIED LIVE, and it hard-requires OIDC bearer auth: `POST /v1/traces`
-      # with no auth → 401 "authentication didn't succeed"; issuer
-      # `https://auth.ai.camer.digital`, audience `lightbridge-api-key`. We have
-      # no way to supply that token yet — the credential helper this plugin's
-      # `tokenCommand` option expects (`governance-auth token`, contract in
-      # lightbridge-governance ADR-0010) is still Proposed, not built. The
-      # groundwork it needs (a real OAuth2 client registry + derived id_token
-      # issuance) landed in lightbridge-authz ADR-0011 (#286/#288), but
-      # `governance-auth` itself doesn't exist yet.
-      # ⚠️ CONSEQUENCE, not cosmetic: as of this plugin's 0.13.0 line
-      # (toolbeit#89) a rejected export is no longer silent — it logs
-      # `otel_export_failed` at `warn`, up to 3× per batch interval, for as
-      # long as this ships without `tokenCommand`. Since plugins have no
-      # per-user opt-out (mandatory-on for everyone once pushed), that's a
-      # standing warning in every opencode user's logs for zero telemetry
-      # value until governance-auth ships. Add `tokenCommand:
-      # "governance-auth token"` to this tuple's config the same day that
-      # tool exists — don't ship this endpoint alone for longer than
-      # necessary.
+      # HELD OUT deliberately (not shipped, not just disabled-by-default —
+      # plugins have no per-user opt-out, so pushing this would be a standing
+      # `otel_export_failed` warning in EVERY opencode user's logs). The
+      # target, `otel.ai.camer.digital`
+      # (`OpenTelemetryCollector/lightbridge-governance-ai-cli-otel` in
+      # `governance` on the Hetzner cluster — lightbridge-opencode-toolbeit#89
+      # verified it live), hard-requires OIDC bearer auth (issuer
+      # `https://auth.ai.camer.digital`, audience `lightbridge-api-key`), and
+      # since toolbeit#89 a rejected export is loud rather than silent
+      # (`otel_export_failed` at `warn`, up to 3× per batch interval). We have
+      # no credential to give it yet: the `tokenCommand` option this plugin
+      # exposes for exactly this case (an async credential-helper hook, docs:
+      # lightbridge-opencode-toolbeit `docs/otel.md#short-lived-credentials`)
+      # expects `governance-auth token` — a CLI specified in lightbridge-
+      # governance ADR-0010 that is still Proposed, not built. Its
+      # prerequisite (a real OAuth2 client registry + derived id_token
+      # issuance) landed in lightbridge-authz ADR-0011 (#286/#288), so the
+      # groundwork exists; `governance-auth` itself doesn't yet, and
+      # separately still needs a distribution story onto each user's PATH
+      # before `tokenCommand` can even reference it.
       #
-      # Part of the 0.14.0 vymalo line — pin matches the four above (0.13.0
-      # was never published: a monorepo-wide `pnpm audit --audit-level=high`
-      # gate blocked ALL eight toolbelt packages over two CVEs in
-      # opencode-browser-mcp/-devtools-mcp's `@modelcontextprotocol/sdk`
-      # transitive deps, unrelated to this package; 0.14.0 fixed it and
-      # shipped straight through). Bump every pin deliberately when a real
-      # release lands, same rule as every other plugin here.
-      - - "@vymalo/opencode-otel@0.14.0"
-        - endpoint: "https://otel.ai.camer.digital"
+      # Wire it back in the same day governance-auth ships AND is
+      # distributable, pinned to whatever @vymalo/opencode-otel is current
+      # then (last confirmed live: 0.14.0):
+      #
+      # - - "@vymalo/opencode-otel@0.14.0"
+      #   - endpoint: "https://otel.ai.camer.digital"
+      #     tokenCommand: "governance-auth token"
       # Gives an agent a real browser: registers `browser_*` tools (open
       # tabs, click, type, scroll, screenshot — in named tab groups) backed
       # by a localhost WebSocket bridge a companion browser EXTENSION dials

--- a/charts/librechat-opencode-wellknown/values.yaml
+++ b/charts/librechat-opencode-wellknown/values.yaml
@@ -79,9 +79,14 @@ wellKnown:
       # fail to send (the plugin logs `otel_traces_init_failed`/etc. and
       # keeps every other signal independent; nothing in opencode breaks).
       # Once the listener is live, traffic starts flowing with zero opencode-
-      # side change. NOT pinned to the 0.12.0 vymalo line above (own release
-      # cadence) — bump deliberately, same rule as every other plugin here.
-      - - "@vymalo/opencode-otel@0.13.0"
+      # side change. Part of the 0.12.0 vymalo line — pin matches the four
+      # above (verified against the npm registry, not just the package's
+      # `main`-branch source: its committed `package.json` was already ahead
+      # at 0.13.0 when this was first pinned, but nothing above 0.12.0 was
+      # actually published — an exact pin one version ahead of npm 404s on
+      # `opencode auth login`). Bump every pin deliberately when a real
+      # release lands, same rule as every other plugin here.
+      - - "@vymalo/opencode-otel@0.12.0"
         - endpoint: "https://otel.ai.camer.digital"
       # Gives an agent a real browser: registers `browser_*` tools (open
       # tabs, click, type, scroll, screenshot — in named tab groups) backed
@@ -97,7 +102,7 @@ wellKnown:
       # in the plugin TUPLE's second arg — this plugin reads its options from
       # there (NOT from provider.options.meta like the others), i.e.
       # opencode's `[name, {opts}]` install form, which toJson renders as a
-      # JSON 2-tuple. Part of the 0.12.0 vymalo line — pin matches the three
+      # JSON 2-tuple. Part of the 0.12.0 vymalo line — pin matches the four
       # above.
       #
       # TWO independent token levers, at different scopes:

--- a/charts/librechat-opencode-wellknown/values.yaml
+++ b/charts/librechat-opencode-wellknown/values.yaml
@@ -47,17 +47,17 @@ wellKnown:
     # subagents, so no primary carries the 27 browser_* schemas every turn.
     default_agent: assistant
     plugin:
-      - "@vymalo/opencode-oauth2@0.12.0"
+      - "@vymalo/opencode-oauth2@0.14.0"
       # Enriches the model catalog with context length, pricing,
       # modalities, capability flags. See ADR-0015.
-      - "@vymalo/opencode-models-info@0.12.0"
+      - "@vymalo/opencode-models-info@0.14.0"
       # Reads the IETF draft-03 `x-ratelimit-*` response headers our
       # Envoy AI Gateway emits (the per-model BackendTrafficPolicy,
       # ADR-0021) and makes opencode rate-limit-aware: on a short burst
       # reset it waits the quota out, and on a days-away monthly-budget
       # reset it fails fast — see the per-model-scoped `rateLimit.tiers`
       # under the provider options below.
-      - "@vymalo/opencode-ratelimit@0.12.0"
+      - "@vymalo/opencode-ratelimit@0.14.0"
       # OpenTelemetry export for OpenCode — the same maintainer's counterpart
       # to Claude Code's native OTLP monitoring and Codex's `[otel]` block
       # ([[ai-usage-telemetry-vendors]]). Ships cost (real USD, from
@@ -71,22 +71,36 @@ wellKnown:
       # OTLP/HTTP+protobuf only (no gRPC — Bun compatibility).
       #
       # `endpoint` points at the governance OTLP ingestion host
-      # (`otel.ai.camer.digital`) — the same public core-gateway endpoint
-      # the Foundry/Copilot governance connectors are designed to land on
-      # (`plans/microsoft-foundry-governance.md` §2: Authorino AuthConfig →
-      # OTel Collector). ⚠️ That gateway listener + AuthConfig are still a
-      # PROPOSED plan, not yet deployed — until it ships, exported spans just
-      # fail to send (the plugin logs `otel_traces_init_failed`/etc. and
-      # keeps every other signal independent; nothing in opencode breaks).
-      # Once the listener is live, traffic starts flowing with zero opencode-
-      # side change. Part of the 0.12.0 vymalo line — pin matches the four
-      # above (verified against the npm registry, not just the package's
-      # `main`-branch source: its committed `package.json` was already ahead
-      # at 0.13.0 when this was first pinned, but nothing above 0.12.0 was
-      # actually published — an exact pin one version ahead of npm 404s on
-      # `opencode auth login`). Bump every pin deliberately when a real
+      # (`otel.ai.camer.digital`) — `OpenTelemetryCollector/lightbridge-governance-ai-cli-otel`
+      # in `governance` on the Hetzner cluster, per lightbridge-opencode-toolbeit#89.
+      # ⚠️ VERIFIED LIVE, and it hard-requires OIDC bearer auth: `POST /v1/traces`
+      # with no auth → 401 "authentication didn't succeed"; issuer
+      # `https://auth.ai.camer.digital`, audience `lightbridge-api-key`. We have
+      # no way to supply that token yet — the credential helper this plugin's
+      # `tokenCommand` option expects (`governance-auth token`, contract in
+      # lightbridge-governance ADR-0010) is still Proposed, not built. The
+      # groundwork it needs (a real OAuth2 client registry + derived id_token
+      # issuance) landed in lightbridge-authz ADR-0011 (#286/#288), but
+      # `governance-auth` itself doesn't exist yet.
+      # ⚠️ CONSEQUENCE, not cosmetic: as of this plugin's 0.13.0 line
+      # (toolbeit#89) a rejected export is no longer silent — it logs
+      # `otel_export_failed` at `warn`, up to 3× per batch interval, for as
+      # long as this ships without `tokenCommand`. Since plugins have no
+      # per-user opt-out (mandatory-on for everyone once pushed), that's a
+      # standing warning in every opencode user's logs for zero telemetry
+      # value until governance-auth ships. Add `tokenCommand:
+      # "governance-auth token"` to this tuple's config the same day that
+      # tool exists — don't ship this endpoint alone for longer than
+      # necessary.
+      #
+      # Part of the 0.14.0 vymalo line — pin matches the four above (0.13.0
+      # was never published: a monorepo-wide `pnpm audit --audit-level=high`
+      # gate blocked ALL eight toolbelt packages over two CVEs in
+      # opencode-browser-mcp/-devtools-mcp's `@modelcontextprotocol/sdk`
+      # transitive deps, unrelated to this package; 0.14.0 fixed it and
+      # shipped straight through). Bump every pin deliberately when a real
       # release lands, same rule as every other plugin here.
-      - - "@vymalo/opencode-otel@0.12.0"
+      - - "@vymalo/opencode-otel@0.14.0"
         - endpoint: "https://otel.ai.camer.digital"
       # Gives an agent a real browser: registers `browser_*` tools (open
       # tabs, click, type, scroll, screenshot — in named tab groups) backed
@@ -102,7 +116,7 @@ wellKnown:
       # in the plugin TUPLE's second arg — this plugin reads its options from
       # there (NOT from provider.options.meta like the others), i.e.
       # opencode's `[name, {opts}]` install form, which toJson renders as a
-      # JSON 2-tuple. Part of the 0.12.0 vymalo line — pin matches the four
+      # JSON 2-tuple. Part of the 0.14.0 vymalo line — pin matches the four
       # above.
       #
       # TWO independent token levers, at different scopes:
@@ -144,7 +158,7 @@ wellKnown:
       # right form here: it's local-only (bridge + extension on the user's box,
       # so it can't ride the remote gateway /mcp/* routes anyway) and its opencode
       # adapter saves screenshots to disk for the model to read. One source only.
-      - - "@vymalo/opencode-browser@0.12.0"
+      - - "@vymalo/opencode-browser@0.14.0"
         - port: 4517
           groups:
             - page


### PR DESCRIPTION
## 1. Summary

This PR changes:

- Bumps `@vymalo/opencode-oauth2`, `@vymalo/opencode-models-info`, `@vymalo/opencode-ratelimit`, `@vymalo/opencode-browser` from `0.12.0` to `0.14.0` in the org-wide opencode `plugin:` list served at `.well-known/opencode` (`charts/librechat-opencode-wellknown/values.yaml`).
- Adds (then deliberately holds out, commented, with a ready-to-uncomment config) `@vymalo/opencode-otel` — see Scope below for why it's not live yet.

It solves:

- Keeps the org-pushed plugin set current with what the maintainer publishes (https://github.com/ADORSYS-GIS/lightbridge-opencode-toolbeit). `opencode-otel` was investigated as a new addition per direct request but turned out to need a dependency (`governance-auth`) that doesn't exist yet — see below.

## 2. Intent

The intent of this PR is:

> Stay on the latest published `@vymalo/opencode*` line (all five packages are pinned in lockstep per this file's existing convention), and evaluate adding OpenTelemetry export (`opencode-otel`) for opencode sessions.

## 3. Scope

### In Scope

- Version bump: `0.12.0` → `0.14.0` for the four already-shipped `@vymalo/*` plugins (verified against the npm registry directly, not GitHub `main` source — `0.13.0` was cut in source but never published due to an audit-gate failure on unrelated CVEs; `0.14.0` fixed it and shipped straight through).
- `opencode-otel` investigated and **not shipped**: the target collector (`otel.ai.camer.digital`, live, verified via `lightbridge-opencode-toolbeit#89`) hard-requires OIDC bearer auth we have no way to supply — the credential helper it needs (`governance-auth`, `lightbridge-governance` ADR-0010) is still Proposed, not built. Plugins have no per-user opt-out, so shipping it endpoint-only would put a standing `otel_export_failed` warning in every opencode user's logs for zero telemetry value. Left commented out with the `tokenCommand` config pre-written, to wire in the day `governance-auth` exists and is distributable to users.

### Out of Scope

- Building `governance-auth` or the `lightbridge-authz` OAuth2 client registry it depends on (that's `lightbridge-authz` ADR-0011, `#286`/`#288` — already merged upstream, unrelated repo).
- The `lightbridge-authz-stack` chart pin in `charts/lightbridge/values.yaml` (currently `0.8.1`, registry latest is `3.0.0`) — explicitly deferred, tracked separately.

## 4. Verification

I verified this change by:

- [x] Running automated tests
- [ ] Running manual tests
- [x] Checking logs
- [ ] Checking metrics
- [ ] Testing error cases
- [ ] Testing permissions/security behavior
- [ ] Testing rollback or failure behavior, if relevant

Commands run:

```bash
helm lint charts/librechat-opencode-wellknown --strict
helm template x charts/librechat-opencode-wellknown --dry-run
curl -s https://registry.npmjs.org/@vymalo/opencode-otel   # + the other four, to confirm 0.14.0 is actually published
curl -s -o /dev/null -w '%{http_code}' -X POST https://otel.ai.camer.digital/v1/traces  # 401, confirms auth is required
```

Results:

```text
==> Linting charts/librechat-opencode-wellknown
[INFO] Chart.yaml: icon is recommended
1 chart(s) linted, 0 chart(s) failed

Rendered plugin list (parsed from the ConfigMap JSON):
[
  "@vymalo/opencode-oauth2@0.14.0",
  "@vymalo/opencode-models-info@0.14.0",
  "@vymalo/opencode-ratelimit@0.14.0",
  ["@vymalo/opencode-browser@0.14.0", {...}],
  "opencode-skills-collection@4.0.14"
]
```

All four bumped plugins confirmed at `dist-tags.latest = 0.14.0` on the npm registry (published 2026-08-15T08:49Z).

## 5. Screenshots / Evidence

* N/A — chart-render change, no UI

## 6. Risk Assessment

Risk level:

* [x] Low

Potential risks:

* A version bump could carry a behavior change from a plugin's own changelog between 0.12.0 and 0.14.0 that isn't visible from this diff alone.

Mitigation:

* All four plugins are the maintainer's own packages, moving in the established lockstep pin group this file already documents; `helm template` confirms the rendered config is valid JSON in the plugin-tuple form opencode expects.
* `opencode-otel` was the higher-risk item (new plugin, new failure mode) and is not shipped in this PR.

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [ ] Refactoring
* [ ] Generating tests
* [x] Drafting documentation
* [ ] Reviewing the diff
* [ ] Not used

Human verification:

* [x] I understand every meaningful change in this PR
* [x] I checked generated code manually
* [ ] I checked generated tests manually
* [x] I removed unsupported AI assumptions
* [x] I accept responsibility for this PR

## 8. Reviewer Focus

Please focus your review on:

* [x] Correctness
* [ ] Architecture
* [ ] Security
* [ ] Performance
* [ ] Tests
* [ ] Maintainability
* [ ] Product intent
* [ ] Edge cases
