### PR TITLE
chore(lightbridge): bump lightbridge-authz-stack chart pin 3.5.0 -> 3.6.0

### DIFF
--- a/charts/lightbridge/values.yaml
+++ b/charts/lightbridge/values.yaml
@@ -95,7 +95,7 @@ app:
   # still floats via argocd-image-updater (annotations below).
   chart:
     chartName: lightbridge-authz-stack
-    targetRevision: "3.5.0"
+    targetRevision: "3.6.0"
   # App-scoped deps (ingress Certificates) — kustomize overlay in this repo,
   # added as a second source (issuer patched per env). ADR-0018 pattern.
   depsOverlay: environments/prod/deps/lightbridge-backend


### PR DESCRIPTION
## 1. Summary

This PR changes:

- `charts/lightbridge/values.yaml`: bump `app.chart.targetRevision` (the pinned
  `lightbridge-authz-stack` OCI chart version consumed by the `lightbridge-app` ArgoCD
  Application) from `"3.5.0"` to `"3.6.0"`.

It solves:

- Keeps the pinned ArgoCD source in sync with what `lightbridge-authz` CI actually publishes, and
  brings in a real behavior fix: today all six lightbridge workloads (api, opa, idp, budget,
  usage, mcp) render `strategy: Recreate` (the `bjw-s/common` 4.6.2 default when `strategy` is
  unset), so every rollout terminates every pod before creating replacements — a full-availability
  gap on every deploy, not an edge case.

---

## 2. Intent

The intent of this PR is:

> Source of truth: https://github.com/ADORSYS-GIS/lightbridge-authz/pull/369 (merged into
> https://github.com/ADORSYS-GIS/lightbridge-authz/pull/367, tag `v3.6.0`). PR #369 sets
> `controllers.main.strategy: RollingUpdate` with `rollingUpdate: {unavailable: "0", surge: 1}`
> and `podDisruptionBudget: {maxUnavailable: 1}` on `charts/lightbridge-authz/values.yaml`,
> `charts/lightbridge-authz-usage/values.yaml`, and `charts/lightbridge-mcp/values.yaml`. This PR
> is the pin bump that lets that fix actually reach prod through the existing pinned-not-floated
> ArgoCD source (`repoURL`/`targetRevision`, ADR-0055) — the chart release alone does not
> auto-deploy.

---

## 3. Scope

### In Scope

- `charts/lightbridge/values.yaml`: one line, `app.chart.targetRevision: "3.5.0"` → `"3.6.0"`.
- `Chart.lock`/dependency refresh from `helm dependency update` (no dependency versions actually
  changed; `bjw-s/common` stays at 4.6.2 upstream).

### Out of Scope

- Any change to `ai-helm-values` (per-env values). This repo's chart owns only the ArgoCD wiring
  and the pin; the hand-maintained `rawRessources` PDBs for api/idp/mcp mentioned in
  `ai-helm-values`'s `lightbridge-app.yaml` are a separate, later cleanup once the chart's own
  native PDBs are confirmed live for all six workloads — not touched here.
- `charts/lightbridge/values.yaml`'s inline `valuesObject` (env vars, resources, ingress) —
  untouched.

---

## 4. Verification

I verified this change by:

- [x] Running automated tests
- [ ] Running manual tests
- [x] Checking logs
- [ ] Checking metrics
- [ ] Testing error cases
- [ ] Testing permissions/security behavior
- [ ] Testing rollback or failure behavior, if relevant

Commands run:

```bash
helm show chart oci://ghcr.io/adorsys-gis/charts/lightbridge-authz-stack --version 3.6.0

helm pull oci://ghcr.io/adorsys-gis/charts/lightbridge-authz-stack --version 3.5.0 --untar --untardir old
helm pull oci://ghcr.io/adorsys-gis/charts/lightbridge-authz-stack --version 3.6.0 --untar --untardir new
diff -rq old/lightbridge-authz-stack new/lightbridge-authz-stack

helm template lightbridge old/lightbridge-authz-stack > old-render.yaml
helm template lightbridge new/lightbridge-authz-stack > new-render.yaml
diff old-render.yaml new-render.yaml

helm dependency update charts/lightbridge && helm lint charts/lightbridge
helm template lightbridge charts/lightbridge | grep -A2 'targetRevision: "3.6.0"'
```

Results:

```text
$ helm show chart oci://ghcr.io/adorsys-gis/charts/lightbridge-authz-stack --version 3.6.0
Pulled: ghcr.io/adorsys-gis/charts/lightbridge-authz-stack:3.6.0
Digest: sha256:b9397bdddbf77cd3f1ef5028cf99043c4041d94ace56e83457b41c48d4dd4148
apiVersion: v2
appVersion: 3.6.0
name: lightbridge-authz-stack
version: 3.6.0

$ diff -rq old/lightbridge-authz-stack new/lightbridge-authz-stack
Files old/.../Chart.lock and new/.../Chart.lock differ            (version bump + regenerated digest/timestamp only)
Files old/.../Chart.yaml and new/.../Chart.yaml differ            (version/appVersion 3.5.0 -> 3.6.0)
Files old/.../charts/lightbridge-authz/Chart.yaml differ          (version/appVersion bump)
Files old/.../charts/lightbridge-authz/values.yaml differ         (+strategy/rollingUpdate/podDisruptionBudget block)
Files old/.../charts/lightbridge-authz-usage/Chart.yaml differ    (version/appVersion bump)
Files old/.../charts/lightbridge-authz-usage/values.yaml differ   (+strategy/rollingUpdate/podDisruptionBudget block)
Files old/.../charts/lightbridge-mcp/Chart.yaml differ            (version/appVersion bump)
Files old/.../charts/lightbridge-mcp/values.yaml differ           (+strategy/rollingUpdate/podDisruptionBudget block)
-- NOT template-inert this time (unlike the 3.4.0 -> 3.5.0 bump). No template files differ; the
-- vendored charts/*/charts/common library trees are byte-identical old vs new (bjw-s/common
-- stays pinned 4.6.2 in Chart.lock, confirmed separately).

$ diff old-render.yaml new-render.yaml   (same release name both sides, so this isolates real changes)
-- 6 new PodDisruptionBudget objects appear (api, budget, idp, mcp, opa, usage), each maxUnavailable: 1
-- All 6 Deployments' .spec.strategy changes:
     type: Recreate
   ->
     type: RollingUpdate
     rollingUpdate:
       maxUnavailable: 0
       maxSurge: 1
-- Only other diff lines are app.kubernetes.io/version / helm.sh/chart label bumps (3.5.0 -> 3.6.0)

$ helm dependency update charts/lightbridge && helm lint charts/lightbridge
Update Complete. Happy Helming!
==> Linting charts/lightbridge
[INFO] Chart.yaml: icon is recommended
1 chart(s) linted, 0 chart(s) failed

$ helm template lightbridge charts/lightbridge | grep -A2 'targetRevision: "3.6.0"'
      - repoURL: "oci://ghcr.io/adorsys-gis/charts/lightbridge-authz-stack"
        chart: "."
        targetRevision: "3.6.0"
```

Prod baseline captured read-only (`kubectl --context hetzner-prod -n converse`, before this pin
lands):

```text
$ kubectl -n converse get deploy lightbridge-{api,opa,idp,budget,usage,mcp}-main -o jsonpath='{.spec.strategy}'
lightbridge-api-main: {"type":"Recreate"}
lightbridge-opa-main: {"type":"Recreate"}
lightbridge-idp-main: {"type":"Recreate"}
lightbridge-budget-main: {"type":"Recreate"}
lightbridge-usage-main: {"type":"Recreate"}
lightbridge-mcp: {"type":"Recreate"}

$ kubectl -n converse get pdb
lightbridge-api-pdb    N/A  1  1  75d   (hand-maintained rawRessources PDB, ai-helm-values)
lightbridge-idp-pdb    N/A  1  1  52m
lightbridge-mcp-pdb    N/A  1  1  75d
-- no PDB yet for opa/budget/usage

All lightbridge-* pods: RESTARTS 0, started 2026-08-17T23:39-23:41Z (unrelated image float from
the #369 merge commit, sha-69cd2d8; independent of this chart pin per argocd-image-updater).
```

---

## 5. Screenshots/Evidence

* Source PR: https://github.com/ADORSYS-GIS/lightbridge-authz/pull/369
* Release PR (merged): https://github.com/ADORSYS-GIS/lightbridge-authz/pull/367
* Tag: https://github.com/ADORSYS-GIS/lightbridge-authz/releases/tag/v3.6.0
* Manual chart publish run: https://github.com/ADORSYS-GIS/lightbridge-authz/actions/runs/32082427348
* Full `diff -rq` and `helm template` output: pasted above in Verification.

---

## 6. Risk Assessment

Risk level:

* [ ] Low
* [x] Medium
* [ ] High

Potential risks:

* This is the first sync where the chart pin bump is NOT template-inert — unlike the prior
  3.3.0/3.4.0/3.5.0 bumps, it changes `.spec.strategy` and adds PDBs on all 6 Deployments.
* If `maxUnavailable` were ever silently dropped from the render (the known bjw-s/common `with`
  pitfall for a bare-int `0`), the effective strategy would fall back to Kubernetes' apiserver
  default (25% rounding down), which happens to also evaluate to 0 at 1-2 replica counts today —
  masking the bug rather than surfacing it.
* New PDBs for opa/budget/usage (previously uncovered) start enforcing `maxUnavailable: 1`
  immediately on sync — combined with existing api/idp/mcp PDBs, any voluntary disruption
  (node drain, etc.) across all 6 workloads now goes through this budget.

Mitigation:

* Verified `unavailable: "0"` is the quoted string in the published artifact for all three
  affected `values.yaml` files (not just source) — see Verification.
* Will watch the ArgoCD sync of `lightbridge-app` post-merge and confirm via read-only `kubectl`
  that `maxUnavailable: 0` (not missing) actually renders on all 6 Deployments, and that no pods
  restart from this sync alone (strategy/PDB changes don't touch the pod template — expected to be
  a no-op for running pods; next image deploy is where the benefit shows).
* Cluster access for this verification pass is read-only (`get`/`describe`/`logs` only); any
  rollback decision (reverting the pin to `3.5.0`) is left to a human if the roll looks wrong.

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [ ] Generating code
* [ ] Refactoring
* [ ] Generating tests
* [x] Drafting documentation
* [x] Reviewing the diff
* [ ] Not used

Human verification:

* [ ] I understand every meaningful change in this PR
* [ ] I checked generated code manually
* [ ] I checked generated tests manually
* [ ] I removed unsupported AI assumptions
* [ ] I accept responsibility for this PR

---

## 8. Reviewer Focus

Please focus your review on:

* [ ] Correctness
* [ ] Architecture
* [x] Security
* [ ] Performance
* [ ] Tests
* [ ] Maintainability
* [ ] Product intent
* [x] Edge cases
