### PR TITLE
feat(webank-training): expose dataset-build knobs as workflow parameters

### DIFF
--- a/charts/webank-training/ci/lint-values.yaml
+++ b/charts/webank-training/ci/lint-values.yaml
@@ -42,6 +42,11 @@ models:
     trainer: document-recognizer
     datasetBuild:
       enabled: true
+      # Exercises the per-model publishToLakefsDefault override branch
+      # (charts/webank-training/values.yaml training.datasetBuild
+      # .publishToLakefsDefault) so CI render-covers a value that differs
+      # from the chart-wide default, not just the default itself.
+      publishToLakefsDefault: false
       target:
         repository: ds-document-recognizer
         branch: main

--- a/charts/webank-training/templates/workflowtemplate.yaml
+++ b/charts/webank-training/templates/workflowtemplate.yaml
@@ -40,6 +40,18 @@ ungated. `datasetBuild.enabled` still guards whether a model's
 *-train templates, which were already gated.
 */ -}}
 {{- $datasetBuildEnabled := $datasetBuild.enabled | default false -}}
+{{- /*
+`default` treats Go zero values (including `false`) as absent, so a naive
+`$datasetBuild.publishToLakefsDefault | default $training.datasetBuild
+.publishToLakefsDefault` would silently discard an explicit per-model
+`false` override and always fall back to the chart-wide default -- exactly
+the config this parameter exists to allow. `hasKey` distinguishes "the key
+is absent" from "the key is present and false".
+*/ -}}
+{{- $publishToLakefsDefault := $training.datasetBuild.publishToLakefsDefault -}}
+{{- if hasKey $datasetBuild "publishToLakefsDefault" -}}
+{{- $publishToLakefsDefault = $datasetBuild.publishToLakefsDefault -}}
+{{- end -}}
 {{- $datasetTarget := required (printf "webank-training: %s datasetBuild.target is required" $id) $datasetBuild.target -}}
 {{- $datasetSource := required (printf "webank-training: %s datasetBuild.source is required" $id) $datasetBuild.source -}}
 {{- $sourceStrategy := required (printf "webank-training: %s datasetBuild.source.strategy is required" $id) $datasetSource.strategy -}}
@@ -104,6 +116,42 @@ spec:
   imagePullSecrets:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+{{- /*
+Dataset-build knobs (webank-models#507 sharding, ai-helm proposition
+0037-019220). Scoped to the three hermetic-synthetic ids only: sface and
+pad-liveness stay on the untouched governed-lakefs path below, per that
+proposition's explicit hard constraint. Every default is a Helm value, never
+a template literal, so an environment's own values file is the reviewed
+record of what a bare `argo submit` actually does; `-p name=value` overrides
+one run without touching the chart.
+*/}}
+{{- if eq $sourceStrategy "hermetic-synthetic" }}
+  arguments:
+    parameters:
+      - name: publish_to_lakefs
+        value: {{ $publishToLakefsDefault | quote }}
+        description: >-
+          Whether this run commits its packed, readiness-gated bundle to
+          LakeFS. "false" still produces and validates the local bundle, then
+          stops before the publish call -- nothing is written to LakeFS.
+{{- if eq $id "document-recognizer" }}
+      - name: shard_rows
+        value: {{ $training.documentRecognizer.shardRows | quote }}
+        description: >-
+          Max rows per ds-<index>.safetensors shard (webank-models
+          --shard-rows / WEBANK_RECOGNIZER_SHARD_ROWS on
+          materialize-synthetic-source; requires webank-models#507 merged and
+          this template's datasetBuild.image bumped to a build that reads it
+          -- inert (silently ignored) on an older image). Larger shards trade
+          lower per-shard overhead for more RAM per load_shard call.
+      - name: samples
+        value: {{ $training.documentRecognizer.samples | quote }}
+        description: >-
+          Synthetic OCR lines to generate (webank_document_recognizer_dataset
+          --samples, 1..10000). Lower this for a fast local iteration run;
+          the default reproduces the reviewed dataset size.
+{{- end }}
+{{- end }}
   templates:
     - name: build
       podSpecPatch: |
