### PR TITLE
feat(core-gateway): restore access-log fan-out to lightbridge-authz-usage

### DIFF
--- a/charts/core-gateway/templates/certificate-usage-ca.yaml
+++ b/charts/core-gateway/templates/certificate-usage-ca.yaml
@@ -1,0 +1,36 @@
+# CA-trust cert for the `-usage` OTel collector (templates/otel.yaml) to verify
+# lightbridge-authz-usage's TLS listener.
+#
+# lightbridge-authz-usage's own server cert is issued by the `authz-tls`
+# Certificate in the `converse` namespace (charts/lightbridge-authz-stack in
+# the lightbridge-authz repo) — but that Secret lives in `converse`, and
+# cert-manager Secrets aren't cluster-readable across namespaces (no reflector
+# controller is running here — verified: no `reflection-allowed`-style
+# annotations anywhere in this repo or ai-helm-values). Copying the literal
+# `authz-tls` Secret name into this chart's namespace and hoping it already
+# exists there (which is what the pre-948814de version of this collector did)
+# would silently fail to mount if that assumption were ever wrong.
+#
+# Instead, issue our OWN Certificate here, from the SAME ClusterIssuer
+# (self-signed-ca) that signs `authz-tls`. Because both certs chain to the
+# same CA root, the `ca.crt` this one writes is sufficient to verify
+# lightbridge-authz-usage's server cert — exactly the pattern
+# ai-helm-values/environments/prod/deps/security-policies already uses for
+# Authorino trusting lightbridge-opa's cert (a second `authorino-lightbridge-ca`
+# Certificate off the same issuer, not a cross-namespace Secret copy).
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "core-gateway.fullname" . }}-usage-ca
+  namespace: {{ .Release.Namespace }}
+spec:
+  secretName: {{ include "core-gateway.fullname" . }}-usage-ca
+  # Only `ca.crt` from this Secret is ever mounted (otel.yaml) — this
+  # Certificate is never presented as a server/client cert itself, so the
+  # commonName/dnsNames just need to be valid, not meaningful.
+  commonName: {{ include "core-gateway.fullname" . }}-usage-collector
+  dnsNames:
+    - {{ include "core-gateway.fullname" . }}-usage-collector
+  issuerRef:
+    name: {{ ((.Values.otelCollector | default dict).usageCa | default dict).issuer | default "self-signed-ca" }}
+    kind: {{ ((.Values.otelCollector | default dict).usageCa | default dict).issuerKind | default "ClusterIssuer" }}

--- a/charts/core-gateway/templates/envoy-proxy.yaml
+++ b/charts/core-gateway/templates/envoy-proxy.yaml
@@ -156,11 +156,19 @@ spec:
         - sinks:
             - type: OpenTelemetry
               openTelemetry:
-                # Send access logs straight to Alloy (→ Loki) for per-user
-                # observability (ADR-0005). The old `-usage` OTel collector
-                # middleman (→ lightbridge-usage billing) was removed —
-                # usage/billing is handled via the AI Gateway + OAuth2 path.
-                host: alloy.observability.svc.cluster.local
+                # Restored fan-out (see templates/otel.yaml, `-usage`
+                # collector): the collector re-exports this exact stream to
+                # BOTH Alloy (→ Loki, ADR-0005 per-user observability —
+                # unchanged) and lightbridge-authz-usage's OTLP/HTTP ingest
+                # (→ usage_events, billing). This EnvoyProxy access-log sink
+                # only speaks OTLP/gRPC (host:port, no URL path, no per-sink
+                # TLS/CA) — verified against the OpenTelemetryEnvoyProxyAccessLog
+                # type in envoyproxy/gateway release/v1.8 — so it cannot reach
+                # lightbridge-authz-usage's HTTP+path ingest
+                # (/v1/otel/logs, no gRPC receiver) directly. The collector
+                # hop is what makes both destinations reachable from one
+                # sink.
+                host: {{ include "core-gateway.fullname" . }}-usage.{{ .Release.Namespace }}.svc.cluster.local
                 port: 4317
                 resources:
                   k8s.cluster.name: "converse-llm-1"

--- a/charts/core-gateway/templates/otel.yaml
+++ b/charts/core-gateway/templates/otel.yaml
@@ -49,8 +49,99 @@ spec:
             - batch
           exporters:
             - otlp/alloy
