### PR TITLE
feat(webank-training): bring the MIDV-2020 dataset-build template under GitOps

### DIFF
--- a/charts/webank-training/ci/lint-values.yaml
+++ b/charts/webank-training/ci/lint-values.yaml
@@ -16,6 +16,11 @@ training:
         effect: NoSchedule
   datasetBuild:
     image: ghcr.io/adorsys-gis/webank-dataset-gpu@sha256:c4ddb832deda7854bb617d422acca099001a6ec2aea1d585b8e460a53e4f6edf
+  midvDatasetBuild:
+    enabled: true
+    labelsVocabulary:
+      repository: PaddlePaddle/PP-OCRv6_small_rec_safetensors
+      revision: fe049fb103f57443fe8840c54ed06b702f3c1de5
 models:
   - id: document-detector
     trainer: document-detector

--- a/charts/webank-training/templates/document-recognizer-midv-dataset-build-workflowtemplate.yaml
+++ b/charts/webank-training/templates/document-recognizer-midv-dataset-build-workflowtemplate.yaml
@@ -1,0 +1,501 @@
+# MIDV-2020 real-crop dataset build for the document-recognizer (RFC-0009,
+# webank-models story #328 / epic #326 / ticket #408). Distinct from the
+# `<id>-dataset-build` templates rendered by workflowtemplate.yaml above:
+# those are one hermetic-synthetic Python generator running in a single
+# container/pod. This is a six-step DAG spanning separate pods (deriving the
+# governed CTC labels vocabulary, a real archive fetch, a release-mode
+# `xtask` crop pass, materialization, packing, and a round-trip validation),
+# so it needs a PVC that outlives any one pod, not an `emptyDir`.
+#
+# This is a fidelity adoption of an object that was already applied directly
+# to hetzner-prod with `kubectl apply` (self-inflicted GitOps drift, not
+# another team's work) and has already run to completion twice, producing
+# the project's only real MIDV-2020 dataset now in LakeFS-adjacent storage.
+# Bringing it under this chart does not change its DAG, its commands, or its
+# step order — see the per-step comments below for exactly what carried over
+# unchanged versus what is now Helm-values-driven.
+#
+# This workflow deliberately never calls LakeFS or `fixed-dataset publish`.
+# MIDV-2020's `source_class: third_party_licensed` cannot clear
+# `readiness-gate` today: RFC-0006's `third_party_licensed` amendment landed
+# as a spec change only (webank-models#402), the schema/xtask/
+# `validate_run_start` implementation remains outstanding (webank-models#401),
+# and webank-models#505's own risk-acceptance PR is still unmerged. It stops
+# after producing a validated bundle staged two ways: as this workflow's one
+# Argo output artifact (archived to the cluster's already-configured default
+# artifact repository), and as a durable copy on a pre-existing, separately
+# managed PVC (`webank-document-recognizer-midv-dataset-build-output`) that
+# survives workflow completion/GC — both stagings already exist on the live
+# object; neither is new. Adding a dormant, always-false-guarded publish step
+# here would be dead code standing in for a capability that does not exist
+# yet, not a kill-switch, so none is added.
+{{- $workflow := .Values.workflow -}}
+{{- $training := .Values.training -}}
+{{- $midv := $training.midvDatasetBuild -}}
+{{- $name := "webank-document-recognizer-midv-dataset-build" -}}
+{{- $outputPvcClaimName := printf "%s-output" $name -}}
+{{- if $midv.enabled }}
+{{- if not $training.datasetBuild.image }}{{ fail "webank-training: training.datasetBuild.image must be an immutable image digest" }}{{- end }}
+{{- if not (contains "@sha256:" $training.datasetBuild.image) }}{{ fail "webank-training: training.datasetBuild.image must be digest-pinned" }}{{- end }}
+{{- if not $workflow.serviceAccountName }}{{ fail "webank-training: workflow.serviceAccountName is required" }}{{- end }}
+{{- if eq (len $training.gpu.nodeSelector) 0 }}{{ fail "webank-training: GPU-capable templates require a non-empty training.gpu.nodeSelector" }}{{- end }}
+{{- if not ($training.gpu.runtimeClassName | default "") }}{{ fail "webank-training: GPU-capable templates require training.gpu.runtimeClassName" }}{{- end }}
+{{- if eq (len $training.gpu.tolerations) 0 }}{{ fail "webank-training: GPU-capable templates require at least one training.gpu.toleration" }}{{- end }}
+{{- if not $training.otel.endpoint }}{{ fail "webank-training: training.otel.endpoint is required" }}{{- end }}
+{{- if not $midv.labelsVocabulary.repository }}{{ fail "webank-training: training.midvDatasetBuild.labelsVocabulary.repository is required" }}{{- end }}
+{{- if not $midv.labelsVocabulary.revision }}{{ fail "webank-training: training.midvDatasetBuild.labelsVocabulary.revision is required" }}{{- end }}
+---
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: {{ $name | quote }}
+  labels:
+    {{- include "common.labels.standard" $ | nindent 4 }}
+    app.kubernetes.io/part-of: webank-models
+    app.kubernetes.io/component: dataset-build
+    webank.io/model: document-recognizer
+  annotations:
+    webank.io/adr: "0034"
+    webank.io/rfc: "0009"
+    webank.io/ticket: "408"
+    webank.io/source-strategy: midv-2020-real
+spec:
+  entrypoint: build
+  # Live value, distinct from the shared `workflow.activeDeadlineSeconds`
+  # (21600s) every other template here uses: this DAG measured well under 4
+  # minutes of compute locally (release build, real 825 MB / 10-document-type
+  # MIDV-2020 cache), so 3600s already budgets generously for a slower
+  # in-cluster archive fetch, image pull, and PVC provisioning while still
+  # bounding a stuck run.
+  activeDeadlineSeconds: 3600
+  ttlStrategy:
+    secondsAfterCompletion: {{ $workflow.ttlSecondsAfterCompletion }}
+  serviceAccountName: {{ $workflow.serviceAccountName | quote }}
+  {{- with $workflow.imagePullSecrets }}
+  imagePullSecrets:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  # One PVC shared by every task in this DAG, so the raw crops, the
+  # materialized inputs.safetensors, the packed bundle, and its unpacked
+  # round-trip copy are never re-uploaded/re-downloaded between steps.
+  # ReadWriteOnce is sufficient: this DAG is a straight-line sequence, never
+  # two tasks mounting the volume concurrently. `longhorn` (not the cluster's
+  # default `hcloud-volumes`): both GPU nodes run the Longhorn CSI plugin,
+  # while the Hetzner Cloud CSI driver's managed fleet does not include them,
+  # so a default-class PVC first bound by a non-GPU step's pod could never
+  # later attach to a GPU node.
+  volumeClaimTemplates:
+    - metadata:
+        name: workspace
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        storageClassName: longhorn
+        resources:
+          requests:
+            storage: {{ $midv.workspaceSizeLimit | quote }}
+  arguments:
+    parameters:
+      - name: run_name
+        description: >-
+          Human-chosen identifier, this build's correlation key across its
+          OTLP traces/logs (ADR-0015).
+        value: {{ printf "midv-dataset-build-{{workflow.name}}" | quote }}
+      - name: exclude_doc_types
+        description: >-
+          Comma-separated MIDV-2020 document-type codes to exclude (e.g.
+          "alb_id,aze_passport") for a doc-type-disjoint holdout split.
+          Empty means no exclusion.
+        value: ""
+      - name: crop_limit
+        description: >-
+          Optional cap on the number of crops materialized. Empty means the
+          full subset.
+        value: {{ $midv.cropLimit | default "" | quote }}
+      - name: midv_archive
+        description: >-
+          Optional override of scripts/fetch-midv2020.sh's own --archive
+          flag. Empty uses the script's own default (templates.tar).
+        value: ""
+      - name: output_destination
+        description: >-
+          Relative directory the validated bundle plus its round-trip
+          SHA-256 report are staged under, both on /workspace/output (this
+          workflow's Argo output artifact) and on the durable outputPvc
+          mounted at /durable. Not a LakeFS path.
+        value: "document-recognizer/midv-dataset-build"
+  templates:
+    - name: build
+      dag:
+        tasks:
+          - name: derive-labels-vocabulary
+            template: derive-labels-vocabulary
+          - name: fetch-midv-source
+            template: fetch-midv-source
+          - name: midv-raw-source
+            dependencies: [fetch-midv-source, derive-labels-vocabulary]
+            template: midv-raw-source
+          - name: materialize-synthetic-source
+            dependencies: [midv-raw-source]
+            template: materialize-synthetic-source
+          - name: pack-dataset
+            dependencies: [materialize-synthetic-source]
+            template: pack-dataset
+          - name: validate-round-trip
+            dependencies: [pack-dataset]
+            template: validate-round-trip
+
+    # Derive the governed document-recognizer CTC vocabulary (labels.json)
+    # in-pod: fetch the publisher's pinned preprocessor_config.json and
+    # extract its character_list (18710 entries, index 0 "blank"). The
+    # HuggingFace repository/revision are Helm values, not hardcoded, so an
+    # environment can re-pin the source without a template change.
+    - name: derive-labels-vocabulary
+      metadata:
+        labels:
+          app.kubernetes.io/part-of: webank-models
+          webank.io/step: derive-labels-vocabulary
+      nodeSelector:
+        {{- toYaml $training.gpu.nodeSelector | nindent 8 }}
+      {{- with $training.gpu.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $training.gpu.priorityClassName }}
+      priorityClassName: {{ . | quote }}
+      {{- end }}
+      securityContext:
+        fsGroup: 10001
+      container:
+        image: {{ $training.datasetBuild.image | quote }}
+        command: ["sh", "-ceu"]
+        args:
+          - |
+            curl -fSL --connect-timeout 30 --max-time 120 \
+              "https://huggingface.co/{{ $midv.labelsVocabulary.repository }}/resolve/{{ $midv.labelsVocabulary.revision }}/preprocessor_config.json" \
+              -o /workspace/preprocessor_config.json
+            python3 -c '
+            import json
+            cfg = json.load(open("/workspace/preprocessor_config.json"))
+            labels = cfg["character_list"]
+            assert isinstance(labels, list) and len(labels) == 18710, "expected 18710 labels, got %d" % len(labels)
+            assert labels[0] == "blank", "index 0 must be blank, got %r" % (labels[0],)
+            json.dump(labels, open("/workspace/labels.json", "w"), ensure_ascii=False, separators=(",", ":"))
+            print("labels %d entries, index0=%r indexN=%r" % (len(labels), labels[0], labels[-1]))
+            '
+        env:
+          - name: OTEL_EXPORTER_OTLP_ENDPOINT
+            value: {{ $training.otel.endpoint | quote }}
+          - name: OTEL_SERVICE_NAME
+            value: "webank-dataset-build-derive-labels-vocabulary"
+        volumeMounts:
+          - name: workspace
+            mountPath: /workspace
+        resources:
+          requests: { cpu: "250m", memory: "256Mi", ephemeral-storage: "256Mi" }
+          limits: { cpu: "500m", memory: "512Mi", ephemeral-storage: "512Mi" }
+
+    # Pull the pinned, checksum-verified MIDV-2020 archive
+    # (scripts/fetch-midv2020.sh, baked into the image: CC BY-SA 2.5,
+    # mock/synthetic documents, no consent gate). This step never touches
+    # the xtask binary, but still needs GPU node placement: `longhorn`
+    # (this DAG's shared-PVC StorageClass) runs its CSI plugin only on
+    # `nvidia.com/gpu.present=true` nodes, and every pod that mounts this PVC
+    # must land on that same node pool regardless of its own compute needs.
+    - name: fetch-midv-source
+      metadata:
+        labels:
+          app.kubernetes.io/part-of: webank-models
+          webank.io/step: fetch-midv-source
+      nodeSelector:
+        {{- toYaml $training.gpu.nodeSelector | nindent 8 }}
+      {{- with $training.gpu.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $training.gpu.priorityClassName }}
+      priorityClassName: {{ . | quote }}
+      {{- end }}
+      securityContext:
+        fsGroup: 10001
+      container:
+        image: {{ $training.datasetBuild.image | quote }}
+        command: ["sh", "-ceu"]
+        args:
+          - |
+            if [ -n "${MIDV_ARCHIVE:-}" ]; then
+              /opt/webank-models/scripts/fetch-midv2020.sh \
+                --dest /workspace/midv-2020 --archive "$MIDV_ARCHIVE"
+            else
+              /opt/webank-models/scripts/fetch-midv2020.sh --dest /workspace/midv-2020
+            fi
+        env:
+          - name: MIDV_ARCHIVE
+            value: "{{`{{workflow.parameters.midv_archive}}`}}"
+          - name: TRAINING_RUN_ID
+            value: "{{`{{workflow.parameters.run_name}}`}}"
+          - name: OTEL_EXPORTER_OTLP_ENDPOINT
+            value: {{ $training.otel.endpoint | quote }}
+          - name: OTEL_SERVICE_NAME
+            value: "webank-dataset-build-fetch-midv-source"
+        volumeMounts:
+          - name: workspace
+            mountPath: /workspace
+        resources:
+          requests: { cpu: "250m", memory: "256Mi", ephemeral-storage: "256Mi" }
+          limits: { cpu: "500m", memory: "512Mi", ephemeral-storage: "512Mi" }
+
+    # Real MIDV-2020 crops in the exact raw source-directory shape
+    # `training-data materialize-synthetic-source --model document-recognizer`
+    # expects. GPU node placement only because the image's release `xtask`
+    # binary links `libcuda.so.1` and cannot start otherwise (ai-helm#949) —
+    # this step's own work stays CPU/IO only.
+    - name: midv-raw-source
+      metadata:
+        labels:
+          app.kubernetes.io/part-of: webank-models
+          webank.io/step: midv-raw-source
+      podSpecPatch: |
+        runtimeClassName: {{ $training.gpu.runtimeClassName | quote }}
+      nodeSelector:
+        {{- toYaml $training.gpu.nodeSelector | nindent 8 }}
+      {{- with $training.gpu.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $training.gpu.priorityClassName }}
+      priorityClassName: {{ . | quote }}
+      {{- end }}
+      securityContext:
+        fsGroup: 10001
+      container:
+        image: {{ $training.datasetBuild.image | quote }}
+        command: ["sh", "-ceu"]
+        args:
+          - |
+            set -- --cache /workspace/midv-2020 \
+                    --labels /workspace/labels.json \
+                    --output-dir /workspace/raw-source
+            if [ -n "${CROP_LIMIT:-}" ]; then
+              set -- "$@" --limit "$CROP_LIMIT"
+            fi
+            if [ -n "${EXCLUDE_DOC_TYPES:-}" ]; then
+              old_ifs=$IFS
+              IFS=,
+              for doc_type in $EXCLUDE_DOC_TYPES; do
+                [ -n "$doc_type" ] && set -- "$@" --exclude-doc-type "$doc_type"
+              done
+              IFS=$old_ifs
+            fi
+            exec xtask midv-raw-source "$@"
+        env:
+          - name: EXCLUDE_DOC_TYPES
+            value: "{{`{{workflow.parameters.exclude_doc_types}}`}}"
+          - name: CROP_LIMIT
+            value: "{{`{{workflow.parameters.crop_limit}}`}}"
+          - name: TRAINING_RUN_ID
+            value: "{{`{{workflow.parameters.run_name}}`}}"
+          - name: OTEL_EXPORTER_OTLP_ENDPOINT
+            value: {{ $training.otel.endpoint | quote }}
+          - name: OTEL_SERVICE_NAME
+            value: "webank-dataset-build-midv-raw-source"
+        volumeMounts:
+          - name: workspace
+            mountPath: /workspace
+        resources:
+          {{- toYaml $training.datasetBuild.resources | nindent 10 }}
+
+    # Apply the document-recognizer's typed model-io/Candle training
+    # contract to the raw crops — the same adapter the document-recognizer
+    # hermetic-synthetic builder already uses. Filesystem-only.
+    - name: materialize-synthetic-source
+      metadata:
+        labels:
+          app.kubernetes.io/part-of: webank-models
+          webank.io/step: materialize-synthetic-source
+      podSpecPatch: |
+        runtimeClassName: {{ $training.gpu.runtimeClassName | quote }}
+      nodeSelector:
+        {{- toYaml $training.gpu.nodeSelector | nindent 8 }}
+      {{- with $training.gpu.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $training.gpu.priorityClassName }}
+      priorityClassName: {{ . | quote }}
+      {{- end }}
+      securityContext:
+        fsGroup: 10001
+      container:
+        image: {{ $training.datasetBuild.image | quote }}
+        command: ["xtask"]
+        args:
+          - training-data
+          - materialize-synthetic-source
+          - --model
+          - document-recognizer
+          - --source
+          - /workspace/raw-source
+          - --output
+          - /workspace/materialized
+        env:
+          - name: TRAINING_RUN_ID
+            value: "{{`{{workflow.parameters.run_name}}`}}"
+          - name: OTEL_EXPORTER_OTLP_ENDPOINT
+            value: {{ $training.otel.endpoint | quote }}
+          - name: OTEL_SERVICE_NAME
+            value: "webank-dataset-build-materialize-synthetic-source"
+        volumeMounts:
+          - name: workspace
+            mountPath: /workspace
+        resources:
+          {{- toYaml $training.datasetBuild.resources | nindent 10 }}
+
+    # Seal the materialized directory into the one archive shape
+    # `fixed-dataset unpack` / the train workflow's `fixed-dataset fetch`
+    # already expect. No network access.
+    - name: pack-dataset
+      metadata:
+        labels:
+          app.kubernetes.io/part-of: webank-models
+          webank.io/step: pack-dataset
+      podSpecPatch: |
+        runtimeClassName: {{ $training.gpu.runtimeClassName | quote }}
+      nodeSelector:
+        {{- toYaml $training.gpu.nodeSelector | nindent 8 }}
+      {{- with $training.gpu.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $training.gpu.priorityClassName }}
+      priorityClassName: {{ . | quote }}
+      {{- end }}
+      securityContext:
+        fsGroup: 10001
+      container:
+        image: {{ $training.datasetBuild.image | quote }}
+        command: ["xtask"]
+        args:
+          - training-data
+          - fixed-dataset
+          - pack
+          - --model
+          - document-recognizer
+          - --input
+          - /workspace/materialized
+          - --output
+          - /workspace/bundle.tar
+        env:
+          - name: TRAINING_RUN_ID
+            value: "{{`{{workflow.parameters.run_name}}`}}"
+          - name: OTEL_EXPORTER_OTLP_ENDPOINT
+            value: {{ $training.otel.endpoint | quote }}
+          - name: OTEL_SERVICE_NAME
+            value: "webank-dataset-build-pack-dataset"
+        volumeMounts:
+          - name: workspace
+            mountPath: /workspace
+        resources:
+          {{- toYaml $training.datasetBuild.resources | nindent 10 }}
+
+    # Unpack the sealed bundle and prove it is byte-identical to what was
+    # packed, then stage the validated bundle two ways: as this workflow's
+    # one output artifact, and as a durable copy on a pre-existing PVC that
+    # survives workflow completion/GC (that PVC is provisioned and owned
+    # outside this chart — see the values.yaml comment on
+    # `midvDatasetBuild.durableOutputPvcClaimName`). No LakeFS publication
+    # step exists — see the top-of-file comment.
+    - name: validate-round-trip
+      metadata:
+        labels:
+          app.kubernetes.io/part-of: webank-models
+          webank.io/step: validate-round-trip
+      podSpecPatch: |
+        runtimeClassName: {{ $training.gpu.runtimeClassName | quote }}
+      nodeSelector:
+        {{- toYaml $training.gpu.nodeSelector | nindent 8 }}
+      {{- with $training.gpu.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $training.gpu.priorityClassName }}
+      priorityClassName: {{ . | quote }}
+      {{- end }}
+      securityContext:
+        fsGroup: 10001
+      volumes:
+        - name: durable-output
+          persistentVolumeClaim:
+            claimName: {{ $midv.durableOutputPvcClaimName | default $outputPvcClaimName | quote }}
+      container:
+        image: {{ $training.datasetBuild.image | quote }}
+        command: ["sh", "-ceu"]
+        args:
+          - |
+            xtask training-data fixed-dataset unpack \
+              --model document-recognizer \
+              --bundle /workspace/bundle.tar \
+              --output /workspace/unpacked
+
+            materialized_dir=/workspace/materialized
+            unpacked_dir=/workspace/unpacked/dataset
+            failed=0
+            for original in "$materialized_dir"/*; do
+              name="$(basename "$original")"
+              original_sha="$(sha256sum "$original" | awk '{print $1}')"
+              roundtrip_sha="$(sha256sum "$unpacked_dir/$name" 2>/dev/null | awk '{print $1}')"
+              if [ "$original_sha" = "$roundtrip_sha" ]; then
+                echo "round-trip ok: $name $original_sha"
+              else
+                echo "ROUND-TRIP MISMATCH: $name original=$original_sha roundtrip=${roundtrip_sha:-<missing>}" >&2
+                failed=1
+              fi
+            done
+            if [ "$failed" -ne 0 ]; then
+              echo "fixed-dataset pack -> unpack is not byte-identical; refusing to stage an output artifact" >&2
+              exit 1
+            fi
+
+            mkdir -p "/workspace/output/$OUTPUT_DESTINATION"
+            cp /workspace/bundle.tar "/workspace/output/$OUTPUT_DESTINATION/training-bundle.tar"
+            sha256sum "$materialized_dir"/* > "/workspace/output/$OUTPUT_DESTINATION/round-trip-sha256.txt"
+            echo "local bundle validated and staged at /workspace/output/$OUTPUT_DESTINATION -- nothing published to LakeFS (webank-models#401, RFC-0006 IP-counsel questions open)"
+
+            # Durable copy: stage into a per-run directory on the outputPvc,
+            # then atomically rename it over the previous run's output. Both
+            # directories live on the same PVC mount, so the final `mv` is a
+            # same-device rename, not a copy.
+            durable_root=/durable
+            dest_dir="$durable_root/$OUTPUT_DESTINATION"
+            stage_dir="$durable_root/.staging-$TRAINING_RUN_ID"
+            rm -rf "$stage_dir"
+            mkdir -p "$stage_dir/$OUTPUT_DESTINATION"
+            cp /workspace/bundle.tar "$stage_dir/$OUTPUT_DESTINATION/training-bundle.tar"
+            sha256sum "$materialized_dir"/* > "$stage_dir/$OUTPUT_DESTINATION/round-trip-sha256.txt"
+            rm -rf "$dest_dir"
+            mkdir -p "$(dirname "$dest_dir")"
+            mv "$stage_dir/$OUTPUT_DESTINATION" "$dest_dir"
+            rmdir "$stage_dir" 2>/dev/null || true
+            echo "durable bundle staged at $dest_dir on PVC $DURABLE_OUTPUT_PVC (overwrites the previous run's output; this copy survives workflow completion/GC)"
+        env:
+          - name: OUTPUT_DESTINATION
+            value: "{{`{{workflow.parameters.output_destination}}`}}"
+          - name: TRAINING_RUN_ID
+            value: "{{`{{workflow.parameters.run_name}}`}}"
+          - name: DURABLE_OUTPUT_PVC
+            value: {{ $midv.durableOutputPvcClaimName | default $outputPvcClaimName | quote }}
+          - name: OTEL_EXPORTER_OTLP_ENDPOINT
+            value: {{ $training.otel.endpoint | quote }}
+          - name: OTEL_SERVICE_NAME
+            value: "webank-dataset-build-validate-round-trip"
+        volumeMounts:
+          - name: workspace
+            mountPath: /workspace
+          - name: durable-output
+            mountPath: /durable
+        resources:
+          {{- toYaml $training.datasetBuild.resources | nindent 10 }}
+      outputs:
+        artifacts:
+          - name: dataset-bundle
+            path: /workspace/output
+{{- end }}

--- a/charts/webank-training/values.yaml
+++ b/charts/webank-training/values.yaml
@@ -153,6 +153,47 @@ training:
     # that default an explicit, reviewable Helm value instead, and lets an
     # operator drop it for a fast local iteration run.
     samples: 256
+  # MIDV-2020 real-crop dataset build for document-recognizer only
+  # (webank-models RFC-0009, story #328, epic #326, ticket #408). Distinct
+  # from `datasetBuild` above: a six-step DAG across separate pods (one
+  # shared PVC plus a second, pre-existing durable-output PVC, not the
+  # single-container/emptyDir pattern the per-model loop below renders), and
+  # it deliberately never calls LakeFS — MIDV-2020's `third_party_licensed`
+  # source_class cannot clear `readiness-gate` today (webank-models#401,
+  # open RFC-0006 IP-counsel questions). `enabled: false` here follows the
+  # same interim-governance-gate convention `models[].datasetBuild.enabled`
+  # already uses in this chart: a real capability whose environment-specific
+  # activation is an explicit, documented per-environment decision, not a
+  # dormant flag. Flipping this to `true` in an environment values file
+  # alone does not reconcile the pre-existing, unmanaged live object this
+  # template adopts — that is a separate, human-owned follow-up.
+  midvDatasetBuild:
+    enabled: false
+    workspaceSizeLimit: 24Gi
+    # Optional cap on crops materialized, wired straight through to
+    # `xtask midv-raw-source --limit`. Empty (the live default) means the
+    # full MIDV-2020 subset; both real production runs so far used the
+    # default. Set per environment, or override per-run with
+    # `argo submit -p crop_limit=<n>`.
+    cropLimit: ""
+    # Name of the pre-existing, separately provisioned PersistentVolumeClaim
+    # (Longhorn, ReadWriteOnce) the validate-round-trip step's durable output
+    # copy lands on. This chart does not create or manage that PVC — it
+    # already exists in hetzner-prod (`webank-document-recognizer-midv-
+    # dataset-build-output`, 20Gi, Bound), itself provisioned outside GitOps
+    # the same way the WorkflowTemplate this file adopts was. Reconciling
+    # that PVC's own ownership is a separate, human decision; leaving this
+    # unset reproduces the live claimName unchanged
+    # (`<WorkflowTemplate name>-output`).
+    durableOutputPvcClaimName: ""
+    labelsVocabulary:
+      # Pinned HuggingFace revision webank-models' own
+      # scripts/fetch-document-recognizer-model.sh derives the governed CTC
+      # vocabulary from (preprocessor_config.json's character_list — 18710
+      # entries, index 0 "blank"). Fetched in-pod at run time so this
+      # template never needs a placeholder labels_vocabulary_url.
+      repository: ""
+      revision: ""
   documentDetector:
     stemChannels: 32
     epochs: 10


### PR DESCRIPTION
## 1. Summary

This PR changes:

- Adds `charts/webank-training/templates/document-recognizer-midv-dataset-build-workflowtemplate.yaml`,
  a new WorkflowTemplate rendering a six-task DAG
  (`derive-labels-vocabulary`, `fetch-midv-source`, `midv-raw-source`,
  `materialize-synthetic-source`, `pack-dataset`, `validate-round-trip`).
- Adds `training.midvDatasetBuild.{enabled,workspaceSizeLimit,cropLimit,
  durableOutputPvcClaimName,labelsVocabulary.{repository,revision}}` to
  `charts/webank-training/values.yaml`.
- Extends `charts/webank-training/ci/lint-values.yaml` with an
  `enabled: true` fixture so `helm lint --strict` / `helm template`
  render-cover the new template.

It solves:

- `WorkflowTemplate/webank-document-recognizer-midv-dataset-build` has
  been running in production (hetzner-prod, namespace `mlops`)
  **untracked by GitOps since 2026-08-14T10:44:27Z**, applied directly
  with `kubectl apply` (self-inflicted drift from an earlier automation
  run today, not another team's work). It has already run to completion
  twice (`webank-document-recognizer-midv-dataset-build-7rzkx`,
  `midv-persist-z6hmn`), producing 13,393 real MIDV-2020 crops and
  12,799 encoded rows — the project's only real dataset. It carries
  drift-tell labels (`app.kubernetes.io/instance: test`,
  `helm.sh/chart: webank-training-0.2.0`, vs. the real ArgoCD release's
  `instance: webank-training` / `chart: webank-training-0.2.23`) and
  only a `kubectl.kubernetes.io/last-applied-configuration` annotation,
  no `argocd.argoproj.io/tracking-id`. This PR brings it under this
  chart so it can be reviewed and reconciled through GitOps instead of
  staying invisible to it.

---

## 2. Intent

The intent of this PR is:

> Adopt an already-running production object into version control with
> zero behavior change — a fidelity exercise, not a redesign. The DAG's
> logic, step order, and commands are unchanged from what
> `kubectl get workflowtemplate ... -o yaml` returns today.

---

## 3. Scope

### In Scope

- Faithful transcription of the live object's six-step DAG, including
  the `validate-round-trip` step's durable-output-PVC copy (an earlier
  local draft of this same adoption had missed that step entirely —
  caught by re-diffing against the live object before opening this PR).
- `training.midvDatasetBuild.enabled` gate, default `false`, matching
  the `models[].datasetBuild.enabled` interim-governance-gate
  convention already in this chart.
- `training.midvDatasetBuild.cropLimit` values-driving the live
  `crop_limit` Argo parameter's default (already wired to `xtask
  midv-raw-source --limit`; both real production runs so far used the
  empty/full-subset default).
- Image and GPU placement reuse the chart's existing
  `training.datasetBuild.image` / `training.gpu.*` values. No new image
  value was needed: prod already pins `training.datasetBuild.image` to
  the same v1.9.0 digest
  (`sha256:b91bdebf35f8098cf2c4742937f8d3d5fc2451211b3ffe56557c43a86fcfb6ad`)
  the live MIDV object uses (`ai-helm-values` #245, merged 2026-08-13).

### Out of Scope

- **No publish step.** MIDV-2020's `source_class: third_party_licensed`
  cannot clear `readiness-gate` today (webank-models#401 implementation
  outstanding; webank-models#505's risk-acceptance PR is unmerged). The
  live object has no publish step; none is added here.
- **No DAG/logic/command change.** Verified byte-for-byte against the
  live object — see Verification below.
- **The durable output PVC is not created or adopted here.**
  `webank-document-recognizer-midv-dataset-build-output` (20Gi,
  Longhorn, Bound) is itself a separate, pre-existing, unmanaged
  resource — no Helm labels, no tracking annotation beyond a bare
  `kubectl apply`. This PR references it by name, unchanged, but
  reconciling its ownership is a separate decision.
- **`training.midvDatasetBuild.enabled: true` is not set anywhere in
  this PR.** Flipping it on in `ai-helm-values` is a follow-up someone
  needs to make deliberately; even then, the still-untracked live
  object's `instance: test` label means ArgoCD will not prune it as an
  orphan (tracking label mismatch) — reconciling/removing it is its own
  follow-up.
- `sface`, `pad-liveness`, and every `<id>-train` template: untouched.

---

## 4. Verification

I verified this change by:

- [ ] Running automated tests
- [x] Running manual tests
- [ ] Checking logs
- [ ] Checking metrics
- [ ] Testing error cases
- [ ] Testing permissions/security behavior
- [ ] Testing rollback or failure behavior, if relevant

Commands run (CI's own commands, from `.github/workflows/helm-lint.yaml`'s
`lint-mode: ci-values` branch, plus the same commands against the real
decoded prod values file for the fidelity check):

```bash
helm dependency update charts/webank-training

# CI fixture (as CI runs it)
helm lint charts/webank-training --strict -f charts/webank-training/ci/lint-values.yaml
helm template webank-training charts/webank-training -f charts/webank-training/ci/lint-values.yaml --dry-run > /dev/null

# Real decoded prod values (ai-helm-values environments/prod/values/webank-training.yaml) —
# proves the change is an inert no-op against today's production config
helm lint charts/webank-training --strict -f environments/prod/values/webank-training.yaml
helm template webank-training charts/webank-training -f environments/prod/values/webank-training.yaml --dry-run > /dev/null

# Same prod values + an overlay that only sets midvDatasetBuild.enabled/labelsVocabulary —
# proves the rendered manifest matches the live object once a human opts in
helm template webank-training charts/webank-training \
  -f environments/prod/values/webank-training.yaml \
  -f midv-enable-overlay.yaml --dry-run > rendered-prod-enabled.yaml

kubectl --context hetzner-prod -n mlops get workflowtemplate \
  webank-document-recognizer-midv-dataset-build -o json > live-midv.json
# structural diff (metadata.name/labels-minus-drift/annotations-minus-last-applied,
# and the full spec) between live-midv.json and the WorkflowTemplate document in
# rendered-prod-enabled.yaml
```

Results:

```text
==> Linting charts/webank-training (both fixtures)
[INFO] Chart.yaml: icon is recommended
1 chart(s) linted, 0 chart(s) failed

helm template ... --dry-run: exit 0 (both fixtures, both prod-values renders)

Baseline (prod values, midvDatasetBuild.enabled unset -> false) vs.
prod values + enable overlay: diff is a pure ADDITION of the one new
WorkflowTemplate document. Nothing else in the chart's rendered output
changes -- 0 lines removed.

Structural diff, live object vs. rendered (prod values + enable overlay),
spec-only and metadata minus drift/runtime fields:

--- live (cleaned)
+++ rendered (prod values + enable overlay)
@@ metadata.labels @@
+    app.kubernetes.io/instance: webank-training
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: webank-training
+    app.kubernetes.io/version: "1.2.0"
+    helm.sh/chart: webank-training-0.2.0

(no other lines differ -- spec: is byte-identical)
```

The only differences are the standard Helm-managed labels replacing the
live object's incorrect `instance: test` / `chart: webank-training-0.2.0`
drift labels — i.e. exactly the labels a correct GitOps adoption is
supposed to add. Every DAG task, command, volume, resource request, and
Argo parameter default in `spec:` is unchanged.

---

## 5. Screenshots / Evidence

* `kubectl get workflowtemplate` (live, hetzner-prod, `mlops`):
  `creationTimestamp: 2026-08-14T10:44:27Z`, `generation: 5`,
  `labels.app.kubernetes.io/instance: test`.
* `kubectl get workflows -n mlops`: `webank-document-recognizer-midv-dataset-build-7rzkx`
  and `midv-persist-z6hmn`, both `Succeeded`.
* `kubectl get pvc webank-document-recognizer-midv-dataset-build-output -n mlops`:
  `20Gi`, `Bound`, `longhorn`, no Helm labels.
* `gh api /orgs/ADORSYS-GIS/packages/container/webank-dataset-gpu/versions`:
  digest `sha256:b91bdebf...` tagged `1.9.0`.

---

## 6. Risk Assessment

Risk level:

* [x] Low
* [ ] Medium
* [ ] High

Potential risks:

* This chart is ArgoCD-managed in production and auto-syncs within
  ~3 minutes of a merge to `main`.
* Merging alone changes nothing live: `training.midvDatasetBuild.enabled`
  defaults `false` and is not flipped on anywhere in this PR, so the
  chart renders no new object against today's prod values (verified
  above).

Mitigation:

* **This PR is explicitly not being merged.** Left open for review only,
  per the task that produced it.
* Flipping `enabled: true` requires a deliberate follow-up PR against
  `ai-helm-values` with the real `labelsVocabulary` values, reviewed on
  its own.

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [ ] Refactoring
* [ ] Generating tests
* [x] Drafting documentation
* [x] Reviewing the diff
* [ ] Not used

Human verification:

* [ ] I understand every meaningful change in this PR
* [ ] I checked generated code manually
* [ ] I checked generated tests manually
* [ ] I removed unsupported AI assumptions
* [ ] I accept responsibility for this PR

---

## 8. Reviewer Focus

Please focus your review on:

* [x] Correctness
* [ ] Architecture
* [ ] Security
* [ ] Performance
* [ ] Tests
* [ ] Maintainability
* [x] Product intent
* [x] Edge cases

---

Relates to ai-helm#1005 (`feat/configurable-dataset-build`, draft): that
PR's design notes describe finding this exact live, untracked
`generation: 5` object during its own investigation and explicitly
declined to implement `crop_limit` because it could not find this
template's source in any repository — it flagged the same drift this PR
resolves rather than guessing at a reconstruction. This PR branches off
`main`, not #1005: #1005 only touches the three hermetic-synthetic
`<id>-dataset-build` templates in `workflowtemplate.yaml` and
`training.documentRecognizer.*` / `training.datasetBuild.
publishToLakefsDefault` values, while this PR adds one new template file
and a disjoint `training.midvDatasetBuild` values key. Neither `values.yaml`
nor `ci/lint-values.yaml` has overlapping lines between the two diffs, so
whichever merges first, the other rebases cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
