### PR TITLE
feat(core-gateway): add debug exporter to both otel collectors

### DIFF
--- a/charts/core-gateway/templates/otel.yaml
+++ b/charts/core-gateway/templates/otel.yaml
@@ -1,3 +1,9 @@
+{{- $tracesDebug := ((.Values.otelCollector | default dict).debug | default dict).traces | default dict -}}
+{{- $tracesDebugEnabled := $tracesDebug.enabled | default false -}}
+{{- $tracesDebugVerbosity := $tracesDebug.verbosity | default "basic" -}}
+{{- $usageDebug := ((.Values.otelCollector | default dict).debug | default dict).usage | default dict -}}
+{{- $usageDebugEnabled := $usageDebug.enabled | default false -}}
+{{- $usageDebugVerbosity := $usageDebug.verbosity | default "basic" -}}
 apiVersion: opentelemetry.io/v1beta1
 kind: OpenTelemetryCollector
 metadata:
@@ -38,8 +44,34 @@ spec:
         endpoint: "alloy.observability.svc.cluster.local:4317"
         tls:
           insecure: true
+      {{- if $tracesDebugEnabled }}
+      # Diagnostic-only: dumps received spans to the collector pod's own
+      # stdout (visible via `kubectl logs`) ALONGSIDE the otlp/alloy export
+      # above — never in place of it. `logging` was the old exporter name;
+      # it was renamed to `debug` and later removed entirely upstream, and
+      # this fleet's deployed image (opentelemetry-collector-k8s:0.157.0,
+      # verified live against the CR) only ships `debug`. Toggle off via
+      # otelCollector.debug.traces.enabled.
+      #
+      # verbosity: every span here carries a `user.id` tag (see the
+      # EnvoyProxy `telemetry.tracing.tags` block in templates/envoy-proxy.yaml,
+      # sourced from x-oidc-user-id) — a correlatable user identifier, not
+      # the full email/name profile the `-usage` collector's access-log JSON
+      # carries, but real user data all the same. The debug exporter's
+      # `normal` verbosity already prints per-span attributes inline (it is
+      # NOT a bare counts view), so `user.id` would land in pod logs/Loki at
+      # `normal`, before ever reaching `detailed`. Default `basic` for that
+      # reason — it proves spans are flowing without printing any attribute
+      # value. Bump to `detailed` only to verify gen_ai.*/token/cost
+      # attribute names+values once, then set back to `basic`.
+      debug:
+        verbosity: {{ $tracesDebugVerbosity }}
+      {{- end }}
 
     service:
+      telemetry:
+        logs:
+          level: debug
       pipelines:
         traces:
           receivers:
@@ -49,6 +81,9 @@ spec:
             - batch
           exporters:
             - otlp/alloy
+            {{- if $tracesDebugEnabled }}
+            - debug
+            {{- end }}
 ---
 # Restores the `-usage` collector removed in 948814de ("remove usage-collector
 # + otel-operator (external)"). That commit repointed the Envoy access-log
@@ -133,8 +168,36 @@ spec:
         endpoint: "alloy.observability.svc.cluster.local:4317"
         tls:
           insecure: true
+      {{- if $usageDebugEnabled }}
+      # Diagnostic-only: dumps received log records (Envoy's access-log
+      # stream) to the collector pod's own stdout, ADDED alongside the two
+      # real exporters above, never replacing them. Same exporter-naming
+      # rationale as the `-traces` collector above (`debug`, not the removed
+      # `logging` name — verified against this fleet's deployed
+      # opentelemetry-collector-k8s:0.157.0 image).
+      #
+      # verbosity: the access-log JSON this collector receives carries real
+      # PII — lc_user_email, oidc_email, oidc_name, lc_user_name, user_id,
+      # oidc_jti, x-forwarded-for (see templates/envoy-proxy.yaml's
+      # accessLog json block) — alongside account_id/project_id/api_key_id
+      # and the gen_ai.*/token/cost attributes this diagnosis actually wants
+      # to check. At `detailed` verbosity every one of those fields'
+      # VALUES gets printed into this collector pod's logs, which ship to
+      # Loki — i.e. PII duplicated into a logging backend with Loki's
+      # retention, not a transient debug session. Default `basic`: it only
+      # prints per-batch record counts, which is enough to confirm data is
+      # flowing at all (the original symptom here — the usage collector's
+      # otelcol_receiver_accepted_* metrics were absent entirely). Bump to
+      # `detailed` only to verify the attribute mapping once data is
+      # confirmed flowing, then set back to `basic` immediately after.
+      debug:
+        verbosity: {{ $usageDebugVerbosity }}
+      {{- end }}
 
     service:
+      telemetry:
+        logs:
+          level: debug
       pipelines:
         logs:
           receivers:
@@ -145,3 +208,6 @@ spec:
           exporters:
             - otlphttp/lightbridge_usage
             - otlp/alloy
+            {{- if $usageDebugEnabled }}
+            - debug
+            {{- end }}

--- a/charts/core-gateway/values.yaml
+++ b/charts/core-gateway/values.yaml
@@ -322,8 +322,13 @@ backendTrafficPolicy:
 # (account_id/project_id/api_key_id/user_id/gen_ai.request.model/token
 # counts/cost) are present with the right names once it does.
 #
-# `enabled: false` removes the exporter and its pipeline entry entirely —
-# use it to fully turn diagnostics back off without a template edit.
+# `enabled: false` removes the `debug` EXPORTER and its pipeline entry
+# entirely — no telemetry payloads/attribute values get printed. It does
+# NOT touch `service.telemetry.logs.level: debug`, which templates/otel.yaml
+# sets unconditionally on both collectors: that's the collector binary's own
+# internal operational logging (component startup, config validation,
+# export errors), not a telemetry-payload dump, so it carries no
+# attribute/PII values and is left on regardless of this toggle.
 #
 # `verbosity: basic | normal | detailed`. `basic` only counts records per
 # batch — proves data is flowing without printing a single attribute

--- a/charts/core-gateway/values.yaml
+++ b/charts/core-gateway/values.yaml
@@ -312,12 +312,58 @@ backendTrafficPolicy:
 # lightbridge-authz-usage's TLS listener — see that template for why this is
 # a same-namespace Certificate off the same issuer rather than a literal
 # cross-namespace `authz-tls` Secret reference.
+#
+# debug: the `debug` exporter (templates/otel.yaml) — stdout diagnostic
+# output on top of, never instead of, each collector's real exporters.
+# Added to confirm data is actually flowing (both collectors'
+# otelcol_receiver_accepted_* metrics had been absent — the `-usage` one
+# because Envoy's access-log sink pointed at a hostname missing its
+# `-collector` suffix) and that the expected attributes
+# (account_id/project_id/api_key_id/user_id/gen_ai.request.model/token
+# counts/cost) are present with the right names once it does.
+#
+# `enabled: false` removes the exporter and its pipeline entry entirely —
+# use it to fully turn diagnostics back off without a template edit.
+#
+# `verbosity: basic | normal | detailed`. `basic` only counts records per
+# batch — proves data is flowing without printing a single attribute
+# value. `detailed` prints every attribute's NAME AND VALUE.
+#
+#   - usage: the access-log JSON this collector receives carries real PII
+#     (lc_user_email, oidc_email, oidc_name, lc_user_name, user_id,
+#     oidc_jti, x-forwarded-for — see templates/envoy-proxy.yaml's
+#     accessLog json block). At `detailed` every one of those VALUES gets
+#     written into this collector pod's own logs, which ship to Loki — PII
+#     duplicated into a logging backend with Loki's retention, not a
+#     transient debug session. Defaults to `basic` for that reason.
+#   - traces: every span carries a `user.id` tag (EnvoyProxy
+#     `telemetry.tracing.tags`, sourced from x-oidc-user-id) — a
+#     correlatable user identifier. The debug exporter's `normal`
+#     verbosity already prints per-span attributes inline (it is not a
+#     bare counts view like `basic`), so `user.id` would land in
+#     pod logs/Loki at `normal`, before ever reaching `detailed`. Defaults
+#     to `basic` here too, for the same reason.
+#
+# To check the attribute MAPPING specifically (names/values, not just
+# flow), temporarily set the relevant collector's verbosity to `detailed`
+# in ai-helm-values (environments/<env>/values/core-gateway.yaml):
+#   otelCollector.debug.usage.verbosity: detailed   (PII — revert after)
+#   otelCollector.debug.traces.verbosity: detailed  (user.id — revert after)
+# then set it back to `basic` once verified. Don't leave `detailed`
+# deployed.
 # ────────────────────────────────────────────────────────────────────────
 otelCollector:
   mode: deployment
   usageCa:
     issuer: self-signed-ca
     issuerKind: ClusterIssuer
