### PR TITLE
feat(lightbridge-db): provision lightbridge-authz-usage database as a Database CR

### DIFF
--- a/charts/lightbridge-db/Chart.yaml
+++ b/charts/lightbridge-db/Chart.yaml
@@ -3,8 +3,9 @@ name: lightbridge-db
 description: |
   CloudNativePG Cluster (lightbridge-main-db) for the Lightbridge authz stack,
   plus its barman-cloud ObjectStore, ScheduledBackup and PodMonitor. Leaf chart
-  of the lightbridge App-of-Apps orchestrator (ADR-0019). The usage DB is
-  dropped (usage component removed).
+  of the lightbridge App-of-Apps orchestrator (ADR-0019). lightbridge-usage-db
+  is restored as a `usage` Database CR on this shared cluster (no dedicated
+  TimescaleDB cluster needed).
 type: application
 version: 0.3.0
 appVersion: "1.0.0"

--- a/charts/lightbridge-db/values.yaml
+++ b/charts/lightbridge-db/values.yaml
@@ -2,7 +2,16 @@
 # ScheduledBackup + PodMonitor. Leaf chart of the lightbridge orchestrator
 # (ADR-0019). Moved verbatim from the old flat app's rawRessources EXCEPT the
 # ObjectStore, which is modernised to Hetzner Object Storage (the old MinIO
-# s3.ssegning.me / ai-ops-backups is decommissioned). The usage DB is dropped.
+# s3.ssegning.me / ai-ops-backups is decommissioned). lightbridge-usage-db was
+# dropped by ADR-0026 and is restored below as a `usage` Database CR on this
+# same shared cluster (repoauth/codeintel/governance/coder pattern) — NOT a
+# dedicated Cluster. `lightbridge-authz-usage` does not need TimescaleDB: its
+# bucketed aggregation uses stock PostgreSQL 14+ `date_bin`
+# (crates/lightbridge-authz-usage/src/repo.rs), and every Timescale statement
+# in migrations-usage/20260223000001_init_usage.sql is guarded behind an
+# `IF EXISTS (SELECT 1 FROM pg_available_extensions WHERE name = 'timescaledb')`
+# check, so it degrades to a plain heap table on this cluster's stock CNPG
+# image.
 #
 # Namespace is `converse` (the orchestrator targets that namespace; these CRs
 # pin it explicitly to match the old flat-app behaviour).
@@ -117,6 +126,18 @@ resources:
             login: true
             passwordSecret:
               name: lightbridge-governance-db-role
+          # Dedicated login role for lightbridge-authz-usage
+          # (ADORSYS-GIS/lightbridge-authz, crates/lightbridge-authz-usage),
+          # isolated from `app`/repoauth/codeintel/etc. Owns the `usage`
+          # Database below; password from the basic-auth Secret
+          # `lightbridge-usage-db-role` (ESO-provisioned, below). No
+          # extensions required — see the top-of-file note on why this is a
+          # plain Database CR, not a dedicated TimescaleDB Cluster.
+          - name: usage
+            ensure: present
+            login: true
+            passwordSecret:
+              name: lightbridge-usage-db-role
   # ────────────────────────────────────────────────────────────────────
   # barman-cloud ObjectStore — MODERNISED TO HETZNER OBJECT STORAGE.
   #
@@ -466,6 +487,64 @@ resources:
           remoteRef:
             key: ai/camer/digital/prod/env
             property: coder_db_password