-# NOTE: the `-usage` OpenTelemetryCollector was removed. Usage/billing
-# metering now goes through the Envoy AI Gateway + OAuth2 path, not a
-# dedicated OTel access-log pipeline to lightbridge-usage. The Envoy
-# access logs that fed it are pointed straight at Alloy (-> Loki) for the
-# per-user observability of ADR-0005 — see templates/envoy-proxy.yaml.
+---
+# Restores the `-usage` collector removed in 948814de ("remove usage-collector
+# + otel-operator (external)"). That commit repointed the Envoy access-log
+# OTLP sink straight at Alloy, which is correct for the per-user Loki path
+# (ADR-0005) but dropped the second leg that used to feed
+# lightbridge-authz-usage's billing ingest. Restoring the collector as a fan-
+# out point lets both consumers keep receiving the exact same access-log
+# stream: Envoy's accessLog sink (templates/envoy-proxy.yaml) now points here
+# instead of at Alloy directly, and this collector re-exports unchanged to
+# both `otlp/alloy` (byte-identical to the pre-restore direct path) and the
+# new `otlphttp/lightbridge_usage` leg.
+#
+# Not merged into the `-traces` collector above: that one is a traces-only
+# pipeline reconciled independently, and keeping them separate matches the
+# pre-948814de shape (two collectors, one per signal grouping) rather than
+# coupling trace and access-log volume/scaling together.
+apiVersion: opentelemetry.io/v1beta1
+kind: OpenTelemetryCollector
+metadata:
+  name: {{ include "core-gateway.fullname" . }}-usage
+  namespace: {{ .Release.Namespace }}
+spec:
+  # See the `mode` comment on the `-traces` collector above — same webhook
+  # requirement applies here.
+  mode: {{ (.Values.otelCollector | default dict).mode | default "deployment" }}
+  # `<fullname>-usage-ca` (certificate-usage-ca.yaml) chains to the same
+  # ClusterIssuer (self-signed-ca) that signs lightbridge-authz-usage's own
+  # `authz-tls` cert in the `converse` namespace — see that template for why
+  # this mounts our own same-namespace Certificate rather than the literal
+  # `authz-tls` Secret name (which lives in a different namespace and isn't
+  # replicated here). Mounting its ca.crt lets the otlphttp/lightbridge_usage
+  # exporter below verify the usage service's HTTPS listener for real — no
+  # `insecure`/skip-verify.
+  volumes:
+    - name: usage-ca
+      secret:
+        secretName: {{ include "core-gateway.fullname" . }}-usage-ca
+        items:
+          - key: ca.crt
+            path: ca.crt
+  volumeMounts:
+    - name: usage-ca
+      mountPath: /etc/otel/tls
+      readOnly: true
+  config:
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+            endpoint: 0.0.0.0:4317
+          http:
+            endpoint: 0.0.0.0:4318
+
+    processors:
+      # Same rationale as the `-traces` collector: memory_limiter first so a
+      # spike sheds load instead of OOMing the pod and losing everything in
+      # flight; batch cuts export frequency.
+      memory_limiter:
+        check_interval: 1s
+        limit_mib: 400
+        spike_limit_mib: 100
+      batch:
+        send_batch_size: 512
+        timeout: 5s
+
+    exporters:
+      # lightbridge-authz-usage's OTLP/HTTP ingest only exposes a logs path
+      # (/v1/otel/logs — see crates/lightbridge-authz-usage/src/routers/mod.rs
+      # in the lightbridge-authz repo); there is no gRPC receiver on that
+      # service, which is exactly why this has to be `otlphttp` (path-aware)
+      # rather than a plain `otlp` gRPC exporter.
+      otlphttp/lightbridge_usage:
+        logs_endpoint: "https://lightbridge-usage.converse.svc.cluster.local:3000/v1/otel/logs"
+        tls:
+          ca_file: /etc/otel/tls/ca.crt
+
+      # Fan the same access-log stream out to Grafana Alloy, which forwards
+      # to Loki (ADR-0005 per-user observability). Identical endpoint/TLS
+      # shape to the sink Envoy used to hit directly pre-restore, so this
+      # leg's behavior is unchanged — only the hop is new.
+      otlp/alloy:
+        endpoint: "alloy.observability.svc.cluster.local:4317"
+        tls:
+          insecure: true
+
+    service:
+      pipelines:
+        logs:
+          receivers:
+            - otlp
+          processors:
+            - memory_limiter
+            - batch
+          exporters:
+            - otlphttp/lightbridge_usage
+            - otlp/alloy

--- a/charts/core-gateway/values.yaml
+++ b/charts/core-gateway/values.yaml
@@ -300,13 +300,24 @@ backendTrafficPolicy:
     - Gzip
 
 # ────────────────────────────────────────────────────────────────────────