+  debug:
+    traces:
+      enabled: true
+      verbosity: basic
+    usage:
+      enabled: true
+      verbosity: basic
 
 # ────────────────────────────────────────────────────────────────────────
 # ExtProc sidecar (the Envoy AI Gateway's per-request processor: token


### PR DESCRIPTION
## 1. Summary

This PR changes:

- `charts/core-gateway/templates/otel.yaml`: adds a `debug` exporter to both `core-gateway-traces` and `core-gateway-usage`, added to each collector's pipeline `exporters` list **alongside** the existing exporters (never replacing them), plus `service.telemetry.logs.level: debug` on both collectors.
- `charts/core-gateway/values.yaml`: makes the debug exporter toggleable (`otelCollector.debug.{traces,usage}.enabled`) and its `verbosity` (`basic|normal|detailed`) a per-collector Helm value, both defaulting to `basic`.

It solves:

- #1010 (open) fixes the `-usage` collector's access-log sink hostname (missing `-collector` suffix), which is why that collector's `otelcol_receiver_accepted_*` metrics have been absent entirely. Once that lands, this PR gives a way to actually *see* the data land — `kubectl logs` on either collector pod — and to check that the attributes the billing/tracing pipeline depends on (`account_id`, `project_id`, `api_key_id`, `user_id`, `gen_ai.request.model`, token counts, cost) show up with the names the ingest side expects.

---

## 2. Intent

> #1010's own "Out of Scope" section flags a second, unrelated failure mode on `core-gateway-traces` (a gRPC message-size limit dropping ~74% of spans), currently being fixed on a separate branch. Between that and the `-usage` hostname bug, both collectors have been effectively dark, and a hostname/sizing fix alone doesn't tell you whether the *data itself* — the specific attribute names Envoy stamps on (`account_id`, `x-oidc-user-id`, `gen_ai.*`, etc., see `templates/envoy-proxy.yaml`) — actually reaches the collector or the shape downstream consumers expect. The `debug` exporter's stdout dump, read via `kubectl logs`, is the fastest way to confirm both "is data flowing" and "does it look right" without standing up a separate observability path. This PR is the instrumentation, not the fix for either collector's data-flow bug.

---

## 3. Scope

### In Scope

