### PR TITLE
chore(lightbridge): pin lightbridge-authz-stack to 3.7.0

### DIFF
--- a/charts/lightbridge/values.yaml
+++ b/charts/lightbridge/values.yaml
@@ -95,7 +95,7 @@ app:
   # still floats via argocd-image-updater (annotations below).
   chart:
     chartName: lightbridge-authz-stack
-    targetRevision: "3.6.0"
+    targetRevision: "3.7.0"
   # App-scoped deps (ingress Certificates) — kustomize overlay in this repo,
   # added as a second source (issuer patched per env). ADR-0018 pattern.
   depsOverlay: environments/prod/deps/lightbridge-backend


### PR DESCRIPTION
## Summary

- Bump the pinned `lightbridge-authz-stack` chart from `3.6.0` to `3.7.0` in `charts/lightbridge/values.yaml` (`app.chart.targetRevision`).

## Intent

Prod (`converse` ns, `hetzner-prod`) has been deadlocked since the `3.6.0`-based deploy: ADR-0015
(https://github.com/ADORSYS-GIS/lightbridge-authz/pull/386) added required rule-data fields the
running budget policy JSON lacks, and the migrate Job that would apply the fix migration was a
Helm `post-install,post-upgrade` hook gated behind ArgoCD PostSync — which never fires because the
new pods can't become Healthy without the migration first. `3.7.0` ships the fix
(https://github.com/ADORSYS-GIS/lightbridge-authz/pull/394,
ADR-0016 — https://github.com/ADORSYS-GIS/lightbridge-authz/blob/main/docs/adr/0016-migrate-job-sync-wave-not-hook.md):
the migrate Job moves from a Helm hook to an ArgoCD sync-wave (`1`, ahead of the workloads at `2`),
so it runs unconditionally instead of depending on the very Deployments it unblocks.

Source of truth: https://github.com/ADORSYS-GIS/lightbridge-authz/releases/tag/v3.7.0

## Scope

Single line: `charts/lightbridge/values.yaml` `app.chart.targetRevision`. No values-file changes,
no other chart touched.

## Verification

- [x] `helm dependency update charts/lightbridge` — succeeded, no errors.
- [x] `helm lint charts/lightbridge` — `0 chart(s) failed`.
- [x] `helm template charts/lightbridge` — confirmed the rendered `lightbridge-app` Application's
      Source A now carries `targetRevision: "3.7.0"`:
```
    - repoURL: "oci://ghcr.io/adorsys-gis/charts/lightbridge-authz-stack"
      chart: "."
      targetRevision: "3.7.0"
```
- [x] Verified against the **published OCI artifact**, not the source tree (this chart previously
      caused an ~8.5h outage from exactly that gap): `helm pull --untar` on
      `oci://ghcr.io/adorsys-gis/charts/lightbridge-authz-stack:3.7.0` shows no
      `helm.sh/hook` annotation on the migrate Job (only the unrelated, legitimately-hooked
      `global-tls-job.yaml` retains one), and `argocd.argoproj.io/sync-wave: "1"` / `"2"` present
      on the migrate Job and main workloads respectively, in both the `lightbridge-authz` and
      `lightbridge-authz-usage` subcharts.

## Screenshots/Evidence

N/A — chart pin bump, no UI surface. Rendered manifest excerpt above is the evidence.

## Risk Assessment

Low risk to render correctness (single pin bump, lint/template clean). This PR is itself the fix
for an active prod incident (crash-looping `api`/`budget`/`idp` pods, no outage — old pods stay
Ready under `maxUnavailable: 0`). Once merged, ArgoCD should run the migrate Job as wave `1`,
apply the ADR-0015 migration, and let the new pods reach `Running`.

## AI Usage Declaration

- AI (Claude) diagnosed the incident, drove the release-please merge and chart publish for
  `lightbridge-authz` v3.7.0, authored this pin bump, and independently ran the verification
  commands above (re-pulled the published OCI artifact rather than trusting a prior report, per
  the lesson from the earlier 8.5h outage on this same chart).
- [x] AI was used for diagnosis, drafting, and verification command execution on this change.
- [ ] A human (Stephane Segning Lambou) has reviewed this change and is accountable for it.
