### PR TITLE
docs(lightbridge): fix stale opa/usage-dropped comments

### DIFF
--- a/charts/lightbridge/Chart.yaml
+++ b/charts/lightbridge/Chart.yaml
@@ -22,9 +22,10 @@ description: |
   workload resources directly — it owns the three child Applications that own
   everything.
 
-  Replaces the old flat `lightbridge-backend` app. The opa + usage components
-  and the lightbridge-usage-db are DROPPED (OPA removed per ADR-0021; usage
-  unused). Namespace stays `converse`.
+  Replaces the old flat `lightbridge-backend` app. OPA stays dropped (ADR-0021),
+  but usage was re-enabled at the values layer (ai-helm-values PR #247),
+  reversing the usage half of ADR-0026 — see values.yaml for detail. Namespace
+  stays `converse`.
 type: application
 version: 1.0.0
 appVersion: "0.8.1"

--- a/charts/lightbridge/values.yaml
+++ b/charts/lightbridge/values.yaml
@@ -4,8 +4,12 @@
 # three child Applications.
 #
 # Replaces the old flat `lightbridge-backend` app. Components: api (main) + mcp
-# only — opa (removed per ADR-0021) and usage (unused) are DROPPED, along with
-# the lightbridge-usage-db. Namespace stays `converse`.
+# are always on; opa stays dropped (ADR-0021), but usage was re-enabled at the
+# values layer (ai-helm-values PR #247 — usage.enabled: true in
+# environments/prod/values/lightbridge-app.yaml), reversing the usage half of
+# ADR-0026. This chart doesn't gate usage itself — the upstream
+# lightbridge-authz-stack chart's own component toggles do. Namespace stays
+# `converse`.
 
 # ────────────────────────────────────────────────────────────────────────
 # Shared ArgoCD wiring for all child Applications.


### PR DESCRIPTION
## 1. Summary

This PR changes:

- `charts/lightbridge/values.yaml` (top comment block, ~line 6-8)
- `charts/lightbridge/Chart.yaml` (description block, ~line 25-27)

It solves:

- Both comments claimed the `usage` component is dropped/unused (from when the chart was split
  into an App-of-Apps orchestrator and opa+usage were dropped, ADR-0026, commit `4b65164c`). That's
  stale: [ai-helm-values#247](https://github.com/ADORSYS-GIS/ai-helm-values/pull/247) re-enabled
  `usage` (`usage.enabled: true` in `environments/prod/values/lightbridge-app.yaml`) with a full
  production deployment (DB, config, secrets), reversing the usage half of ADR-0026. OPA remains
  dropped (ADR-0021, still accurate) — only the usage claim was wrong.

---

## 2. Intent

The intent of this PR is:

> Prevent future readers from believing `usage` is dropped/unused when it has been live in prod
> since ai-helm-values#247. Discovered as a side finding while diagnosing/fixing why the usage
> image wasn't being auto-promoted by argocd-image-updater in #1015, which deliberately left this
> doc fix out of scope.

---

## 3. Scope

### In Scope

- Correcting the two stale comment blocks to say opa is still dropped (ADR-0021) but usage was
  re-enabled via ai-helm-values#247 (reversing the usage half of ADR-0026).

### Out of Scope

- The argocd-image-updater annotation fix itself (already landed in #1015).
- The unrelated, closed-without-merge `claude/lightbridge-usage-db-restore` branch
  ([#1007](https://github.com/ADORSYS-GIS/ai-helm/pull/1007)), which touches `lightbridge-usage-db`
  restoration — a different, still-unmerged effort not addressed here.
- Lines 13-15 of `Chart.yaml` (the CR-by-CR breakdown listing "api (main) + mcp components" for
  `lightbridge-app`) are also now incomplete since usage deploys through that same Application, but
  fixing that structural list is a larger edit than the two DROPPED/unused comment claims this PR
  targets — left for a follow-up.

---

## 4. Verification

I verified this change by:

- [x] Checking logs (n/a — doc-only, no runtime behavior)
- [ ] Running automated tests
- [ ] Running manual tests
- [ ] Checking metrics
- [ ] Testing error cases
- [ ] Testing permissions/security behavior
- [ ] Testing rollback or failure behavior, if relevant

Commands run:

```bash
git diff -- charts/lightbridge/values.yaml charts/lightbridge/Chart.yaml
grep -rn "usage (unused)\|usage.*DROPPED\|usage unused" charts/lightbridge/
helm lint charts/lightbridge
```

Results:

```text
git diff: only the two comment blocks changed, no YAML values/logic touched.
grep: no matches — no stale "usage dropped/unused" phrasing remains anywhere in charts/lightbridge/.
helm lint: fails on a pre-existing missing "common" chart dependency (not vendored in this
checkout), unrelated to this change and present before it; Chart.yaml/values.yaml both parsed
without error.
```

---

## 5. Screenshots / Evidence

Add evidence here:

* Source of truth: https://github.com/ADORSYS-GIS/ai-helm-values/pull/247
* Discovery context: https://github.com/ADORSYS-GIS/ai-helm/pull/1015

---

## 6. Risk Assessment

Risk level:

* [x] Low
* [ ] Medium
* [ ] High

Potential risks:

* None — comment-only change, no rendered manifest or values change.

Mitigation:

* n/a

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Drafting documentation
* [x] Reviewing the diff
* [ ] Generating code
* [ ] Refactoring
* [ ] Generating tests

Human verification:

* [x] I understand every meaningful change in this PR
* [x] I checked generated code manually
* [x] I removed unsupported AI assumptions
* [x] I accept responsibility for this PR

---

## 8. Reviewer Focus

Please focus your review on:

* [x] Correctness
* [x] Maintainability
* [ ] Architecture
* [ ] Security
* [ ] Performance
* [ ] Tests
* [ ] Product intent
* [ ] Edge cases