-# OpenTelemetryCollector (-traces): receives OTLP, forwards to Alloy → Tempo.
-# `mode` MUST be set (otel-operator v1beta1 webhook rejects an empty mode);
-# it is immutable on an existing collector. deployment | daemonset |
-# statefulset | sidecar.
+# OpenTelemetryCollector (-traces, -usage): receive OTLP. -traces forwards to
+# Alloy → Tempo; -usage receives Envoy's access-log stream and fans it out to
+# both Alloy → Loki (per-user observability, ADR-0005, unchanged) and
+# lightbridge-authz-usage's OTLP/HTTP ingest (billing). `mode` MUST be set on
+# both (otel-operator v1beta1 webhook rejects an empty mode); it is immutable
+# on an existing collector. deployment | daemonset | statefulset | sidecar.
+#
+# usageCa: issuer for the `<fullname>-usage-ca` Certificate
+# (certificate-usage-ca.yaml) the -usage collector mounts to verify
+# lightbridge-authz-usage's TLS listener — see that template for why this is
+# a same-namespace Certificate off the same issuer rather than a literal
+# cross-namespace `authz-tls` Secret reference.
 # ────────────────────────────────────────────────────────────────────────
 otelCollector:
   mode: deployment
+  usageCa:
+    issuer: self-signed-ca
+    issuerKind: ClusterIssuer
 
 # ────────────────────────────────────────────────────────────────────────
 # ExtProc sidecar (the Envoy AI Gateway's per-request processor: token


### PR DESCRIPTION
## 1. Summary

This PR changes:

- `charts/core-gateway/templates/otel.yaml`: restores a dedicated `-usage` `OpenTelemetryCollector`, removed in `948814de` ("remove usage-collector + otel-operator (external)"), that receives Envoy's access-log OTLP stream and fans it out to **both** Grafana Alloy (unchanged, → Loki, ADR-0005 per-user observability) **and** a new `otlphttp/lightbridge_usage` exporter hitting `lightbridge-authz-usage`'s `/v1/otel/logs` ingest.
- `charts/core-gateway/templates/envoy-proxy.yaml`: points the `EnvoyProxy` `telemetry.accessLog` OTLP sink at the new collector instead of straight at Alloy.
- `charts/core-gateway/templates/certificate-usage-ca.yaml` (new): a same-namespace `cert-manager` `Certificate`, off the same `self-signed-ca` `ClusterIssuer` that signs `lightbridge-authz-usage`'s own TLS cert, so the collector can verify that service's HTTPS listener with a real CA — no `insecure: true`/skip-verify.
- `charts/core-gateway/values.yaml`: adds the `otelCollector.usageCa.{issuer,issuerKind}` knob backing the new Certificate.

It solves:

- `lightbridge-authz-usage` (crates/lightbridge-authz-usage in the `lightbridge-authz` repo) has been receiving zero access-log telemetry since https://github.com/ADORSYS-GIS/ai-helm/commit/948814de3157e1763e42fcfa4878df4203296810 (2026-05-31) repointed the Envoy access-log sink straight at Alloy and dropped the `-usage` collector that used to feed it. Its `usage_events` table has had no `account_id`-tagged rows landing from the gateway since. Source of truth for the restore requirement + the ingest routes this PR targets: https://github.com/ADORSYS-GIS/lightbridge-authz/blob/main/crates/lightbridge-authz-usage/src/routers/mod.rs and https://github.com/ADORSYS-GIS/lightbridge-authz/blob/main/AGENTS.md (usage-service section).

---

## 2. Intent

Restore the access-log feed to `lightbridge-authz-usage` **without disturbing the existing Alloy/Loki path** — the per-user Loki observability (ADR-0005) that `948814de` correctly preserved when it simplified the direct-to-Alloy sink must keep working exactly as today.

Two options were evaluated:

**(a) Add a second entry to `EnvoyProxy`'s own `accessLog.settings[].sinks[]`, pointing straight at the usage service.** Ruled out — not a design preference, a hard capability gap:
- Verified against `envoyproxy/gateway` `release/v1.8`'s `OpenTelemetryEnvoyProxyAccessLog` Go type (`api/v1alpha1/envoyproxy_accesslogging_types.go`): it only speaks **OTLP/gRPC** — `host`/`port` (default 4317), gRPC initial-metadata headers, `BackendCluster`-based TLS. There is **no URL-path field**, so it cannot target an OTLP/**HTTP** endpoint like `/v1/otel/logs`.
- `lightbridge-authz-usage`'s ingest is exactly the opposite: axum routes at `/v1/otel/{traces,metrics,logs}` (`crates/lightbridge-authz-usage/src/routers/mod.rs`), with **no gRPC receiver at all**.
- The two sides genuinely cannot speak to each other directly — this is the deciding factor, not a style choice.