- Add `debug` exporter (the current, non-deprecated name — `logging` was renamed and later removed upstream; verified against this fleet's live image, `opentelemetry-collector-k8s:0.157.0`) to both collectors' `exporters` and pipeline `exporters` lists.
- Set `service.telemetry.logs.level: debug` on both collectors' internal logging.
- Make the exporter toggleable (`enabled`) and its `verbosity` a per-collector Helm value, both **defaulting to `basic`** — see Risk Assessment for why.

### Out of Scope

- The `-usage` collector hostname fix (#1010) and the `-traces` batch/exporter-sizing fix (separate in-flight branch) — this PR does not touch `envoy-proxy.yaml` or the `batch`/exporter sizing blocks in `otel.yaml`, specifically to avoid colliding with either.
- Any change to Alloy's config (owned in `ai-helm-values`).
- Turning `detailed` verbosity on by default anywhere — see below.

---

## 4. Verification

I verified this change by:

- [x] Running automated tests
- [x] Checking logs
- [ ] Running manual tests
- [ ] Checking metrics
- [ ] Testing error cases
- [ ] Testing permissions/security behavior
- [ ] Testing rollback or failure behavior, if relevant

Commands run:

```bash
cd charts/core-gateway
helm dependency build
helm lint --strict . -f ~/dev/gis/ai-helm-values/environments/prod/values/core-gateway.yaml
helm template core-gateway . -f ~/dev/gis/ai-helm-values/environments/prod/values/core-gateway.yaml -s templates/otel.yaml
# confirm the debug exporter can be toggled off cleanly too
helm template core-gateway . -f ~/dev/gis/ai-helm-values/environments/prod/values/core-gateway.yaml \
  --set otelCollector.debug.traces.enabled=false --set otelCollector.debug.usage.enabled=false \
  -s templates/otel.yaml
```

Results:

```text
$ helm lint --strict charts/core-gateway -f ~/dev/gis/ai-helm-values/environments/prod/values/core-gateway.yaml
==> Linting charts/core-gateway
[INFO] Chart.yaml: icon is recommended

1 chart(s) linted, 0 chart(s) failed
```

Rendered `core-gateway-traces` (relevant excerpt):

```yaml
    exporters:
      otlp/alloy:
        endpoint: "alloy.observability.svc.cluster.local:4317"
        tls:
          insecure: true
      debug:
        verbosity: basic

    service:
      telemetry:
        logs:
          level: debug
      pipelines:
        traces:
          receivers:
            - otlp
          processors:
            - memory_limiter
            - batch
          exporters:
            - otlp/alloy
            - debug
```

Rendered `core-gateway-usage` (relevant excerpt):

```yaml
    exporters:
      otlphttp/lightbridge_usage:
        logs_endpoint: "https://lightbridge-usage.converse.svc.cluster.local:3000/v1/otel/logs"
        tls:
          ca_file: /etc/otel/tls/ca.crt
      otlp/alloy:
        endpoint: "alloy.observability.svc.cluster.local:4317"
        tls:
          insecure: true
      debug:
        verbosity: basic

    service:
      telemetry:
        logs:
          level: debug
      pipelines:
        logs:
          receivers:
            - otlp
          processors:
            - memory_limiter
            - batch
          exporters:
            - otlphttp/lightbridge_usage
            - otlp/alloy
            - debug
```

Both existing exporters (`otlp/alloy` on `-traces`; `otlphttp/lightbridge_usage` + `otlp/alloy` on `-usage`) are untouched — `debug` is additive in both the `exporters` map and each pipeline's `exporters` list. With `otelCollector.debug.{traces,usage}.enabled=false` the `debug` entries disappear from both the exporters map and the pipeline lists entirely (verified via the same `helm template` render).

---

## 5. Screenshots / Evidence

* Live collector image (confirms `debug` is the right exporter name, not the removed `logging`):

```text
$ kubectl --context hetzner-prod get opentelemetrycollectors -A
NAMESPACE          NAME                   MODE         VERSION   READY   IMAGE
converse-gateway   core-gateway-traces    deployment   0.157.0   1/1     ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-k8s:0.157.0
converse-gateway   core-gateway-usage     deployment   0.157.0   1/1     ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-k8s:0.157.0
```

* Full rendered `templates/otel.yaml` for both collectors: see Verification section above (complete, not truncated, for the changed parts).

---

## 6. Risk Assessment

Risk level:

* [x] Low

Potential risks:

* **PII duplication into Loki if `verbosity: detailed` is left on.** The `-usage` collector receives Envoy's access-log stream, whose JSON carries real PII (`lc_user_email`, `oidc_email`, `oidc_name`, `lc_user_name`, `user_id`, `oidc_jti`, `x-forwarded-for` — see `templates/envoy-proxy.yaml`'s `accessLog` block). At `detailed` verbosity the debug exporter prints every attribute's value, and this collector's pod logs ship to Loki — so `detailed` there duplicates PII into a logging backend with Loki's own retention, not a transient debug session.
* **`-traces` spans also carry a user identifier.** Every span gets a `user.id` tag (`EnvoyProxy` `telemetry.tracing.tags`, sourced from `x-oidc-user-id`). I checked the debug exporter's own verbosity semantics against the upstream README (`opentelemetry-collector` v0.157.0, matching the deployed image): `normal` is **not** a bare-counts view — it already prints one line per span including its attributes — so `user.id` would land in pod logs/Loki at `normal`, before ever reaching `detailed`. That's why `-traces` also defaults to `basic` here rather than `normal`.
* Both risks are mitigated by defaulting `verbosity: basic` on **both** collectors (counts only, no attribute values) and by making the exporter itself toggleable off (`enabled: false`) so it can be fully removed again without a chart release.

Mitigation:

* Defaults: `otelCollector.debug.traces.verbosity: basic`, `otelCollector.debug.usage.verbosity: basic`.
* To do a one-off attribute-mapping check once #1010 (and the `-traces` sizing fix) land, flip in `ai-helm-values` (`environments/<env>/values/core-gateway.yaml`):
  * `otelCollector.debug.usage.verbosity: detailed` — PII, revert immediately after checking.
  * `otelCollector.debug.traces.verbosity: detailed` — `user.id`, revert immediately after checking.
  * Or `otelCollector.debug.{traces,usage}.enabled: false` to remove the exporter entirely again.

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [x] Reviewing the diff

Human verification:

* [ ] I understand every meaningful change in this PR
* [ ] I checked generated code manually
* [ ] I checked generated tests manually
* [ ] I removed unsupported AI assumptions
* [ ] I accept responsibility for this PR

---

## 8. Reviewer Focus

Please focus your review on:

* [x] Correctness
* [x] Security
* [x] Product intent
