### PR TITLE
feat(lightbridge-db): restore lightbridge-usage-db CNPG cluster (TimescaleDB)

### DIFF
--- a/charts/lightbridge-db/Chart.yaml
+++ b/charts/lightbridge-db/Chart.yaml
@@ -1,10 +1,11 @@
 apiVersion: v2
 name: lightbridge-db
 description: |
-  CloudNativePG Cluster (lightbridge-main-db) for the Lightbridge authz stack,
-  plus its barman-cloud ObjectStore, ScheduledBackup and PodMonitor. Leaf chart
-  of the lightbridge App-of-Apps orchestrator (ADR-0019). The usage DB is
-  dropped (usage component removed).
+  CloudNativePG Clusters (lightbridge-main-db + lightbridge-usage-db) for the
+  Lightbridge authz stack, plus their barman-cloud ObjectStores,
+  ScheduledBackups and PodMonitors. Leaf chart of the lightbridge App-of-Apps
+  orchestrator (ADR-0019). lightbridge-usage-db is a dedicated
+  TimescaleDB-image cluster, restored after ADR-0026 dropped it.
 type: application
 version: 0.3.0
 appVersion: "1.0.0"

--- a/charts/lightbridge-db/values.yaml
+++ b/charts/lightbridge-db/values.yaml
@@ -227,21 +227,55 @@ resources:
   # lightbridge-usage-db — RESTORED (reverses the usage-db half of ADR-0026).
   # lightbridge-authz-usage (crates/lightbridge-authz-usage,
   # migrations-usage/) needs a Postgres it can call `create_hypertable()` on.
-  # It is NOT a `Database` CR on the shared lightbridge-main-db cluster like
-  # repoauth/codeintel/coder/governance below — those all work because their
-  # extensions (pgvector for codeintel) ship in the standard/system
-  # cloudnative-pg/postgresql image. TimescaleDB does NOT: it isn't in the
-  # Debian apt repos cloudnative-pg's images build from (unlike pgvector),
-  # so `CREATE EXTENSION timescaledb` would fail on lightbridge-main-db's
-  # plain ghcr.io/cloudnative-pg/postgresql:18.4-system-trixie image — there
-  # is no shared library for it to load. A dedicated Cluster on a
-  # Timescale-vendor image (via ClusterImageCatalog, since imageCatalogRef
-  # doesn't accept arbitrary third-party repos as imageName-equivalent
-  # inline) is the only viable mechanism, exactly as it was before
-  # ADR-0026 dropped it — see the restore runbook at
-  # docs/cnpg-native-backup/lightbridge-usage-db-restore.yaml, which still
-  # references this ClusterImageCatalog/Cluster pair and proves the prior
-  # setup was live and backed up. migrations-usage/20260223000001_init_usage.sql
+  #
+  # It is NOT a `Database` CR on the shared lightbridge-main-db cluster —
+  # confirmed against the LIVE cluster, not just the chart: lightbridge-main-db
+  # carries FIVE tenants today (database `app` — lightbridge-authz's own,
+  # verified via `\dt` → accounts/api_keys/projects/budget_grants/...— plus
+  # Database CRs `codeintel`/`coder`/`governance`/`repoauth` below), its image
+  # is the unmodified ghcr.io/cloudnative-pg/postgresql:18.4-system-trixie
+  # (no imageCatalogRef), and `codeintel` has pgvector ACTIVELY INSTALLED
+  # (`select extname, extversion from pg_extension` → vector 0.8.2) while
+  # `pg_available_extensions` on that same cluster does not list `timescaledb`
+  # at all. A `Database` CR's `extensions` field can only `CREATE EXTENSION`
+  # something the running image already ships, so `timescaledb` is out on the
+  # current image.
+  #
+  # Swapping lightbridge-main-db's image to a Timescale vendor image was
+  # evaluated too (both `timescale/timescaledb` and `timescale/timescaledb-ha`
+  # DO bundle pgvector — confirmed from their own Dockerfiles — so pgvector
+  # parity for codeintel is not actually the blocker one might expect).
+  # Rejected anyway: that image change would move ALL FIVE tenants —
+  # including lightbridge-authz's own `app` database, the platform's
+  # auth boundary — onto a different vendor image in one rolling operation,
+  # for a feature (`usage`) that has never been live in prod before now.
+  # Two concrete, checkable reasons this is not a routine image bump:
+  # (1) CNPG's admission webhook makes `.spec.postgresUID`/`postgresGID`
+  #     immutable once a Cluster has bootstrapped. lightbridge-main-db has
+  #     neither field set today, so it runs at CNPG's own default (26, the
+  #     `ghcr.io/cloudnative-pg/postgresql` convention). Timescale's
+  #     Alpine-based `timescaledb` image defaults postgres to UID 70 (why
+  #     THIS cluster, below, sets postgresUID/GID to 70 explicitly); the
+  #     Ubuntu-based `timescaledb-ha` image creates it at UID 1000. Neither
+  #     matches — an in-place swap is blocked short of re-bootstrapping,
+  #     which is a new cluster + a live data migration in every way that
+  #     matters, not a reuse of the existing one.
+  # (2) Debian trixie (glibc) → Alpine (musl) or → Ubuntu 22.04 (a different
+  #     glibc build) changes the C library backing Postgres's collations,
+  #     the textbook trigger for a collation-version mismatch: existing text
+  #     indexes across all five tenants (including codeintel's vector/text
+  #     indexes) would need an audited REINDEX pass to rule out silently
+  #     wrong comparisons post-swap.
+  # Given both, a small, fully isolated dedicated cluster is the lower-risk
+  # path to unblock a currently-broken service; consolidating onto
+  # lightbridge-main-db is a legitimate idea to revisit deliberately later,
+  # not something to fold into this fix. See the PR description for the
+  # full evaluation.
+  #
+  # This is exactly what existed before ADR-0026 dropped it — see the
+  # restore runbook at docs/cnpg-native-backup/lightbridge-usage-db-restore.yaml,
+  # which still references this ClusterImageCatalog/Cluster pair and proves
+  # the prior setup was live and backed up. migrations-usage/20260223000001_init_usage.sql
   # already guards this defensively (`IF EXISTS (SELECT 1 FROM
   # pg_available_extensions WHERE name = 'timescaledb') THEN CREATE
   # EXTENSION ...`), so it degrades to plain Postgres if this ever regresses