**(b) Restore a dedicated `OpenTelemetryCollector`.** Chosen. The commit that removed the `-usage` collector also removed the `opentelemetry-operator` chart as "installed externally" — but this repo's own `CLAUDE.md` (and `charts/apps/values.yaml`'s comment) still document the OTel Operator as live in-cluster (`opentelemetry-system`, all `opentelemetry.io` CRDs present), reconciling the surviving `-traces` collector today. No operator reinstatement needed; this is a same-shaped resource next to one that's already running.

---

## 3. Scope

### In Scope

- Restoring the second (usage/billing) leg of the access-log fan-out via a collector.
- A same-namespace CA-trust `Certificate` for the collector, since the old `secretName: authz-tls` reference (pre-`948814de`) pointed at a Secret that lives in a **different** namespace (`converse`, owned by `lightbridge-authz-stack`) than this collector (`converse-gateway`) — and no cross-namespace secret replication (reflector, etc.) exists anywhere in `ai-helm` or `ai-helm-values`. Issuing a second cert off the same CA root and trusting only its `ca.crt` is the same pattern `ai-helm-values/environments/prod/deps/security-policies` already uses for Authorino trusting `lightbridge-opa`'s cert.

### Out of Scope

- The `ai-helm-values` `usage: enabled` flip (already merged on `main` as `ac34fa9`, by a parallel change) and anything else in that values repo.
- Any change to the Alloy/Loki/Tempo path, the `-traces` collector, or ADR-0005 per-user observability behavior.
- Re-adding the OpenTelemetry Operator chart (still external/already installed).

---

## 4. Verification

I verified this change by:

- [x] Running automated tests
- [ ] Running manual tests
- [ ] Checking logs
- [ ] Checking metrics
- [ ] Testing error cases
- [ ] Testing permissions/security behavior
- [ ] Testing rollback or failure behavior, if relevant

No live cluster access from this session — verification is `helm lint`/`helm template` only. Manual post-deploy verification is described below for whoever applies this.

Commands run:

```bash
cd charts/core-gateway
helm dependency update .
helm lint . --strict
helm template core-gateway . --namespace converse-gateway
helm template lightbridge-gateway . --namespace converse-gateway \
  -f <ai-helm-values>/environments/prod/values/core-gateway.yaml
```

Results:

```text
==> Linting .
[INFO] Chart.yaml: icon is recommended
1 chart(s) linted, 0 chart(s) failed
```

Rendered `EnvoyProxy.spec.telemetry.accessLog` sink (prod values):

```yaml
accessLog:
  settings:
    - sinks:
        - type: OpenTelemetry
          openTelemetry:
            host: lightbridge-gateway-core-gateway-usage.converse-gateway.svc.cluster.local
            port: 4317
            resources:
              k8s.cluster.name: "converse-llm-1"
              service.name: "envoy-ai-gateway"
      matches:
        - "request.headers['x-ai-eg-model'] != ''"
      # ...unchanged format.json block (all existing fields, byte-identical)
```

Rendered `-usage` `OpenTelemetryCollector` (prod values):

```yaml
apiVersion: opentelemetry.io/v1beta1
kind: OpenTelemetryCollector
metadata:
  name: lightbridge-gateway-core-gateway-usage
  namespace: converse-gateway
spec:
  mode: deployment
  volumes:
    - name: usage-ca
      secret:
        secretName: lightbridge-gateway-core-gateway-usage-ca
        items:
          - key: ca.crt
            path: ca.crt
  volumeMounts:
    - name: usage-ca
      mountPath: /etc/otel/tls
      readOnly: true
  config:
    receivers:
      otlp:
        protocols:
          grpc: { endpoint: 0.0.0.0:4317 }
          http: { endpoint: 0.0.0.0:4318 }
    processors:
      memory_limiter: { check_interval: 1s, limit_mib: 400, spike_limit_mib: 100 }
      batch: { send_batch_size: 512, timeout: 5s }
    exporters:
      otlphttp/lightbridge_usage:
        logs_endpoint: "https://lightbridge-usage.converse.svc.cluster.local:3000/v1/otel/logs"
        tls:
          ca_file: /etc/otel/tls/ca.crt
      otlp/alloy:
        endpoint: "alloy.observability.svc.cluster.local:4317"
        tls:
          insecure: true
    service:
      pipelines:
        logs:
          receivers: [otlp]
          processors: [memory_limiter, batch]
          exporters: [otlphttp/lightbridge_usage, otlp/alloy]
```

