### PR TITLE
feat(ai-models-info): serve /anthropic/v1/models for Claude Code model discovery

### DIFF
--- a/charts/ai-models-info/templates/_helpers.tpl
+++ b/charts/ai-models-info/templates/_helpers.tpl
@@ -138,3 +138,56 @@ Output: full JSON string `{"data":[...]}`.
 {{- end -}}
 {{- dict "data" $entries | toJson -}}
 {{- end -}}
+
+{{/*
+Anthropic-shape model catalog for Claude Code's gateway model discovery.
+
+Claude Code (with CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY=1) issues
+`GET <ANTHROPIC_BASE_URL>/v1/models?limit=1000` at startup and adds the results
+to its `/model` picker. It reads only two fields per entry -- `id` and the
+optional `display_name` -- from a top-level `data` array. Everything else in
+the OpenRouter-shape catalog (pricing, architecture, context_length) is
+ignored here, which is why this is a separate renderer rather than a reshaping
+of `ai-models-info.catalog`.
+
+⚠️ THE `id` PREFIX IS LOAD-BEARING, NOT DECORATION. Claude Code keeps an entry
+only when its `id` contains "claude" or "anthropic", matched case-insensitively
+ANYWHERE in the string, and silently drops the rest -- the filter exists so a
+gateway backed by a shared key doesn't surface every model to every user.
+NONE of this platform's model ids contain either substring, so without a prefix
+this endpoint renders an empty picker and the whole feature is inert.
+Provider-prefixed ids are explicitly supported by the protocol (its own
+examples are `vertex_ai/claude-sonnet-4-6` and
+`bedrock/anthropic.claude-sonnet-4-5`), which is what `anthropicCatalog.idPrefix`
+uses.
+
+⚠️ CONSEQUENCE: the id advertised here is the id Claude Code sends back as the
+`model` on `/anthropic/v1/messages`. The gateway MUST accept the prefixed form
+(or strip the prefix on the way in), or a developer picks a model from the
+picker and every request fails. See the chart README before changing the
+prefix. `display_name` carries the human-readable name, so the prefix is not
+what anyone reads in the picker.
+
+Applies the SAME exclusions as the OpenRouter catalog -- `enabled: false`,
+`kind` in `excludeKinds`, and `disableExternal: true` -- because this is served
+on the same public host, and an internal-only model must not become externally
+discoverable just because it is reached through a different path.
+*/}}
+{{- define "ai-models-info.anthropicCatalog" -}}
+{{- $excluded := default (list) .Values.excludeKinds -}}
+{{- $cfgRoot := default (dict) .Values.anthropicCatalog -}}
+{{- $prefix := default "" $cfgRoot.idPrefix -}}
+{{- $entries := list -}}
+{{- range $name, $cfg := .Values.models -}}
+  {{- $kind := default "text" $cfg.kind -}}
+  {{- if and (not (eq $cfg.enabled false)) (not (has $kind $excluded)) (not (eq (default false $cfg.disableExternal) true)) -}}
+    {{- $info := default (dict) $cfg.info -}}
+    {{- $entry := dict
+        "id"           (printf "%s%s" $prefix $name)
+        "display_name" (default $name (index $info "displayName"))
+    -}}
+    {{- $entries = append $entries $entry -}}
+  {{- end -}}
+{{- end -}}
+{{- dict "data" $entries | toJson -}}
+{{- end -}}

--- a/charts/ai-models-info/templates/configmap.yaml
+++ b/charts/ai-models-info/templates/configmap.yaml
@@ -39,6 +39,16 @@ data:
 
       # Exact-match catalog endpoint. File lives at
       # /usr/share/nginx/html/v1/models/info (mounted via subPath).
