### PR TITLE
fix(lightbridge): add usage image to argocd-image-updater annotations

### DIFF
--- a/charts/lightbridge/templates/applications.yaml
+++ b/charts/lightbridge/templates/applications.yaml
@@ -93,12 +93,23 @@ metadata:
     # COSIGN-signed `sha-<gitsha>` build of each first-party image and git
     # write-backs the image into environments/prod/values/lightbridge-app.yaml on
     # ai-helm-values `main` (api → global.authz.image.{repository,version}, mcp →
-    # global.authz_mcp.image.{repository,version}). BOTH image-name (repository)
+    # global.authz_mcp.image.{repository,version}, usage →
+    # global.authz_usage.image.{repository,version}). BOTH image-name (repository)
     # and image-tag (version) are required — the operator errors ("could not find
     # an image-name") if only the tag param is given. cosign identity = the
     # lightbridge-authz CI workflow that signs the images. Until a signed build
     # exists the updater finds no verifiable tag and leaves the version untouched.
-    argocd-image-updater.argoproj.io/image-list: api=ghcr.io/adorsys-gis/lightbridge-authz,mcp=ghcr.io/adorsys-gis/lightbridge-authz-mcp
+    #
+    # The `usage` alias was missing entirely until this change: usage was
+    # re-enabled in ai-helm-values #247 (global.authz_usage.image.* pinned
+    # manually there to unblock a prod ImagePullBackOff), but the api/mcp
+    # write-back annotations added here in #592/#602 predate that re-enable and
+    # were never extended to cover the third image, so argocd-image-updater
+    # never once considered it — the annotations-only alias, not the CR, is the
+    # gate: `lightbridge-app` is already a `useAnnotations: true` entry in
+    # ai-helm's charts/imageupdater/values.yaml, so adding the alias here is
+    # sufficient with no change needed there.
+    argocd-image-updater.argoproj.io/image-list: api=ghcr.io/adorsys-gis/lightbridge-authz,mcp=ghcr.io/adorsys-gis/lightbridge-authz-mcp,usage=ghcr.io/adorsys-gis/lightbridge-authz-usage
     argocd-image-updater.argoproj.io/api.update-strategy: newest-build
     argocd-image-updater.argoproj.io/api.allow-tags: regexp:^sha-[0-9a-f]+$
     argocd-image-updater.argoproj.io/api.force-update: "true"
@@ -120,6 +131,15 @@ metadata:
     argocd-image-updater.argoproj.io/mcp.signature-type: cosign
     argocd-image-updater.argoproj.io/mcp.cosign.certificate-oidc-issuer: https://token.actions.githubusercontent.com
     argocd-image-updater.argoproj.io/mcp.cosign.certificate-identity-regexp: ^https://github\.com/ADORSYS-GIS/lightbridge-authz/\.github/workflows/ci\.yml@.*$
+    argocd-image-updater.argoproj.io/usage.update-strategy: newest-build
+    argocd-image-updater.argoproj.io/usage.allow-tags: regexp:^sha-[0-9a-f]+$
+    argocd-image-updater.argoproj.io/usage.force-update: "true"
+    argocd-image-updater.argoproj.io/usage.pull-secret: pullsecret:argocd/adorsys-gis-ghcr-pull
+    argocd-image-updater.argoproj.io/usage.helm.image-name: global.authz_usage.image.repository
+    argocd-image-updater.argoproj.io/usage.helm.image-tag: global.authz_usage.image.version
+    argocd-image-updater.argoproj.io/usage.signature-type: cosign
+    argocd-image-updater.argoproj.io/usage.cosign.certificate-oidc-issuer: https://token.actions.githubusercontent.com
+    argocd-image-updater.argoproj.io/usage.cosign.certificate-identity-regexp: ^https://github\.com/ADORSYS-GIS/lightbridge-authz/\.github/workflows/ci\.yml@.*$
     argocd-image-updater.argoproj.io/write-back-method: git
     argocd-image-updater.argoproj.io/git-branch: main
     argocd-image-updater.argoproj.io/git-repository: https://github.com/adorsys-gis/ai-helm-values.git


### PR DESCRIPTION
## 1. Summary

This PR changes:

- `charts/lightbridge/templates/applications.yaml`: adds a third `usage=ghcr.io/adorsys-gis/lightbridge-authz-usage` alias to the `lightbridge-app` Application's `argocd-image-updater.argoproj.io/image-list` annotation, plus the full matching set of per-alias `usage.*` annotations (update-strategy, allow-tags, force-update, pull-secret, `helm.image-name`/`helm.image-tag`, cosign signature-type/issuer/identity-regexp) — copied verbatim from the existing `api`/`mcp` blocks, only the alias prefix and the two `helm.image-name`/`helm.image-tag` values differ (`global.authz_usage.image.repository` / `global.authz_usage.image.version`).

