### PR TITLE
chore(lightbridge): bump lightbridge-authz-stack chart pin 3.3.0 -> 3.4.0

### DIFF
--- a/charts/lightbridge/values.yaml
+++ b/charts/lightbridge/values.yaml
@@ -95,7 +95,7 @@ app:
   # still floats via argocd-image-updater (annotations below).
   chart:
     chartName: lightbridge-authz-stack
-    targetRevision: "3.3.0"
+    targetRevision: "3.4.0"
   # App-scoped deps (ingress Certificates) — kustomize overlay in this repo,
   # added as a second source (issuer patched per env). ADR-0018 pattern.
   depsOverlay: environments/prod/deps/lightbridge-backend


### PR DESCRIPTION
## Summary

Bump the `lightbridge-authz-stack` chart pin in `charts/lightbridge/values.yaml`
(`app.chart.targetRevision`) from `3.3.0` to `3.4.0`. One line, one file.

## Intent

Source of truth: https://github.com/ADORSYS-GIS/lightbridge-authz/pull/357

Chart 3.4.0 adds the `authz-budget` workload: a new `budget` subcommand alias on the existing
`lightbridge-authz` image, serving 14 budget RPC procedures at `POST /budget/rpc/{op_id}`. Prod
currently runs `api` ×2, `mcp` ×2, `opa` ×2, `usage` ×2, `idp` ×1 on chart 3.3.0; this bump adds
`budget` ×1 alongside them.

## Scope

- `charts/lightbridge/values.yaml`: `app.chart.targetRevision: "3.3.0"` → `"3.4.0"` only.
- No other files touched. Does not modify `ai-helm-values` or `lightbridge-authz`.

## Verification

**1. Chart 3.4.0 is published and contains the workload** (verified against the registry, not
the source repo):

```
$ gh api /orgs/adorsys-gis/packages/container/charts%2Flightbridge-authz-stack/versions
...
{"created_at":"2026-08-17T08:30:48Z", "metadata":{"container":{"tags":["3.4.0"]}},
 "description":"Umbrella chart deploying the full lightbridge-authz stack (api, opa, idp, budget, usage, mcp)"}
```

```
$ helm show values oci://ghcr.io/adorsys-gis/charts/lightbridge-authz-stack --version 3.4.0
...
# budget — the budget-domain RPC surface (`/budget/rpc/{op_id}`) PR #351 carried off `authz-api`
# as a hard cutover (not a transitional duplication like `idp` above): every `budget:*`-gated
# procedure now 404s on `authz-api` and only answers here. Same image + shared lightbridge-authz
# subchart as api/opa/idp, started with the `budget` subcommand instead. Budget RPCs will
# eventually need frontend exposure, but enabling that is a separate deliberate decision — the
# frontend can't call the new `/budget` prefix until converse-frontends#175 lands, so this gets an
# optional Ingress, default OFF, exactly like idp's. Host below is a best-effort placeholder (no
# real DNS convention exists for this surface yet) — confirm/replace before ever flipping
# `enabled: true`.
budget:
  enabled: true
  controllers:
    main:
      replicas: 1
      containers:
        authz:
          args:
            - budget
            - --config-path
            - /etc/lightbridge/config.yaml
  persistence:
    tls:
      name: lightbridge-authz-tls
  ingress:
    main:
      enabled: false
      hosts:
        - host: budget.ai.camer.digital
          ...
```

`budget:` sits alongside `api`/`opa`/`idp`/`usage`/`mcp` as expected.

**2. The prod values block landed first** — `ai-helm-values` `origin/main` already has the
override commit, confirmed read-only (no worktree created there per isolation instructions):

```
$ git -C ai-helm-values log origin/main --oneline | head -1
bd3022a feat(lightbridge): add authz-budget values block ahead of chart pin 3.4.0 (#267)

$ git -C ai-helm-values show bd3022a --stat
 environments/prod/values/lightbridge-app.yaml | 293 ++++++++++++++++++++++++++
 1 file changed, 293 insertions(+)
```