+      # Claude Code gateway model discovery. Exact-match, same as the
+      # OpenRouter catalog below: the protocol treats ANY redirect on this
+      # request as failure (even http->https) and gives it a 3s timeout, so
+      # it must be served directly here with no rewrite hop.
+      location = /anthropic/v1/models {
+        add_header Cache-Control "public, max-age=300" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        try_files /anthropic/v1/models =404;
+      }
+
       location = /v1/models/info {
         # opencode's models-info plugin sends the cached ETag as
         # If-None-Match; nginx replies 304 automatically when the
@@ -72,3 +82,30 @@ data:
   # `/v1/models/info` (matching the location block above).
   info: |
     {{- include "ai-models-info.catalog" . | nindent 4 }}
+---
+{{- /*
+Anthropic-shape catalog for Claude Code's gateway model discovery.
+
+A SEPARATE ConfigMap from `-content`, not another key in it, because bjw-s
+projects each data key as a file inside the mount directory -- so the mount
+path fixes the URL path. `-content` is mounted at
+`/usr/share/nginx/html/v1/models` (key `info` -> `/v1/models/info`); this one
+mounts at `/usr/share/nginx/html/anthropic/v1` (key `models` ->
+`/anthropic/v1/models`). Two different directories, therefore two ConfigMaps.
+
+The path is `/anthropic/v1/models` and NOT `/v1/models` because Claude Code
+appends `/v1/models` to ANTHROPIC_BASE_URL, which this platform sets to
+`https://api.ai.camer.digital/anthropic` (written into settings.json by
+`governance-auth configure`). The existing root-level `/v1/models` is a
+different endpoint in a different (OpenAI-ish) shape and is left alone.
+*/ -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-anthropic-content
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "common.labels.standard" . | nindent 4 }}
+data:
+  models: |
+    {{- include "ai-models-info.anthropicCatalog" . | nindent 4 }}

--- a/charts/ai-models-info/templates/configmap.yaml
+++ b/charts/ai-models-info/templates/configmap.yaml
@@ -83,7 +83,7 @@ data:
   info: |
     {{- include "ai-models-info.catalog" . | nindent 4 }}
 ---
-{{- /*
+{{/*
 Anthropic-shape catalog for Claude Code's gateway model discovery.
 
 A SEPARATE ConfigMap from `-content`, not another key in it, because bjw-s

--- a/charts/ai-models-info/values.yaml
+++ b/charts/ai-models-info/values.yaml
@@ -58,6 +58,22 @@ excludeKinds:
 # Defaults for the `context_length` + `top_provider.{context_length,
 # max_completion_tokens}` fields emitted on EVERY catalog entry. Override
 # per-model via that model's `info.contextLength` / `info.maxOutputTokens`.
+# Claude Code gateway model discovery (`/anthropic/v1/models`).
+#
+# ⚠️ `idPrefix` is what makes this endpoint do anything at all. Claude Code
+# keeps a discovered model only when its `id` contains "claude" or "anthropic"
+# anywhere in the string; none of this platform's ids do, so with an empty
+# prefix the picker gains nothing and the endpoint is inert. Provider-prefixed
+# ids are explicitly supported by the protocol (`vertex_ai/claude-sonnet-4-6`).
+#
+# ⚠️ The advertised id is the id Claude Code sends back as `model` on
+# /anthropic/v1/messages, so the gateway must accept this prefixed form (or
+# strip it inbound). Verify before relying on it — a picker offering models
+# that 400 on use is worse than an empty picker. `display_name` carries the
+# readable name, so nobody reads the prefix.
+anthropicCatalog:
+  idPrefix: "anthropic/"
+
 catalogDefaults:
   contextLength: 128000
   maxCompletionTokens: 8192
@@ -180,6 +196,16 @@ models-info:
           backendRefs:
             - identifier: main
               port: 80
+        # Claude Code gateway model discovery. A separate rule rather than a
+        # second match on the rule above, so either catalog can be withdrawn
+        # without touching the other.
+        - matches:
+            - path:
+                type: Exact
+                value: /anthropic/v1/models
+          backendRefs:
+            - identifier: main
+              port: 80
 
   # Mount the two externally-rendered ConfigMaps + nginx-unprivileged's
   # required writable scratch dirs.
@@ -208,6 +234,20 @@ models-info:
         main:
           nginx:
             - path: /usr/share/nginx/html/v1/models
+              readOnly: true
+    anthropic-content:
+      enabled: true
+      type: configMap
+      name: '{{ .Release.Name }}-anthropic-content'
+      # Mount path fixes the URL path: key `models` projects to file
+      # `/usr/share/nginx/html/anthropic/v1/models` — matching the nginx
+      # `location = /anthropic/v1/models` block, which is where Claude Code
+      # looks (ANTHROPIC_BASE_URL is `…/anthropic`, and it appends
+      # `/v1/models`). Separate ConfigMap because the directory differs.
+      advancedMounts:
+        main:
+          nginx:
+            - path: /usr/share/nginx/html/anthropic/v1
               readOnly: true
     # nginx-unprivileged needs writable scratch space (root FS is RO).
     tmp:


### PR DESCRIPTION
## 1. Summary

This PR changes:

- Adds an Anthropic-shape model catalog served at `/anthropic/v1/models`, rendered from the
  same `.Values.models` source as the existing OpenRouter catalog
- Adds the matching nginx `location`, HTTPRoute rule and ConfigMap mount
- Adds `anthropicCatalog.idPrefix` (default `anthropic/`)

It solves:

- Claude Code's gateway model discovery has been enabled and silently doing nothing.
  `governance-auth configure` writes `CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY: "1"` and
  `ANTHROPIC_BASE_URL: https://api.ai.camer.digital/anthropic`; Claude Code appends
  `/v1/models` to the **base URL**, so it has been requesting a 404:

```
GET https://api.ai.camer.digital/v1/models            -> 200  (OpenAI-ish, 21 models)
GET https://api.ai.camer.digital/anthropic/v1/models  -> 404
```

- Protocol reference: https://code.claude.com/docs/en/llm-gateway-protocol#model-discovery
- Related: ADORSYS-GIS/lightbridge-governance#141 (the `governance-auth` config surface that
  writes these settings)

---

## 2. Intent

The intent of this PR is:

> To make an already-enabled feature actually work, using the pattern this repo already
> uses for `/v1/models/info`. Discovery failing is invisible — the protocol says the picker
> silently falls back to the built-in list — so the flag reads as "this works" while
> returning nothing.

---

## 3. Scope

### In Scope

- `/anthropic/v1/models` served by the existing `ai-models-info` nginx
- Same exclusions as the OpenRouter catalog: `enabled: false`, `excludeKinds`,
  `disableExternal` — same public host, so an internal-only model must not become
  discoverable via a different path

### Out of Scope

- The existing root-level `/v1/models` (different shape, different consumer) — untouched
- Gateway acceptance of the prefixed model id — see Risk
- `Chart.yaml` version: `charts/ai-models-info` is release-please managed
  (`component: ai-models-info`), so this `feat:` drives the bump. I bumped it by hand first
  and reverted on finding the config

---

## 4. Verification

I verified this change by:

- [x] Running automated tests
- [x] Running manual tests
- [x] Testing error cases

Commands run:

```bash
helm lint charts/ai-models-info --strict
helm template x charts/ai-models-info -f /tmp/tv.yaml
curl -s https://api.ai.camer.digital/v1/models?limit=1000
```

Results:

```text
1 chart(s) linted, 0 chart(s) failed

ids: ['anthropic/adorsys-coder', 'anthropic/mimo-v2p5']
HTTPRoute paths:  Exact /v1/models/info | Exact /anthropic/v1/models
mounts:           /usr/share/nginx/html/anthropic/v1
                  /usr/share/nginx/html/v1/models

exclusions: of 5 test models, disableExternal / embedding / enabled:false all dropped
filter:     2/2 rendered ids pass Claude Code's claude|anthropic test
live catalogue today: 0/21 ids would pass unprefixed
```

---

## 5. Screenshots / Evidence

* Live 404 reproducing the bug: `GET /anthropic/v1/models -> 404` while
  `POST /anthropic/v1/messages -> 400` (route exists, empty body rejected)
* First push failed `lint` and `release` with
  `invalid Yaml document separator: apiVersion: v1` — my `{{- /* */ -}}` after `---` trimmed
  the newline on both sides and welded the separator onto `apiVersion`. Fixed in 31bbc17d;
  `helm lint --strict` clean after.

---

## 6. Risk Assessment

Risk level:

* [x] Medium

Potential risks:

* **`idPrefix` is load-bearing and its counterpart is unverified.** Claude Code keeps a
  discovered model only when its `id` contains `claude` or `anthropic` anywhere. None of the
  21 live ids do, so an unprefixed catalog filters to nothing. But the advertised id is the
  id Claude Code sends back as `model` on `/anthropic/v1/messages` — **I could not verify
  from here that the gateway accepts the prefixed form.**
* A picker offering models that `400` on use is worse than an empty picker.

Mitigation:

* Both facts are written into `values.yaml`, not just this PR body.
* `idPrefix: ""` degrades to an honest empty-after-filtering catalog rather than a
  misleading one.
* Serving is exact-path with no rewrite hop: the discovery request has a **3s timeout** and
  treats **any redirect as failure**, including `http`→`https`.

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [x] Drafting documentation

Human verification:

* [x] I understand every meaningful change in this PR
* [x] I checked generated code manually
* [x] I removed unsupported AI assumptions

---

## 8. Reviewer Focus

Please focus your review on:

- Whether `anthropic/<model>` is acceptable as a `model` value at `/anthropic/v1/messages`,
  or whether the gateway should strip the prefix inbound. This is the one thing I could not
  test.
- Whether discovery's auth differs enough to matter: it sends the `apiKeyHelper` value in
  **`x-api-key` only**, unlike inference which sends both headers.