It solves:

- `lightbridge-authz-usage` never auto-promoting to prod via argocd-image-updater, while `lightbridge-authz` and `lightbridge-authz-mcp` do, every day, without issue.

---

## 2. Intent

> Diagnosed against the live prod state today (2026-08-15): in `ai-helm-values/environments/prod/values/lightbridge-app.yaml` on `origin/main`, `global.authz.image.version` and `global.authz_mcp.image.version` are both `sha-5c4db334d54191087c086e0cb5d6d534e1fd83da` (today's latest `lightbridge-authz` main commit), actively promoted all day. `global.authz_usage.image.version` is still `sha-2ec252fe90862067afdea4158f2591fe11b4992e` — many releases behind, untouched since it was manually pinned in https://github.com/ADORSYS-GIS/ai-helm-values/pull/247 to fix a prod `ImagePullBackOff` when `usage.enabled: true` first went live.
>
> The `lightbridge-authz` CI pipeline (`.github/workflows/ci.yml`) builds all three images — `runtime`, `mcp-runtime`, `usage-runtime` — from the same `container-build` matrix job, using the same `./.github/actions/container-build` composite for all three, so they are cosign-signed identically. I confirmed this by resolving each image's digest for `sha-5c4db334d54191087c086e0cb5d6d534e1fd83da` against the GHCR registry API and checking for a `200` on the corresponding `<digest>.sig` manifest:
>
> - `ghcr.io/adorsys-gis/lightbridge-authz` @ `sha256:bb4ea01e...` → `.sig` = `200` (known-good control)
> - `ghcr.io/adorsys-gis/lightbridge-authz-mcp` @ `sha256:4bedebef...` → digest resolves fine
> - `ghcr.io/adorsys-gis/lightbridge-authz-usage` @ `sha256:00e4108e...` → `.sig` = `200`
>
> **The usage image is signed and published correctly.** So the root cause is not in `lightbridge-authz`'s CI — it's that argocd-image-updater was never told the usage image exists. This cluster runs the CRD-based operator (`imageUpdaters[]` in `ai-helm`'s `charts/imageupdater/values.yaml`); the `lightbridge-app` entry there is already `useAnnotations: true`, so it defers entirely to whatever `argocd-image-updater.argoproj.io/*` annotations live on the `lightbridge-app` Application — no CR change needed. Those annotations (`charts/lightbridge/templates/applications.yaml`) were added in #592/#602 for `api`+`mcp` only. Usage was re-enabled later, in the separate `ai-helm-values` repo (https://github.com/ADORSYS-GIS/ai-helm-values/pull/247), and nobody circled back to extend this chart's write-back annotation block to a third alias — so the updater's reconcile loop has never once considered the usage image, the same failure mode already diagnosed once before for `lightbridge-governance` (see the comment above the `lightbridge-governance` entry in `charts/imageupdater/values.yaml`, https://github.com/ADORSYS-GIS/ai-helm/pull/939).
>
> This PR closes that gap by mirroring the `mcp` block exactly, pointing the new `usage` alias at `global.authz_usage.image.{repository,version}` — the same values keys the manual pin in https://github.com/ADORSYS-GIS/ai-helm-values/pull/247 already established.

---

## 3. Scope

### In Scope

- Adding the `usage` alias to `image-list` and the corresponding `usage.*` write-back/signature-verification annotations on the `lightbridge-app` Application in `charts/lightbridge/templates/applications.yaml`.
- A short comment explaining why the alias was missing and why no `charts/imageupdater/values.yaml` change is required.

### Out of Scope

- Manually bumping `global.authz_usage.image.version` in `ai-helm-values` to the current commit — that fixes today's staleness but not the automation gap. If prod should also be caught up immediately, that belongs in its own, separately-labelled `ai-helm-values` commit/PR (not bundled here), since bumping it there is a distinct action from fixing the updater.
- The stale `charts/lightbridge/Chart.yaml` / `values.yaml` header comments ("usage (unused) are DROPPED") — factually stale since https://github.com/ADORSYS-GIS/ai-helm-values/pull/247 re-enabled `usage.enabled: true`, but a pure doc fix unrelated to this bug; flagged separately rather than folded into a deployment-automation PR.
- Any change to `charts/imageupdater/values.yaml` — the `lightbridge-app` `useAnnotations: true` entry already covers this Application; verified no CR-level change is needed.
- Any live-cluster verification (`kubectl -n argocd-image-updater logs ...`) — not run; this is a GitOps-repo-only change. See Verification section for what could and couldn't be checked pre-merge.

---

## 4. Verification

I verified this change by:

- [x] Running automated tests
- [ ] Running manual tests
- [ ] Checking logs
- [ ] Checking metrics
- [ ] Testing error cases
- [ ] Testing permissions/security behavior
- [ ] Testing rollback or failure behavior, if relevant

Commands run:

```bash
# GHCR signature check (usage image, today's commit, via zsh -i -c for $GITHUB_TOKEN)
# resolved digest sha256:00e4108eed54f2a18949a14e467d175054be71c13b487d7d71e4ab4216b1e0da
# for tag sha-5c4db334d54191087c086e0cb5d6d534e1fd83da, then:
curl -sD - -H "Authorization: Bearer $REG_TOKEN" \
  "https://ghcr.io/v2/adorsys-gis/lightbridge-authz-usage/manifests/sha256-00e4108eed54f2a18949a14e467d175054be71c13b487d7d71e4ab4216b1e0da.sig" \
  -o /dev/null | grep "^HTTP"

helm dependency build charts/lightbridge
helm lint charts/lightbridge
helm template test charts/lightbridge --show-only templates/applications.yaml
```

Results:

```text
$ curl ... .sig
HTTP/2 200   # usage image IS signed at today's commit — rules out a CI signing gap

$ helm lint charts/lightbridge
==> Linting charts/lightbridge
[INFO] Chart.yaml: icon is recommended
1 chart(s) linted, 0 chart(s) failed

$ helm template test charts/lightbridge --show-only templates/applications.yaml
# lightbridge-app Application renders with:
argocd-image-updater.argoproj.io/image-list: api=ghcr.io/adorsys-gis/lightbridge-authz,mcp=ghcr.io/adorsys-gis/lightbridge-authz-mcp,usage=ghcr.io/adorsys-gis/lightbridge-authz-usage
argocd-image-updater.argoproj.io/usage.helm.image-name: global.authz_usage.image.repository
argocd-image-updater.argoproj.io/usage.helm.image-tag: global.authz_usage.image.version
argocd-image-updater.argoproj.io/usage.signature-type: cosign
argocd-image-updater.argoproj.io/usage.cosign.certificate-identity-regexp: ^https://github\.com/ADORSYS-GIS/lightbridge-authz/\.github/workflows/ci\.yml@.*$
# (full usage.* block present, mirroring api./mcp. exactly)
```

Real-world confirmation that argocd-image-updater actually picks this up requires cluster access this session doesn't have. The owner should run, after this PR is live and ArgoCD has synced:

```bash
kubectl -n argocd-image-updater logs deploy/argocd-image-updater-controller | grep -i usage
```

and confirm `global.authz_usage.image.version` gets written back to `ai-helm-values` `environments/prod/values/lightbridge-app.yaml` on the next reconcile.

---

## 5. Screenshots / Evidence

* GHCR signature check output: pasted above (Verification section).
* Related prior fix for the identical CR-vs-annotations gap on a different app: the `lightbridge-governance` comment in `charts/imageupdater/values.yaml`, https://github.com/ADORSYS-GIS/ai-helm/pull/939

---

## 6. Risk Assessment

Risk level:

* [x] Low

Potential risks:

* This change only affects annotations on the `lightbridge-app` Application — no workload resources, no image pin, no schema change. Worst case if wrong: the updater still doesn't pick up the usage image (no regression vs. today), or (if a typo in the `helm.image-name`/`helm.image-tag` paths) a bad write-back to `ai-helm-values` — but that write-back is itself a normal git commit to `main`, reviewable/revertable like any other, not a direct cluster mutation.
* Untestable pre-merge: whether argocd-image-updater's live reconcile loop actually picks up the new annotation set. The `ci.yml`/`container-build` job pattern this depends on is itself main-only in `lightbridge-authz` (not relevant here, but noting the general shape of this kind of change — annotation-only fixes in this chart are only provable once ArgoCD syncs against a real cluster).

Mitigation:

* Annotation-only change, trivially revertable (single commit revert).
* Mirrors the already-proven `api`/`mcp` pattern exactly — no new mechanism introduced, just extending an existing one to a third alias.
* Owner can confirm via the `kubectl` log command above once merged and synced.

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [x] Reviewing the diff

Human verification:

* [ ] I understand every meaningful change in this PR
* [ ] I checked generated code manually
* [ ] I checked generated tests manually
* [ ] I removed unsupported AI assumptions
* [ ] I accept responsibility for this PR

---

## 8. Reviewer Focus

Please focus your review on:

* [x] Correctness
* [x] Product intent
* [x] Maintainability