Without this, `budget` would render on chart defaults — including a reference to the
`lightbridge-authz-tls` secret and no real Redis/`oauth2.signing` wiring — and crash-loop the
same way `idp` did on its first rollout.

**3. The values block wires what the service actually needs** (worth flagging because two of
these differ from sibling services `opa`/`idp`):
- `budget` requires **real Redis** — unconditional in `start_budget_server`, unlike `opa`/`idp`
  where it's neutralised.
- `budget` **does** need an `oauth2.signing` block, because `AuthzStoreImpl::with_pool_and_oauth2`
  hard-errors without one under `oauth2.type: self` — even though `budget` never calls
  `bootstrap_signing_key` and never writes to the shared `signing_keys` row.

**4. Pod baseline before this change** (`kubectl -n converse get pods`, prod/`hetzner-prod`,
2026-08-17):

```
lightbridge-api-main-b485cdc89-9jhvg    2/2   Running   0   23m
lightbridge-api-main-b485cdc89-swfl7    2/2   Running   0   23m
lightbridge-idp-main-69c5b54b9c-4qh5b   1/1   Running   0   23m
lightbridge-mcp-68b7c9856c-4b9rs        1/1   Running   0   23m
lightbridge-mcp-68b7c9856c-f27mf        1/1   Running   0   23m
lightbridge-opa-main-bfdbc7bc7-ffhw9    1/1   Running   0   23m
lightbridge-opa-main-bfdbc7bc7-xc4tz    1/1   Running   0   23m
lightbridge-usage-main-6457658974-7cfk5 1/1   Running   0   23m
lightbridge-usage-main-6457658974-lql8w 1/1   Running   0   23m
```

api ×2, mcp ×2, opa ×2, usage ×2, idp ×1 — matches expectations. No `budget` pod yet.

**5. Render check** — `helm dependency build charts/lightbridge && helm lint charts/lightbridge`
passes (0 failed), and `helm template lightbridge charts/lightbridge` produces the ArgoCD
`Application` with:

```yaml
    - repoURL: "oci://ghcr.io/adorsys-gis/charts/lightbridge-authz-stack"
      chart: "."
      targetRevision: "3.4.0"
      helm:
        releaseName: "lightbridge"
        valueFiles:
          - $values/environments/prod/values/lightbridge-app.yaml
```

## Risk Assessment

- ArgoCD re-renders the `lightbridge` release; a new `authz-budget` workload (`lightbridge-budget-main`)
  appears in the `converse` namespace.
- Its ingress is default-off (`budget.ingress.main.enabled: false`), so it serves no external
  traffic. The frontend cannot call `/budget/rpc/` until `converse-frontends#175` lands anyway.
- **What to watch during rollout**: `lightbridge-budget-main` reaching `Running`. This is the
  first deployment of that workload, and the two prior first-deployments in this stack
  (`idp`, and the migrate-hook Job) both failed on missing/misconfigured secrets the first time.
  Also watch that `lightbridge-opa` and `lightbridge-idp` stay `Running` through the sync — they
  share the same umbrella chart bump.
- **Rollback**: revert this one line back to `"3.3.0"`, a known-good published tag currently
  serving prod traffic.

## AI Usage Declaration

- [x] AI was used to draft this change (diff authorship, verification commands, and this PR body).
- [x] AI was used to query GHCR/registry state and render the chart for verification.
- [ ] A human has reviewed this diff line-by-line.
- [ ] A human has confirmed the verification evidence above against their own run.
- [ ] A human has watched the rollout in ArgoCD/kubectl after merge.

## Reviewer Focus

- Confirm this is a single-line, single-file diff (`git diff --stat`).
- Confirm `ai-helm-values#267` is actually merged to `main` before merging this (it is, per
  verification above, but worth a second look since ArgoCD will pull both at sync time).
- After merge, watch the ArgoCD sync for `lightbridge-budget-main` reaching `Running` and for
  `lightbridge-opa`/`lightbridge-idp` staying `Running` throughout.