@@ -147,16 +195,20 @@ spec:
               --manifest /workspace/output/document-detector-bootstrap/governance/source-manifest.json \
               --lakefs-ref "$BASE_REF" \
               --readiness /workspace/output/document-detector-bootstrap/governance/readiness.json
-            cargo xtask training-data fixed-dataset publish \
-              --model document-detector \
-              --bundle /workspace/output/document-detector-bootstrap/document-detector-training-v1.tar \
-              --lakefs-branch "$WEBANK_DATASET_LAKEFS_BRANCH" \
-              --lakefs-endpoint "$WEBANK_LAKEFS_ENDPOINT" \
-              --lakefs-repository "$WEBANK_DATASET_LAKEFS_REPOSITORY" \
-              --lakefs-storage-namespace "$WEBANK_DATASET_LAKEFS_STORAGE_NAMESPACE" \
-              --manifest /workspace/output/document-detector-bootstrap/governance/source-manifest.json \
-              --readiness /workspace/output/document-detector-bootstrap/governance/readiness.json \
-              --lakefs-ref "$BASE_REF"
+            if [ "$WEBANK_PUBLISH_TO_LAKEFS" = "true" ]; then
+              cargo xtask training-data fixed-dataset publish \
+                --model document-detector \
+                --bundle /workspace/output/document-detector-bootstrap/document-detector-training-v1.tar \
+                --lakefs-branch "$WEBANK_DATASET_LAKEFS_BRANCH" \
+                --lakefs-endpoint "$WEBANK_LAKEFS_ENDPOINT" \
+                --lakefs-repository "$WEBANK_DATASET_LAKEFS_REPOSITORY" \
+                --lakefs-storage-namespace "$WEBANK_DATASET_LAKEFS_STORAGE_NAMESPACE" \
+                --manifest /workspace/output/document-detector-bootstrap/governance/source-manifest.json \
+                --readiness /workspace/output/document-detector-bootstrap/governance/readiness.json \
+                --lakefs-ref "$BASE_REF"
+            else
+              echo "publish_to_lakefs=false: bundle produced and readiness-gated locally; skipping LakeFS publish." >&2
+            fi
 {{- else if eq $id "document-recognizer" }}
             BASE_REF="$(cargo xtask training-data bootstrap-model-repository \
               --model document-recognizer \
@@ -171,7 +223,8 @@ spec:
               --output /workspace/output/document-recognizer-raw \
               --lakefs-ref "$BASE_REF" \
               --lakefs-repository "$WEBANK_DATASET_LAKEFS_REPOSITORY" \
-              --code-revision "$WEBANK_SOURCE_REVISION"
+              --code-revision "$WEBANK_SOURCE_REVISION" \
+              --samples "$WEBANK_RECOGNIZER_SAMPLES"
             cargo xtask training-data readiness-gate \
               --manifest /workspace/output/document-recognizer-raw/governance/source-manifest.json \
               --lakefs-ref "$BASE_REF" \
@@ -184,16 +237,20 @@ spec:
               --model document-recognizer \
               --input /workspace/output/document-recognizer-materialized \
               --output /workspace/output/document-recognizer-training-bundle.tar