@@ -250,7 +284,22 @@ resources:
   #
   # instances/storage/resources/archive_timeout mirror the pre-ADR-0026 spec
   # verbatim (dedicated cluster, not shared, so no need for main-db's later
-  # max_connections/memory bump — that was sized for 7 shared tenant roles).
+  # max_connections/memory bump — that was sized for its shared tenants).
+  #
+  # Image major PINNED TO 18 (was 17 — wrong: latest TimescaleDB targets
+  # Postgres 18, and pg18 also matches lightbridge-main-db's own major, so a
+  # pg17 usage DB next to a pg18 estate would have been its own, unforced
+  # inconsistency). Tag verified live on Docker Hub: `GET
+  # https://hub.docker.com/v2/repositories/timescale/timescaledb/tags/2.29.1-pg18`
+  # → exists, multi-arch (amd64/arm64/...), pushed 2026-08-04 — the latest
+  # published TimescaleDB (2.29.1) built against Postgres 18. Deliberately
+  # the plain `timescale/timescaledb` image, not `timescale/timescaledb-ha`:
+  # the `-ha` variant bundles Patroni, pgBackRest, and Spilo glue for
+  # Zalando/Patroni-style HA — all of which CNPG replaces with its own
+  # controller and the barman-cloud plugin sidecar (already used below), so
+  # none of that tooling is used here; it would only add ~1.5GB of unused
+  # surface and move the default postgres UID to 1000 instead of the 70 this
+  # Cluster is already pinned to for the plain image.
   # ────────────────────────────────────────────────────────────────────
   - |
     apiVersion: postgresql.cnpg.io/v1
@@ -260,8 +309,8 @@ resources:
       namespace: converse
     spec:
       images:
-        - major: 17
-          image: timescale/timescaledb:2.21.1-pg17
+        - major: 18
+          image: timescale/timescaledb:2.29.1-pg18
   - |
     apiVersion: postgresql.cnpg.io/v1
     kind: Cluster
@@ -276,7 +325,7 @@ resources:
         apiGroup: postgresql.cnpg.io
         kind: ClusterImageCatalog
         name: lightbridge-usage-db
-        major: 17
+        major: 18
       storage:
         size: "10Gi"
       plugins:

--- a/charts/lightbridge-db/values.yaml
+++ b/charts/lightbridge-db/values.yaml
@@ -1,8 +1,11 @@
-# lightbridge-db — CNPG Cluster (lightbridge-main-db) + barman ObjectStore +
-# ScheduledBackup + PodMonitor. Leaf chart of the lightbridge orchestrator
-# (ADR-0019). Moved verbatim from the old flat app's rawRessources EXCEPT the
-# ObjectStore, which is modernised to Hetzner Object Storage (the old MinIO
-# s3.ssegning.me / ai-ops-backups is decommissioned). The usage DB is dropped.
+# lightbridge-db — CNPG Clusters (lightbridge-main-db, lightbridge-usage-db) +
+# their barman ObjectStores + ScheduledBackups + PodMonitors. Leaf chart of
+# the lightbridge orchestrator (ADR-0019). Moved verbatim from the old flat
+# app's rawRessources EXCEPT the ObjectStores, which are modernised to
+# Hetzner Object Storage (the old MinIO s3.ssegning.me / ai-ops-backups is
+# decommissioned). lightbridge-usage-db was dropped by ADR-0026 and is
+# restored below (see the block's own comment for why it is a separate
+# Cluster+ClusterImageCatalog rather than a Database CR on lightbridge-main-db).
 #
 # Namespace is `converse` (the orchestrator targets that namespace; these CRs
 # pin it explicitly to match the old flat-app behaviour).
