### PR TITLE
fix(core-gateway): add missing -collector suffix to usage otel accessLog sink

### DIFF
--- a/charts/core-gateway/templates/envoy-proxy.yaml
+++ b/charts/core-gateway/templates/envoy-proxy.yaml
@@ -168,7 +168,22 @@ spec:
                 # (/v1/otel/logs, no gRPC receiver) directly. The collector
                 # hop is what makes both destinations reachable from one
                 # sink.
-                host: {{ include "core-gateway.fullname" . }}-usage.{{ .Release.Namespace }}.svc.cluster.local
+                #
+                # MUST carry the `-collector` suffix: the otel-operator names
+                # the Service it generates for an OpenTelemetryCollector
+                # named `<fullname>-usage` (templates/otel.yaml) as
+                # `<fullname>-usage-collector`, not `<fullname>-usage` — same
+                # pattern the traces leg already gets right in
+                # templates/gateway-config.yaml
+                # (`{{ include "core-gateway.fullname" $ }}-traces-collector`).
+                # Verified live: `kubectl get svc -n converse-gateway` has no
+                # `core-gateway-usage` Service, only `-collector`,
+                # `-collector-headless` and `-collector-monitoring`; the
+                # pre-fix hostname left the STRICT_DNS `accesslog_otel_0_0`
+                # cluster with zero resolved hosts and the collector's
+                # `:8888/metrics` never emitted a single
+                # `otelcol_receiver_accepted_*` series since deploy.
+                host: {{ include "core-gateway.fullname" . }}-usage-collector.{{ .Release.Namespace }}.svc.cluster.local
                 port: 4317
                 resources:
                   k8s.cluster.name: "converse-llm-1"


### PR DESCRIPTION
## 1. Summary

This PR changes:

- `charts/core-gateway/templates/envoy-proxy.yaml`: the EnvoyProxy accessLog OTLP sink's `host` now includes the `-collector` suffix that the otel-operator actually gives the Service it generates for the `core-gateway-usage` `OpenTelemetryCollector`.

It solves:

- PR #1008 (`dd414175`, "restore access-log fan-out to lightbridge-authz-usage") is currently a **no-op in prod**: the sink hostname it shipped (`core-gateway-usage.converse-gateway.svc.cluster.local`) has never resolved, so no access log has reached the `-usage` collector since that PR merged.

---

## 2. Intent

> The otel-operator names the Service for an `OpenTelemetryCollector` named `core-gateway-usage` as `core-gateway-usage-collector` — it appends `-collector`, it does not reuse the CR name verbatim. `templates/gateway-config.yaml` already gets this right for the sibling traces leg (`{{ include "core-gateway.fullname" $ }}-traces-collector`), and `templates/certificate-usage-ca.yaml`'s cert SAN already gets it right too (`{{ include "core-gateway.fullname" . }}-usage-collector`). Only the accessLog sink's `host` in `envoy-proxy.yaml` was missing the suffix. This PR makes that one reference consistent with the pattern already used correctly elsewhere in the same chart, so Envoy can actually resolve and reach the collector PR #1008 stood up.

---

## 3. Scope

### In Scope

- Add the `-collector` suffix to the accessLog OTLP sink `host` in `envoy-proxy.yaml`.
- Audit the whole chart for the same class of mistake (any other reference to a collector Service missing `-collector`).

### Out of Scope

- Bug 2 (`core-gateway-traces` dropping ~74% of spans to Alloy on a gRPC message-size limit) — unrelated failure mode on a different collector, filed as a separate PR: #TBD (linked in that PR's own description).
- Any change to Alloy's config (owned in the `ai-helm-values` repo).

---

## 4. Verification

I verified this change by:

- [x] Running manual tests
- [x] Checking logs
- [x] Checking metrics
- [ ] Testing error cases
- [ ] Testing permissions/security behavior
- [ ] Testing rollback or failure behavior, if relevant

Commands run:

```bash
# Live Service names, hetzner-prod, converse-gateway namespace
kubectl get svc -n converse-gateway

# Confirm Envoy's STRICT_DNS accesslog cluster has zero resolved hosts (pre-fix)
kubectl port-forward -n envoy-gateway-system pod/envoy-converse-gateway-core-gateway-c480b207-cdbffc859-c6pnw 19000:19000
curl -s http://127.0.0.1:19000/clusters | grep "^accesslog_otel_0_0::"   # only static config keys, no ::<ip>:: host entries, no cx_active/rq_success
curl -s http://127.0.0.1:19000/clusters | grep "^tracing::"              # sibling cluster (correct hostname) DOES show host entries + live counters

# Confirm the usage collector has never accepted anything (pre-fix)
kubectl port-forward -n converse-gateway pod/core-gateway-usage-collector-b8759bfc6-tq9xk 8888:8888
curl -s http://127.0.0.1:8888/metrics | grep otelcol_receiver_accepted   # empty

# Render the chart with the real prod values and confirm the sink host
# now exactly matches the live Service name
cd charts/core-gateway
helm dependency build
helm template core-gateway . -f <ai-helm-values>/environments/prod/values/core-gateway.yaml \
  --namespace converse-gateway | grep -A1 "host:.*usage"

# Chart-wide audit for the same mistake
grep -rn "OpenTelemetryCollector" charts/            # only charts/core-gateway/templates/otel.yaml defines any
grep -rn '\-usage\.\|\-traces\.' charts/core-gateway/templates/
```

Results:

```text
$ kubectl get svc -n converse-gateway
NAME                                             TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)              AGE
core-gateway-traces-collector                    ClusterIP   10.43.194.108   <none>        4317/TCP,4318/TCP    71d
core-gateway-traces-collector-headless           ClusterIP   None            <none>        4317/TCP,4318/TCP    71d
core-gateway-traces-collector-monitoring         ClusterIP   10.43.57.217    <none>        8888/TCP             71d
core-gateway-usage-collector                     ClusterIP   10.43.168.93    <none>        4317/TCP,4318/TCP    20m
core-gateway-usage-collector-headless            ClusterIP   None            <none>        4317/TCP,4318/TCP    20m
core-gateway-usage-collector-monitoring          ClusterIP   10.43.89.151    <none>        8888/TCP             20m
...
# No "core-gateway-usage" Service — only the -collector variants exist.

$ curl -s http://127.0.0.1:19000/clusters | grep "^accesslog_otel_0_0::"
accesslog_otel_0_0::observability_name::accesslog_otel_0_0
accesslog_otel_0_0::default_priority::max_connections::1024
... (only static per-priority config, zero ::<ip>:port:: entries — DNS never resolved)

$ curl -s http://127.0.0.1:19000/clusters | grep "^tracing::"
tracing::10.43.135.65:4317::cx_active::2
tracing::10.43.135.65:4317::rq_success::616
tracing::10.43.135.65:4317::hostname::alloy.observability.svc.cluster.local
... (sibling cluster with a resolving hostname looks like this — the contrast is the proof)

$ curl -s http://127.0.0.1:8888/metrics | grep otelcol_receiver_accepted
(empty)

$ helm template ... | grep -A1 "host:.*usage"
                host: core-gateway-usage-collector.converse-gateway.svc.cluster.local
                port: 4317
# Now matches the live Service name exactly.

$ grep -rn "OpenTelemetryCollector" charts/
charts/core-gateway/templates/otel.yaml:kind: OpenTelemetryCollector   (x2, -traces and -usage)
$ grep -rn '\-usage\.\|\-traces\.' charts/core-gateway/templates/
(no remaining bare, un-suffixed references — gateway-config.yaml and
certificate-usage-ca.yaml already used -collector correctly; the
envoy-proxy.yaml accessLog host, now fixed, was the only stray one)
```

---

## 5. Screenshots / Evidence

* Metrics/logs: pasted above (live `hetzner-prod` cluster, `converse-gateway`/`envoy-gateway-system` namespaces).

---

## 6. Risk Assessment

Risk level:

* [x] Low

Potential risks:

* None expected beyond the intended behavior change: Envoy will start actually connecting to and sending access-log OTLP data to `core-gateway-usage-collector`, which previously received nothing. This is the intended fix, not a side effect — `otelcol_receiver_accepted_log_records` on that collector going from absent to present/growing is the success signal.

Mitigation:

* Change is a single hostname string in one template; trivially revertable. No schema/CRD/RBAC changes.

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [x] Reviewing the diff

Human verification:

* [ ] I understand every meaningful change in this PR
* [ ] I checked generated code manually
* [ ] I checked generated tests manually
* [ ] I removed unsupported AI assumptions
* [ ] I accept responsibility for this PR

---

## 8. Reviewer Focus

Please focus your review on:

* [x] Correctness
* [x] Product intent