-            cargo xtask training-data fixed-dataset publish \
-              --model document-recognizer \
-              --bundle /workspace/output/document-recognizer-training-bundle.tar \
-              --lakefs-branch "$WEBANK_DATASET_LAKEFS_BRANCH" \
-              --lakefs-endpoint "$WEBANK_LAKEFS_ENDPOINT" \
-              --lakefs-repository "$WEBANK_DATASET_LAKEFS_REPOSITORY" \
-              --lakefs-storage-namespace "$WEBANK_DATASET_LAKEFS_STORAGE_NAMESPACE" \
-              --manifest /workspace/output/document-recognizer-raw/governance/source-manifest.json \
-              --readiness /workspace/output/document-recognizer-raw/governance/readiness.json \
-              --lakefs-ref "$BASE_REF"
+            if [ "$WEBANK_PUBLISH_TO_LAKEFS" = "true" ]; then
+              cargo xtask training-data fixed-dataset publish \
+                --model document-recognizer \
+                --bundle /workspace/output/document-recognizer-training-bundle.tar \
+                --lakefs-branch "$WEBANK_DATASET_LAKEFS_BRANCH" \
+                --lakefs-endpoint "$WEBANK_LAKEFS_ENDPOINT" \
+                --lakefs-repository "$WEBANK_DATASET_LAKEFS_REPOSITORY" \
+                --lakefs-storage-namespace "$WEBANK_DATASET_LAKEFS_STORAGE_NAMESPACE" \
+                --manifest /workspace/output/document-recognizer-raw/governance/source-manifest.json \
+                --readiness /workspace/output/document-recognizer-raw/governance/readiness.json \
+                --lakefs-ref "$BASE_REF"
+            else
+              echo "publish_to_lakefs=false: bundle produced and readiness-gated locally; skipping LakeFS publish." >&2
+            fi
 {{- else if eq $id "face-detector" }}
             BASE_REF="$(cargo xtask training-data bootstrap-model-repository \
               --model face-detector \
@@ -221,16 +278,20 @@ spec:
               --model face-detector \
               --input /workspace/output/face-detector-materialized \
               --output /workspace/output/face-detector-training-bundle.tar
-            cargo xtask training-data fixed-dataset publish \
-              --model face-detector \
-              --bundle /workspace/output/face-detector-training-bundle.tar \
-              --lakefs-branch "$WEBANK_DATASET_LAKEFS_BRANCH" \
-              --lakefs-endpoint "$WEBANK_LAKEFS_ENDPOINT" \
-              --lakefs-repository "$WEBANK_DATASET_LAKEFS_REPOSITORY" \
-              --lakefs-storage-namespace "$WEBANK_DATASET_LAKEFS_STORAGE_NAMESPACE" \
-              --manifest /workspace/output/face-detector-raw/governance/source-manifest.json \
-              --readiness /workspace/output/face-detector-raw/governance/readiness.json \
-              --lakefs-ref "$BASE_REF"
+            if [ "$WEBANK_PUBLISH_TO_LAKEFS" = "true" ]; then
+              cargo xtask training-data fixed-dataset publish \
+                --model face-detector \
+                --bundle /workspace/output/face-detector-training-bundle.tar \
+                --lakefs-branch "$WEBANK_DATASET_LAKEFS_BRANCH" \
+                --lakefs-endpoint "$WEBANK_LAKEFS_ENDPOINT" \
+                --lakefs-repository "$WEBANK_DATASET_LAKEFS_REPOSITORY" \
+                --lakefs-storage-namespace "$WEBANK_DATASET_LAKEFS_STORAGE_NAMESPACE" \
+                --manifest /workspace/output/face-detector-raw/governance/source-manifest.json \
+                --readiness /workspace/output/face-detector-raw/governance/readiness.json \
+                --lakefs-ref "$BASE_REF"
+            else
+              echo "publish_to_lakefs=false: bundle produced and readiness-gated locally; skipping LakeFS publish." >&2
+            fi
 {{- else }}
             SOURCE_REF="$(cargo xtask training-data resolve-governed-source-branch \
               --model {{ $id }} \
@@ -272,6 +333,21 @@ spec:
             value: {{ $datasetStorageNamespace | quote }}
           - name: WEBANK_DATASET_SOURCE_STRATEGY
             value: {{ $sourceStrategy | quote }}
+{{- if eq $sourceStrategy "hermetic-synthetic" }}
+          - name: WEBANK_PUBLISH_TO_LAKEFS
+            value: "{{`{{workflow.parameters.publish_to_lakefs}}`}}"
+{{- end }}
+{{- if eq $id "document-recognizer" }}
+          # Consumed directly by materialize-synthetic-source's own `env =
+          # "WEBANK_RECOGNIZER_SHARD_ROWS"` clap attribute (webank-models#507)
+          # -- no --shard-rows CLI flag needed here. An image built before
+          # that PR merges simply never reads this var, so setting it ahead
+          # of the image bump is inert, not breaking.
+          - name: WEBANK_RECOGNIZER_SHARD_ROWS
+            value: "{{`{{workflow.parameters.shard_rows}}`}}"
+          - name: WEBANK_RECOGNIZER_SAMPLES
+            value: "{{`{{workflow.parameters.samples}}`}}"
+{{- end }}
 {{- if eq $sourceStrategy "governed-lakefs" }}
           - name: WEBANK_SOURCE_LAKEFS_REPOSITORY
             value: {{ $datasetSource.repository | quote }}

