### PR TITLE
chore(lightbridge): bump lightbridge-authz-stack chart pin 0.8.1 -> 3.3.0

### DIFF
--- a/charts/lightbridge/values.yaml
+++ b/charts/lightbridge/values.yaml
@@ -95,7 +95,7 @@ app:
   # still floats via argocd-image-updater (annotations below).
   chart:
     chartName: lightbridge-authz-stack
-    targetRevision: "0.8.1"
+    targetRevision: "3.3.0"
   # App-scoped deps (ingress Certificates) — kustomize overlay in this repo,
   # added as a second source (issuer patched per env). ADR-0018 pattern.
   depsOverlay: environments/prod/deps/lightbridge-backend


### PR DESCRIPTION
## 1. Summary

This PR changes:

- `charts/lightbridge/values.yaml`: bumps `app.chart.targetRevision` for `lightbridge-authz-stack` from `0.8.1` to `3.3.0`. One line, one file (`git diff --stat`: `charts/lightbridge/values.yaml | 2 +-`).

It solves:

- Re-attempts the chart pin bump that caused tonight's ~8.5h `lightbridge-opa` outage (#1018 reverted it to `0.8.1`), now that the root cause is fixed upstream and the missing prod prerequisites have landed.

---

## 2. Intent

The intent of this PR is:

> Move the pinned `lightbridge-authz-stack` chart forward to the current release (`3.3.0`), bringing in `authz-idp` for the first time in prod, now that both halves of tonight's incident are independently fixed: the publish pipeline no longer republishes an already-tagged version with different content, and the prod values overlay carries the `idp:` block and the neutralised `redis-secret` reference that `0.8.1`→`3.2.0` was missing.
>
> Source of truth: https://github.com/ADORSYS-GIS/lightbridge-authz/pull/349

---

## 3. Scope

### In Scope

- The single `targetRevision` pin bump in `charts/lightbridge/values.yaml`.

### Out of Scope

- Enabling `idp`'s Ingress (`idp.ingress.main.enabled`) or repointing `auth.ai.camer.digital` DNS away from Keycloak — the chart's own `idp:` block comment (and the values chain below) keeps that default-OFF on purpose; it stays a deliberate, separate cutover.
- Any change to `lightbridge-authz` (chart publish pipeline) or `ai-helm-values` (prod values) — both prerequisite fixes are already merged upstream and are only *verified*, not modified, here.

---

## 4. Verification

I verified this change by:

- [x] Checking logs
- [x] Testing rollback or failure behavior, if relevant
- [x] Running manual tests (helm lint / helm template)

Commands run and results — three independent prerequisite checks, plus the render check:

**1. Tag immutability fix is merged (lightbridge-authz#349):**

```bash
gh api repos/ADORSYS-GIS/lightbridge-authz/pulls/349 --jq '{title,merged,merge_commit_sha,merged_at}'
```

```json
{"merge_commit_sha":"c74911197907dcf390020042a9bd0250d3de4507","merged":true,"merged_at":"2026-08-16T22:26:22Z","title":"[INCIDENT MITIGATION] fix(ci): gate helm chart publish on release tags, refuse to overwrite published versions"}
```

**2. `3.3.0` is genuinely published, and the published artifact (not the source repo) contains `idp`:**

```bash
# GHCR tag listing (authenticated — this registry is private)
curl -s -H "Authorization: Bearer $GHCR_TOKEN" \
  "https://ghcr.io/v2/adorsys-gis/charts/lightbridge-authz-stack/tags/list"
```

```json
{"name":"adorsys-gis/charts/lightbridge-authz-stack","tags":["0.8.1","1.0.0","1.1.0","2.0.0","2.1.0","2.1.1","3.0.0","3.1.0","3.2.0","3.3.0"]}
```

```bash
helm show values oci://ghcr.io/adorsys-gis/charts/lightbridge-authz-stack --version 3.3.0
```

```
Pulled: ghcr.io/adorsys-gis/charts/lightbridge-authz-stack:3.3.0
Digest: sha256:ff7203d573915b697165a3667dac8a17b105e86ec17fd174ce112481f7265757
nameOverride: lightbridge

global: ...
api: ...
opa: ...
idp:
  enabled: true
  controllers:
    main:
      replicas: 1
      containers:
        authz:
          args:
            - idp
            - --config-path
            - /etc/lightbridge/config.yaml
  persistence:
    tls:
      name: lightbridge-authz-tls
  ingress:
    main:
      enabled: false          # <-- default OFF, confirmed
      hosts:
        - host: auth.ai.camer.digital
          ...
usage: ...
mcp: ...
```

(`idp:` key present alongside `api`/`opa`/`usage`/`mcp`, exactly as claimed; `idp.ingress.main.enabled: false` confirmed by direct inspection of the published artifact, not the source chart.)

**3. Prod values prerequisites landed (ai-helm-values#266):**

```bash
gh api repos/ADORSYS-GIS/ai-helm-values/pulls/266 --jq '{title,merged,merge_commit_sha,merged_at}'
```

```json
{"merge_commit_sha":"0b50b91aeb7dae983005011e46d8580f7b5bbf69","merged":true,"merged_at":"2026-08-17T01:04:42Z","title":"fix(lightbridge): neutralise opa REDIS_URL default + add missing idp values block"}
```

Read the full diff (`gh pr diff 266 --repo ADORSYS-GIS/ai-helm-values`) and confirmed by inspection:

- `opa.controllers.main.containers.authz.env.REDIS_URL` is neutralised (`value: "unused"`, `valueFrom: null`) — opa's server never takes a `redis` parameter at all, so this deletes a broken `secretKeyRef` rather than repointing it.
- A full `idp:` block is added: `persistence.tls.name: authz-tls` (the cert-manager-issued Certificate api/opa/usage already reuse; its SANs already cover `lightbridge-idp.converse.svc`), `DATABASE_URL` from `lightbridge-main-db-app`, `idp`'s own `REDIS_URL` neutralised the same way as opa's, and `oauth2.signing` (`issuer: https://auth.ai.camer.digital`, `audience: lightbridge-api-key`) byte-identical to api's and mcp's blocks. This is load-bearing, not cosmetic: `start_idp_server` bootstraps the signing key against the same shared `signing_keys` row (under `pg_advisory_xact_lock`) that api/mcp bootstrap against, so a divergent issuer here could have broken token validation for api/mcp too.
- `oauth2.token_exchange` is deliberately left unset — confirmed the idp binary only touches `redis` inside that (absent) branch, so the neutralised `REDIS_URL` is safe.

**4. Render check — `charts/lightbridge` renders with the new pin:**

```bash
cd charts/lightbridge && helm dependency build . && helm lint .
```

```
==> Linting .
[INFO] Chart.yaml: icon is recommended

1 chart(s) linted, 0 chart(s) failed
```

```bash
helm template test . | grep -B5 -A5 'targetRevision: "3.3.0"'
```

```
    - repoURL: "oci://ghcr.io/adorsys-gis/charts/lightbridge-authz-stack"
      chart: "."
      targetRevision: "3.3.0"
      helm:
        releaseName: "lightbridge"
        valueFiles:
          - $values/environments/prod/values/lightbridge-app.yaml
        ignoreMissingValueFiles: true
```

**Current prod state before this change** (`kubectl --context hetzner-prod -n converse get pods`, confirms no `idp` pods running today, matching the current `0.8.1` pin):

```
NAME                                      READY   STATUS    RESTARTS   AGE
lightbridge-api-main-db67b6cfd-26kcb      2/2     Running   0          6m49s
lightbridge-api-main-db67b6cfd-h4tzd      2/2     Running   0          6m49s
lightbridge-mcp-695867bf5b-jfswx          1/1     Running   0          6m49s
lightbridge-mcp-695867bf5b-xkphf          1/1     Running   0          6m49s
lightbridge-opa-main-5b8c94d4b4-jssrd     1/1     Running   0          6m49s
lightbridge-opa-main-5b8c94d4b4-njdtq     1/1     Running   0          6m49s
lightbridge-usage-main-66cf747497-6g678   1/1     Running   0          6m49s
lightbridge-usage-main-66cf747497-s2lrv   1/1     Running   0          6m49s
```

---

## 5. Screenshots / Evidence

* Logs: `kubectl -n converse get pods` output above (pre-change baseline).
* Incident PR (root cause + fix): https://github.com/ADORSYS-GIS/lightbridge-authz/pull/349
* Prod values prerequisite PR: https://github.com/ADORSYS-GIS/ai-helm-values/pull/266
* Prior incident/revert in this repo: https://github.com/ADORSYS-GIS/ai-helm/pull/1018

---

## 6. Risk Assessment

Risk level:

* [ ] Low
* [ ] Medium
* [x] High

Potential risks:

* **ArgoCD re-renders every workload in the `lightbridge-app` release on sync — all pods roll** (api, opa, usage, mcp, and the new idp), not just the changed component. Any latent issue in any of these charts' current prod values can surface during this rollout, not only the `idp`-specific ones this PR is nominally about.
* **This brings up `authz-idp` in prod for the first time.** Its Ingress is default-disabled in the chart (`idp.ingress.main.enabled: false`, confirmed above against the published `3.3.0` artifact) and ai-helm-values#266 does not turn it on, so it will not serve external traffic — but it is a new workload with its own migrate Job, DB connection, and signing-key bootstrap against the shared `signing_keys` row, which is a real (if scoped) blast-radius increase over today's api/opa/usage/mcp-only deployment.
* **Same failure class as the earlier `3.2.0` incident is possible again if any further gap exists** beyond the redis-secret/idp-values gap already fixed — this PR trusts that #266 covers every prod-values gap between `0.8.1` and `3.3.0`'s chart defaults, which was verified by reading the diff, not by a green rollout yet.
* Restores the `ttlSecondsAfterFinished` migrate-Job backstop (present in `3.x`, given up when reverting to `0.8.1`) — a Job left permanently around is a minor cluster-hygiene risk in the *other* direction, i.e. this is a risk of `0.8.1`, not of this bump, but it changes behavior versus what's running today.

Mitigation:

* **Primary signal to watch post-sync: `lightbridge-opa-main` pods staying `Running`** (`kubectl --context hetzner-prod -n converse get pods -l app.kubernetes.io/instance=lightbridge -w`) — that is the exact pod that went to `CreateContainerConfigError`/`0/2` for ~8.5h in the `3.2.0` incident. Also watch `lightbridge-idp-main` (new) and the `lightbridge-app` ArgoCD Application's sync status/health.
* **Rollback is reverting this one line back to `"0.8.1"`** — a known-good, already-published, immutable tag (same rollback mechanism #1018 already exercised successfully tonight).
* Do not merge without a human watching the ArgoCD sync and the pod rollout live, given the incident context.

---

## 7. AI Usage Declaration

AI was used for:

* [ ] Understanding existing code
* [ ] Generating code
* [x] Refactoring
* [ ] Generating tests
* [ ] Drafting documentation
* [x] Reviewing the diff
* [ ] Not used

Human verification:

* [ ] I understand every meaningful change in this PR
* [ ] I checked generated code manually
* [ ] I checked generated tests manually
* [ ] I removed unsupported AI assumptions
* [ ] I accept responsibility for this PR

---

## 8. Reviewer Focus

Please focus your review on:

* [ ] Correctness
* [ ] Architecture
* [x] Security
* [ ] Performance
* [ ] Tests
* [ ] Maintainability
* [ ] Product intent
* [x] Edge cases