@@ -217,6 +220,152 @@ resources:
       selector:
         matchLabels:
           cnpg.io/cluster: lightbridge-main-db
+      podMetricsEndpoints:
+        - port: metrics
+          interval: 30s
+  # ────────────────────────────────────────────────────────────────────
+  # lightbridge-usage-db — RESTORED (reverses the usage-db half of ADR-0026).
+  # lightbridge-authz-usage (crates/lightbridge-authz-usage,
+  # migrations-usage/) needs a Postgres it can call `create_hypertable()` on.
+  # It is NOT a `Database` CR on the shared lightbridge-main-db cluster like
+  # repoauth/codeintel/coder/governance below — those all work because their
+  # extensions (pgvector for codeintel) ship in the standard/system
+  # cloudnative-pg/postgresql image. TimescaleDB does NOT: it isn't in the
+  # Debian apt repos cloudnative-pg's images build from (unlike pgvector),
+  # so `CREATE EXTENSION timescaledb` would fail on lightbridge-main-db's
+  # plain ghcr.io/cloudnative-pg/postgresql:18.4-system-trixie image — there
+  # is no shared library for it to load. A dedicated Cluster on a
+  # Timescale-vendor image (via ClusterImageCatalog, since imageCatalogRef
+  # doesn't accept arbitrary third-party repos as imageName-equivalent
+  # inline) is the only viable mechanism, exactly as it was before
+  # ADR-0026 dropped it — see the restore runbook at
+  # docs/cnpg-native-backup/lightbridge-usage-db-restore.yaml, which still
+  # references this ClusterImageCatalog/Cluster pair and proves the prior
+  # setup was live and backed up. migrations-usage/20260223000001_init_usage.sql
+  # already guards this defensively (`IF EXISTS (SELECT 1 FROM
+  # pg_available_extensions WHERE name = 'timescaledb') THEN CREATE
+  # EXTENSION ...`), so it degrades to plain Postgres if this ever regresses
+  # — but hypertable partitioning (the reason usage_events exists on
+  # Timescale at all) only kicks in with the extension actually present.
+  #
+  # instances/storage/resources/archive_timeout mirror the pre-ADR-0026 spec
+  # verbatim (dedicated cluster, not shared, so no need for main-db's later
+  # max_connections/memory bump — that was sized for 7 shared tenant roles).
+  # ────────────────────────────────────────────────────────────────────
+  - |
+    apiVersion: postgresql.cnpg.io/v1
+    kind: ClusterImageCatalog
+    metadata:
+      name: lightbridge-usage-db
+      namespace: converse
+    spec:
+      images:
+        - major: 17
+          image: timescale/timescaledb:2.21.1-pg17
+  - |
+    apiVersion: postgresql.cnpg.io/v1
+    kind: Cluster
+    metadata:
+      name: lightbridge-usage-db
+      namespace: converse
+      annotations:
+        argocd.argoproj.io/sync-wave: "2"
+    spec:
+      instances: 2
+      imageCatalogRef:
+        apiGroup: postgresql.cnpg.io
+        kind: ClusterImageCatalog
+        name: lightbridge-usage-db
+        major: 17
+      storage:
+        size: "10Gi"
+      plugins:
+        - name: barman-cloud.cloudnative-pg.io
+          enabled: true
+          isWALArchiver: true
+          parameters:
+            barmanObjectName: lightbridge-usage-db
+            serverName: lightbridge-usage-db
+      postgresql:
+        parameters:
+          archive_timeout: "30min"
+        shared_preload_libraries:
+          - timescaledb
+      resources:
+        limits:
+          cpu: 300m
+          memory: 1Gi
+        requests:
+          cpu: 200m
+          memory: 500Mi
+      postgresUID: 70
+      postgresGID: 70
+      bootstrap:
+        initdb:
+          postInitTemplateSQL:
+            - CREATE EXTENSION IF NOT EXISTS timescaledb;
+  # ────────────────────────────────────────────────────────────────────
+  # barman-cloud ObjectStore for lightbridge-usage-db. Same Hetzner bucket +
+  # throttling/retention fixes as lightbridge-main-db's ObjectStore above
+  # (7d retention, jobs:1 + gzip) rather than the old 180d/unthrottled config
+  # the pre-ADR-0026 setup shipped with — that config is what rate-limited
+  # main-db's backups on Hetzner (see the note above); no reason to
+  # reintroduce the same bug for a second cluster on the same bucket.
+  # ────────────────────────────────────────────────────────────────────
+  - |
+    apiVersion: barmancloud.cnpg.io/v1
+    kind: ObjectStore
+    metadata:
+      name: lightbridge-usage-db
+      namespace: converse
+      annotations:
+        argocd.argoproj.io/sync-wave: "1"
+        argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    spec:
+      retentionPolicy: "7d"
+      configuration:
+        destinationPath: s3://ssegning-k8s-state/lightbridge-usage-db
+        endpointURL: https://nbg1.your-objectstorage.com
+        data:
+          jobs: 1
+          compression: gzip
+        s3Credentials:
+          accessKeyId:
+            name: lightbridge-cnpg-s3
+            key: s3_access_key_id
+          secretAccessKey:
+            name: lightbridge-cnpg-s3
+            key: s3_secret_access_key
+  - |
+    apiVersion: postgresql.cnpg.io/v1
+    kind: ScheduledBackup
+    metadata:
+      name: lightbridge-usage-db-daily
+      namespace: converse
+      annotations:
+        argocd.argoproj.io/sync-wave: "3"
+        argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    spec:
+      immediate: true
+      schedule: "0 0 */6 * * *"
+      backupOwnerReference: self
+      cluster:
+        name: lightbridge-usage-db
+      method: plugin
+      pluginConfiguration:
+        name: barman-cloud.cloudnative-pg.io
+  - |
+    apiVersion: monitoring.coreos.com/v1
+    kind: PodMonitor
+    metadata:
+      name: lightbridge-usage-db
+      namespace: converse
+      annotations:
+        argocd.argoproj.io/sync-wave: "3"
+    spec:
+      selector:
+        matchLabels:
+          cnpg.io/cluster: lightbridge-usage-db
       podMetricsEndpoints:
         - port: metrics
           interval: 30s