--- a/charts/webank-training/values.yaml
+++ b/charts/webank-training/values.yaml
@@ -115,6 +115,44 @@ training:
     # governed-lakefs model (sface, pad-liveness) with a differently sized
     # source checkout stays covered by the same generous margin.
     workspaceSizeLimit: 24Gi
+    # Default for the `publish_to_lakefs` Argo parameter on every
+    # hermetic-synthetic `<id>-dataset-build` template (document-detector,
+    # document-recognizer, face-detector; sface/pad-liveness are untouched
+    # governed-lakefs templates and never render this parameter). `true`
+    # preserves this chart's existing behavior -- every one of those three
+    # templates has always published unconditionally -- because none of
+    # their sources carries an unresolved redistribution-scope determination
+    # today (all three are CC0 hermetic-synthetic output, see each model's
+    # bootstrap-policy.json `generated_output_licence_reference`). A future
+    # model whose dataset-build must stop short of LakeFS by default (for
+    # example, an unresolved-licence real-photo source) sets its own
+    # `models[].datasetBuild.publishToLakefsDefault: false` in
+    # ai-helm-values; that per-model field overrides this one when present.
+    publishToLakefsDefault: true
+  # document-recognizer-only dataset-build knobs. Both back a real,
+  # already-existing CLI surface on the webank-models side (see this PR's
+  # description for the exact commands/flags/env vars matched); neither is
+  # invented, and neither applies to document-detector or face-detector,
+  # whose row counts come from a reviewed, signed bootstrap-policy.json
+  # instead of a CLI flag.
+  documentRecognizer:
+    # `materialize-synthetic-source --shard-rows` / env
+    # `WEBANK_RECOGNIZER_SHARD_ROWS` (webank-models#507, open at the time of
+    # writing -- see that PR for status before relying on this taking
+    # effect). Rows per `ds-<index>.safetensors` shard; the last shard is
+    # short. 2000 is the accountable
+    # owner's chosen default: a desktop and a dedicated training server want
+    # different chunk sizes, and networking is not the constraint (this
+    # tensor never leaves the pod that writes it), so there is no single
+    # "right" size to hardcode. At U8 [2000, 3, 48, 640] one shard is
+    # ~184 MB.
+    shardRows: 2000
+    # webank_document_recognizer_dataset --samples (1..10000), already live
+    # on `main` today. Not passed by this template before this change, so
+    # the tool's own argparse default (256) applied silently; this makes
+    # that default an explicit, reviewable Helm value instead, and lets an
+    # operator drop it for a fast local iteration run.
+    samples: 256
   documentDetector:
     stemChannels: 32
     epochs: 10
@@ -138,4 +176,10 @@ training:
 # `<id>-dataset-build` WorkflowTemplate does not exist in the cluster at all
 # and cannot be `argo submit`-able. Flip to `true` per model only once that
 # gate can be satisfied.
+#
+# `datasetBuild.publishToLakefsDefault` (bool, optional, hermetic-synthetic
+# ids only): per-model override for `training.datasetBuild
+# .publishToLakefsDefault` above. Leave unset to inherit that chart-wide
+# default; set explicitly only when one model's dataset-build must default
+# to stopping short of LakeFS while the others still publish.
 models: []


### PR DESCRIPTION
## 1. Summary

This PR changes:

- Adds three Argo workflow parameters to the `document-detector`,
  `document-recognizer`, and `face-detector` `<id>-dataset-build`
  `WorkflowTemplate`s in `charts/webank-training/templates/workflowtemplate.yaml`:
  `publish_to_lakefs`, `shard_rows` (document-recognizer only), `samples`
  (document-recognizer only).
