### PR TITLE
fix(ai-models-info): drop the anthropic/ id prefix, it 404s on selection

### DIFF
--- a/charts/ai-models-info/values.yaml
+++ b/charts/ai-models-info/values.yaml
@@ -60,19 +60,40 @@ excludeKinds:
 # per-model via that model's `info.contextLength` / `info.maxOutputTokens`.
 # Claude Code gateway model discovery (`/anthropic/v1/models`).
 #
-# ⚠️ `idPrefix` is what makes this endpoint do anything at all. Claude Code
-# keeps a discovered model only when its `id` contains "claude" or "anthropic"
-# anywhere in the string; none of this platform's ids do, so with an empty
-# prefix the picker gains nothing and the endpoint is inert. Provider-prefixed
-# ids are explicitly supported by the protocol (`vertex_ai/claude-sonnet-4-6`).
+# ⚠️ `idPrefix` is EMPTY ON PURPOSE, and turning it back on without a gateway
+# change re-breaks the picker. Measured against production:
 #
-# ⚠️ The advertised id is the id Claude Code sends back as `model` on
-# /anthropic/v1/messages, so the gateway must accept this prefixed form (or
-# strip it inbound). Verify before relying on it — a picker offering models
-# that 400 on use is worse than an empty picker. `display_name` carries the
-# readable name, so nobody reads the prefix.
+#     POST /anthropic/v1/messages  model=anthropic/adorsys-coder
+#       -> 404 "No matching route found. It is likely because the model
+#               specified in your request is not configured in the Gateway."
+#     POST /anthropic/v1/messages  model=adorsys-coder
+#       -> reaches routing (the plain name is what the gateway knows)
+#
+# Claude Code sends a discovered `id` back VERBATIM as the `model`. It has no
+# client-side aliasing that could strip a prefix: `modelOverrides` keys must be
+# real Anthropic model IDs and "unknown keys are ignored", and
+# ANTHROPIC_CUSTOM_MODEL_OPTION passes its value through unchanged. So a
+# prefixed id is an id that 404s on selection.
+#
+# The bind: Claude Code KEEPS a discovered model only when its id contains
+# "claude" or "anthropic", and this platform's ids contain neither. Prefixed
+# ids survive the filter but don't route; bare ids route but are filtered out.
+# Empty prefix is the fail-safe end of that: the catalog serves, every entry is
+# filtered, the picker is unchanged. An empty picker beats a picker full of
+# models that fail on use.
+#
+# ⚠️ If you ever DO add claude-ish aliases, do NOT embed "claude-" in them.
+# Claude Code resolves any id CONTAINING a Claude model name (e.g.
+# `anthropic/claude-opus-4-8`) to that model and applies ITS context window and
+# capabilities -- silently wrong for a non-Claude backend, and
+# CLAUDE_CODE_MAX_CONTEXT_TOKENS cannot correct it in that case. An
+# "anthropic/"-style prefix stays unrecognized, which is the correctable case.
+#
+# Note discovery conveys ONLY `id` and `display_name`; context length and
+# capabilities cannot be advertised here at all
+# (CLAUDE_CODE_MAX_CONTEXT_TOKENS is per-session and global, not per-model).
 anthropicCatalog:
-  idPrefix: "anthropic/"
+  idPrefix: ""
 
 catalogDefaults:
   contextLength: 128000


### PR DESCRIPTION
## 1. Summary

This PR changes:

- `anthropicCatalog.idPrefix` from `anthropic/` to `""`

It solves:

- The live catalog is advertising model ids the gateway does not route, so selecting one
  from the `/model` picker fails. Introduced by #1031 (mine).

---

## 2. Intent

The intent of this PR is:

> To stop shipping a picker full of models that 404 on use. I shipped #1031 with a prefix
> whose counterpart I had explicitly flagged as unverified, then verified it and found it
> wrong. Empty prefix is the fail-safe end of the same knob.

Source: https://code.claude.com/docs/en/llm-gateway-protocol#model-discovery and
https://code.claude.com/docs/en/model-config

---

## 3. Scope

### In Scope

- The default prefix value and the reasoning recorded next to it

### Out of Scope

- The endpoint, route and renderer from #1031 — all retained and working
- Any gateway change to accept prefixed ids

---

## 4. Verification

I verified this change by:

- [x] Running manual tests
- [x] Testing error cases

Commands run:

```bash
curl -X POST https://api.ai.camer.digital/anthropic/v1/messages \
  -d '{"model":"anthropic/adorsys-coder","max_tokens":1,...}'
curl -X POST https://api.ai.camer.digital/anthropic/v1/messages \
  -d '{"model":"adorsys-coder","max_tokens":1,...}'
helm lint charts/ai-models-info --strict && helm template …
```

Results:

```text
model=anthropic/adorsys-coder -> 404 "No matching route found. It is likely because the
                                      model specified in your request is not configured
                                      in the Gateway."
model=adorsys-coder           -> reaches routing (plain name is what the gateway knows)

after this change: ids: ['adorsys-coder', 'mimo-v2p5']
                   pass Claude Code filter: 0/2  -> picker unchanged (fail-safe)
1 chart(s) linted, 0 chart(s) failed
```

---

## 5. Screenshots / Evidence

* The prefixed and bare requests differ **only** in the model string; the 404 body names
  the model as the cause.
* `GET /anthropic/v1/models` returns 200 and is unaffected — only the ids change.

---

## 6. Risk Assessment

Risk level:

* [x] Low

Potential risks:

* With an empty prefix every entry fails Claude Code's `claude|anthropic` filter, so
  discovery surfaces nothing. The endpoint is inert — but inert is the status quo, and
  strictly better than offering broken models.

Mitigation:

* The bind is written into `values.yaml`: prefixed ids survive the filter but do not route;
  bare ids route but are filtered out. Re-enabling the prefix requires the gateway to accept
  or strip it first.
* Also recorded: a `claude-`-containing alias would be **worse**, not better — Claude Code
  resolves any id containing a Claude model name to that model and applies its context
  window and capabilities, which `CLAUDE_CODE_MAX_CONTEXT_TOKENS` cannot correct.

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [x] Reviewing the diff

Human verification:

* [x] I understand every meaningful change in this PR
* [x] I removed unsupported AI assumptions

---

## 8. Reviewer Focus

Please focus your review on:

- Whether to keep the endpoint at all while it is inert. I kept it: it costs one static file
  and becomes useful the moment the gateway can route claude-ish aliases.