--- a/charts/lightbridge/values.yaml
+++ b/charts/lightbridge/values.yaml
@@ -4,8 +4,12 @@
 # three child Applications.
 #
 # Replaces the old flat `lightbridge-backend` app. Components: api (main) + mcp
-# only — opa (removed per ADR-0021) and usage (unused) are DROPPED, along with
-# the lightbridge-usage-db. Namespace stays `converse`.
+# are always on; opa and usage were dropped by ADR-0021/ADR-0026 but have since
+# been re-enabled at the values layer (ai-helm-values
+# environments/prod/values/lightbridge-app.yaml — this chart doesn't gate them
+# itself, the upstream lightbridge-authz-stack chart's own component toggles
+# do). lightbridge-usage-db (below, in the db child) was restored alongside
+# usage. Namespace stays `converse`.
 
 # ────────────────────────────────────────────────────────────────────────
 # Shared ArgoCD wiring for all child Applications.


### PR DESCRIPTION
## 1. Summary

This PR changes:

- Adds a `lightbridge-usage-db` CloudNativePG `Cluster` (dedicated, TimescaleDB-image) to the `charts/lightbridge-db` leaf chart, alongside a matching `ClusterImageCatalog`, `ObjectStore`, `ScheduledBackup`, and `PodMonitor`.
- Restores the `lightbridge-usage-db` database that ADR-0026 dropped, on the same declarative pattern already used for `lightbridge-main-db`.
- Fixes stale top-of-file comments in `charts/lightbridge-db/values.yaml` / `charts/lightbridge-db/Chart.yaml` / `charts/lightbridge/values.yaml` that said the usage DB / opa were dropped (opa was already re-enabled at the values layer; only the usage DB was still genuinely missing).
- **(this revision)** Fixes the TimescaleDB image pin from pg17 to pg18, and rewrites the "why not reuse `lightbridge-main-db`" reasoning against the **live cluster**, not just the chart, after a decision-owner challenge (see [#4](#4-decision-why-not-reuse-lightbridge-main-db) below).

It solves:

- [`ADORSYS-GIS/ai-helm-values@ac34fa9e`](https://github.com/ADORSYS-GIS/ai-helm-values/commit/ac34fa9e) flipped `usage.enabled: true` in `environments/prod/values/lightbridge-app.yaml` with **no supporting database** — the `lightbridge-authz-usage` pods (and their pre-upgrade migrate Job) have nothing to connect to and cannot start. Companion, already-merged PR: [ADORSYS-GIS/ai-helm-values#247](https://github.com/ADORSYS-GIS/ai-helm-values/pull/247).

Source of truth: [ADORSYS-GIS/lightbridge-authz `migrations-usage/20260223000001_init_usage.sql`](https://github.com/ADORSYS-GIS/lightbridge-authz/blob/main/migrations-usage/20260223000001_init_usage.sql) (the `create_hypertable()` call this whole PR exists to support) and `docs/adr/0026-lightbridge-orchestrator-split.md` in this repo (the ADR that dropped the cluster this PR restores).

---

## 2. Intent

`lightbridge-authz-usage` (`crates/lightbridge-authz-usage` in ADORSYS-GIS/lightbridge-authz, `migrations-usage/`) needs its own Postgres database, distinct from the api/opa/mcp `lightbridge-main-db`, because its schema calls TimescaleDB's `create_hypertable()`. ADR-0026 (`docs/adr/0026-lightbridge-orchestrator-split.md`) dropped this cluster along with the whole usage component back in June. The companion PR ([ai-helm-values#247](https://github.com/ADORSYS-GIS/ai-helm-values/pull/247), merged) finishes wiring the `usage:` values block; this PR provides the database it needs to actually run.

### 4. Decision: why not reuse `lightbridge-main-db`?

A reviewer asked directly: *"why're we creating a new cnpg cluster? why not reuse the existing cnpg?"* The first pass at this PR answered with "TimescaleDB isn't in the standard cloudnative-pg image" — true, but incomplete: it silently assumed `lightbridge-main-db`'s **image** was fixed. It isn't; CNPG clusters can change image. So the real question is whether **changing `lightbridge-main-db`'s image** to a Timescale vendor image, then declaring `usage` as a `Database` CR on it (the same pattern `repoauth`/`codeintel`/`coder`/`governance` already use), is viable. Evaluated properly this time, against the **live cluster**, not just the chart:

**Which cluster, and who's on it.** `lightbridge-main-db`, namespace `converse`. Confirmed live: exactly 2 instances, healthy, image `ghcr.io/cloudnative-pg/postgresql:18.4-system-trixie` (no `imageCatalogRef` — the unmodified CNPG system image), CNPG operator **1.30.0** (so the standalone `Database` CRD, introduced in CNPG 1.25, is supported — moot here since the operator's own presence is what already runs 4 live `Database` CRs on this cluster). It carries **five tenants**: the `app` database — **lightbridge-authz's own** database, verified via `\dt` → `accounts, api_keys, projects, budget_grants, budget_balances, signing_keys, exchange_refresh_tokens` — plus `Database` CRs `codeintel`, `coder`, `governance`, `repoauth` (all four declared in `charts/lightbridge-db/values.yaml`, this file).

**Is a Timescale image a drop-in? Extension-wise, closer than the first pass claimed — but that's not why this stays a dedicated cluster.** `codeintel` has pgvector **actively installed**: `select extname, extversion from pg_extension` on that database returns `vector | 0.8.2`. I checked both Timescale vendor image families against that requirement, reading their Dockerfiles directly rather than assuming: **both `timescale/timescaledb` and `timescale/timescaledb-ha` bundle pgvector** (the plain image builds it from source — `git clone --branch ${PGVECTOR_VERSION} .../pgvector.git && make install`; the `-ha` image apt-installs `postgresql-${pg}-pgvector` for every supported major). So pgvector parity for `codeintel` is *not* the blocker the first pass implied it might be — that claim needed correcting. What TimescaleDB genuinely lacks on the running image is confirmed the other way too: `select * from pg_available_extensions where name = 'timescaledb'` on the live `lightbridge-main-db` returns **no rows** — it isn't installable via `Database.spec.extensions` today, full stop, on the current image.

**So the real question is the image swap itself, and that's where it stops being attractive:**

1. **CNPG immutability blocks it outright without a re-bootstrap.** `.spec.postgresUID`/`.spec.postgresGID` are validated as immutable once a Cluster has bootstrapped ([cloudnative-pg/cloudnative-pg#3331](https://github.com/cloudnative-pg/cloudnative-pg/issues/3331); CNPG bootstrap docs). `lightbridge-main-db` sets neither field, so it runs at CNPG's own default UID **26** (the `ghcr.io/cloudnative-pg/postgresql` convention). Timescale's Alpine-based `timescaledb` image defaults postgres to UID **70** — which is precisely why *this PR's own* `lightbridge-usage-db` Cluster sets `postgresUID: 70` / `postgresGID: 70` explicitly. The Ubuntu-based `timescaledb-ha` image creates postgres at UID **1000**. Neither matches 26, and CNPG's webhook won't let the field move on an already-bootstrapped cluster — an in-place swap needs a fresh bootstrap, i.e. a new cluster plus a live data migration for all five tenants. That is not "reuse," it's this PR's own approach with extra steps and much higher blast radius.
2. **Even ignoring (1), it's a base-OS/libc change under five live tenants.** Debian trixie (glibc) → Alpine (musl) or Ubuntu 22.04 (a different glibc build) is the textbook trigger for a PostgreSQL collation-version mismatch: existing text/vector indexes across `app` (authz's own auth-path tables), `codeintel`, `coder`, `governance`, and `repoauth` would all need an audited `REINDEX` pass to rule out silently-wrong comparisons after the swap. `lightbridge-authz`'s own `app` database is the auth boundary for the whole platform's api/opa/mcp traffic — the highest-consequence database on this cluster by this repo's own review doctrine, and not one to put through an unforced base-image change to add one extension for a service (`usage`) that has never been live in prod.
3. **Blast radius asymmetry.** A dedicated `lightbridge-usage-db` cluster is fully additive and isolated — zero risk to any existing tenant, as the diff here shows. An in-place image change on `lightbridge-main-db` is a rolling operation across all five tenants simultaneously, all to unblock one currently-broken, previously-never-live service.

**Verdict: keep the dedicated cluster (this PR).** This is not "TimescaleDB will never work on the shared cluster" — with a Timescale vendor image it likely would, pgvector included. It's "swapping a production image under five live tenants, one of which is the platform's own auth database, is not the right way to unblock a currently-broken service on a time-pressured fix." If there's appetite to consolidate onto one cluster later, that's a deliberate, scheduled migration (new UID-compatible cluster, physical data move, collation audit, its own PR) — not something to fold into restoring a dropped database.

This is also exactly what existed before ADR-0026 dropped it — recovered from `ai-helm@4b65164c^:charts/apps/values.yaml` (the flat app before the App-of-Apps split) and cross-checked against the still-present restore runbook `docs/cnpg-native-backup/lightbridge-usage-db-restore.yaml`, which references the identical `ClusterImageCatalog`/`Cluster` pair and proves this setup was live and backed up in production before it was dropped.

`migrations-usage/20260223000001_init_usage.sql` already guards the extension defensively:

```sql
IF EXISTS (SELECT 1 FROM pg_available_extensions WHERE name = 'timescaledb') THEN
    CREATE EXTENSION IF NOT EXISTS timescaledb;
    ...
    PERFORM create_hypertable('usage_events', 'observed_at', if_not_exists => TRUE, migrate_data => TRUE);
```

— so the service degrades to plain Postgres rather than crash-looping if this ever regresses, but the whole reason `usage_events` is meant to live on Timescale (hypertable partitioning at ingest volume) only happens with the extension actually present.

### Version fix: pg17 → pg18

The prior revision pinned `timescale/timescaledb:2.21.1-pg17` — wrong on two counts, per the decision owner: (a) latest TimescaleDB targets Postgres **18**, not 17; (b) `lightbridge-main-db` (the rest of the estate) is already on Postgres **18.4** — a pg17 usage DB next to a pg18 estate is its own, unforced inconsistency. Verified live against Docker Hub's API (not assumed):

```text
$ curl -s 'https://hub.docker.com/v2/repositories/timescale/timescaledb/tags/2.29.1-pg18'
{"name": "2.29.1-pg18", "last_updated": "2026-08-04T10:29:49Z",
 "images": [{"architecture": "386"}, {"architecture": "amd64"}, {"architecture": "arm"},
            {"architecture": "arm"}, {"architecture": "arm64"}, ...]}
```

`2.29.1-pg18` is the latest published TimescaleDB (2.29.1) built against Postgres 18, multi-arch, pushed 2026-08-04 — matches `latest-pg18`. Now pinned in `ClusterImageCatalog`/`imageCatalogRef` (`major: 18`).

**Plain `timescale/timescaledb`, not `timescale/timescaledb-ha`.** The `-ha` image bundles Patroni, pgBackRest, and Spilo glue for Zalando/Patroni-style HA — CNPG replaces all of that with its own controller and the barman-cloud plugin sidecar (already wired below), so none of it would be used. It would only add roughly 1.5GB of unused surface and move the default postgres UID to 1000 instead of the 70 this Cluster is already pinned to for the plain image.

---

## 3. Scope

### In Scope

- `charts/lightbridge-db/values.yaml`: new `lightbridge-usage-db` `ClusterImageCatalog` + `Cluster` + `ObjectStore` + `ScheduledBackup` + `PodMonitor` resources, pinned to TimescaleDB pg18.
- `charts/lightbridge-db/Chart.yaml`: description update (no version bump — release-please owns `Chart.yaml` `version:`/`CHANGELOG.md` for this repo, confirmed via `release-please-config.json` + `.release-please-manifest.json`; I did not touch either).
- `charts/lightbridge/values.yaml`: stale top comment fix.

### Out of Scope

- The `usage:` values block wiring (config, env, TLS, `DATABASE_URL` secret reference) — companion PR [ai-helm-values#247](https://github.com/ADORSYS-GIS/ai-helm-values/pull/247) (merged).
- **The `lightbridge-authz-usage` image tag itself.** Independently of this PR, prod is currently broken a second way: `ai-helm-values#247` left the `usage` component's image tag at the upstream chart's stale default (`global.authz_usage.image.version: "0.8.1"` in `ADORSYS-GIS/lightbridge-authz`'s `charts/lightbridge-authz-usage/values.yaml`), which was never overridden the way `global.authz.image.version`/`global.authz_mcp.image.version` are — and `0.8.1` does not exist in GHCR (`ghcr.io/adorsys-gis/lightbridge-authz-usage` currently publishes `latest`/`main`/`sha-<sha>` tags from CI, not that semver). This is an **`ImagePullBackOff`, independent of and prior to this PR's database** — see the follow-up `ai-helm-values` PR opened alongside this one. **Merge order:** the image-tag fix is safe to merge immediately (it's the current hard blocker); this PR's database must land and its `lightbridge-usage-db-app` secret must exist before the usage pods can actually connect.
- Fixing the stale `0.8.1` default at its source in `ADORSYS-GIS/lightbridge-authz`'s chart — flagged there, not fixed in this cross-repo PR.
- Fixing the two other upstream `lightbridge-authz-stack` chart bugs (shared `db-secret` name collision between api/opa and usage; `usage.persistence.tls.name` pointing at a secret nothing creates in this cluster) at the chart level — worked around from the values side in the companion PR; tracked there as follow-up chart fixes needed in `ADORSYS-GIS/lightbridge-authz`.
- Any ingress/public exposure for the usage API — it was previously routed at `/usage/v1`; re-adding that is a separate decision not requested here.
- The CNPG operator itself — confirmed pre-existing and externally managed (`charts/apps/values.yaml:257-263`: "CloudNativePG ... NOT deployed by this repo ... installed externally"), version **1.30.0** live.

---

## 4. Verification

I verified this change by:

- [x] Running automated tests
- [ ] Running manual tests
- [ ] Checking logs
- [ ] Checking metrics
- [ ] Testing error cases
- [ ] Testing permissions/security behavior
- [ ] Testing rollback or failure behavior, if relevant

Commands run:

```bash
helm lint charts/lightbridge-db
helm template lightbridge-db charts/lightbridge-db
```

Results:

```text
$ helm lint charts/lightbridge-db
==> Linting charts/lightbridge-db
[INFO] Chart.yaml: icon is recommended
1 chart(s) linted, 0 chart(s) failed

$ helm template lightbridge-db charts/lightbridge-db | grep -E '^kind:|^  name:'
kind: Cluster
  name: lightbridge-main-db          # unchanged
kind: Cluster
  name: lightbridge-usage-db         # new — imageCatalogRef major: 18
kind: ClusterImageCatalog
  name: lightbridge-usage-db         # new — timescale/timescaledb:2.29.1-pg18
kind: Database
  name: repoauth                     # unchanged
kind: Database
  name: codeintel                    # unchanged (pgvector 0.8.2 live on this one)
kind: Database
  name: governance                   # unchanged
kind: Database
  name: coder                        # unchanged
kind: ExternalSecret
  name: repo-auth-db-role            # unchanged
  name: lightbridge-codeintel-db-role
  name: lightbridge-governance-db-role
  name: lightbridge-grafana-ro-db-role
  name: coder-db-role
kind: ObjectStore
  name: lightbridge-main-db          # unchanged
kind: ObjectStore
  name: lightbridge-usage-db         # new
kind: PodMonitor
  name: lightbridge-main-db          # unchanged
kind: PodMonitor
  name: lightbridge-usage-db         # new
kind: ScheduledBackup
  name: lightbridge-main-db-daily    # unchanged
kind: ScheduledBackup
  name: lightbridge-usage-db-daily   # new
```

The rendered `Cluster/lightbridge-usage-db` carries `imageCatalogRef` → the new `ClusterImageCatalog` (`timescale/timescaledb:2.29.1-pg18`, major 18), `shared_preload_libraries: [timescaledb]`, `postgresUID/GID: 70`, and `bootstrap.initdb.postInitTemplateSQL: [CREATE EXTENSION IF NOT EXISTS timescaledb;]`. Full rendered manifest for `lightbridge-usage-db` (Cluster + ClusterImageCatalog):

```yaml
apiVersion: postgresql.cnpg.io/v1
kind: Cluster
metadata:
  name: lightbridge-usage-db
  namespace: converse
  annotations:
    argocd.argoproj.io/sync-wave: "2"
spec:
  instances: 2
  imageCatalogRef:
    apiGroup: postgresql.cnpg.io
    kind: ClusterImageCatalog
    name: lightbridge-usage-db
    major: 18
  storage:
    size: "10Gi"
  plugins:
    - name: barman-cloud.cloudnative-pg.io
      enabled: true
      isWALArchiver: true
      parameters:
        barmanObjectName: lightbridge-usage-db
        serverName: lightbridge-usage-db
  postgresql:
    parameters:
      archive_timeout: "30min"
    shared_preload_libraries:
      - timescaledb
  resources:
    limits:
      cpu: 300m
      memory: 1Gi
    requests:
      cpu: 200m
      memory: 500Mi
  postgresUID: 70
  postgresGID: 70
  bootstrap:
    initdb:
      postInitTemplateSQL:
        - CREATE EXTENSION IF NOT EXISTS timescaledb;
---
apiVersion: postgresql.cnpg.io/v1
kind: ClusterImageCatalog
metadata:
  name: lightbridge-usage-db
  namespace: converse
spec:
  images:
    - major: 18
      image: timescale/timescaledb:2.29.1-pg18
```

I could not verify against a live cluster (no `kubectl`/ArgoCD access from this environment) — this is a values/manifest-level verification only, plus live read-only cluster facts relayed by a teammate with `kubectl` access (cited inline above: cluster count/health, tenant list, `codeintel`'s installed `pgvector` version, `pg_available_extensions` on `lightbridge-main-db`, CNPG operator version, and confirmation no `lightbridge-usage-db` cluster or `lightbridge-usage-db-app` secret exists yet). Once merged, `publish-charts-oci.yml` republishes `lightbridge-db` on push to `main` (derived version = `Chart.yaml` MAJOR.MINOR + commit-count PATCH per ADR-0055), and the `lightbridge-db` child Application (`automated: {prune: true, selfHeal: true}`, floats `>=0.0.0`) picks it up on its next ArgoCD sync — someone with cluster access should confirm `Cluster/lightbridge-usage-db`'s two instances go `Healthy` and that `lightbridge-usage-db-app` (the CNPG-auto-generated bootstrap secret, same naming convention as `lightbridge-main-db-app`) exists before/alongside the usage pods coming up.

---

## 5. Screenshots / Evidence

- `helm lint` / `helm template` output above.
- Historical evidence: `ai-helm@4b65164c` commit message ("Dropped: ... the usage component ... its TimescaleDB ..., the usage-db ...") and the pre-split spec at `4b65164c^:charts/apps/values.yaml` (lines ~1479-1528), which this PR's `lightbridge-usage-db` block mirrors.
- `docs/cnpg-native-backup/lightbridge-usage-db-restore.yaml` (already in this repo, untouched by this PR) references the identical `ClusterImageCatalog`/`Cluster` names this PR (re)introduces.
- Docker Hub tag existence for `timescale/timescaledb:2.29.1-pg18` (command + output above).
- Live-cluster facts relayed by a teammate with `kubectl` access (cited inline in §2/§4): `lightbridge-main-db`'s tenant list and image, `codeintel`'s installed `pgvector 0.8.2`, `pg_available_extensions` lacking `timescaledb`, CNPG operator `1.30.0`, and confirmation that no `lightbridge-usage-db` cluster/secret exists in-cluster yet.
- `timescale/timescaledb` and `timescale/timescaledb-ha` Dockerfiles (`github.com/timescale/timescaledb-docker` / `timescaledb-docker-ha`, `master`/`main` branch) — read directly to confirm both bundle pgvector, cited in §2.

---

## 6. Risk Assessment

Risk level:

* [ ] Low
* [x] Medium
* [ ] High

Potential risks:

* A brand-new CNPG `Cluster` provisions fresh, empty storage (10Gi) — this is **not** a restore of old data (the prior `lightbridge-usage-db` backups referenced in the restore runbook are for the pre-ADR-0026 cluster and are almost certainly outside any retention window by now; not attempting to reuse them here).
* `automated: {prune: true, selfHeal: true}` on the `lightbridge-db` child Application means this deploys as soon as ArgoCD syncs post-merge — coordinate with the companion `ai-helm-values` PRs (the DB one here, and the follow-up image-tag fix) so the app doesn't come up half-wired.
* Timescale's vendor image (`timescale/timescaledb:2.29.1-pg18`) is a third-party image, not cloudnative-pg's own — same trust boundary the pre-ADR-0026 setup already accepted, not a new one introduced here.

Mitigation:

* `ObjectStore`/`ScheduledBackup` wired from the first sync (6h schedule, 7d retention, same throttling fix as `lightbridge-main-db`) so backups start immediately rather than being an afterthought.
* This PR alone does not remove or touch `lightbridge-main-db` or any of its existing `Database` CRs (repoauth/codeintel/governance/coder) — diff is additive only, and the "reuse the shared cluster" alternative was rejected specifically to avoid putting those four tenants (plus authz's own `app` database) through an unforced image change — see §2.

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [x] Drafting documentation
* [ ] Refactoring
* [ ] Generating tests
* [x] Reviewing the diff
* [ ] Not used

Human verification:

* [ ] I understand every meaningful change in this PR
* [ ] I checked generated code manually
* [ ] I checked generated tests manually
* [ ] I removed unsupported AI assumptions
* [ ] I accept responsibility for this PR

---

## 8. Reviewer Focus

Please focus your review on:

* [x] Correctness
* [x] Architecture
* [ ] Security
* [ ] Performance
* [ ] Tests
* [x] Maintainability
* [ ] Product intent
* [x] Edge cases