- Adds their defaults as new Helm values in `charts/webank-training/values.yaml`:
  `training.datasetBuild.publishToLakefsDefault` (chart-wide, `true`),
  `training.documentRecognizer.shardRows` (`2000`),
  `training.documentRecognizer.samples` (`256`), plus an optional
  per-model override `models[].datasetBuild.publishToLakefsDefault`.
- Wraps each of the three templates' final `cargo xtask training-data
  fixed-dataset publish` call in a shell `if [ "$WEBANK_PUBLISH_TO_LAKEFS" =
  "true" ]; then ... fi`.
- Adds `--samples "$WEBANK_RECOGNIZER_SAMPLES"` to document-recognizer's
  Python generator invocation, and a `WEBANK_RECOGNIZER_SHARD_ROWS` env var
  consumed directly by `materialize-synthetic-source`'s own `env =
  "WEBANK_RECOGNIZER_SHARD_ROWS"` clap attribute (webank-models#507).
- Extends `charts/webank-training/ci/lint-values.yaml` with a
  `publishToLakefsDefault: false` override on document-recognizer so CI
  render-covers the per-model-override branch, not just the default.
- **sface, pad-liveness, and every `<id>-train` template are untouched.**
  Verified: rendering this branch and the pre-change branch against the
  same fixture produces byte-identical `webank-sface-train`,
  `webank-pad-liveness-train`, and all three hermetic-synthetic `*-train`
  templates; neither `sface` nor `pad-liveness` renders a dataset-build
  `WorkflowTemplate` at all today (`datasetBuild.enabled` is unset for both
  in every values file I could find, chart and production alike), so
  there is nothing live to gate on that path regardless.

It solves:

- The requested "operator never has to think about a knob, but can
  override it per run" gap for dataset-build: `shard_rows`, `samples`, and
  `publish_to_lakefs` were previously either not exposed at all or
  hardcoded into the always-publish behavior baked into each template's
  shell script.

---

## 2. Intent

Make the dataset-build workflows configurable, with sensible defaults
living in the chart config (`values.yaml`), so an operator can override a
run's shard size, synthetic sample count, or whether it publishes to
LakeFS with `argo submit ... -p name=value`, without ever having to edit
the chart to get today's behavior.

---

## 3. Scope

### In Scope

- `shard_rows`, `publish_to_lakefs`, `samples` as Argo workflow parameters
  on the three hermetic-synthetic dataset-build templates, with Helm-value
  defaults.
- The `hasKey`-based per-model `publishToLakefsDefault` override.

### Out of Scope / Declined

- **`crop_limit`, as literally named in the task, is not implemented.**
  See "Design notes" below — its real referent (`xtask midv-raw-source
  --limit`) has no live call site in this chart. `samples` is the closest
  real, live substitute for document-recognizer; I did not invent a
  `crop_limit` knob with no binary underneath it.
- `sface`, `pad-liveness`, and all `<id>-train` templates (hard
  constraint).
- Any change to `ai-helm-values` (the private prod-values repo). All new
  fields have chart-level defaults that reproduce today's behavior
  unchanged, so no environment values file needs editing for this PR to
  be safe to merge later.
- Any change to `webank-models` itself (the sharding PR, #507, is a
  separate, already-open PR this one depends on for `shard_rows` to take
  runtime effect).
- Fixing the pre-existing, unrelated `$WEBANK_SOURCE_REVISION` env var
  that every one of these scripts references but that I could not find
  defined anywhere in this template's `env:` list, in either the base
  commit or my diff. Flagging it here since I noticed it while reading
  the file closely, but reproducing/fixing it is outside this PR's scope.

---

## 4. Design notes (read before merging)

**`publish_to_lakefs` is a shell `if`, not an Argo `when:` on a DAG task.**
The task brief that produced this PR assumed `charts/webank-training`
already used Argo `dag: tasks:` with a separable "publish" task node. It
doesn't: every `<id>-dataset-build` `WorkflowTemplate` here is **one
`container` template running one shell script in one pod**
(`charts/webank-training/values.yaml`'s own comment: "unlike
webank-models' own (undeployed, documentation-by-example)
`deploy/argo-workflows/dataset-build-workflowtemplate.yaml` ... every
`build`/`train` template here runs as ONE container in ONE pod — no
multi-step DAG spanning separate pods"). Restructuring that into a real
multi-task DAG (to attach a native `when:`) would mean splitting each
template into multiple pods with artifacts passed between them, replacing
the shared `emptyDir` volume design, and touching the GPU-placement /
volume contract this chart deliberately keeps simple — a much larger,
riskier change than this proposition asked for. A shell-level `if` inside
the existing single-container script produces the identical operator-
facing behavior ("stop after producing/validating the local bundle") with
a far smaller, more reviewable diff. Flagging this explicitly as a
deviation from the suggested mechanism, not a silent substitution.

**The "MIDV template" is real, but exists only as an unmerged, live,
non-GitOps object — not in this chart or any branch I could find.** I
searched before writing any code: `grep`-ing `ai-helm` and
`ai-helm-values` (both at `main`) for "midv" returns zero matches in
either repository. But `kubectl get workflowtemplate -n mlops` against
`hetzner-prod` (read-only, as permitted) shows a live
`webank-document-recognizer-midv-dataset-build` object:
  - `metadata.creationTimestamp: 2026-08-14T10:44:27Z`, `generation: 5`
    (edited five times already — actively being iterated on, today).
  - `labels: {app.kubernetes.io/instance: test, helm.sh/chart:
    webank-training-0.2.0}` — **not** `instance: webank-training`
    (chart `0.2.23`), which is the real ArgoCD-managed
    `aii-webank-training` release's label on every other WorkflowTemplate
    in the namespace. `helm --kube-context hetzner-prod -n mlops list -a`
    shows no tracked release named `test` either, so this was applied via
    `kubectl apply` (very likely `helm template ... | kubectl apply -f -`
    from a local chart checkout) directly against the production
    namespace, bypassing ArgoCD/GitOps review entirely.
  - Its `spec.arguments.parameters` already include `crop_limit`
    (`"Optional cap on the number of crops materialized. Empty means the
    full subset."`), `exclude_doc_types`, `midv_archive`, and
    `output_destination` — `crop_limit` here matches this proposition's
    requested name and semantics **exactly**, feeding
    `xtask midv-raw-source --limit "$CROP_LIMIT"` when set.
  - Its `spec.templates[0].dag.tasks` genuinely is a multi-task DAG
    (`fetch-midv-source`, `derive-labels-vocabulary`, `midv-raw-source`,
    `materialize-synthetic-source`, `pack-dataset`, `validate-round-trip`)
    with per-step `volumeClaimTemplates`, unlike every other template in
    this chart. It has **no publish task** — it stages the bundle on a
    workspace PVC and a durable output PVC only, with an explicit
    in-script comment: `"nothing published to LakeFS (webank-models#401,
    RFC-0006 IP-counsel questions open)"`. This matches the hard
    constraint's description of the MIDV template precisely.
  - **It already ran for real**: `kubectl get workflows -n mlops` shows
    `webank-document-recognizer-midv-dataset-build-7rzkx`, `Succeeded`,
    `2026-08-14T10:53:13Z` → `11:06:45Z` (started with no parameter
    overrides, so `crop_limit=""` — the **full** real MIDV-2020 subset,
    not a limited one), followed by a `midv-persist-z6hmn` workflow,
    `Succeeded`, ~4h13m before this check, and a durable
    `webank-document-recognizer-midv-dataset-build-output` PVC (20Gi,
    Bound, longhorn) it staged output onto.