+  # ────────────────────────────────────────────────────────────────────
+  # lightbridge-authz-usage: a `usage` Database owned by the managed `usage`
+  # role above, plus the role's basic-auth Secret (username + password)
+  # consumed by BOTH CNPG (passwordSecret) and the app. Mirrors the codeintel
+  # pattern (ADR-0047) — a dedicated login role + dedicated Database on this
+  # shared cluster, NOT a bootstrap-app-role/dedicated-cluster setup.
+  # ai-helm-values assembles DATABASE_URL as
+  # postgresql://usage:$(DB_PASSWORD)@lightbridge-main-db-rw.converse.svc.cluster.local:5432/usage,
+  # with $(DB_PASSWORD) sourced from this Secret's `password` key (same
+  # $(DB_PASSWORD) kubelet-interpolation pattern lightbridge-code-intelligence
+  # uses for codeintel).
+  #
+  # ⚠️ Without TimescaleDB's `add_retention_policy`, `usage_events` has no
+  # automatic pruning on this plain Postgres database — it grows unbounded.
+  # Tracked as a follow-up (pg_cron, a scheduled job, or app-side pruning),
+  # not implemented here.
+  # ────────────────────────────────────────────────────────────────────
+  - |
+    apiVersion: postgresql.cnpg.io/v1
+    kind: Database
+    metadata:
+      name: usage
+      namespace: converse
+      annotations:
+        argocd.argoproj.io/sync-wave: "3"
+        argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    spec:
+      cluster:
+        name: lightbridge-main-db
+      name: usage
+      owner: usage
+      ensure: present
+  - |
+    apiVersion: external-secrets.io/v1
+    kind: ExternalSecret
+    metadata:
+      name: lightbridge-usage-db-role
+      namespace: converse
+      annotations:
+        argocd.argoproj.io/sync-wave: "1"
+    spec:
+      refreshInterval: 1h
+      secretStoreRef:
+        kind: ClusterSecretStore
+        name: ssegning-aws
+      target:
+        name: lightbridge-usage-db-role
+        creationPolicy: Owner
+        template:
+          type: kubernetes.io/basic-auth
+          data:
+            username: "usage"
+            password: "{{ "{{ .password }}" }}"
+      data:
+        - secretKey: password
+          remoteRef:
+            key: ai/camer/digital/prod/env
+            property: usage_db_password
   # MLflow's `mlflow`/`mlflow_oidc` Database CRs + `mlflow-db-role`
   # ExternalSecret used to live here (ADR-0085). Removed — hard cutover, no
   # dormant parallel path — now that MLflow is cut over to mlops-main-db


### PR DESCRIPTION
## 1. Summary

This PR changes:

- Adds a `usage` managed CNPG role + `usage` `Database` CR to the existing shared `lightbridge-main-db` cluster in `charts/lightbridge-db/values.yaml`, plus the ESO `lightbridge-usage-db-role` basic-auth Secret CNPG uses to set that role's password (same `repoauth`/`codeintel`/`governance`/`coder` pattern already in this file).
- Fixes the now-inaccurate top-of-file comment and `Chart.yaml` description that said "the usage DB is dropped."

It solves:

- `lightbridge-authz-usage` pods (and their pre-upgrade migrate Job) have no database to connect to — [ai-helm-values#247](https://github.com/ADORSYS-GIS/ai-helm-values/pull/247) (merged) flipped `usage.enabled: true`, and [ai-helm-values#249](https://github.com/ADORSYS-GIS/ai-helm-values/pull/249) (merged) fixed the image tag, but `usage.controllers.main.containers.authz.env.DATABASE_URL` still points at a `lightbridge-usage-db-app` secret that nothing creates.

This **replaces** [#1007](https://github.com/ADORSYS-GIS/ai-helm/pull/1007) ("restore lightbridge-usage-db CNPG cluster (TimescaleDB)"), which is being closed as superseded — see that PR's closing comment for the full rationale. Short version: `lightbridge-authz-usage` does not need TimescaleDB, so the dedicated cluster #1007 proposed is unnecessary complexity; a `Database` CR on the already-live shared cluster (the pattern `repoauth`/`codeintel`/`governance`/`coder` already use here) is sufficient.

Source of truth: [`lightbridge-authz` `crates/lightbridge-authz-usage/src/repo.rs:113-116`](https://github.com/ADORSYS-GIS/lightbridge-authz/blob/main/crates/lightbridge-authz-usage/src/repo.rs) (bucketed aggregation uses stock PostgreSQL `date_bin`, not Timescale's `time_bucket`) and [`migrations-usage/20260223000001_init_usage.sql`](https://github.com/ADORSYS-GIS/lightbridge-authz/blob/main/migrations-usage/20260223000001_init_usage.sql) (every Timescale statement gated behind `IF EXISTS (SELECT 1 FROM pg_available_extensions WHERE name = 'timescaledb')`).

---

## 2. Intent

`lightbridge-authz-usage` needs its own Postgres database, distinct from the api/opa/mcp `app` database, but it runs correctly on stock PostgreSQL — no TimescaleDB extension required. The existing `lightbridge-main-db` cluster (namespace `converse`, 2 instances, `ghcr.io/cloudnative-pg/postgresql:18.4-system-trixie`, CNPG operator 1.30.0) already hosts four sibling tenants this exact way (`repoauth`, `codeintel`, `governance`, `coder`) via CNPG's standalone `Database` CRD. This PR follows that same, already-proven pattern instead of standing up a second dedicated cluster.

**How the sibling tenants actually get their connection string (the mechanism this PR follows):** a CNPG `Database` CR only creates the database — it does not mint an app-facing secret the way a `Cluster` bootstrap does. Each tenant instead gets: (1) a dedicated `managed.roles` entry on the shared `lightbridge-main-db` Cluster with its own `passwordSecret`; (2) an ESO `ExternalSecret` that pulls that role's password from AWS Secrets Manager (`ai/camer/digital/prod/env`) into a `kubernetes.io/basic-auth` Secret (`username` + `password`); (3) the `Database` CR itself, owned by that role. The app's own chart (e.g. `charts/lightbridge-code-intelligence`) reads the `password` key from that Secret into a `DB_PASSWORD` env var and assembles `DATABASE_URL` with `$(DB_PASSWORD)` kubelet interpolation — the actual connection-string `value` (host/namespace/db) is supplied per-environment in `ai-helm-values`, not baked into this chart. `usage` follows the identical shape: new `usage` role → `lightbridge-usage-db-role` ExternalSecret → `usage` Database CR, and the companion `ai-helm-values` PR assembles `postgresql://usage:$(DB_PASSWORD)@lightbridge-main-db-rw.converse.svc.cluster.local:5432/usage`.

**Database name: `usage`.** The cluster's existing `Database` CRs are all short, single-word, no-prefix names (`repoauth`, `codeintel`, `governance`, `coder`) — matching the CNPG role name 1:1. `usage` follows that convention. (`lightbridge-authz`'s own local-dev Compose uses `lightbridge_authz_usage`, but this cluster's naming convention — driven by "one word, matches the role, matches the tenant" — takes precedence for consistency with its four existing siblings.)

---

## 3. Scope

### In Scope

- `charts/lightbridge-db/values.yaml`: new `usage` managed role (on `lightbridge-main-db`), new `usage` `Database` CR, new `lightbridge-usage-db-role` `ExternalSecret`.
- `charts/lightbridge-db/Chart.yaml`: description update (no version bump — release-please owns `Chart.yaml` `version:`/`CHANGELOG.md` for this repo; not touched here).
- Comment cleanup in both files ("the usage DB is dropped" → describes the restored `Database` CR).

### Out of Scope

- The `usage:` values block wiring (config, env, TLS) — already merged in [ai-helm-values#247](https://github.com/ADORSYS-GIS/ai-helm-values/pull/247)/[#249](https://github.com/ADORSYS-GIS/ai-helm-values/pull/249).
- Fixing `DATABASE_URL`'s `secretKeyRef` to point at the right secret/key for this `Database` CR design — companion PR in `ai-helm-values` (linked below); **that PR is the remaining hard blocker** for usage pods actually connecting.
- `usage_events` retention/pruning. TimescaleDB's `add_retention_policy('usage_events', INTERVAL '30 days')` (in `migrations-usage/20260223000001_init_usage.sql`) is skipped on this plain-Postgres database — `usage_events` will grow unbounded without it. This needs a follow-up (`pg_cron`, a scheduled job, or app-side pruning); not implemented here.
- Any ingress/public exposure for the usage API.
- The CNPG operator itself (pre-existing, externally managed, confirmed live at 1.30.0).

---

## 4. Verification

I verified this change by:

- [x] Running automated tests
- [ ] Running manual tests
- [ ] Checking logs
- [ ] Checking metrics
- [ ] Testing error cases
- [ ] Testing permissions/security behavior
- [ ] Testing rollback or failure behavior, if relevant

Commands run:

```bash
helm lint charts/lightbridge-db
helm template lightbridge-db charts/lightbridge-db | grep -E '^kind:|^  name:'
```

Results:

```text
$ helm lint charts/lightbridge-db
==> Linting charts/lightbridge-db
[INFO] Chart.yaml: icon is recommended
1 chart(s) linted, 0 chart(s) failed

$ helm template lightbridge-db charts/lightbridge-db | grep -E '^kind:|^  name:'
kind: Cluster
  name: lightbridge-main-db
kind: Database
  name: repoauth
  name: repoauth
kind: Database
  name: codeintel
  name: codeintel
kind: Database
  name: governance
  name: governance
kind: Database
  name: coder
  name: coder
kind: Database
  name: usage          # new
  name: usage
kind: ExternalSecret
  name: repo-auth-db-role
kind: ExternalSecret
  name: lightbridge-codeintel-db-role
kind: ExternalSecret
  name: lightbridge-governance-db-role
kind: ExternalSecret
  name: lightbridge-grafana-ro-db-role
kind: ExternalSecret
  name: coder-db-role
kind: ExternalSecret
  name: lightbridge-usage-db-role   # new
kind: ObjectStore
  name: lightbridge-main-db
kind: PodMonitor
  name: lightbridge-main-db
kind: ScheduledBackup
  name: lightbridge-main-db-daily
```

Rendered `Database/usage` + managed role:

```yaml
apiVersion: postgresql.cnpg.io/v1
kind: Database
metadata:
  name: usage
  namespace: converse
  annotations:
    argocd.argoproj.io/sync-wave: "3"
    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
spec:
  cluster:
    name: lightbridge-main-db
  name: usage
  owner: usage
  ensure: present
```

```yaml
      - name: usage
        ensure: present
        login: true
        passwordSecret:
          name: lightbridge-usage-db-role
```

I could not verify against the live cluster (no `kubectl`/ArgoCD access from this environment) — this is a values/manifest-level verification only. Someone with cluster access should confirm `Database/usage` reaches `Ready` and that `lightbridge-usage-db-role` (the ESO-synced Secret) exists before/alongside the usage pods coming up — this requires `usage_db_password` to exist as a new property in the `ai/camer/digital/prod/env` Secrets Manager bucket (mirrors `codeintel_db_password`/`coder_db_password`/`governance_db_password`), which I could not set from here.

---

## 5. Screenshots / Evidence

- `helm lint` / `helm template` output above.
- Live cluster facts (relayed, not independently re-verified here — inherited from #1007's investigation): `lightbridge-main-db`, namespace `converse`, 2 instances, healthy, image `ghcr.io/cloudnative-pg/postgresql:18.4-system-trixie`, CNPG operator 1.30.0, existing `Database` CRs `codeintel`/`coder`/`governance`/`repoauth`.
- `lightbridge-authz` source confirming no TimescaleDB dependency: `crates/lightbridge-authz-usage/src/repo.rs:113-116` (`date_bin`), `migrations-usage/20260223000001_init_usage.sql` (gated Timescale block), `grep -rn "time_bucket|hypertable|timescale" crates/lightbridge-authz-usage/ app/lightbridge-authz-usage/` → zero matches.

---

## 6. Risk Assessment

Risk level:

* [x] Low
* [ ] Medium
* [ ] High

Potential risks:

* A brand-new `Database` CR provisions an empty database — no data migration needed since `usage_events` has never been live in prod on the dropped cluster.
* `usage_events` has no retention/pruning without TimescaleDB (flagged above, follow-up needed).
* This PR alone does not remove or touch `lightbridge-main-db`'s Cluster spec beyond adding one more `managed.roles` entry, or any of the existing `Database` CRs (repoauth/codeintel/governance/coder) — diff is additive only.

Mitigation:

* `usage` reuses the cluster's existing backup/HA posture (2 instances, barman-cloud ObjectStore + ScheduledBackup already covering the whole cluster) automatically — no new backup infra needed, unlike #1007's dedicated-cluster approach.
* The companion `ai-helm-values` PR must land before/alongside this one, or `DATABASE_URL` keeps pointing at a secret that never existed.

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [x] Drafting documentation
* [x] Reviewing the diff
* [ ] Refactoring
* [ ] Generating tests
* [ ] Not used

Human verification:

* [ ] I understand every meaningful change in this PR
* [ ] I checked generated code manually
* [ ] I checked generated tests manually
* [ ] I removed unsupported AI assumptions
* [ ] I accept responsibility for this PR

---

## 8. Reviewer Focus

Please focus your review on:

* [x] Correctness
* [x] Architecture
* [ ] Security
* [ ] Performance
* [ ] Tests
* [x] Maintainability
* [ ] Product intent
* [x] Edge cases