Plus the new `certificate-usage-ca.yaml` Certificate (`lightbridge-gateway-core-gateway-usage-ca`, `issuerRef: {name: self-signed-ca, kind: ClusterIssuer}`) and the untouched `-traces` collector, both rendered cleanly alongside it.

The **usage endpoint**: `https://lightbridge-usage.converse.svc.cluster.local:3000/v1/otel/logs` — service name/port/namespace confirmed by `helm template`-ing `lightbridge-authz`'s own `charts/lightbridge-authz-stack` against `ai-helm-values/environments/prod/values/lightbridge-app.yaml` (which enables `usage.enabled: true` as of `ac34fa9` on `main`), not assumed. **TLS**: real CA verification via the new `<fullname>-usage-ca` Certificate's `ca.crt` (same CA root as `lightbridge-authz-usage`'s own cert) — no `insecure`/skip-verify on that leg. **Alloy path**: unchanged endpoint (`alloy.observability.svc.cluster.local:4317`), unchanged `insecure: true` (that leg was never CA-verified, and this PR doesn't change that), unchanged JSON access-log format — only the hop changed (via the collector instead of direct), not the payload or destination.

---

## 5. Screenshots / Evidence

No screenshots (Helm chart change, not UI). Evidence is the rendered manifests in Section 4, and:

* Rendered EnvoyProxy diff, `-usage` collector, and `certificate-usage-ca.yaml`: this PR's diff.
* Prior state (what was removed): commit `948814de` ("chore(observability): remove usage-collector + otel-operator (external)").
* Endpoint confirmation: `lightbridge-authz` repo, `crates/lightbridge-authz-usage/src/routers/mod.rs` (`/v1/otel/logs` route) + `charts/lightbridge-authz-stack` rendered against `ai-helm-values/environments/prod/values/lightbridge-app.yaml` (service `lightbridge-usage`, namespace `converse`, port `3000`, HTTPS).

---

## 6. Risk Assessment

Risk level:

* [x] Low
* [ ] Medium
* [ ] High

Potential risks:

* The new `otlphttp/lightbridge_usage` exporter could back-pressure or error if `lightbridge-authz-usage` is slow/unreachable. Mitigated by `memory_limiter` (sheds load before OOM) and the fact that OTel Collector exporters fail independently per pipeline export — a failing `otlphttp` export doesn't block the `otlp/alloy` export in the same pipeline run (they're two exporters on one pipeline, not chained).
* If the CA cert doesn't propagate before the collector pod starts, `otlphttp/lightbridge_usage` exports would fail-closed with TLS errors (visible in collector logs) rather than silently accepting an unverified cert — since `insecure`/skip-verify was deliberately not used.
* No change to any resource the Alloy/Loki path depends on (same endpoint string, same `insecure: true`, same JSON format) — the only behavior change on that leg is an added collector hop.

Mitigation:

* Post-deploy: watch the `-usage` collector pod logs for exporter errors on both legs.
* Post-deploy: confirm Loki still receives per-user labels (query Grafana/Loki for `user_id`/`azp` as before) to prove the Alloy leg is unaffected.
* Post-deploy: query `usage_events` for rows with non-null `account_id` landing after the AI Gateway routes traffic, to prove the new leg is working:

  ```sql
  select count(*) from usage_events
  where account_id is not null
    and time > now() - interval '15 minutes';
  ```

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [ ] Refactoring
* [ ] Generating tests
* [x] Drafting documentation
* [x] Reviewing the diff
* [ ] Not used

Human verification:

* [ ] I understand every meaningful change in this PR
* [ ] I checked generated code manually
* [ ] I checked generated tests manually
* [ ] I removed unsupported AI assumptions
* [ ] I accept responsibility for this PR

This PR was authored by an AI agent (Claude) in a non-interactive session. The boxes above are left unchecked because they are human attestations — a human reviewer should verify this PR before merge, particularly the CA/TLS reasoning and the option (a)/(b) capability claim about `EnvoyProxy`'s access-log sink type.

---

## 8. Reviewer Focus

Please focus your review on:

* [x] Correctness
* [x] Architecture
* [x] Security
* [ ] Performance
* [ ] Tests
* [ ] Maintainability
* [x] Product intent
* [ ] Edge cases

Specifically: (1) is the `OpenTelemetryEnvoyProxyAccessLog` gRPC-only claim (Section 2) actually correct for the Envoy Gateway version this cluster runs; (2) is issuing a second `Certificate` off `self-signed-ca` the right way to get the collector a trusted CA, versus some cross-namespace secret mechanism this PR's author may have missed; (3) whether the `-usage` collector's resource sizing (same `memory_limiter`/`batch` tuning as `-traces`) is appropriate for access-log volume, which is likely much higher than trace volume.
