### PR TITLE
fix(librechat-code-interpreter): co-locate package-init Job with sandbox-runner (#1032)

### DIFF
--- a/charts/librechat-code-interpreter/values.yaml
+++ b/charts/librechat-code-interpreter/values.yaml
@@ -588,6 +588,21 @@ codeapi:
       # version. Fixed at the Application level instead.
       pod:
         restartPolicy: Never
+        # Co-locate with sandbox-runner (the only other consumer of the shared
+        # `packages` PVC). That PVC is ReadWriteOnce on hcloud-volumes, so it
+        # can attach to a single node only — the node that holds it is where
+        # sandbox-runner lives (it mounts the same volume read-only at
+        # /host-packages). Without this affinity the Job pod can be scheduled
+        # onto any node and then sits in ContainerCreating forever, unable to
+        # attach the RWO volume from a second node. (Live-incident fix, Story
+        # #995 / ticket #1032 — see issue for the evidence.)
+        affinity:
+          podAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              - labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/controller: sandbox-runner
+                topologyKey: kubernetes.io/hostname
       containers:
         package-init:
           image:


### PR DESCRIPTION
## 1. Summary

This PR changes:

- Adds a required `podAffinity` to the `package-init` controller in `charts/librechat-code-interpreter/values.yaml` so its Job pod always schedules onto the same node as `sandbox-runner` (`topologyKey: kubernetes.io/hostname`, label `app.kubernetes.io/controller: sandbox-runner`).

It solves:

- The wedged `codeapi-package-init` Job sitting in `ContainerCreating` for 10+ days. The shared `packages` PVC is `ReadWriteOnce` (hcloud-volumes supports only RWO) and attaches to a single node — the one where `sandbox-runner` lives. The Job pod was being scheduled onto a different node (`worker-1`) and could never attach the RWO volume from a second node.
- Ticket: https://github.com/ADORSYS-GIS/ai-helm/issues/1032
- Story: https://github.com/ADORSYS-GIS/ai-helm/issues/995

---

## 2. Intent

The intent of this PR is:

> Break the RWO volume placement deadlock. `package-init` and `sandbox-runner` both consume the same `ReadWriteOnce` `packages` PVC; with no placement constraint, the Job pod can land on any node and hang forever trying to attach a volume that is already attached to another node. Forcing co-location on the node where `sandbox-runner` (and therefore the attached volume) lives lets the Job attach, complete, and populate `/pkgs`.

---

## 3. Scope

### In Scope

- Add `podAffinity` to the `package-init` controller to co-locate with `sandbox-runner`.

### Out of Scope

- Changing the PVC access mode or storage class (Hetzner `hcloud-volumes` is RWO-only).
- Job backoff/cleanup hardening (tracked separately, not in this ticket).
- Broader sandbox architecture redesign (Story #995 out-of-scope).

---

## 4. Verification

I verified this change by:

- [x] Running automated tests
- [ ] Running manual tests
- [ ] Checking logs
- [ ] Checking metrics
- [x] Testing error cases
- [ ] Testing permissions/security behavior
- [ ] Testing rollback or failure behavior, if relevant

Commands run:

```bash
helm dependency build charts/librechat-code-interpreter
helm template test charts/librechat-code-interpreter --set codeapi.enabled=true
```

Results:

```text
The rendered Job spec now contains:
  affinity:
    podAffinity:
      requiredDuringSchedulingIgnoredDuringExecution:
      - labelSelector:
          matchLabels:
            app.kubernetes.io/controller: sandbox-runner
        topologyKey: kubernetes.io/hostname
```

(Note: live-cluster verification that the Job completes `1/1` and co-locates on the sandbox-runner node is pending deployment via ArgoCD.)

---

## 5. Screenshots / Evidence

* Rendered Job affinity from `helm template` (see Verification results).
* Live evidence of the bug (root cause): PVC `codeapi` is `ReadWriteOnce` with `volume.kubernetes.io/selected-node: ssegning-hetzner-k3s-worker-3` (sandbox-runner's node), while `codeapi-package-init-wrfn4` is scheduled on `worker-1`.

---

## 6. Risk Assessment

Risk level:

* [x] Low
* [ ] Medium
* [ ] High

Potential risks:

* If affinity forces co-location onto a node without the RWO volume, the deadlock could recur.

Mitigation:

* Affinity targets the node of the `sandbox-runner` controller pod, which is where the volume is attached; placement will be verified after deployment.
* PVC has `helm.sh/resource-policy: keep` — no data-loss risk.

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [ ] Refactoring
* [ ] Generating tests
* [x] Drafting documentation
* [x] Reviewing the diff
* [ ] Not used

Human verification:

* [x] I understand every meaningful change in this PR
* [x] I checked generated code manually
* [ ] I checked generated tests manually
* [x] I removed unsupported AI assumptions
* [x] I accept responsibility for this PR

---

## 8. Reviewer Focus

Please focus your review on:

* [x] Correctness
* [ ] Architecture
* [ ] Security
* [ ] Performance
* [ ] Tests
* [x] Maintainability
* [x] Product intent
* [x] Edge cases