I take three things from this: (1) `crop_limit` was never a
misunderstanding on the brief's part — it's a real parameter someone has
already built, matching this proposition's description word-for-word;
(2) that work is not in any repository I have access to, so I cannot
review, extend, or merge it responsibly from this PR — reconstructing an
entire six-step DAG plus durable-PVC design from a `kubectl get -o yaml`
dump of someone else's `generation: 5`, actively-iterated prototype risks
getting it wrong and colliding with work already in flight; (3) real,
governed MIDV-2020 data (ShareAlike, `redistribution_scope_determination:
unresolved` per webank-models RFC-0006, and webank-models#505's own
"docs/midv2020-risk-acceptance" PR is still **open**) was processed
end-to-end in the `mlops` production namespace outside of GitOps review,
today. I'm not taking any action on that (no mutating kubectl, and
deleting/altering someone else's in-flight object is well outside this
task), but flagging it plainly rather than deciding it belongs to a
"future" template, per this repo's own instruction not to decide what's
reserved for a human. Whoever owns that live object should either open
its own PR against this chart (at which point its
`publishToLakefsDefault` should default `false`, exactly as the brief's
hard constraint already anticipates) or explain why it was applied
directly.

**`crop_limit` therefore stays out of this PR, not because it's unneeded,
but because its real implementation lives elsewhere and I don't have its
source.** Adding `samples` instead, scoped to what I could actually
verify end-to-end in this chart:
  - `document-detector` and `face-detector`'s row/sample counts are baked
    into a reviewed, signed `bootstrap-policy.json` shipped in the image,
    not a CLI flag — deliberately not a runtime knob (RFC-0008's governed
    bootstrap-policy chain), so I did not add an override for either.
  - `document-recognizer`'s Python generator (`webank_document_recognizer
    _dataset`) has a real `--samples INT` flag (default 256, "1..10000")
    that this template never passed, so the tool's own default applied
    silently. I exposed that as `samples`, defaulting to 256 (today's
    silent behavior, made explicit and reviewable) — a genuine "vary this
    for a faster local run" knob on the committed, hermetic-synthetic
    path this PR actually touches. It does not have "unset = everything"
    semantics (no natural "everything" exists for a synthetic generator),
    so it is not a rename of the requested `crop_limit` — see above for
    where that parameter actually lives today.

**Ordering dependency on webank-models#507.** `shard_rows` /
`WEBANK_RECOGNIZER_SHARD_ROWS` is
[webank-models#507](https://github.com/ADORSYS-GIS/webank-models/pull/507)
(**open**, not yet merged at the time of writing) — its `--shard-rows`
flag definition is:
```rust
#[arg(
    long,
    env = "WEBANK_RECOGNIZER_SHARD_ROWS",
    default_value_t = recognizer_training::DEFAULT_SHARD_ROWS  // = 2000
)]
shard_rows: usize,
```
on `xtask training-data materialize-synthetic-source`. This PR only ever
sets the **env var**, never an explicit `--shard-rows` CLI flag, so on a
`training.datasetBuild.image` built from `main` today (pre-#507) the
extra env var is simply unread — inert, not a breaking "unrecognized
argument" failure. `shard_rows` only takes real effect once #507 merges
**and** `training.datasetBuild.image` in `ai-helm-values` is bumped to a
digest built after that merge. `samples` and `publish_to_lakefs` have no
such dependency — both work against the image pinned in production today.

---

## 5. Verification

Evidence links:

- Sharding PR whose flag names this chart matches: https://github.com/ADORSYS-GIS/webank-models/pull/507
- Deployed chart consumer (ArgoCD app `aii-webank-training`) values: https://github.com/ADORSYS-GIS/ai-helm-values/blob/main/environments/prod/values/webank-training.yaml

Literal CI-command output, run against both the CI fixture and the real decoded prod values:

```console
$ helm lint charts/webank-training --strict -f charts/webank-training/ci/lint-values.yaml
1 chart(s) linted, 0 chart(s) failed
$ helm lint charts/webank-training --strict -f <decoded prod values>
1 chart(s) linted, 0 chart(s) failed
$ helm template webank-training charts/webank-training -f charts/webank-training/ci/lint-values.yaml --dry-run
(exit 0)
```

Rendered parameter defaults, confirming the plumbing: `publish_to_lakefs: "true"`, `shard_rows: "2000"`, `samples: "256"`. An overlay setting `training.datasetBuild.publishToLakefsDefault: false` with a per-model `true` on document-recognizer rendered `"false"`/`"true"` correctly — this test caught a real bug where Helm's `default` silently discards an explicit `false`, fixed with `hasKey`.


I verified this change by:

- [ ] Running automated tests
- [ ] Running manual tests
- [ ] Checking logs
- [ ] Checking metrics
- [ ] Testing error cases
- [ ] Testing permissions/security behavior
- [ ] Testing rollback or failure behavior, if relevant

Commands run (Helm v3.16.1 locally; CI pins v3.15.4 via
`.github/workflows/helm-lint.yaml`):

```bash
helm dependency update charts/webank-training
helm lint charts/webank-training --strict -f charts/webank-training/ci/lint-values.yaml
helm template webank-training charts/webank-training -f charts/webank-training/ci/lint-values.yaml --dry-run
helm lint charts/webank-training --strict -f <decoded ai-helm-values prod webank-training.yaml>
helm template webank-training charts/webank-training -f <decoded prod values> --dry-run
  # override proof: chart-wide + per-model publishToLakefsDefault, and
  # shardRows/samples, via an overlay values file
helm template webank-training charts/webank-training -f charts/webank-training/ci/lint-values.yaml -f <override overlay> --dry-run
```

Results: all `helm lint --strict` runs report `1 chart(s) linted, 0
chart(s) failed`; all `helm template --dry-run` runs exit 0. Rendered
`publish_to_lakefs` defaults to `"true"` on all three templates against
both the CI fixture and real prod values (preserving today's behavior);
`shard_rows` renders `"2000"` and `samples` renders `"256"` against both.
Overriding `training.datasetBuild.publishToLakefsDefault: false`
chart-wide plus a per-model `publishToLakefsDefault: true` override on
`document-recognizer` renders `"false"` for document-detector and
`"true"` for document-recognizer, proving the `hasKey` override chain
(fixed a real `default`-on-`false` bug caught during this exact test —
see commit message). All five `<id>-train` templates and the CI fixture's
`webank-sface-train` / `webank-pad-liveness-train` render byte-identical
to the pre-change template. Neither `sface` nor `pad-liveness` renders a
dataset-build `WorkflowTemplate` in the CI fixture or real prod values
(not `enabled: true` in either), so this diff has zero live effect on
that path independent of the `hermetic-synthetic` gating I also added.

Full rendered-output excerpts and raw command output are in the PR
description's linked report; ask if you want the complete `helm template`
dumps attached instead of excerpted.

---

## 6. Risk Assessment

Risk level:

* [x] Low

Potential risks:

* `shard_rows` is inert until webank-models#507 merges and the image
  digest bumps — if someone submits `-p shard_rows=...` before then
  expecting it to take effect, it silently won't (no error, just ignored
  by the older binary).
* `publish_to_lakefs=false` changes operational behavior on real
  `argo submit -p publish_to_lakefs=false` runs against production LakeFS
  (a run will silently not land its dataset) — mitigated by defaulting to
  `true` everywhere, matching today's behavior exactly.

Mitigation:

* PR description states the #507 ordering dependency explicitly (see
  "Design notes"); do not rely on `shard_rows` until that PR is merged
  and the image is rebuilt/re-pinned.
* All new parameters default to today's exact behavior; nothing changes
  for an operator who submits with no `-p` overrides.

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [x] Refactoring
* [ ] Generating tests
* [x] Drafting documentation
* [ ] Reviewing the diff
* [ ] Not used

Human verification:

* [ ] I understand every meaningful change in this PR
* [ ] I checked generated code manually
* [ ] I checked generated tests manually
* [ ] I removed unsupported AI assumptions
* [ ] I accept responsibility for this PR

---

## 8. Reviewer Focus

Please focus your review on:

* [x] Correctness
* [x] Architecture
* [ ] Security
* [ ] Performance
* [ ] Tests
* [x] Maintainability
* [x] Product intent
* [x] Edge cases

In particular: (1) whether the "no MIDV template exists here" reading is
correct, or whether I'm missing a template/environment I didn't find; (2)
whether the shell-`if` substitution for Argo `when:` is an acceptable
trade for keeping the one-pod-per-template design; (3) whether declining
`crop_limit` and substituting `samples` is the right call, or whether
`midv-raw-source` should instead gain a live call site in this chart as a
follow-up.

**Not merged.** This chart renders onto `hetzner-prod` via the ArgoCD app
`aii-webank-training` within roughly 3 minutes of a merge to `main` — do
not merge until the questions above are resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

